### PR TITLE
Fix for #263: prevent overflow in multipart chunk offset reconstruction

### DIFF
--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -571,7 +571,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
             
             
             
-            if(partNumber<0 || partNumber>int(parts.size()))
+            if(partNumber<0 || partNumber> static_cast<int>(parts.size()))
             {
                 throw IEX_NAMESPACE::IoExc("part number out of range");
             }

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -511,7 +511,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
     
     vector<TileOffsets*> tileOffsets(parts.size());
     
-    // for scanline-based parts, number of scanlines in each part
+    // for scanline-based parts, number of scanlines in each chunk
     vector<int> rowsizes(parts.size());
         
     for(size_t i = 0 ; i < parts.size() ; i++)
@@ -639,13 +639,18 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 int y_coordinate;
                 OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, y_coordinate);
                 
+                
+                if(y_coordinate < header.dataWindow().min.y || y_coordinate > header.dataWindow().max.y)
+                {
+                    // bail to exception catcher: y out of range. Test now to prevent overflow in following arithmetic
+                   throw int();
+                }
                 y_coordinate -= header.dataWindow().min.y;
                 y_coordinate /= rowsizes[partNumber];   
                 
                 if(y_coordinate < 0 || y_coordinate >= int(parts[partNumber]->chunkOffsets.size()))
                 {
-                    //std::cout << "aborting reconstruction: bad data " << y_coordinate << endl;
-                    //bail to exception catcher: broken scanline
+                    //bail to exception catcher: broken scanline: out of range of chunk table size
                     throw int();
                 }
                 

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -573,8 +573,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
             
             if(partNumber<0 || partNumber>int(parts.size()))
             {
-                // bail here - bad part number
-                throw int();
+                throw IEX_NAMESPACE::IoExc("part number out of range");
             }
             
             Header& header = parts[partNumber]->header;
@@ -601,14 +600,13 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 {
                     // this shouldn't actually happen - we should have allocated a valid
                     // tileOffsets for any part which isTiled
-                    throw int();
+                    throw IEX_NAMESPACE::IoExc("part not tiled");
                     
                 }
                 
                 if(!tileOffsets[partNumber]->isValidTile(tilex,tiley,levelx,levely))
                 {
-                    //std::cout << "invalid tile : aborting\n";
-                    throw int();
+                    throw IEX_NAMESPACE::IoExc("invalid tile coordinates");
                 }
                 
                 (*tileOffsets[partNumber])(tilex,tiley,levelx,levely)=chunk_start;
@@ -642,20 +640,17 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 
                 if(y_coordinate < header.dataWindow().min.y || y_coordinate > header.dataWindow().max.y)
                 {
-                    // bail to exception catcher: y out of range. Test now to prevent overflow in following arithmetic
-                   throw int();
+                   throw IEX_NAMESPACE::IoExc("y out of range");
                 }
                 y_coordinate -= header.dataWindow().min.y;
                 y_coordinate /= rowsizes[partNumber];   
                 
                 if(y_coordinate < 0 || y_coordinate >= int(parts[partNumber]->chunkOffsets.size()))
                 {
-                    //bail to exception catcher: broken scanline: out of range of chunk table size
-                    throw int();
+                   throw IEX_NAMESPACE::IoExc("chunk index out of range");
                 }
                 
                 parts[partNumber]->chunkOffsets[y_coordinate]=chunk_start;
-                //std::cout << "chunk_start for " << y_coordinate << ':' << chunk_start << std::endl;
                 
                 if(header.type()==DEEPSCANLINE)
                 {
@@ -682,8 +677,6 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
             }
             
             chunk_start+=size_of_chunk;
-            
-            //std::cout << " next chunk +"<<size_of_chunk << " = " << chunk_start << std::endl;
             
             is.seekg(chunk_start);
             


### PR DESCRIPTION
Minor change. The original test is probably redundant now, but I'm not completely sure that there isn't an edge case