### PR TITLE
Implements #15, request for hardware concurrency utility function

### DIFF
--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -854,7 +854,7 @@ ThreadPool::addGlobalTask (Task* task)
 }
 
 unsigned
-ThreadPool::hardwareConcurrency ()
+ThreadPool::estimateThreadCountForFileIO ()
 {
 #ifdef ILMBASE_FORCE_CXX03
 #    if defined(_WIN32)

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -48,6 +48,10 @@
 # include <memory>
 # include <atomic>
 # include <thread>
+#else
+# ifndef _WIN32
+#  include <unistd.h>
+# endif
 #endif
 
 using namespace std;
@@ -849,5 +853,23 @@ ThreadPool::addGlobalTask (Task* task)
     globalThreadPool().addTask (task);
 }
 
+unsigned
+ThreadPool::hardwareConcurrency ()
+{
+#ifdef ILMBASE_FORCE_CXX03
+#    if defined(_WIN32)
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo (&sysinfo);
+    return static_cast<unsigned> (sysinfo.dwNumberOfProcessors);
+#    elif defined(_SC_NPROCESSORS_ONLN)
+    int count = sysconf (_SC_NPROCESSORS_ONLN);
+    return static_cast<unsigned>( count < 0 ? 0 : count );
+#    else
+    return 0;
+#    endif
+#else
+    return std::thread::hardware_concurrency ();
+#endif
+}
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/IlmBase/IlmThread/IlmThreadPool.h
+++ b/IlmBase/IlmThread/IlmThreadPool.h
@@ -109,13 +109,17 @@ class ILMTHREAD_EXPORT ThreadPool
 {
   public:
     //-------------------------------------------------------
-    // static routine to query how many processors are currently
-    // online / suggested. This gives no indication of load
-    // balancing with other threads that may be active in the
-    // application / system. When compiling for >= c++11 this
-    // is the same as hardware_concurrency
+    // static routine to query how many processors should be
+    // used for processing exr files. The user of ThreadPool
+    // is free to use std::thread::hardware_concurrency or
+    // whatever number of threads is appropriate based on the
+    // application. However, this routine exists such that
+    // in the future, if core counts expand faster than
+    // memory bandwidth, or higher order NUMA machines are built
+    // that we can query, this routine gives a place where we
+    // can centralize that logic
     //-------------------------------------------------------
-    static unsigned hardwareConcurrency ();
+    static unsigned estimateThreadCountForFileIO ();
 
     //-------------------------------------------------------
     // Constructor -- creates numThreads worker threads which

--- a/IlmBase/IlmThread/IlmThreadPool.h
+++ b/IlmBase/IlmThread/IlmThreadPool.h
@@ -108,7 +108,14 @@ class ILMTHREAD_EXPORT ThreadPoolProvider
 class ILMTHREAD_EXPORT ThreadPool  
 {
   public:
-
+    //-------------------------------------------------------
+    // static routine to query how many processors are currently
+    // online / suggested. This gives no indication of load
+    // balancing with other threads that may be active in the
+    // application / system. When compiling for >= c++11 this
+    // is the same as hardware_concurrency
+    //-------------------------------------------------------
+    static unsigned hardwareConcurrency ();
 
     //-------------------------------------------------------
     // Constructor -- creates numThreads worker threads which


### PR DESCRIPTION
new static member of ThreadPool, call as
ThreadPool::hardwareConcurrency, so no abi breakage or api change

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>