### PR TITLE
Add missing Pkg-Config file for CMake builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,11 @@ if(ENABLE_TESTS)
   enable_testing()
 endif()
 
+# Default directory for .pc files
+if(NOT DEFINED PKGCONFIG_INSTALL_DIR AND NOT WIN32)
+  set(PKGCONFIG_INSTALL_DIR lib/pkgconfig CACHE STRING "The directory to install the Pkg-Config files.")
+endif()
+
 # CPACK
 set(CPACK_PROJECT_NAME             ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION          ${PROJECT_VERSION})

--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -174,22 +174,20 @@ INSTALL ( FILES
 )
 
 IF ( NOT WIN32 )
-  FILE ( WRITE ${CMAKE_BINARY_DIR}/IlmBase.pc "prefix=${CMAKE_INSTALL_PREFIX}\n" )
-  FILE ( APPEND ${CMAKE_BINARY_DIR}/IlmBase.pc "exec_prefix=\${prefix}
-libdir=\${exec_prefix}/lib
-includedir=\${prefix}/include
-OpenEXR_includedir=\${prefix}/include/OpenEXR
+  FILE ( WRITE ${CMAKE_BINARY_DIR}/IlmBase.pc "libdir=${CMAKE_INSTALL_PREFIX}/lib\n" )
+  FILE ( APPEND ${CMAKE_BINARY_DIR}/IlmBase.pc "includedir=${CMAKE_INSTALL_PREFIX}/include
 
 Name: IlmBase
 Description: Base math and exception libraries
 Version: ${ILMBASE_VERSION}
+
 Libs: -L\${libdir} -lImath${ILMBASE_LIBSUFFIX} -lIexMath${ILMBASE_LIBSUFFIX} -lHalf${ILMBASE_LIBSUFFIX} -lIex${ILMBASE_LIBSUFFIX} -lIlmThread${ILMBASE_LIBSUFFIX} -pthread
-Cflags: -pthread -I\${OpenEXR_includedir}
+Cflags: -pthread -I\${includedir}/OpenEXR
 ")
 
   INSTALL ( FILES
     ${CMAKE_BINARY_DIR}/IlmBase.pc
     DESTINATION
-    lib/pkgconfig
+    ${PKGCONFIG_INSTALL_DIR}
   )
 ENDIF()

--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -199,6 +199,27 @@ INSTALL ( FILES
   ${CMAKE_INSTALL_PREFIX}/include/OpenEXR
   )
 
+IF ( NOT WIN32 )
+  FILE ( WRITE ${CMAKE_BINARY_DIR}/OpenEXR.pc "libdir=${CMAKE_INSTALL_PREFIX}/lib\n" )
+  FILE ( APPEND ${CMAKE_BINARY_DIR}/OpenEXR.pc "includedir=${CMAKE_INSTALL_PREFIX}/include
+
+Name: OpenEXR
+Description: OpenEXR image library
+Version: ${OPENEXR_VERSION}
+
+Libs: -L\${libdir} -lIlmImf${ILMBASE_LIBSUFFIX} -llmImfUtil${ILMBASE_LIBSUFFIX}
+Cflags: -pthread -I\${includedir}/OpenEXR
+Requires: IlmBase
+Libs.private: -lz
+")
+
+  INSTALL ( FILES
+    ${CMAKE_BINARY_DIR}/IlmBase.pc
+    DESTINATION
+    ${PKGCONFIG_INSTALL_DIR}
+  )
+ENDIF()
+
 # Documentation
 INSTALL ( FILES
   doc/TechnicalIntroduction.pdf


### PR DESCRIPTION
The Autotools build adds Pkg-Config files for all four modules,
however only IlmBase is installed with CMake builds.

Signed-off-by: Jonathan Scruggs <j.scruggs@gmail.com>

Still studying and testing this, but this gives a good idea to the proposed missing Pkg-Config files. I left it so everything is by default of what you already have, so there should be no drastic changes. The only thing I really added as a variable for PkgConfig directory in case that differs between systems, but it's set to the original default.

What really needs checking is the library names to make sure all are spelled correctly and that all of them are listed along with the needed non-openexr library dependencies.

I also tried writing this in the existing styles.

Thanks.