### PR TITLE
Fix for #378, bswap on read on big-endian architectures

### DIFF
--- a/OpenEXR/IlmImfTest/Makefile.am
+++ b/OpenEXR/IlmImfTest/Makefile.am
@@ -51,7 +51,8 @@ IlmImfTest_SOURCES = main.cpp tmpDir.h testAttributes.cpp testChannels.cpp \
 		     testFutureProofing.cpp testFutureProofing.h \
 	             compareDwa.cpp compareDwa.h \
 	             testDwaCompressorSimd.cpp testDwaCompressorSimd.h \
-	             testRle.cpp testRle.h
+	             testRle.cpp testRle.h \
+		     bswap_32.h
 
 AM_CPPFLAGS = -DILM_IMF_TEST_IMAGEDIR=\"$(srcdir)/\"
 

--- a/OpenEXR/IlmImfTest/bswap_32.h
+++ b/OpenEXR/IlmImfTest/bswap_32.h
@@ -1,0 +1,29 @@
+//
+// SPDX-License-Identifier: Modified-BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project. See LICENSE file for details.
+// 
+
+#ifdef _MSC_VER
+#include <stdlib.h>
+#define bswap_32(x) _byteswap_ulong(x)
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define bswap_32(x) OSSwapInt32(x)
+#elif defined(__sun) || defined(sun)
+#include <sys/byteorder.h>
+#define bswap_32(x) BSWAP_32(x)
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#elif defined(__OpenBSD__)
+#include <sys/types.h>
+#define bswap_32(x) swap32(x)
+#elif defined(__NetBSD__)
+#include <sys/types.h>
+#include <machine/bswap.h>
+#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#define bswap_32(x) bswap32(x)
+#endif
+#else
+#include <byteswap.h>
+#endif

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <byteswap.h>
 
 #include "tmpDir.h"
 #include "testFutureProofing.h"
@@ -64,6 +65,7 @@
 #include <ImfNamespace.h>
 #include <ImathNamespace.h>
 #include <IlmThreadNamespace.h>
+#include <ImfSystemSpecific.h>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;
@@ -1234,6 +1236,12 @@ modifyType (bool modify_version)
             
             //length of attribute
             fread(&length,4,1,f);
+            if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
+            {
+                int tmp = bswap_32(length);
+        	length = tmp;
+            }
+
             if(!modify_version && attrib_name=="type")
             {
                 // modify the type of part 1 to be 'X<whatevever>'

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -40,7 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <byteswap.h>
+#include "bswap_32.h"
 
 #include "tmpDir.h"
 #include "testFutureProofing.h"
@@ -1238,8 +1238,7 @@ modifyType (bool modify_version)
             fread(&length,4,1,f);
             if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
             {
-                int tmp = bswap_32(length);
-        	length = tmp;
+        	length = bswap_32(length);
             }
 
             if(!modify_version && attrib_name=="type")

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -40,7 +40,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <byteswap.h>
+
+#include "bswap_32.h"
 
 #include "tmpDir.h"
 #include "testMultiPartFileMixingBasic.h"
@@ -1387,8 +1388,7 @@ killOffsetTables (const std::string & fn)
             fread(&length,4,1,f);
     	    if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
     	    {
-    		int tmp = bswap_32(length);
-    		length = tmp;
+    		length = bswap_32(length);
     	    }
             
             //value of attribute

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <byteswap.h>
 
 #include "tmpDir.h"
 #include "testMultiPartFileMixingBasic.h"
@@ -59,6 +60,7 @@
 #include <ImfDeepScanLineInputPart.h>
 #include <ImfPartType.h>
 #include <ImfMisc.h>
+#include <ImfSystemSpecific.h>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;
@@ -1383,6 +1385,11 @@ killOffsetTables (const std::string & fn)
             
             //length of attribute
             fread(&length,4,1,f);
+    	    if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
+    	    {
+    		int tmp = bswap_32(length);
+    		length = tmp;
+    	    }
             
             //value of attribute
             for(int i=0;i<length;i++) 


### PR DESCRIPTION
Every system seems to have a different implementation of bswap, is there a simpler way than this?

I don't have big-endian machine to test this, so just assuming this works.

Fixes #378