### PR TITLE
WIN32 to _WIN32 for Compiler portability

### DIFF
--- a/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
+++ b/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
@@ -69,10 +69,6 @@
 #include <fstream>
 #include <string>
 #include <assert.h>
-#include <time.h>
-#ifndef _WIN32
-#include <sys/times.h>
-#endif // _WIN32
 
 #ifndef ILM_IMF_TEST_IMAGEDIR
     #define ILM_IMF_TEST_IMAGEDIR

--- a/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
+++ b/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
@@ -70,9 +70,9 @@
 #include <string>
 #include <assert.h>
 #include <time.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <sys/times.h>
-#endif // WIN32
+#endif // _WIN32
 
 #ifndef ILM_IMF_TEST_IMAGEDIR
     #define ILM_IMF_TEST_IMAGEDIR


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019
_WIN32 is the standard according to the official documentation from Microsoft and also this fixes MinGW compile error.