### PR TITLE
Choose DwaCompressor huffman encoder based on tile size (fix #344)

### DIFF
--- a/OpenEXR/IlmImf/ImfCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfCompressor.cpp
@@ -211,9 +211,12 @@ newTileCompressor (Compression c,
 
       case DWAA_COMPRESSION:
       case DWAB_COMPRESSION:
-
-	return new DwaCompressor (hdr, tileLineSize, numTileLines, 
-                               DwaCompressor::DEFLATE);
+        // the threshold below is tileSize (48x48) times pixelSize(RGB, half)
+        // see also https://github.com/openexr/openexr/issues/344
+	return new DwaCompressor (hdr, tileLineSize, numTileLines,
+                               tileLineSize * numTileLines < 48 * 48 * 6
+                               ? DwaCompressor::DEFLATE
+                               : DwaCompressor::STATIC_HUFFMAN);
 
       default:
 


### PR DESCRIPTION
For a detailed discussion, see #344. Some further narrowing in on the optimal switching threshold revealed the number 48 (for my specific DSLR photo sample stored in RGB, half). This produces better compression and better performance for all tile-sizes above 48 and the same as before for those below.