### PR TITLE
fix for failing PyIlmBase/configure because it can't run the IlmBase test program.

### DIFF
--- a/PyIlmBase/configure.ac
+++ b/PyIlmBase/configure.ac
@@ -79,6 +79,7 @@ AM_PATH_PKGCONFIG(
    [ILMBASE_CXXFLAGS],
    [ILMBASE_LDFLAGS],
    [ILMBASE_LIBS],
+   [ILMBASE_RPATH],
    [IlmBase],
    [OpenEXR],
    [-L/usr/local/lib],
@@ -90,7 +91,8 @@ AM_COMPILELINKRUN(
    [ilmbasetest],
    [$ILMBASE_CXXFLAGS],
    [$ILMBASE_LDFLAGS],
-   [$ILMBASE_LIBS],[[
+   [$ILMBASE_LIBS],
+   [$ILMBASE_RPATH],[[
 #include <stdlib.h>
 #include <ImathFun.h>
 #ifndef IMATH_NAMESPACE 
@@ -147,6 +149,7 @@ AM_COMPILELINKRUN(
    [boostpythontest],
    [$CXXFLAGS],
    [$LDFLAGS],
+   [],
    [$LIBS $BOOST_PYTHON_LIBS],[[
 #include <Python.h>
 #include <boost/python.hpp>

--- a/PyIlmBase/m4/compilelinkrun.m4
+++ b/PyIlmBase/m4/compilelinkrun.m4
@@ -38,11 +38,11 @@ define([arg_disable],$2)
 define([arg_cxxflags],$3)
 define([arg_ldflags],$4)
 define([arg_libs],$5)
-define([arg_include_source],$6)
-define([arg_body_source],$7)
-define([arg_do_yes],$8)
-define([arg_do_no],$9)
-
+define([arg_rpath],$6)
+define([arg_include_source],$7)
+define([arg_body_source],$8)
+define([arg_do_yes],$9)
+define([arg_do_no],$10)
 
 dnl check arguments
 AC_ARG_ENABLE(arg_disable, [  --disable-arg_disable  Do not try to compile and run a test arg_pkg_name program],, enable_programtest=yes)
@@ -64,6 +64,7 @@ dnl
     CXXFLAGS="arg_cxxflags $CXXFLAGS"
     LDFLAGS="arg_ldflags $LDFLAGS"
     LIBS="arg_libs $LIBS"
+    LD_LIBRARY_PATH="arg_rpath:$LD_LIBRARY_PATH"
     AC_REQUIRE_CPP()
     AC_LANG_PUSH([C++])
     rm -f conf.testprogram

--- a/PyIlmBase/m4/path.pkgconfig.m4
+++ b/PyIlmBase/m4/path.pkgconfig.m4
@@ -37,15 +37,17 @@ dnl create some local m4 "variables" so that we don't have to use numbers
 define([arg_cxxflags],$1)
 define([arg_ldflags],$2)
 define([arg_libs],$3)
-define([arg_pkg_name],$4)
-define([arg_include_subdir],$5)
-define([arg_default_ldflags],$6)
-define([arg_default_libs],$7)
-define([arg_test_prefix],$8)
+define([arg_rpath],$4)
+define([arg_pkg_name],$5)
+define([arg_include_subdir],$6)
+define([arg_default_ldflags],$7)
+define([arg_default_libs],$8)
+define([arg_test_prefix],$9)
 
 TEST_CXXFLAGS=""
 TEST_LDFLAGS=""
 TEST_LIBS=""
+TEST_RPATH=""
 
 AC_ARG_WITH(arg_test_prefix,[  --with-arg_test_prefix=PFX  Prefix where tested libraries are supposed to be installed (optional)], test_prefix="$withval", test_prefix="NONE")
 echo "test_prefix = $test_prefix"
@@ -64,6 +66,7 @@ if test "x$test_prefix" != "xNONE" ; then
    TEST_LDFLAGS="-L$test_prefix/lib"
    TEST_LDFLAGS="$TEST_LDFLAGS arg_default_ldflags"
    TEST_LIBS="arg_default_libs"
+   TEST_RPATH="$test_prefix/lib"
 else
    dnl
    dnl Get the cflags and libraries from the arg_pkg_name package using 
@@ -78,11 +81,13 @@ else
       TEST_CXXFLAGS="`$PKG_CONFIG --cflags arg_pkg_name`"
       TEST_LDFLAGS="`$PKG_CONFIG --libs-only-L arg_pkg_name`"
       TEST_LIBS="`$PKG_CONFIG --libs arg_pkg_name`"
+      TEST_RPATH="`$PKG_CONFIG --variable=libdir arg_pkg_name`"
    else
       echo "Not using pkg-config."
       TEST_CXXFLAGS=""
       TEST_LDFLAGS=""
       TEST_LIBS=""
+      TEST_RPATH=""
    fi
 
    dnl
@@ -117,12 +122,13 @@ echo "    arg_libs = $TEST_LIBS"
 AC_SUBST(arg_cxxflags, $TEST_CXXFLAGS)
 AC_SUBST(arg_ldflags, $TEST_LDFLAGS)
 AC_SUBST(arg_libs, $TEST_LIBS)
-
+AC_SUBST(arg_rpath, $TEST_RPATH)
 
 dnl clean up local "variables"
 undefine([arg_cxxflags])
 undefine([arg_ldflags])
 undefine([arg_libs])
+undefine([arg_rpath])
 undefine([arg_pkg_name])
 undefine([arg_include_subdir])
 undefine([arg_default_ldflags])


### PR DESCRIPTION
In PyIlmBase/configure.ac, set LD_LIBRARY_PATH explicitly for the ilmbase test program,
so that it finds the libraries when it executes.

Signed-off-by: Cary Phillips <cary@ilm.com>