### PR TITLE
Handle exceptions, per SonarCloud rules

### DIFF
--- a/IlmBase/IexTest/testBaseExc.cpp
+++ b/IlmBase/IexTest/testBaseExc.cpp
@@ -69,13 +69,17 @@ throwNested()
     }
     catch (const IEX_INTERNAL_NAMESPACE::ArgExc &)
     {
+        bool caught = false;
 	try
 	{
 	    throwInt();
 	}
 	catch (...)
 	{
+            caught = true;
 	}
+
+        assert (caught);
 
 	throw;
     }

--- a/IlmBase/ImathTest/testFrustum.cpp
+++ b/IlmBase/ImathTest/testFrustum.cpp
@@ -216,31 +216,48 @@ testFrustum ()
     cout << "\nexceptions ";
     IMATH_INTERNAL_NAMESPACE::Frustum<float> badFrustum;
 
+    bool caught;
+
     badFrustum.set (n, n, l, r, t, b, false);
+    caught = false;
     try
     {
 	(void)badFrustum.projectionMatrix();
 	assert (!"near == far didn't throw an exception");
     }
-    catch (IEX_NAMESPACE::DivzeroExc) {}
+    catch (IEX_NAMESPACE::DivzeroExc)
+    {
+        caught = true;
+    }
+    assert (caught);
     cout << "1";
 
     badFrustum.set (n, f, l, l, t, b, false);
+    caught = false;
     try
     {
 	(void)badFrustum.projectionMatrix();
 	assert (!"left == right didn't throw an exception");
     }
-    catch (IEX_NAMESPACE::DivzeroExc) {}
+    catch (IEX_NAMESPACE::DivzeroExc)
+    {
+        caught = true;
+    }
+    assert (caught);
     cout << "2";
 
     badFrustum.set (n, f, l, r, t, t, false);
+    caught = false;
     try
     {
 	(void)badFrustum.projectionMatrix();
 	assert (!"top == bottom didn't throw an exception");
     }
-    catch (IEX_NAMESPACE::DivzeroExc) {}
+    catch (IEX_NAMESPACE::DivzeroExc)
+    {
+        caught = true;
+    }
+    assert (caught);
     cout << "3";
 
     cout << "\northographic ";

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.cpp
@@ -264,6 +264,7 @@ void readFile(const char filename[])
         }catch(...)
         {
             // if readPixels excepts we must clean up
+            assert (true);
         }
         
         for (int i = 0; i < height; i++)
@@ -276,6 +277,7 @@ void readFile(const char filename[])
     }catch(std::exception & e)
     {
         /* ... yeah, that's likely to happen a lot ... */
+        assert (true);
     }
     
     
@@ -352,7 +354,7 @@ void readFile(const char filename[])
                 inpart.readPixels(dataWindow.min.y, dataWindow.max.y);
             }catch(...)
             {
-                
+                assert (true);
             }
     
             for (int i = 0; i < height; i++)
@@ -369,6 +371,7 @@ void readFile(const char filename[])
     }catch(...)
     {
         // nothing
+        assert (true);
     }
 }
 

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.cpp
@@ -321,6 +321,7 @@ void readFile(const char filename[])
                  }catch(...)
                  {
                      // catch exceptions thrown by readTiles, clean up anyway
+                     assert (true);
                  }
                  for (int i = 0; i < file.levelHeight(ly); i++)
                  {
@@ -338,6 +339,7 @@ void readFile(const char filename[])
     }catch(std::exception & e)
     {
         /* expect to get exceptions*/
+        assert (true);
     }
     
     
@@ -433,7 +435,7 @@ void readFile(const char filename[])
                         part.readTiles(0, part.numXTiles(lx) - 1, 0, part.numYTiles(ly) - 1, lx, ly);
                     }catch(...)
                     {
-                        
+                        assert (true);
                     }
                     
                     for (int i = 0; i < part.levelHeight(ly); i++)
@@ -452,6 +454,7 @@ void readFile(const char filename[])
     }catch(std::exception & e)
     {
         /* expect to get exceptions*/
+        assert (true);
     }
         
 }

--- a/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.cpp
@@ -172,6 +172,7 @@ readImage (const char fileName[])
     }catch(...)
     {
         // expect exceptions
+        assert (true);
     }
     try{
         // now test Multipart interface (even for single part files)
@@ -205,6 +206,7 @@ readImage (const char fileName[])
     catch (...)
     {
         // empty
+        assert (true);
     }
 }
 

--- a/OpenEXR/IlmImfFuzzTest/testFuzzTiles.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzTiles.cpp
@@ -168,6 +168,7 @@ readImageONE (const char fileName[])
     catch (...)
     {
         // empty
+        assert (true);
     }
     try
     {
@@ -197,7 +198,8 @@ readImageONE (const char fileName[])
     }
     catch (...)
     {
-                // empty
+        // empty
+        assert (true);
     }
 }
 
@@ -270,6 +272,7 @@ readImageMIP (const char fileName[])
     catch (...)
     {
 	// empty
+        assert (true);
     }
 }
 
@@ -350,6 +353,7 @@ readImageRIP (const char fileName[])
     catch (...)
     {
 	// empty
+        assert (true);
     }
 }
 

--- a/OpenEXR/IlmImfTest/testBadTypeAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testBadTypeAttributes.cpp
@@ -161,41 +161,62 @@ template<class T> void readScanlineThing(T& input,bool test)
 
 void checkDeepTypesFailToLoad(const char * file)
 {
-        
+    bool caught = false;
+
     // trying to open it as a deep tiled file should fail
-    try{
+
+    try
+    {
+        caught = false;
         DeepTiledInputFile f(file);
         assert(false);
-    }catch(...)
-    {
     }
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
+
     // trying to open it as a deep tiled part of a multipart file should fail
-    try{
+    try
+    {
+        caught = false;
         MultiPartInputFile multiin(file);
         DeepTiledInputPart p(multiin,0);
         assert(false);
-    }catch(...)
-    {
     }
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
     
     // trying to open it as a deep scanline file should fail
-    try{
+    try
+    {
+        caught = false;
         DeepScanLineInputFile f(file);
         assert(false);
-    }catch(...)
-    {
-        
     }
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
+
     // trying to open it as a deep scanline part of a multipart file should fail
-    try{
+    try
+    {
+        caught = false;
         MultiPartInputFile multiin(file);
         DeepScanLineInputPart p(multiin,0);
         assert(false);
-    }catch(...)
-    {
-        
     }
-    
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
 }
 
 
@@ -230,6 +251,8 @@ void testTiledWithBadAttribute(const char* file)
 
 void testScanLineWithBadAttribute(const char * file)
 {
+    bool caught;
+
     InputFile in(file);
     readScanlineThing(in,false);
  
@@ -241,20 +264,31 @@ void testScanLineWithBadAttribute(const char * file)
     checkDeepTypesFailToLoad(file);
     
     // trying to open it as a tiled file should also fail
-    try{
+    try
+    {
+        caught = false;
         TiledInputFile f(file);
         assert(false);
-    }catch(...)
-    {
     }
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
+    
     // trying to open it as a tiled part of a multipart file should fail
-    try{
+    try
+    {
+        caught = false;
         MultiPartInputFile multiin(file);
         TiledInputPart p(multiin,0);
         assert(false);
-    }catch(...)
-    {
     }
+    catch(...)
+    {
+        caught = true;
+    }
+    assert (caught);
 }
 
 const std::string & NOTYPEATTR="";

--- a/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
+++ b/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
@@ -511,37 +511,61 @@ void testCompressionTypeChecks()
     //
     // these should fail
     //
-    try{
+    bool caught = false;
+    try
+    {
         h.compression()=ZIP_COMPRESSION;
         h.sanityCheck();    
         assert(false);
-    }catch(...){ 
-        cout << "correctly identified bad compression setting (zip)\n";
     }
-    try{
+    catch(...)
+    { 
+        cout << "correctly identified bad compression setting (zip)\n";
+        caught = true;
+    }
+    assert (caught);
+
+    try
+    {
+        caught = false;
         h.compression()=B44_COMPRESSION;
         h.sanityCheck();
         assert(false);
-    }catch(...){ 
-        cout << "correctly identified bad compression setting (b44)\n";
     }
-    try{
+    catch(...)
+    { 
+        cout << "correctly identified bad compression setting (b44)\n";
+        caught = true;
+    }
+    assert (caught);
+
+    try
+    {
+        caught = false;
         h.compression()=B44A_COMPRESSION;
         h.sanityCheck();
         assert(false);
-    }catch(...) { 
-        cout << "correctly identified bad compression setting (b44a)\n";
     }
-    try{
+    catch(...)
+    { 
+        cout << "correctly identified bad compression setting (b44a)\n";
+        caught = true;
+    }
+    assert (caught);
+
+    try
+    {
+        caught = false;
         h.compression()=PXR24_COMPRESSION;
         h.sanityCheck();
         assert(false);
-    }catch(...) {
-        cout << "correctly identified bad compression setting (pxr24)\n";
     }
-    
-    
-    return;
+    catch(...)
+    {
+        cout << "correctly identified bad compression setting (pxr24)\n";
+        caught = true;
+    }
+    assert (caught);
 }
 
 }; // namespace

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -1308,12 +1308,15 @@ testWriteRead (int partNumber)
         readWholeFiles(0);
         
         
+        bool caught = false;
+
         // for deep images, check that "version 2" files don't load
         if(headers[0].type()==DEEPSCANLINE || headers[0].type()==DEEPTILE)
         {
             modifyType(true);
             try
             {
+                caught = false;
                 readFirstPart();
                 cerr << " part reading succeeded but should have failed\n";
                 assert(false);
@@ -1321,17 +1324,18 @@ testWriteRead (int partNumber)
             catch(std::exception & e)
             {
                 cout << "recieved exception (" << e.what() << ") as expected\n";
+                caught = true;
                 // that's what we thought would happen
             }
+            assert (caught);
             readWholeFiles(2);
-            
         }
         
         modifyType(false);
         
-        
         try
         {
+            caught = false;
             readFirstPart();
             cerr << " part reading succeeded but should have failed\n";
             assert(false);
@@ -1339,8 +1343,10 @@ testWriteRead (int partNumber)
         catch(std::exception & e)
         {
             cout << "recieved exception (" << e.what() << ") as expected\n";
+            caught = true;
             // that's what we thought would happen
         }
+        assert (caught);
         
         // this should always succeed: it doesn't try to read the strange new type in part 0
         readWholeFiles(1);

--- a/OpenEXR/IlmImfTest/testMalformedImages.cpp
+++ b/OpenEXR/IlmImfTest/testMalformedImages.cpp
@@ -96,58 +96,69 @@ readBadBoundsImage (const char fileName[])
 void
 testMalformedImages (const std::string&)
 {
-	try
-	{
-		// id:000012,sig:11,src:000328+001154,op:splice,rep:16
-		readImage (ILM_IMF_TEST_IMAGEDIR "comp_short_decode_piz.exr");
-		cerr << "Malformed Images : InputFile : incorrect input file passed\n";
-		assert (false);
-	}
-	catch (const IEX_NAMESPACE::BaseExc &e)
-	{
-		// expected behaviour
-	}
+    bool caught;
 
-	try
-	{
-		// id:000077,sig:11,src:002575,op:havoc,rep:4
-		readImage (ILM_IMF_TEST_IMAGEDIR "comp_invalid_unknown.exr");
-		cerr << "Malformed Images : InputFile : incorrect input file passed\n";
-		assert (false);
-	}
-	catch (const IEX_NAMESPACE::IoExc &e)
-	{
-		// expected behaviour
-	}
+    try
+    {
+        // id:000012,sig:11,src:000328+001154,op:splice,rep:16
+        caught = false;
+        readImage (ILM_IMF_TEST_IMAGEDIR "comp_short_decode_piz.exr");
+        cerr << "Malformed Images : InputFile : incorrect input file passed\n";
+        assert (false);
+    }
+    catch (const IEX_NAMESPACE::BaseExc &e)
+    {
+        // expected behaviour
+        caught = true;
+    }
+    assert (caught);
 
-	try
-	{
-		// id:000103,sig:11,src:002037+004745,op:splice,rep:2
-		readImage (ILM_IMF_TEST_IMAGEDIR "comp_early_eof_piz.exr");
-		cerr << "Malformed Images : InputFile : incorrect input file passed\n";
-		assert (false);
-	}
-	catch (const IEX_NAMESPACE::InputExc &e)
-	{
-		// expected behaviour
-	}
+    try
+    {
+        // id:000077,sig:11,src:002575,op:havoc,rep:4
+        caught = false;
+        readImage (ILM_IMF_TEST_IMAGEDIR "comp_invalid_unknown.exr");
+        cerr << "Malformed Images : InputFile : incorrect input file passed\n";
+        assert (false);
+    }
+    catch (const IEX_NAMESPACE::IoExc &e)
+    {
+        // expected behaviour
+        caught = true;
+    }
+    assert (caught);
 
-	// The files below expose a bug in the test code (readImage which uses the
-	// logic taken from exr2aces) that calculates an invalid pointer for the
-	// framebuffer.  The dataWindow and displayWindow values used in these files
-	// seem valid based on a cursory reading of the OpenEXR specification. As
-	// such, the best we can do is ensure that parsing the basic header
-	// information doesn't cause any unexpected exceptions.
+    try
+    {
+        // id:000103,sig:11,src:002037+004745,op:splice,rep:2
+        caught = false;
+        readImage (ILM_IMF_TEST_IMAGEDIR "comp_early_eof_piz.exr");
+        cerr << "Malformed Images : InputFile : incorrect input file passed\n";
+        assert (false);
+    }
+    catch (const IEX_NAMESPACE::InputExc &e)
+    {
+        // expected behaviour
+        caught = true;
+    }
+    assert (caught);
 
-	// id:000087,sig:11,src:000562+000300,op:splice,rep:2
-	readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_pos_bounds_piz.exr");
+    // The files below expose a bug in the test code (readImage which uses the
+    // logic taken from exr2aces) that calculates an invalid pointer for the
+    // framebuffer.  The dataWindow and displayWindow values used in these files
+    // seem valid based on a cursory reading of the OpenEXR specification. As
+    // such, the best we can do is ensure that parsing the basic header
+    // information doesn't cause any unexpected exceptions.
 
-	// id:000104,sig:11,src:001329+000334,op:splice,rep:2
-	readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_pos_bounds_pxr24.exr");
+    // id:000087,sig:11,src:000562+000300,op:splice,rep:2
+    readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_pos_bounds_piz.exr");
 
-	// id:000131,sig:11,src:000514+002831,op:splice,rep:16
-	readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_neg_bounds_pxr24.exr");
+    // id:000104,sig:11,src:001329+000334,op:splice,rep:2
+    readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_pos_bounds_pxr24.exr");
 
-	// id:000132,sig:11,src:000895,op:havoc,rep:32
-	readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_bounds_piz.exr");
+    // id:000131,sig:11,src:000514+002831,op:splice,rep:16
+    readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_neg_bounds_pxr24.exr");
+
+    // id:000132,sig:11,src:000895,op:havoc,rep:32
+    readBadBoundsImage (ILM_IMF_TEST_IMAGEDIR "comp_bad_bounds_piz.exr");
 }

--- a/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
@@ -147,6 +147,8 @@ testMultiPartOutputFileForExpectedFailure (const vector<Header> & headers,
                                            const std::string & fn,
                                            const string & failMessage="")
 {
+    bool caught = false;
+
     try
     {
         remove(fn.c_str());
@@ -157,9 +159,9 @@ testMultiPartOutputFileForExpectedFailure (const vector<Header> & headers,
     catch (const IEX_NAMESPACE::ArgExc & e)
     {
         // expected behaviour
+        caught = true;
     }
-
-    return;
+    assert (caught);
 }
 
 
@@ -373,6 +375,7 @@ testHeaders (const std::string & fn)
     //
     // expect this to fail - header has incorrect image attribute type
     //
+    bool caught = false;
     try
     {
         headers[0].setType ("invalid image type");
@@ -382,7 +385,9 @@ testHeaders (const std::string & fn)
     catch (const IEX_NAMESPACE::ArgExc & e)
     {
         // expected behaviour
+        caught = true;
     }
+    assert (caught);
 
 
     //
@@ -484,6 +489,7 @@ testHeaders (const std::string & fn)
     //
     try
     {
+        caught = false;
         MultiPartInputFile file (ILM_IMF_TEST_IMAGEDIR "invalid_shared_attrs_multipart.exr");
         cerr << "Shared Attributes : InputFile : incorrect input file passed\n";
         assert (false);
@@ -491,9 +497,9 @@ testHeaders (const std::string & fn)
     catch (const IEX_NAMESPACE::InputExc &e)
     {
         // expectected behaviour
+        caught = true;
     }
-
-    return;
+    assert (caught);
 }
 
 

--- a/OpenEXR/IlmImfUtilTest/testDeepImage.cpp
+++ b/OpenEXR/IlmImfUtilTest/testDeepImage.cpp
@@ -622,6 +622,8 @@ testRenameChannel ()
         assert (level.findTypedChannel <half> ("C") != 0);
     }
 
+    bool caught = false;
+
     try
     {
         img.renameChannel ("A", "D");   // "A" doesn't exist
@@ -630,8 +632,11 @@ testRenameChannel ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 
+    caught = false;
     try
     {
         img.renameChannel ("C", "B");   // "B" exists already
@@ -640,7 +645,9 @@ testRenameChannel ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 }
 
 
@@ -693,6 +700,7 @@ testRenameChannels ()
     assert (img.level(1).typedChannel<half>("D").at(0, 0)[0] == 4);
     assert (img.level(1).typedChannel<half>("E").at(0, 0)[0] == 3);
 
+    bool caught = false;
     try
     {
         RenamingMap oldToNewNames;
@@ -705,8 +713,11 @@ testRenameChannels ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 
+    caught = false;
     try
     {
         RenamingMap oldToNewNames;
@@ -718,7 +729,9 @@ testRenameChannels ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 }
 
 } // namespace

--- a/OpenEXR/IlmImfUtilTest/testFlatImage.cpp
+++ b/OpenEXR/IlmImfUtilTest/testFlatImage.cpp
@@ -522,6 +522,8 @@ testRenameChannel ()
         assert (level.findTypedChannel <half> ("C") != 0);
     }
 
+    bool caught = false;
+
     try
     {
         img.renameChannel ("A", "D");   // "A" doesn't exist
@@ -530,8 +532,11 @@ testRenameChannel ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 
+    caught = false;
     try
     {
         img.renameChannel ("C", "B");   // "B" exists already
@@ -540,7 +545,9 @@ testRenameChannel ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 }
 
 
@@ -591,6 +598,8 @@ testRenameChannels ()
     assert (img.level(1).typedChannel<half>("D").at (0, 0) == 4);
     assert (img.level(1).typedChannel<half>("E").at (0, 0) == 3);
 
+    bool caught = false;
+
     try
     {
         RenamingMap oldToNewNames;
@@ -603,8 +612,11 @@ testRenameChannels ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 
+    caught = false;
     try
     {
         RenamingMap oldToNewNames;
@@ -616,7 +628,9 @@ testRenameChannels ()
     catch (...)
     {
         // expecting exception
+        caught = true;
     }
+    assert (caught);
 }
 
 } // namespace


### PR DESCRIPTION
All catch blocks must do something to indicate the exception isn't ignored.

Signed-off-by: Cary Phillips <cary@ilm.com>