### PR TITLE
added missing files in autoconf setup

### DIFF
--- a/IlmBase/IlmThread/Makefile.am
+++ b/IlmBase/IlmThread/Makefile.am
@@ -8,6 +8,7 @@ libIlmThread_la_SOURCES = IlmThreadPool.h IlmThread.h \
 			  IlmThreadSemaphore.cpp IlmThreadMutex.cpp \
 			  IlmThreadPosix.cpp IlmThreadSemaphorePosix.cpp \
 			  IlmThreadSemaphorePosixCompat.cpp \
+			  IlmThreadSemaphoreOSX.cpp \
 			  IlmThreadMutexPosix.cpp
 
 libIlmThread_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ -no-undefined

--- a/PyIlmBase/PyIlmBase.pc.in
+++ b/PyIlmBase/PyIlmBase.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+PyIlmBase_includedir=@includedir@/OpenEXR
+
+Name: PyIlmBase
+Description: Python bindings for the IlmBase libraries
+Version: @PYILMBASE_VERSION@
+Libs: -L${libdir} @ILMBASE_LDFLAGS@ -lIlmImf -lz @ILMBASE_LIBS@
+Cflags: @ILMBASE_CXXFLAGS@ -I${PyIlmBase_includedir}


### PR DESCRIPTION
Added IlmThreadSemaphoreOSX to IlmBase/IlmThread/Makefile.am and added PyIlmBase/PyIlmBase.pc.in back in, looks like it got inadvertently removed by a previous commit.

Signed-off-by: Cary Phillips <cary@ilm.com>