### PR TITLE
specific check for bad size field in header attributes (related to #248)

### DIFF
--- a/OpenEXR/IlmImf/ImfHeader.cpp
+++ b/OpenEXR/IlmImf/ImfHeader.cpp
@@ -1181,6 +1181,11 @@ Header::readFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int &version)
 	checkIsNullTerminated (typeName, "attribute type name");
 	OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, size);
 
+    if( size < 0 )
+    {
+        throw IEX_NAMESPACE::InputExc("Invalid size field in header attribute");
+    }
+
 	AttributeMap::iterator i = _map.find (name);
 
 	if (i != _map.end())


### PR DESCRIPTION
Throws a more intuitive error message if the size field of a header attribute is negative when reading the OpenEXR Header. On x86_64 architectures, all negative sizes previously caused a std::bad_alloc exception to be thrown, since negative values are treated as positive values bigger than the maximum addressable space. This change throws a clearer message.