### PR TITLE
Issue #262

### DIFF
--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -38,6 +38,7 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "ImfCheckedArithmetic.h"
 #include "ImfInputFile.h"
 #include "ImfScanLineInputFile.h"
 #include "ImfTiledInputFile.h"
@@ -679,8 +680,9 @@ InputFile::setFrameBuffer (const FrameBuffer &frameBuffer)
 	    _data->cachedBuffer = new FrameBuffer();
 	    _data->offset = dataWindow.min.x;
 	    
-	    int tileRowSize = (dataWindow.max.x - dataWindow.min.x + 1) *
-			      _data->tFile->tileYSize();
+	    unsigned int tileRowSize =
+                uiMult(dataWindow.max.x - dataWindow.min.x + 1U,
+                       _data->tFile->tileYSize());
 
 	    for (FrameBuffer::ConstIterator k = frameBuffer.begin();
 		 k != frameBuffer.end();

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -377,7 +377,7 @@ readTileData (InputStreamMutex *streamData,
     if (levelY != ly)
         throw IEX_NAMESPACE::InputExc ("Unexpected tile y level number coordinate.");
 
-    if (dataSize > (int) ifd->tileBufferSize)
+    if (dataSize < 0 || dataSize > static_cast<int>(ifd->tileBufferSize) )
         throw IEX_NAMESPACE::InputExc ("Unexpected tile block length.");
 
     //


### PR DESCRIPTION
Fixes Issue #262 by testing for overflow. Enforces a previously implicit limit on maximum dimensions of tiled image that can be read through the InputFile API.
Also files case in #261, which was caused by a tile claiming to have a negative size