### PR TITLE
Add exr2aces to autoconf build script

### DIFF
--- a/OpenEXR/Makefile.am
+++ b/OpenEXR/Makefile.am
@@ -6,7 +6,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = config IlmImf IlmImfUtil IlmImfTest IlmImfUtilTest \
 	  IlmImfFuzzTest exrheader exrmaketiled IlmImfExamples doc \
-	  exrstdattr exrmakepreview exrenvmap exrmultiview exrmultipart
+	  exrstdattr exrmakepreview exrenvmap exrmultiview exrmultipart exr2aces
 
 DIST_SUBDIRS = \
 	$(SUBDIRS) 

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -385,6 +385,7 @@ IlmImfUtil/Makefile
 IlmImfUtilTest/Makefile
 IlmImfFuzzTest/Makefile
 exrheader/Makefile
+exr2aces/Makefile
 exrmaketiled/Makefile
 IlmImfExamples/Makefile
 doc/Makefile


### PR DESCRIPTION
exr2aces built via CMake but not ./configure