### PR TITLE
address #271: catch scanlines with negative sizes

### DIFF
--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -429,8 +429,8 @@ readPixelData (InputStreamMutex *streamData,
     if (yInFile != minY)
         throw IEX_NAMESPACE::InputExc ("Unexpected data block y coordinate.");
 
-    if (dataSize > (int) ifd->lineBufferSize)
-	throw IEX_NAMESPACE::InputExc ("Unexpected data block length.");
+    if (dataSize < 0 || dataSize > static_cast<int>(ifd->lineBufferSize) )
+        throw IEX_NAMESPACE::InputExc ("Unexpected data block length.");
 
     //
     // Read the pixel data.


### PR DESCRIPTION
Catch negative size scanlines the same way PR #434 does for tiles.