### PR TITLE
Address issues causing C++warnings

### DIFF
--- a/ASWF/tsc-meetings/2019-06-20.md
+++ b/ASWF/tsc-meetings/2019-06-20.md
@@ -1,0 +1,43 @@
+# 6/20/2019
+
+### Agenda:
+* Update on SonarCloud?
+* Document CVE’s
+* C++ 98?
+* Strategy on standalone Imath
+* Review outstanding PR’s, via Kimball’s [PR spreadsheet](https://docs.google.com/spreadsheets/d/1dwgWs5GWur-BJkYf4J3ChbjMfb5ZlVn7q1QHq9XmB2Y/edit?ts=5d0409a9#gid=0)
+
+### Attending:
+* Cary Phillips
+* Larry Gritz
+* Peter Hillman
+* Nick Porcino
+* Rod Bogart
+* Don Dempsey (public)
+
+###Discussion:
+
+* Christina has started investigating SonarCloud, nothing to report yet.
+
+* Documentation of CVE’s. The CII Best Practices badge says all
+  publicly filed CVE’s must be noted in the release notes. Rod to
+  investigate, including the process for updating information at
+  cve.mitre.org.
+
+* C++ compatibility: is there a need to still maintain support for
+  C++98? With the VFX reference platform at C++11, can any software
+  reasonably claim to need new releases of OpenEXR to compile with
+  pre-C++11? Probably not, but worth confirming with the community,
+  and with the TAC.
+
+* TSC members should act on commenting on and closings PR's as noted
+  in the spreadsheet.
+
+* Assigned #401 and #378 to Peter, to investigate.
+
+* Standalone Imath: Needs further discussion with the TAC, and a
+  concrete proposal, potentially a straw/trial repo that folks can
+  comment on. Needs to be unencumbered by dependencies like Iex, and
+  by exceptions in general, or with the current on-the-fly code
+  generation of eLut and toFloat.
+

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -156,8 +156,8 @@ struct ThreadPool::Data
     ThreadPoolProvider *provider;
     ThreadPoolProvider *oldprovider;
 #else
-    std::atomic<ThreadPoolProvider *> provider;
     std::atomic<int> provUsers;
+    std::atomic<ThreadPoolProvider *> provider;
 #endif
 };
 
@@ -459,7 +459,7 @@ class NullThreadPoolProvider : public ThreadPoolProvider
 // struct TaskGroup::Data
 //
 
-TaskGroup::Data::Data (): isEmpty (1), numPending (0)
+TaskGroup::Data::Data () : numPending (0), isEmpty (1)
 {
     // empty
 }

--- a/IlmBase/Imath/ImathFun.cpp
+++ b/IlmBase/Imath/ImathFun.cpp
@@ -41,7 +41,7 @@ IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 float
 succf (float f)
 {
-    union {float f; int i;} u;
+    union {float f; unsigned int i;} u;
     u.f = f;
 
     if ((u.i & 0x7f800000) == 0x7f800000)
@@ -76,7 +76,7 @@ succf (float f)
 float
 predf (float f)
 {
-    union {float f; int i;} u;
+    union {float f; unsigned int i;} u;
     u.f = f;
 
     if ((u.i & 0x7f800000) == 0x7f800000)

--- a/IlmBase/Imath/ImathMatrixAlgo.cpp
+++ b/IlmBase/Imath/ImathMatrixAlgo.cpp
@@ -115,7 +115,7 @@ procrustesRotationAndTranslation (const Vec3<T>* A, const Vec3<T>* B, const T* w
 
     if (weights == 0)
     {
-        for (int i = 0; i < numPoints; ++i)
+        for (size_t i = 0; i < numPoints; ++i)
         {
             Acenter += (V3d) A[i];
             Bcenter += (V3d) B[i];
@@ -124,7 +124,7 @@ procrustesRotationAndTranslation (const Vec3<T>* A, const Vec3<T>* B, const T* w
     }
     else
     {
-        for (int i = 0; i < numPoints; ++i)
+        for (size_t i = 0; i < numPoints; ++i)
         {
             const double w = weights[i];
             weightsSum += w;
@@ -152,12 +152,12 @@ procrustesRotationAndTranslation (const Vec3<T>* A, const Vec3<T>* B, const T* w
     M33d C (0.0);
     if (weights == 0)
     {
-        for (int i = 0; i < numPoints; ++i)
+        for (size_t i = 0; i < numPoints; ++i)
             C += outerProduct ((V3d) B[i] - Bcenter, (V3d) A[i] - Acenter);
     }
     else
     {
-        for (int i = 0; i < numPoints; ++i)
+        for (size_t i = 0; i < numPoints; ++i)
         {
             const double w = weights[i];
             C += outerProduct (w * ((V3d) B[i] - Bcenter), (V3d) A[i] - Acenter);
@@ -197,12 +197,12 @@ procrustesRotationAndTranslation (const Vec3<T>* A, const Vec3<T>* B, const T* w
         KahanSum traceATA;
         if (weights == 0)
         {
-            for (int i = 0; i < numPoints; ++i)
+            for (size_t i = 0; i < numPoints; ++i)
                 traceATA += ((V3d) A[i] - Acenter).length2();
         }
         else
         {
-            for (int i = 0; i < numPoints; ++i)
+            for (size_t i = 0; i < numPoints; ++i)
                 traceATA += ((double) weights[i]) * ((V3d) A[i] - Acenter).length2();
         }
 

--- a/IlmBase/ImathTest/testBoxAlgo.cpp
+++ b/IlmBase/ImathTest/testBoxAlgo.cpp
@@ -356,7 +356,7 @@ entryAndExitPoints1 ()
 	Box3f ()
     };
 
-    for (int i = 0; i < sizeof (boxes) / sizeof (boxes[0]); ++i)
+    for (size_t i = 0; i < sizeof (boxes) / sizeof (boxes[0]); ++i)
 	testEntryAndExitPoints (boxes[i]);
 }
 
@@ -738,7 +738,7 @@ rayBoxIntersection1 ()
 	Box3f ()
     };
 
-    for (int i = 0; i < sizeof (boxes) / sizeof (boxes[0]); ++i)
+    for (size_t i = 0; i < sizeof (boxes) / sizeof (boxes[0]); ++i)
 	testRayBoxIntersection (boxes[i]);
 }
 
@@ -907,44 +907,6 @@ boxMatrixTransform ()
     assert (approximatelyEqual (b5.max, b6.max, e));
     assert (b51 == b5);
     
-}
-
-
-void
-pointInBox ()
-{
-    cout << "  closest point in box" << endl;
-
-    Box3f box (V3f (1, 2, 3), V3f (5, 4, 6));
-
-    //
-    // Points outside the box
-    //
-
-    assert (closestPointInBox (V3f (0, 0, 0), box) == V3f (1, 2, 3));
-    assert (closestPointInBox (V3f (7, 7, 7), box) == V3f (5, 4, 6));
-
-    assert (closestPointInBox (V3f (2, 3, 0), box) == V3f (2, 3, 3));
-    assert (closestPointInBox (V3f (2, 3, 7), box) == V3f (2, 3, 6));
-
-    assert (closestPointInBox (V3f (2, 0, 4), box) == V3f (2, 2, 4));
-    assert (closestPointInBox (V3f (2, 7, 4), box) == V3f (2, 4, 4));
-
-    assert (closestPointInBox (V3f (0, 3, 4), box) == V3f (1, 3, 4));
-    assert (closestPointInBox (V3f (7, 3, 4), box) == V3f (5, 3, 4));
-
-    //
-    // Points inside the box
-    //
-
-    assert (closestPointInBox (V3f (1.5, 3, 5), box) == V3f (1.5, 3, 5));
-    assert (closestPointInBox (V3f (4.5, 3, 5), box) == V3f (4.5, 3, 5));
-
-    assert (closestPointInBox (V3f (2, 2.5, 4), box) == V3f (2, 2.5, 4));
-    assert (closestPointInBox (V3f (2, 3.5, 4), box) == V3f (2, 3.5, 4));
-
-    assert (closestPointInBox (V3f (2, 3, 3.5), box) == V3f (2, 3, 3.5));
-    assert (closestPointInBox (V3f (2, 3, 5.5), box) == V3f (2, 3, 5.5));
 }
 
 

--- a/IlmBase/ImathTest/testExtractEuler.cpp
+++ b/IlmBase/ImathTest/testExtractEuler.cpp
@@ -48,7 +48,6 @@ using namespace IMATH_INTERNAL_NAMESPACE;
 namespace {
 
 float rad (float deg) {return deg * (M_PI / 180);}
-float deg (float rad) {return rad * (180 / M_PI);}
 
 
 M44f

--- a/IlmBase/ImathTest/testExtractSHRT.cpp
+++ b/IlmBase/ImathTest/testExtractSHRT.cpp
@@ -57,7 +57,6 @@ using namespace IMATH_INTERNAL_NAMESPACE;
 namespace {
 
 float rad (float deg) {return deg * (M_PI / 180);}
-float deg (float rad) {return rad * (180 / M_PI);}
 
 
 void

--- a/IlmBase/ImathTest/testJacobiEigenSolver.cpp
+++ b/IlmBase/ImathTest/testJacobiEigenSolver.cpp
@@ -85,8 +85,8 @@ void
 verifyOrthonormal (const TM& A, const typename TM::BaseType threshold)
 {
     const TM prod = A * A.transposed();
-    for (int i = 0; i < TM::dimensions(); ++i)
-        for (int j = 0; j < TM::dimensions(); ++j)
+    for (size_t i = 0; i < TM::dimensions(); ++i)
+        for (size_t j = 0; j < TM::dimensions(); ++j)
             if (i == j) 
                 assert (std::abs (prod[i][j] - 1) < threshold);
             else
@@ -100,8 +100,8 @@ computeThreshold(const TM& A)
    typedef typename TM::BaseType T;
    T maxAbsEntry(0);
 
-   for (int i = 0; i < TM::dimensions(); ++i)
-       for (int j = 0; j < TM::dimensions(); ++j)
+   for (size_t i = 0; i < TM::dimensions(); ++i)
+       for (size_t j = 0; j < TM::dimensions(); ++j)
            maxAbsEntry = std::max (maxAbsEntry, std::abs(A[i][j]));
 
    const T eps = std::numeric_limits<T>::epsilon();
@@ -135,8 +135,8 @@ testJacobiEigenSolver(const TM& A)
 
     // Determinant of A and S
     TM MS;
-    for (int i = 0; i < TM::dimensions(); ++i)
-        for (int j = 0; j < TM::dimensions(); ++j)
+    for (size_t i = 0; i < TM::dimensions(); ++i)
+        for (size_t j = 0; j < TM::dimensions(); ++j)
             if(i == j)
                 MS[i][j] = S[i];
             else
@@ -148,8 +148,8 @@ testJacobiEigenSolver(const TM& A)
     // A = V * S * V^T
     TM MA = V * MS * V.transposed();
 
-    for (int i = 0; i < TM::dimensions(); ++i) 
-        for (int j =0; j < TM::dimensions(); ++j) 
+    for (size_t i = 0; i < TM::dimensions(); ++i) 
+        for (size_t j =0; j < TM::dimensions(); ++j) 
             assert(abs(A[i][j]-MA[i][j]) < threshold);
 }
 

--- a/IlmBase/ImathTest/testLineAlgo.cpp
+++ b/IlmBase/ImathTest/testLineAlgo.cpp
@@ -399,7 +399,6 @@ testIntersect ()
 	    V3f p1 = v0 * b.x + v1 * b.y + v2 * b.z;
 
 	    V3f p0;
-	    int j = 0;
 
 	    do
 	    {

--- a/IlmBase/ImathTest/testProcrustes.cpp
+++ b/IlmBase/ImathTest/testProcrustes.cpp
@@ -151,8 +151,6 @@ void
 verifyProcrustes (const std::vector<IMATH_INTERNAL_NAMESPACE::Vec3<T> >& from, 
                   const std::vector<IMATH_INTERNAL_NAMESPACE::Vec3<T> >& to)
 {
-    typedef IMATH_INTERNAL_NAMESPACE::Vec3<T> V3;
-
     const T eps = std::sqrt(std::numeric_limits<T>::epsilon());
 
     const size_t n = from.size();
@@ -242,7 +240,7 @@ verifyProcrustes (const std::vector<IMATH_INTERNAL_NAMESPACE::Vec3<T> >& from,
 
         IMATH_INTERNAL_NAMESPACE::V3d netForce(0);
         IMATH_INTERNAL_NAMESPACE::V3d netTorque(0);
-        for (int iPoint = 0; iPoint < n; ++iPoint)
+        for (size_t iPoint = 0; iPoint < n; ++iPoint)
         {
             const IMATH_INTERNAL_NAMESPACE::V3d force = weights[iPoint] * (from[iPoint]*m - to[iPoint]);
             netForce += force;

--- a/IlmBase/ImathTest/testShear.cpp
+++ b/IlmBase/ImathTest/testShear.cpp
@@ -54,7 +54,6 @@ testShear ()
 
     const float         epsilon = IMATH_INTERNAL_NAMESPACE::limits< float >::epsilon();
 
-    float    	        array[6] = { 1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F };
     IMATH_INTERNAL_NAMESPACE::Shear6f    	testConstructor1;
     IMATH_INTERNAL_NAMESPACE::Shear6f    	testConstructor2( testConstructor1 );
 

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -458,59 +458,6 @@ readTileData (InputStreamMutex *streamData,
 }
 
 
-void
-readNextTileData (InputStreamMutex *streamData,
-                  DeepTiledInputFile::Data *ifd,
-                  int &dx, int &dy,
-                  int &lx, int &ly,
-                  char * & buffer,
-                  Int64 &dataSize,
-                  Int64 &unpackedDataSize)
-{
-    //
-    // Read the next tile block from the file
-    //
-
-    //
-    // Read the first few bytes of the tile (the header).
-    //
-
-    Xdr::read <StreamIO> (*streamData->is, dx);
-    Xdr::read <StreamIO> (*streamData->is, dy);
-    Xdr::read <StreamIO> (*streamData->is, lx);
-    Xdr::read <StreamIO> (*streamData->is, ly);
-
-    Int64 tableSize;
-    Xdr::read <StreamIO> (*streamData->is, tableSize);
-
-    Xdr::read <StreamIO> (*streamData->is, dataSize);
-    Xdr::read <StreamIO> (*streamData->is, unpackedDataSize);
-
-    //
-    // Skip the pixel sample count table because we have read this data.
-    //
-
-    Xdr::skip <StreamIO> (*streamData->is, tableSize);
-
-    //
-    // Read the pixel data.
-    //
-
-    streamData->is->read (buffer, dataSize);
-
-    //
-    // Keep track of which tile is the next one in
-    // the file, so that we can avoid redundant seekg()
-    // operations (seekg() can be fairly expensive).
-    //
-
-    streamData->currentPosition += 4 * Xdr::size<int>()   +
-                                   3 * Xdr::size<Int64>() +
-                                   tableSize              +
-                                   dataSize;
-}
-
-
 //
 // A TileBufferTask encapsulates the task of uncompressing
 // a single tile and copying it into the frame buffer.
@@ -1957,7 +1904,7 @@ DeepTiledInputFile::totalTiles() const
                 for (int i_lx = 0; i_lx < numXLevels (); ++i_lx)
                     numAllTiles += numXTiles (i_lx) * numYTiles (i_ly);
                 
-                break;
+            break;
             
         default:
             

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -1465,13 +1465,11 @@ DeepTiledOutputFile::writeTiles (int dx1, int dx2, int dy1, int dy2,
             swap (dy1, dy2);
 
         int dyStart = dy1;
-        int dyStop  = dy2 + 1;
         int dY      = 1;
 
         if (_data->lineOrder == DECREASING_Y)
         {
             dyStart = dy2;
-            dyStop  = dy1 - 1;
             dY      = -1;
         }
 

--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -87,7 +87,7 @@ class SimdAlignedBuffer64
             alloc();
         }
 
-        SimdAlignedBuffer64(const SimdAlignedBuffer64 &rhs): _handle(0)
+        SimdAlignedBuffer64(const SimdAlignedBuffer64 &rhs): _buffer (0), _handle(0)
         {
             alloc();
             memcpy (_buffer, rhs._buffer, 64 * sizeof (T));
@@ -101,7 +101,7 @@ class SimdAlignedBuffer64
 
 #if __cplusplus >= 201103L
         SimdAlignedBuffer64(SimdAlignedBuffer64 &&rhs) noexcept
-            : _handle(rhs._handle), _buffer(rhs._buffer)
+        : _buffer(rhs._buffer), _handle(rhs._handle)
         {
             rhs._handle = nullptr;
             rhs._buffer = nullptr;

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -167,9 +167,10 @@ cachePadding (ptrdiff_t size)
     // we are running on.  (It is ok if CACHE_LINE_SIZE is larger
     // than a real cache line.)
     //
+    // CACHE_LINE_SIZE = (1 << LOG2_CACHE_LINE_SIZE)
+    //
 
     static int LOG2_CACHE_LINE_SIZE = 8;
-    static const ptrdiff_t CACHE_LINE_SIZE = (1 << LOG2_CACHE_LINE_SIZE);
 
     int i = LOG2_CACHE_LINE_SIZE + 2;
 

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1418,6 +1418,10 @@ ScanLineInputFile::setFrameBuffer (const FrameBuffer &frameBuffer)
                   case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT :
                       offset+=2;
                       break;
+                  case OPENEXR_IMF_INTERNAL_NAMESPACE::NUM_PIXELTYPES:
+                  default:
+                      // not possible.
+                      break;
               }
               ++i;
 	}
@@ -1487,6 +1491,10 @@ ScanLineInputFile::setFrameBuffer (const FrameBuffer &frameBuffer)
                       break;
                   case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT :
                       offset+=2;
+                      break;
+                  case OPENEXR_IMF_INTERNAL_NAMESPACE::NUM_PIXELTYPES:
+                  default:
+                      // not possible.
                       break;
               }
           }

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -1230,13 +1230,11 @@ TiledOutputFile::writeTiles (int dx1, int dx2, int dy1, int dy2,
             swap (dy1, dy2);
         
         int dyStart = dy1;
-	int dyStop  = dy2 + 1;
 	int dY      = 1;
     
         if (_data->lineOrder == DECREASING_Y)
         {
             dyStart = dy2;
-            dyStop  = dy1 - 1;
             dY      = -1;
         }
         

--- a/PyIlmBase/PyIex/PyIexTypeTranslator.h
+++ b/PyIlmBase/PyIex/PyIexTypeTranslator.h
@@ -306,7 +306,7 @@ TypeTranslator<BaseClass>::ClassDesc::ClassDesc
 template <class BaseClass>
 TypeTranslator<BaseClass>::ClassDesc::~ClassDesc ()
 {
-    for (int i = 0; i < _derivedClasses.size(); ++i)
+    for (size_t i = 0; i < _derivedClasses.size(); ++i)
 	delete _derivedClasses[i];
 }
 

--- a/PyIlmBase/PyImath/PyImathAutovectorize.h
+++ b/PyIlmBase/PyImath/PyImathAutovectorize.h
@@ -738,7 +738,7 @@ struct VectorizedVoidMaskableMemberFunction1 {
         size_t len = cls.match_dimension(arg1, false);
         op_precompute<Op>::apply(len);
 
-        if (cls.isMaskedReference() && arg1.len() == cls.unmaskedLength())
+        if (cls.isMaskedReference() && (size_t) arg1.len() == cls.unmaskedLength())
         {
             // class is masked, and the unmasked length matches the right hand side
             VectorizedMaskedVoidOperation1<Op,class_type,arg1_type> vop(cls,arg1);

--- a/PyIlmBase/PyImath/PyImathBox.cpp
+++ b/PyIlmBase/PyImath/PyImathBox.cpp
@@ -316,7 +316,7 @@ box_extendBy(IMATH_NAMESPACE::Box<T> &box, const PyImath::FixedArray<T> &points)
     std::vector<IMATH_NAMESPACE::Box<T> > boxes(numBoxes);
     ExtendByTask<T> task(boxes,points);
     dispatchTask(task,points.len());
-    for (int i=0; i<numBoxes; ++i) {
+    for (size_t i=0; i<numBoxes; ++i) {
         box.extendBy(boxes[i]);
     }
 }

--- a/PyIlmBase/PyImath/PyImathBoxArrayImpl.h
+++ b/PyIlmBase/PyImath/PyImathBoxArrayImpl.h
@@ -78,7 +78,7 @@ setItemTuple(FixedArray<IMATH_NAMESPACE::Box<T> > &va, Py_ssize_t index, const t
         Box<T> v;
         v.min = extract<T>(t[0]);
         v.max = extract<T>(t[1]);
-        va[va.canonical_index(index)] = v;
+        va[(size_t)va.canonical_index(index)] = v;
     }
     else
         THROW(IEX_NAMESPACE::LogicExc, "tuple of length 2 expected");

--- a/PyIlmBase/PyImath/PyImathEuler.cpp
+++ b/PyIlmBase/PyImath/PyImathEuler.cpp
@@ -113,6 +113,8 @@ static std::string nameOfOrder(typename IMATH_NAMESPACE::Euler<T>::Order order)
             return "EULER_ZYZr";
         case IMATH_NAMESPACE::Euler<T>::ZXZr:
             return "EULER_ZXZr";
+        default:
+            break;
     }
     
     return "";
@@ -306,6 +308,8 @@ static typename Euler<T>::Order interpretOrder(typename IMATH_NAMESPACE::Eulerf:
         {
             o = Euler<T>::ZXZr;
         }break;            
+        default:
+            break;
     }
     
     return o;

--- a/PyIlmBase/PyImath/PyImathFixedArray.h
+++ b/PyIlmBase/PyImath/PyImathFixedArray.h
@@ -116,7 +116,7 @@ class FixedArray
         }
         boost::shared_array<T> a(new T[length]);
         T tmp = FixedArrayDefaultValue<T>::value();
-        for (size_t i=0; i<length; ++i) a[i] = tmp;
+        for (Py_ssize_t i=0; i<length; ++i) a[i] = tmp;
         _handle = a;
         _ptr = a.get();
     }
@@ -139,7 +139,7 @@ class FixedArray
             throw IEX_NAMESPACE::LogicExc("Fixed array length must be non-negative");
         }
         boost::shared_array<T> a(new T[length]);
-        for (size_t i=0; i<length; ++i) a[i] = initialValue;
+        for (Py_ssize_t i=0; i<length; ++i) a[i] = initialValue;
         _handle = a;
         _ptr = a.get();
     }
@@ -229,8 +229,8 @@ class FixedArray
     //
     size_t canonical_index(Py_ssize_t index) const
     {
-        if (index < 0) index += _length;
-        if (index >= _length || index < 0) {
+        if (index < 0) index += len();
+        if (index >= len() || index < 0) {
             PyErr_SetString(PyExc_IndexError, "Index out of range");
             boost::python::throw_error_already_set();
         }
@@ -345,7 +345,7 @@ class FixedArray
         extract_slice_indices(index,start,end,step,slicelength);
         
         // we have a valid range of indices
-        if (data.len() != slicelength) {
+        if ((size_t)data.len() != slicelength) {
             PyErr_SetString(PyExc_IndexError, "Dimensions of source do not match destination");
 	    boost::python::throw_error_already_set();
         }
@@ -374,7 +374,7 @@ class FixedArray
         }
 
         size_t len = match_dimension(mask);
-        if (data.len() == len)
+        if ((size_t)data.len() == len)
         {
             for (size_t i = 0; i < len; ++i)
                 if (mask[i]) _ptr[i*_stride] = data[i];
@@ -385,7 +385,7 @@ class FixedArray
             for (size_t i = 0; i < len; ++i)
                 if (mask[i]) count++;
 
-            if (data.len() != count) {
+            if ((size_t)data.len() != count) {
                 throw IEX_NAMESPACE::ArgExc("Dimensions of source data do not match destination either masked or unmasked");
             }
 
@@ -493,7 +493,7 @@ class FixedArray
             throwExc = true;
         else if (_indices)
         {
-            if (_unmaskedLength != a1.len())
+            if (_unmaskedLength != (size_t) a1.len())
                 throwExc = true;
         }
         else

--- a/PyIlmBase/PyImath/PyImathFixedArray2D.h
+++ b/PyIlmBase/PyImath/PyImathFixedArray2D.h
@@ -183,7 +183,7 @@ class FixedArray2D
     size_t canonical_index(Py_ssize_t index, size_t length) const
     {
         if (index < 0) index += length;
-        if (index >= length || index < 0) {
+        if ((size_t) index >= length || index < 0) {
             PyErr_SetString(PyExc_IndexError, "Index out of range");
             boost::python::throw_error_already_set();
         }
@@ -355,7 +355,7 @@ class FixedArray2D
     setitem_array1d_mask(const FixedArray2D<int> &mask, const FixedArray<T> &data)
     {
         IMATH_NAMESPACE::Vec2<size_t> len = match_dimension(mask);
-        if (data.len() == len.x*len.y) {
+        if ((size_t) data.len() == len.x*len.y) {
             for (size_t j = 0, z = 0; j < len.y; j++)
                 for (size_t i=0; i<len.x; ++i, ++z)
                     if (mask(i,j))
@@ -366,7 +366,7 @@ class FixedArray2D
                 for (size_t i=0; i<len.x; ++i, ++z)
                     if (mask(i,j)) count++;
 
-            if (data.len() != count) {
+            if ((size_t) data.len() != count) {
                 PyErr_SetString(PyExc_IndexError, "Dimensions of source data do not match destination either masked or unmasked");
                 boost::python::throw_error_already_set();
             }
@@ -389,7 +389,7 @@ class FixedArray2D
         extract_slice_indices(PyTuple_GetItem(index, 0),_length.x,startx,endx,stepx,slicelengthx);
         extract_slice_indices(PyTuple_GetItem(index, 1),_length.y,starty,endy,stepy,slicelengthy);
         // we have a valid range of indices
-        if (data.len() != slicelengthx*slicelengthy) {
+        if ((size_t) data.len() != slicelengthx*slicelengthy) {
             PyErr_SetString(PyExc_IndexError, "Dimensions of source data do not match destination");
             boost::python::throw_error_already_set();
         }
@@ -489,8 +489,8 @@ FixedArray2D<Ret> apply_array2d_unary_op(const FixedArray2D<T1> &a1)
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.len();
     FixedArray2D<Ret> retval(len.x,len.y);
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             retval(i,j) = Op<T1,Ret>::apply(a1(i,j));
         }
     }
@@ -503,8 +503,8 @@ FixedArray2D<Ret> apply_array2d_array2d_binary_op(const FixedArray2D<T1> &a1, co
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.match_dimension(a2);
     FixedArray2D<Ret> retval(len.x,len.y);
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             retval(i,j) = Op<T1,T2,Ret>::apply(a1(i,j),a2(i,j));
         }
     }
@@ -516,8 +516,8 @@ FixedArray2D<Ret> apply_array2d_scalar_binary_op(const FixedArray2D<T1> &a1, con
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.len();
     FixedArray2D<Ret> retval(len.x,len.y);
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             retval(i,j) = Op<T1,T2,Ret>::apply(a1(i,j),a2);
         }
     }
@@ -529,8 +529,8 @@ FixedArray2D<Ret> apply_array2d_scalar_binary_rop(const FixedArray2D<T1> &a1, co
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.len();
     FixedArray2D<Ret> retval(len.x,len.y);
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             retval(i,j) = Op<T2,T1,Ret>::apply(a2,a1(i,j));
         }
     }
@@ -542,8 +542,8 @@ template <template <class,class> class Op, class T1, class T2>
 FixedArray2D<T1> & apply_array2d_array2d_ibinary_op(FixedArray2D<T1> &a1, const FixedArray2D<T2> &a2)
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.match_dimension(a2);
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             Op<T1,T2>::apply(a1(i,j),a2(i,j));
         }
     }
@@ -555,8 +555,8 @@ template <template <class,class> class Op, class T1, class T2>
 FixedArray2D<T1> & apply_array2d_scalar_ibinary_op(FixedArray2D<T1> &a1, const T2 &a2)
 {
     IMATH_NAMESPACE::Vec2<size_t> len = a1.len();
-    for (int j=0; j<len.y; ++j) {
-        for (int i=0;i<len.x;++i) {
+    for (size_t j=0; j<len.y; ++j) {
+        for (size_t i=0;i<len.x;++i) {
             Op<T1,T2>::apply(a1(i,j),a2);
         }
     }

--- a/PyIlmBase/PyImath/PyImathFixedVArray.cpp
+++ b/PyIlmBase/PyImath/PyImathFixedVArray.cpp
@@ -117,7 +117,7 @@ FixedVArray<T>::FixedVArray(const T& initialValue, Py_ssize_t length)
     }
 
     boost::shared_array<std::vector<T> > a(new std::vector<T>[length]);
-    for (size_t i = 0; i < length; ++i)
+    for (Py_ssize_t i = 0; i < length; ++i)
     {
         a[i].push_back (initialValue);
     }
@@ -135,7 +135,7 @@ FixedVArray<T>::FixedVArray(FixedVArray<T>& other, const FixedArray<int>& mask)
             ("Masking an already-masked FixedVArray is not supported yet (SQ27000)");
     }
 
-    size_t len = other.match_dimension (mask);
+    size_t len = (size_t) other.match_dimension (mask);
     _unmaskedLength = len;
 
     size_t reduced_len = 0;
@@ -228,7 +228,7 @@ canonical_index (Py_ssize_t index, const size_t& totalLength)
     {
         index += totalLength;
     }
-    if (index >= totalLength || index < 0)
+    if ((size_t) index >= totalLength || index < 0)
     {
         PyErr_SetString (PyExc_IndexError, "Index out of range");
         boost::python::throw_error_already_set();
@@ -402,7 +402,7 @@ FixedVArray<T>::setitem_vector (PyObject* index, const FixedVArray<T>& data)
     Py_ssize_t step;
     extract_slice_indices (index, start, end, step, sliceLength, _length);
 
-    if (data.len() != sliceLength)
+    if ((size_t) data.len() != sliceLength)
     {
         PyErr_SetString (PyExc_IndexError,
                          "Dimensions of source do not match destination");
@@ -439,7 +439,7 @@ FixedVArray<T>::setitem_vector_mask (const FixedArray<int>& mask,
 
     size_t len = match_dimension(mask);
 
-    if (data.len() == len)
+    if ((size_t) data.len() == len)
     {
         for (size_t i = 0; i < len; ++i)
         {
@@ -459,7 +459,7 @@ FixedVArray<T>::setitem_vector_mask (const FixedArray<int>& mask,
                 count++;
             }
         }
-        if (data.len() != count)
+        if ((size_t) data.len() != count)
         {
             throw IEX_NAMESPACE::ArgExc
                 ("Dimensions of source data do not match destination "

--- a/PyIlmBase/PyImath/PyImathFixedVArray.h
+++ b/PyIlmBase/PyImath/PyImathFixedVArray.h
@@ -146,7 +146,7 @@ class FixedVArray
         }
         else if (_indices)
         {
-            if (_unmaskedLength != mask.len())
+            if (_unmaskedLength != (size_t) mask.len())
             {
                 throwExc = true;
             }
@@ -179,7 +179,7 @@ class FixedVArray
         }
         else if (_indices)
         {
-            if (_unmaskedLength != other.len())
+            if (_unmaskedLength != (size_t) other.len())
             {
                 throwExc = true;
             }

--- a/PyIlmBase/PyImath/PyImathStringArray.cpp
+++ b/PyIlmBase/PyImath/PyImathStringArray.cpp
@@ -153,7 +153,7 @@ StringArrayT<T>::setitem_string_vector(PyObject *index, const StringArrayT<T> &d
     extract_slice_indices(index,start,end,step,slicelength);
         
     // we have a valid range of indices
-    if (data.len() != slicelength) {
+    if ((size_t) data.len() != slicelength) {
         PyErr_SetString(PyExc_IndexError, "Dimensions of source do not match destination");
         throw_error_already_set();
     }
@@ -168,7 +168,7 @@ void
 StringArrayT<T>::setitem_string_vector_mask(const FixedArray<int> &mask, const StringArrayT<T> &data)
 {
     size_t len = match_dimension(mask);
-    if (data.len() == len) {
+    if ((size_t) data.len() == len) {
         for (size_t i=0; i<len; ++i) {
             if (mask[i]) {
                 StringTableIndex di = _table.intern(data._table.lookup(data[i]));
@@ -181,7 +181,7 @@ StringArrayT<T>::setitem_string_vector_mask(const FixedArray<int> &mask, const S
             if (mask[i]) count += 1;
         }
 
-        if (data.len() != count) {
+        if ((size_t) data.len() != count) {
             PyErr_SetString(PyExc_IndexError, "Dimensions of source data do not match destination either masked or unmasked");
             throw_error_already_set();
         }

--- a/PyIlmBase/PyImath/imathmodule.cpp
+++ b/PyIlmBase/PyImath/imathmodule.cpp
@@ -102,7 +102,7 @@ procrustes1 (PyObject* from_input,
     bool useWeights = PySequence_Check (weights_input);
 
     // Now verify the lengths:
-    const size_t n = PySequence_Length (from_input);
+    const Py_ssize_t n = PySequence_Length (from_input);
     if (n != PySequence_Length (to_input) ||
         (useWeights && n != PySequence_Length (weights_input)))
     {
@@ -114,7 +114,7 @@ procrustes1 (PyObject* from_input,
     std::vector<IMATH_NAMESPACE::V3d> to;    to.reserve (n);
     std::vector<double> weights;   weights.reserve (n);
 
-    for (size_t i = 0; i < n; ++i)
+    for (Py_ssize_t i = 0; i < n; ++i)
     {
         PyObject* f = PySequence_GetItem (from_input, i);
         PyObject* t = PySequence_GetItem (to_input, i);


### PR DESCRIPTION
Not sure why the meeting minutes commit is in this PR.

This fixes many of the compiler warnings from -Wall:
- removed unused variables and functions.
- fixed member initialization order in constructors
- added default cases to switch statements
- signed/unsigned comparisons fixed via:
  o use size_t instead of int in for loops
  o cast to size_t where appropriate.

There are *lots* more signed/unsigned comparison issues in ImfDwaCompressor.cpp that need more careful consideration.