### PR TITLE
Address #270: limit Tiled images to INT_MAX total number of tiles

### DIFF
--- a/OpenEXR/IlmImf/ImfHeader.cpp
+++ b/OpenEXR/IlmImf/ImfHeader.cpp
@@ -73,7 +73,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <time.h>
-
+#include "ImfTiledMisc.h"
 #include "ImfNamespace.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
@@ -914,6 +914,10 @@ Header::sanityCheck (bool isTiled, bool isMultipartFile) const
 	    THROW (IEX_NAMESPACE::ArgExc, "The width of the tiles exceeds the maximum "
 				"width of " << maxTileHeight << "pixels.");
 	}
+
+    // computes size of chunk offset table. Throws an exception if this exceeds
+    // the maximum allowable size
+    getTiledChunkOffsetTableSize(*this);
 
 	if (tileDesc.mode != ONE_LEVEL &&
 	    tileDesc.mode != MIPMAP_LEVELS &&

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -361,20 +361,34 @@ getTiledChunkOffsetTableSize(const Header& header)
     //
     // Calculate lineOffsetSize.
     //
-    int lineOffsetSize = 0;
+    Int64 lineOffsetSize = 0;
     const TileDescription &desc = header.tileDescription();
     switch (desc.mode)
     {
         case ONE_LEVEL:
         case MIPMAP_LEVELS:
             for (int i = 0; i < numXLevels; i++)
-                lineOffsetSize += numXTiles[i] * numYTiles[i];
-            break;
+            {
+                lineOffsetSize += Int64(numXTiles[i]) * Int64(numYTiles[i]);
+                if ( lineOffsetSize > INT_MAX )
+                {
+                    throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
+                }
+            }
+           break;
         case RIPMAP_LEVELS:
             for (int i = 0; i < numXLevels; i++)
+            {
                 for (int j = 0; j < numYLevels; j++)
-                    lineOffsetSize += numXTiles[i] * numYTiles[j];
-            break;
+                {
+                     lineOffsetSize += Int64(numXTiles[i]) * Int64(numYTiles[j]);
+                     if ( lineOffsetSize > INT_MAX )
+                     {
+                        throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
+                     }
+                }
+            }
+           break;
         case NUM_LEVELMODES :
             throw IEX_NAMESPACE::LogicExc("Bad level mode getting chunk offset table size");
     }
@@ -382,7 +396,7 @@ getTiledChunkOffsetTableSize(const Header& header)
     delete[] numXTiles;
     delete[] numYTiles;
 
-    return lineOffsetSize;
+    return int(lineOffsetSize);
 }
 
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -369,8 +369,8 @@ getTiledChunkOffsetTableSize(const Header& header)
         case MIPMAP_LEVELS:
             for (int i = 0; i < numXLevels; i++)
             {
-                lineOffsetSize += Int64(numXTiles[i]) * Int64(numYTiles[i]);
-                if ( lineOffsetSize > INT_MAX )
+                lineOffsetSize += static_cast<Int64>(numXTiles[i]) * static_cast<Int64>(numYTiles[i]);
+                if ( lineOffsetSize > std::numeric_limits<int>::max() )
                 {
                     throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
                 }
@@ -381,8 +381,8 @@ getTiledChunkOffsetTableSize(const Header& header)
             {
                 for (int j = 0; j < numYLevels; j++)
                 {
-                     lineOffsetSize += Int64(numXTiles[i]) * Int64(numYTiles[j]);
-                     if ( lineOffsetSize > INT_MAX )
+                     lineOffsetSize += static_cast<Int64>(numXTiles[i]) * static_cast<Int64>(numYTiles[j]);
+                     if ( lineOffsetSize > std::numeric_limits<int>::max() )
                      {
                         throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
                      }
@@ -396,7 +396,7 @@ getTiledChunkOffsetTableSize(const Header& header)
     delete[] numXTiles;
     delete[] numYTiles;
 
-    return int(lineOffsetSize);
+    return static_cast<int>(lineOffsetSize);
 }
 
 


### PR DESCRIPTION
If Multipart API was used, or a file has multiple parts and the TiledInputFile API is used, there's an implicit maximum tile count of INT_MAX. This change enforces that limit on reading and writing all tiled images. 
INT_MAX tiles is normally not exceeded unless very large images are written with very small tiles.