### PR TITLE
Fixed the 2.3.0 release notes to mention that CVE-2017-12596 is fixed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 
 * 25+ various bug fixes (see detailed Release Notes for the full list)
 
+* This release addresses vulnerability [CVE-2017-12596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12596).
+
 ### Build Fixes:
 
 * Various fixes to the cmake and autoconf build infrastructures


### PR DESCRIPTION
Signed-off-by: Cary Phillips <cary@ilm.com>