### PR TITLE
Sideeffects uncompress crash fix

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -547,12 +547,12 @@ TileBufferTask::execute ()
                 int count = _ifd->getSampleCount(x - xOffset, y - yOffset);
                 for (unsigned int c = 0; c < _ifd->slices.size(); ++c)
                 {
-		    // This slice does not exist in the file.
-		    if (_ifd->slices[c]->fill)
-			continue;
-		    
-                    sizeOfTile += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
-                    bytesPerLine += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
+                    // This slice does not exist in the file.
+                    if ( !_ifd->slices[c]->fill)
+                    {
+                          sizeOfTile += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
+                          bytesPerLine += count * pixelTypeSize(_ifd->slices[c]->typeInFile);     
+                    }
                 }
                 numPixelsPerScanLine[y - tileRange.min.y] += count;
             }

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -600,6 +600,10 @@ TileBufferTask::execute ()
                 int count = _ifd->getSampleCount(x - xOffset, y - yOffset);
                 for (unsigned int c = 0; c < _ifd->slices.size(); ++c)
                 {
+		    // This slice does not exist in the file.
+		    if (_ifd->slices[c]->fill)
+			continue;
+		    
                     sizeOfTile += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
                     bytesPerLine += count * pixelTypeSize(_ifd->slices[c]->typeInFile);
                 }

--- a/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
+++ b/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
@@ -271,8 +271,13 @@ void readFile (const std::string & filename,
 
     Array2D<unsigned int> localSampleCount;
     localSampleCount.resizeErase(height, width);
-    Array<Array2D< void* > > data(channelCount);
-    for (int i = 0; i < channelCount; i++)
+    
+        
+    // also test filling channels. Generate up to 2 extra channels
+    int fillChannels=rand()%3;
+    
+    Array<Array2D< void* > > data(channelCount+fillChannels);
+    for (int i = 0; i < channelCount+fillChannels; i++)
         data[i].resizeErase(height, width);
 
     DeepFrameBuffer frameBuffer;
@@ -335,7 +340,24 @@ void readFile (const std::string & filename,
       cout << "skipping " <<flush;
       return;
     }
-    
+    for(int i = 0 ; i < fillChannels ; ++i )
+    { 
+            PixelType type  = IMF::FLOAT;
+            int sampleSize = sizeof(float);            
+            int pointerSize = sizeof (char *);
+            stringstream ss;
+            // generate channel names that aren't in file but (might) interleave with existing file
+            ss << i << "fill";
+            string str = ss.str();
+               frameBuffer.insert (str,                            // name // 6
+                                DeepSlice (type,                    // type // 7
+                                (char *) (&data[i+channelCount][0][0]
+                                          - dataWindow.min.x
+                                          - dataWindow.min.y * width),               // base // 8)
+                                pointerSize * 1,          // xStride// 9
+                                pointerSize * width,      // yStride// 10
+                                sampleSize));             // sampleStride
+    }
     file.setFrameBuffer(frameBuffer);
 
     if (bulkRead)
@@ -353,15 +375,19 @@ void readFile (const std::string & filename,
             {
                 for (int k = 0; k < channelCount; k++)
                 {
-   		     if(!randomChannels || read_channel[k]==1)
-		     {
-                         if (channelTypes[k] == 0)
-                              data[k][i][j] = new unsigned int[localSampleCount[i][j]];
-                         if (channelTypes[k] == 1)
-                              data[k][i][j] = new half[localSampleCount[i][j]];
-                         if (channelTypes[k] == 2)
-                             data[k][i][j] = new float[localSampleCount[i][j]];
-		     }
+                    if(!randomChannels || read_channel[k]==1)
+                    {
+                                if (channelTypes[k] == 0)
+                                    data[k][i][j] = new unsigned int[localSampleCount[i][j]];
+                                if (channelTypes[k] == 1)
+                                    data[k][i][j] = new half[localSampleCount[i][j]];
+                                if (channelTypes[k] == 2)
+                                    data[k][i][j] = new float[localSampleCount[i][j]];
+                    }
+                }
+                for( int f = 0 ; f < fillChannels ; ++f )
+                {
+                       data[f+channelCount][i][j] = new float[localSampleCount[i][j]];
                 }
             }
         }
@@ -384,15 +410,19 @@ void readFile (const std::string & filename,
             {
                 for (int k = 0; k < channelCount; k++)
                 {
-		    if( !randomChannels || read_channel[k]==1)
-		    {
-                        if (channelTypes[k] == 0)
-                            data[k][i][j] = new unsigned int[localSampleCount[i][j]];
-                        if (channelTypes[k] == 1)
-                            data[k][i][j] = new half[localSampleCount[i][j]];
-                        if (channelTypes[k] == 2)
-                            data[k][i][j] = new float[localSampleCount[i][j]];
-		    }
+                    if( !randomChannels || read_channel[k]==1)
+                    {
+                                if (channelTypes[k] == 0)
+                                    data[k][i][j] = new unsigned int[localSampleCount[i][j]];
+                                if (channelTypes[k] == 1)
+                                    data[k][i][j] = new half[localSampleCount[i][j]];
+                                if (channelTypes[k] == 2)
+                                    data[k][i][j] = new float[localSampleCount[i][j]];
+                    }
+                }
+                for( int f = 0 ; f < fillChannels ; ++f )
+                {
+                       data[f+channelCount][i][j] = new float[localSampleCount[i][j]];
                 }
             }
 
@@ -405,8 +435,8 @@ void readFile (const std::string & filename,
         for (int j = 0; j < width; j++)
             for (int k = 0; k < channelCount; k++)
             {
-	        if( !randomChannels || read_channel[k]==1 )
-		{
+                if( !randomChannels || read_channel[k]==1 )
+                {
                     for (int l = 0; l < sampleCount[i][j]; l++)
                     {
                         if (channelTypes[k] == 0)
@@ -437,23 +467,29 @@ void readFile (const std::string & filename,
                             assert (((float*)(data[k][i][j]))[l] == (i * width + j) % 2049);
                         }
                     }
-		}
+                }
             }
 
     for (int i = 0; i < height; i++)
         for (int j = 0; j < width; j++)
+        {
             for (int k = 0; k < channelCount; k++)
             {
-      	        if( !randomChannels || read_channel[k]==1 )
-		{
+                if( !randomChannels || read_channel[k]==1 )
+                {
                     if (channelTypes[k] == 0)
                         delete[] (unsigned int*) data[k][i][j];
                     if (channelTypes[k] == 1)
                         delete[] (half*) data[k][i][j];
                     if (channelTypes[k] == 2)
                         delete[] (float*) data[k][i][j];
-		}
+                }
             }
+            for( int f = 0 ; f < fillChannels ; ++f )
+            {
+                 delete[] (float*) data[f+channelCount][i][j];
+            }
+       }
 }
 
 void readWriteTest(const std::string & tempDir, int channelCount, int testTimes)

--- a/OpenEXR/IlmImfTest/testDeepTiledBasic.cpp
+++ b/OpenEXR/IlmImfTest/testDeepTiledBasic.cpp
@@ -407,6 +407,7 @@ void checkValue (void* sampleRawData,
 void readFile (int channelCount,
                bool bulkRead,
                bool relativeCoords,
+               bool randomChannels,
                const std::string & filename)
 {
     if (relativeCoords)
@@ -430,8 +431,12 @@ void readFile (int channelCount,
 
     Array2D<unsigned int> localSampleCount;
     localSampleCount.resizeErase(height, width);
-    Array<Array2D< void* > > data(channelCount);
-    for (int i = 0; i < channelCount; i++)
+    
+    // also test filling channels. Generate up to 2 extra channels
+    int fillChannels=rand()%3;
+    
+    Array<Array2D< void* > > data(channelCount+fillChannels);
+    for (int i = 0; i < channelCount+fillChannels; i++)
         data[i].resizeErase(height, width);
 
     DeepFrameBuffer frameBuffer;
@@ -450,37 +455,74 @@ void readFile (int channelCount,
                                         relativeCoords,
                                         relativeCoords));
 
+    
+    vector<int> read_channel(channelCount);
+    int channels_added=0;
     for (int i = 0; i < channelCount; i++)
     {
-        PixelType type;
-        if (channelTypes[i] == 0)
-            type = IMF::UINT;
-        if (channelTypes[i] == 1)
-            type = IMF::HALF;
-        if (channelTypes[i] == 2)
-            type = IMF::FLOAT;
+         if(randomChannels)
+        {
+	     read_channel[i] = rand() % 2;
+	     
+        }
+        if(!randomChannels || read_channel[i]==1)
+        {
+            PixelType type;
+            if (channelTypes[i] == 0)
+                type = IMF::UINT;
+            if (channelTypes[i] == 1)
+                type = IMF::HALF;
+            if (channelTypes[i] == 2)
+                type = IMF::FLOAT;
 
-        stringstream ss;
-        ss << i;
-        string str = ss.str();
+            stringstream ss;
+            ss << i;
+            string str = ss.str();
 
-        int sampleSize;
-        if (channelTypes[i] == 0) sampleSize = sizeof (unsigned int);
-        if (channelTypes[i] == 1) sampleSize = sizeof (half);
-        if (channelTypes[i] == 2) sampleSize = sizeof (float);
+            int sampleSize;
+            if (channelTypes[i] == 0) sampleSize = sizeof (unsigned int);
+            if (channelTypes[i] == 1) sampleSize = sizeof (half);
+            if (channelTypes[i] == 2) sampleSize = sizeof (float);
 
-        int pointerSize = sizeof (char *);
+            int pointerSize = sizeof (char *);
 
-        frameBuffer.insert (str,
-                            DeepSlice (type,
-                            (char *) (&data[i][0][0] - memOffset),
-                            pointerSize * 1,
-                            pointerSize * width,
-                            sampleSize,
-                            1, 1,
-                            0,
-                            relativeCoords,
-                            relativeCoords));
+            frameBuffer.insert (str,
+                                DeepSlice (type,
+                                (char *) (&data[i][0][0] - memOffset),
+                                pointerSize * 1,
+                                pointerSize * width,
+                                sampleSize,
+                                1, 1,
+                                0,
+                                relativeCoords,
+                                relativeCoords));
+                channels_added++;
+            }
+    }
+     if(channels_added==0)
+    {
+      cout << "skipping " <<flush;
+      return;
+    }
+    for(int i = 0 ; i < fillChannels ; ++i )
+    { 
+            PixelType type  = IMF::FLOAT;
+            int sampleSize = sizeof(float);            
+    int pointerSize = sizeof (char *);
+            stringstream ss;
+            // generate channel names that aren't in file but (might) interleave with existing file
+            ss << i << "fill";
+            string str = ss.str();
+         frameBuffer.insert (str,
+                                DeepSlice (type,
+                                (char *) (&data[i+channelCount][0][0] - memOffset),
+                                pointerSize * 1,
+                                pointerSize * width,
+                                sampleSize,
+                                1, 1,
+                                0,
+                                relativeCoords,
+                                relativeCoords));
     }
 
     file.setFrameBuffer(frameBuffer);
@@ -529,7 +571,14 @@ void readFile (int channelCount,
                                     if (channelTypes[k] == 2)
                                         data[k][dwy][dwx] = new float[localSampleCount[dwy][dwx]];
                                 }
+                                
+                                for( int f = 0 ; f < fillChannels ; ++f )
+                                {
+                                     data[f + channelTypes.size()][dwy][dwx] = new float[localSampleCount[dwy][dwx]];
+                                }
+                                
                             }
+                            
                     }
                 }
 
@@ -566,6 +615,10 @@ void readFile (int channelCount,
                                         if (channelTypes[k] == 2)
                                             data[k][dwy][dwx] = new float[localSampleCount[dwy][dwx]];
                                     }
+                                    for( int f = 0 ; f < fillChannels ; ++f )
+                                    {
+                                       data[f + channelTypes.size()][dwy][dwx] = new float[localSampleCount[dwy][dwx]];
+                                    }
                                 }
 
                             file.readTile(j, i, lx, ly);
@@ -596,12 +649,21 @@ void readFile (int channelCount,
 
                                     for (int k = 0; k < channelTypes.size(); k++)
                                     {
-                                        if (channelTypes[k] == 0)
-                                            data[k][ty][tx] = new unsigned int[localSampleCount[ty][tx]];
-                                        if (channelTypes[k] == 1)
-                                            data[k][ty][tx] = new half[localSampleCount[ty][tx]];
-                                        if (channelTypes[k] == 2)
-                                            data[k][ty][tx] = new float[localSampleCount[ty][tx]];
+                                          if( !randomChannels || read_channel[k]==1)
+                                          {
+                                                if (channelTypes[k] == 0)
+                                                    data[k][ty][tx] = new unsigned int[localSampleCount[ty][tx]];
+                                                if (channelTypes[k] == 1)
+                                                    data[k][ty][tx] = new half[localSampleCount[ty][tx]];
+                                                if (channelTypes[k] == 2)
+                                                    data[k][ty][tx] = new float[localSampleCount[ty][tx]];
+                                          }
+                                            
+                                         
+                                    }
+                                    for( int f = 0 ; f < fillChannels ; ++f )
+                                    {
+                                        data[f + channelTypes.size()][ty][tx] = new float[localSampleCount[ty][tx]];
                                     }
                                 }
 
@@ -617,16 +679,23 @@ void readFile (int channelCount,
 
                                     for (int k = 0; k < channelTypes.size(); k++)
                                     {
-                                        checkValue(data[k][ty][tx],
-                                                   localSampleCount[ty][tx],
-                                                   channelTypes[k],
-                                                   dwx, dwy);
-                                        if (channelTypes[k] == 0)
-                                            delete[] (unsigned int*) data[k][ty][tx];
-                                        if (channelTypes[k] == 1)
-                                            delete[] (half*) data[k][ty][tx];
-                                        if (channelTypes[k] == 2)
-                                            delete[] (float*) data[k][ty][tx];
+                                         if( !randomChannels || read_channel[k]==1)
+                                         {
+                                                checkValue(data[k][ty][tx],
+                                                        localSampleCount[ty][tx],
+                                                        channelTypes[k],
+                                                        dwx, dwy);
+                                                if (channelTypes[k] == 0)
+                                                    delete[] (unsigned int*) data[k][ty][tx];
+                                                if (channelTypes[k] == 1)
+                                                    delete[] (half*) data[k][ty][tx];
+                                                if (channelTypes[k] == 2)
+                                                    delete[] (float*) data[k][ty][tx];
+                                         }
+                                    }
+                                    for( int f = 0 ; f < fillChannels ; ++f )
+                                    {
+                                         delete[] (float*) data[f+channelTypes.size()][ty][tx];
                                     }
                                 }
                         }
@@ -640,49 +709,61 @@ void readFile (int channelCount,
                     for (int j = 0; j < file.levelWidth(lx); j++)
                         for (int k = 0; k < channelCount; k++)
                         {
-                            for (int l = 0; l < localSampleCount[i][j]; l++)
+                            if( !randomChannels || read_channel[k]==1)
                             {
-                                if (channelTypes[k] == 0)
+                                for (int l = 0; l < localSampleCount[i][j]; l++)
                                 {
-                                    unsigned int* value = (unsigned int*)(data[k][i][j]);
-                                    if (value[l] != (i * width + j) % 2049)
-                                        cout << j << ", " << i << " error, should be "
-                                             << (i * width + j) % 2049 << ", is " << value[l]
-                                             << endl << flush;
-                                    assert (value[l] == (i * width + j) % 2049);
-                                }
-                                if (channelTypes[k] == 1)
-                                {
-                                    half* value = (half*)(data[k][i][j]);
-                                    if (value[l] != (i * width + j) % 2049)
-                                        cout << j << ", " << i << " error, should be "
-                                             << (i * width + j) % 2049 << ", is " << value[l]
-                                             << endl << flush;
-                                    assert (((half*)(data[k][i][j]))[l] == (i * width + j) % 2049);
-                                }
-                                if (channelTypes[k] == 2)
-                                {
-                                    float* value = (float*)(data[k][i][j]);
-                                    if (value[l] != (i * width + j) % 2049)
-                                        cout << j << ", " << i << " error, should be "
-                                             << (i * width + j) % 2049 << ", is " << value[l]
-                                             << endl << flush;
-                                    assert (((float*)(data[k][i][j]))[l] == (i * width + j) % 2049);
+                                    if (channelTypes[k] == 0)
+                                    {
+                                        unsigned int* value = (unsigned int*)(data[k][i][j]);
+                                        if (value[l] != (i * width + j) % 2049)
+                                            cout << j << ", " << i << " error, should be "
+                                                << (i * width + j) % 2049 << ", is " << value[l]
+                                                << endl << flush;
+                                        assert (value[l] == (i * width + j) % 2049);
+                                    }
+                                    if (channelTypes[k] == 1)
+                                    {
+                                        half* value = (half*)(data[k][i][j]);
+                                        if (value[l] != (i * width + j) % 2049)
+                                            cout << j << ", " << i << " error, should be "
+                                                << (i * width + j) % 2049 << ", is " << value[l]
+                                                << endl << flush;
+                                        assert (((half*)(data[k][i][j]))[l] == (i * width + j) % 2049);
+                                    }
+                                    if (channelTypes[k] == 2)
+                                    {
+                                        float* value = (float*)(data[k][i][j]);
+                                        if (value[l] != (i * width + j) % 2049)
+                                            cout << j << ", " << i << " error, should be "
+                                                << (i * width + j) % 2049 << ", is " << value[l]
+                                                << endl << flush;
+                                        assert (((float*)(data[k][i][j]))[l] == (i * width + j) % 2049);
+                                    }
                                 }
                             }
                         }
 
                 for (int i = 0; i < file.levelHeight(ly); i++)
                     for (int j = 0; j < file.levelWidth(lx); j++)
+                    {
                         for (int k = 0; k < channelCount; k++)
                         {
-                            if (channelTypes[k] == 0)
-                                delete[] (unsigned int*) data[k][i][j];
-                            if (channelTypes[k] == 1)
-                                delete[] (half*) data[k][i][j];
-                            if (channelTypes[k] == 2)
-                                delete[] (float*) data[k][i][j];
+                            if( !randomChannels || read_channel[k]==1)
+                            {
+                                if (channelTypes[k] == 0)
+                                    delete[] (unsigned int*) data[k][i][j];
+                                if (channelTypes[k] == 1)
+                                    delete[] (half*) data[k][i][j];
+                                if (channelTypes[k] == 2)
+                                    delete[] (float*) data[k][i][j];
+                            }
                         }
+                        for( int f = 0 ; f < fillChannels ; ++f )
+                        {
+                            delete[] (float*) data[f+channelTypes.size()][i][j];
+                        }
+                    }
             }
         }
 }
@@ -716,17 +797,22 @@ void readWriteTestWithAbsoluateCoordinates (int channelCount,
         }
 
         generateRandomFile (channelCount, compression, false, false, fn);
-        readFile (channelCount, false, false, fn);
+        readFile (channelCount, false, false, false , fn);
+        readFile (channelCount, false, false, true , fn);
         remove (fn.c_str());
         cout << endl << flush;
 
         generateRandomFile (channelCount, compression, true, false, fn);
-        readFile (channelCount, true, false, fn);
+        readFile (channelCount, true, false, false, fn);
+        readFile (channelCount, true, false, true, fn);
+        
         remove (fn.c_str());
         cout << endl << flush;
 
         generateRandomFile (channelCount, compression, false, true, fn);
-        readFile (channelCount, false, true, fn);
+        readFile (channelCount, false, true, false , fn);
+        readFile (channelCount, false, true, true , fn);
+
         remove (fn.c_str());
         cout << endl << flush;
     }
@@ -745,10 +831,12 @@ void testDeepTiledBasic (const std::string & tempDir)
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(2);
 
-        readWriteTestWithAbsoluateCoordinates ( 1, 2, tempDir);
-        readWriteTestWithAbsoluateCoordinates ( 3, 2, tempDir);
-        readWriteTestWithAbsoluateCoordinates (10, 2, tempDir);
-
+        for(int pass = 0 ; pass < 4 ; pass++)
+        {
+           readWriteTestWithAbsoluateCoordinates ( 1, 2, tempDir);
+           readWriteTestWithAbsoluateCoordinates ( 3, 2, tempDir);
+           readWriteTestWithAbsoluateCoordinates (10, 2, tempDir);
+        }
         ThreadPool::globalThreadPool().setNumThreads(numThreads);
 
         cout << "ok\n" << endl;


### PR DESCRIPTION
Same fix as in #62. Also modified the test case to test filled channels to confirm the fix: updated testDeepTiledBasic will fail without the modifications to ImfDeepTiledInputFile.cpp, but now passes.
For consistency, testDeepScanlineBasic also tests filled channels, though that test succeeded before.
