### PR TITLE
Add ImfFloatVectorAttribute.h to the automake install

### DIFF
--- a/OpenEXR/IlmImf/Makefile.am
+++ b/OpenEXR/IlmImf/Makefile.am
@@ -110,7 +110,7 @@ libIlmImfinclude_HEADERS = ImfForward.h ImfAttribute.h ImfBoxAttribute.h \
 			   ImfCRgbaFile.h ImfChannelList.h \
 			   ImfChannelListAttribute.h \
 			   ImfCompressionAttribute.h \
-			   ImfDoubleAttribute.h ImfFloatAttribute.h \
+			   ImfDoubleAttribute.h ImfFloatAttribute.h ImfFloatVectorAttribute.h \
 			   ImfFrameBuffer.h ImfHeader.h ImfIO.h \
 			   ImfInputFile.h ImfIntAttribute.h \
 			   ImfLineOrderAttribute.h ImfMatrixAttribute.h \


### PR DESCRIPTION
The CMake file was previously updated to include this file on install,
but was missing from the automake side.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>