### PR TITLE
Fixes #95, compilation issue with mingw

### DIFF
--- a/OpenEXR/IlmImfTest/bswap_32.h
+++ b/OpenEXR/IlmImfTest/bswap_32.h
@@ -3,7 +3,7 @@
 // Copyright Contributors to the OpenEXR Project. See LICENSE file for details.
 // 
 
-#ifdef _MSC_VER
+#if defined(_WIN32) || defined(_WIN64)
 #include <stdlib.h>
 #define bswap_32(x) _byteswap_ulong(x)
 #elif defined(__APPLE__)


### PR DESCRIPTION
The tree now compiles using mingw to compile, tested by cross compiling
for windows from linux

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>