### PR TITLE
change OpaqueAttribute's _typeName field to be std::string

### DIFF
--- a/OpenEXR/IlmImf/ImfOpaqueAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfOpaqueAttribute.cpp
@@ -49,19 +49,17 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 
 OpaqueAttribute::OpaqueAttribute (const char typeName[]):
-    _typeName (strlen (typeName) + 1),
+    _typeName (typeName),
     _dataSize (0)
 {
-    strcpy (_typeName, typeName);
 }
 
 
 OpaqueAttribute::OpaqueAttribute (const OpaqueAttribute &other):
-    _typeName (strlen (other._typeName) + 1),
+    _typeName (other._typeName),
     _dataSize (other._dataSize),
     _data (other._dataSize)
 {
-    strcpy (_typeName, other._typeName);
     _data.resizeErase (other._dataSize);
     memcpy ((char *) _data, (const char *) other._data, other._dataSize);
 }
@@ -76,7 +74,7 @@ OpaqueAttribute::~OpaqueAttribute ()
 const char *
 OpaqueAttribute::typeName () const
 {
-    return _typeName;
+    return _typeName.c_str();
 }
 
 
@@ -108,7 +106,7 @@ OpaqueAttribute::copyValueFrom (const Attribute &other)
 {
     const OpaqueAttribute *oa = dynamic_cast <const OpaqueAttribute *> (&other);
 
-    if (oa == 0 || strcmp (_typeName, oa->_typeName))
+    if (oa == 0 || _typeName != oa->_typeName)
     {
 	THROW (IEX_NAMESPACE::TypeExc, "Cannot copy the value of an "
 			     "image file attribute of type "

--- a/OpenEXR/IlmImf/ImfOpaqueAttribute.h
+++ b/OpenEXR/IlmImf/ImfOpaqueAttribute.h
@@ -105,9 +105,12 @@ class OpaqueAttribute: public Attribute
     virtual void		copyValueFrom (const Attribute &other);
 
 
+    const int                   dataSize() const { return _dataSize; }
+    const Array<char>&          data() const { return _data; }
+        
   private:
 
-    Array<char>			_typeName;
+    std::string			_typeName;
     long			_dataSize;
     Array<char>			_data;
 };


### PR DESCRIPTION
SonarCloud considers strcpy() a vulernability. strcpy() was used only in OpaqueAttribute, whose type name was stored as Array<char>.  I changed the type to std::string. I suspect this simply dates to a time before std::string was commonly used.

Also, it appears that nothing in the test suite validated opaque attributes, which hold values read from a file when the attribute type is not known. I added a test to validate the behavior, which also validates that the typeName() works when implemented with std::string instead of Array<char>.

Signed-off-by: Cary Phillips <cary@ilm.com>