### PR TITLE
Fix #350 - memory leak on exit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # OpenEXR Release Notes
 
+## Version X.X.X (Some Date)
+
+* Fix CVE-2018-18443, a memory leak in ThreadPool
+
 ## Version 2.3.0 (August 13, 2018)
 
 ### Features/Improvements:

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -566,9 +566,11 @@ ThreadPool::Data::~Data()
 {
 #ifdef ILMBASE_FORCE_CXX03
     provider->finish();
+    delete provider;
 #else
     ThreadPoolProvider *p = provider.load( std::memory_order_relaxed );
     p->finish();
+    delete p;
 #endif
 }
 


### PR DESCRIPTION
This fixes CVE-2018-18443, the last thread pool provider set into the
pool was not being correctly cleaned up at shutdown of the thread pool.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>