### PR TITLE
added missing copyright notices

### DIFF
--- a/Contrib/DtexToExr/Makefile.am
+++ b/Contrib/DtexToExr/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # tell autoconf to include the m4 macros in the /m4 directory

--- a/Contrib/DtexToExr/configure.ac
+++ b/Contrib/DtexToExr/configure.ac
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(DtexToExr, 1.0.0)
 AC_SUBST(DTEXTOEXR_VERSION, 1.0.0)

--- a/Contrib/DtexToExr/m4/compilelinkrun.m4
+++ b/Contrib/DtexToExr/m4/compilelinkrun.m4
@@ -1,4 +1,8 @@
 dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+dnl
 dnl
 dnl compilelinkrun.m4 - used to check whether a required package is properly 
 dnl installed.  Compiles, links and runs a c++ test program that uses the 

--- a/Contrib/DtexToExr/m4/path.pkgconfig.m4
+++ b/Contrib/DtexToExr/m4/path.pkgconfig.m4
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 AC_DEFUN([AM_PATH_PKGCONFIG],
 [
 

--- a/Contrib/DtexToExr/m4/threads.m4
+++ b/Contrib/DtexToExr/m4/threads.m4
@@ -1,4 +1,7 @@
-
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl @synopsis ACX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
 dnl
 dnl Modified by Wojciech Jarosz (2005) to include check for POSIX

--- a/IlmBase/Half/Makefile.am
+++ b/IlmBase/Half/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 INCLUDES = -I$(top_srcdir)/config

--- a/IlmBase/HalfTest/CMakeLists.txt
+++ b/IlmBase/HalfTest/CMakeLists.txt
@@ -1,3 +1,7 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
 
 add_executable(HalfTest
   main.cpp

--- a/IlmBase/HalfTest/Makefile.am
+++ b/IlmBase/HalfTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 check_PROGRAMS = HalfTest

--- a/IlmBase/HalfTest/main.cpp
+++ b/IlmBase/HalfTest/main.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testSize.h>
 #include <testArithmetic.h>
 #include <testError.h>

--- a/IlmBase/HalfTest/testArithmetic.cpp
+++ b/IlmBase/HalfTest/testArithmetic.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testArithmetic.h>
 #include "half.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testArithmetic.h
+++ b/IlmBase/HalfTest/testArithmetic.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testArithmetic ();
 

--- a/IlmBase/HalfTest/testBitPatterns.cpp
+++ b/IlmBase/HalfTest/testBitPatterns.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testBitPatterns.h>
 #include "half.h"
 #include <float.h>

--- a/IlmBase/HalfTest/testBitPatterns.h
+++ b/IlmBase/HalfTest/testBitPatterns.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testBitPatterns ();
 

--- a/IlmBase/HalfTest/testClassification.cpp
+++ b/IlmBase/HalfTest/testClassification.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testClassification.h>
 #include "half.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testClassification.h
+++ b/IlmBase/HalfTest/testClassification.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testClassification ();
 

--- a/IlmBase/HalfTest/testError.cpp
+++ b/IlmBase/HalfTest/testError.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testError.h>
 #include "half.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testError.h
+++ b/IlmBase/HalfTest/testError.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testNormalizedConversionError ();
 void testDenormalizedConversionError ();

--- a/IlmBase/HalfTest/testFunction.cpp
+++ b/IlmBase/HalfTest/testFunction.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testFunction.h>
 #include "halfFunction.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testFunction.h
+++ b/IlmBase/HalfTest/testFunction.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testFunction ();
 

--- a/IlmBase/HalfTest/testLimits.cpp
+++ b/IlmBase/HalfTest/testLimits.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testLimits.h>
 #include "halfLimits.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testLimits.h
+++ b/IlmBase/HalfTest/testLimits.h
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 void testLimits ();
 

--- a/IlmBase/HalfTest/testSize.cpp
+++ b/IlmBase/HalfTest/testSize.cpp
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 #include <testSize.h>
 #include "half.h"
 #include <iostream>

--- a/IlmBase/HalfTest/testSize.h
+++ b/IlmBase/HalfTest/testSize.h
@@ -1,3 +1,7 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
 
 void testSize ();
 

--- a/IlmBase/Iex/Makefile.am
+++ b/IlmBase/Iex/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 INCLUDES = -I$(top_srcdir)/config

--- a/IlmBase/IexMath/Makefile.am
+++ b/IlmBase/IexMath/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 lib_LTLIBRARIES = libIexMath.la

--- a/IlmBase/IexTest/Makefile.am
+++ b/IlmBase/IexTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 check_PROGRAMS = IexTest

--- a/IlmBase/IlmBase.pc.in
+++ b/IlmBase/IlmBase.pc.in
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@

--- a/IlmBase/IlmThread/Makefile.am
+++ b/IlmBase/IlmThread/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 lib_LTLIBRARIES = libIlmThread.la

--- a/IlmBase/Imath/Makefile.am
+++ b/IlmBase/Imath/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 lib_LTLIBRARIES = libImath.la

--- a/IlmBase/ImathTest/Makefile.am
+++ b/IlmBase/ImathTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 check_PROGRAMS = ImathTest

--- a/IlmBase/Makefile.am
+++ b/IlmBase/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 ACLOCAL_AMFLAGS = -I m4

--- a/IlmBase/bootstrap
+++ b/IlmBase/bootstrap
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/IlmBase/config/IlmBaseConfigInternal.h.in
+++ b/IlmBase/config/IlmBaseConfigInternal.h.in
@@ -1,3 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
 
 //
 // Dealing with FPEs

--- a/IlmBase/config/Makefile.am
+++ b/IlmBase/config/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 configincludedir = $(includedir)/OpenEXR

--- a/IlmBase/configure.ac
+++ b/IlmBase/configure.ac
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(IlmBase, 2.3.0)
 

--- a/IlmBase/m4/threads.m4
+++ b/IlmBase/m4/threads.m4
@@ -1,4 +1,7 @@
-
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl @synopsis ACX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
 dnl
 dnl Modified by Wojciech Jarosz (2005) to include check for POSIX

--- a/OpenEXR/IlmImf/Makefile.am
+++ b/OpenEXR/IlmImf/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 lib_LTLIBRARIES = libIlmImf.la

--- a/OpenEXR/IlmImfExamples/Makefile.am
+++ b/OpenEXR/IlmImfExamples/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 if BUILD_IMFEXAMPLES

--- a/OpenEXR/IlmImfFuzzTest/Makefile.am
+++ b/OpenEXR/IlmImfFuzzTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 if BUILD_IMFFUZZTEST

--- a/OpenEXR/IlmImfTest/Makefile.am
+++ b/OpenEXR/IlmImfTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 check_PROGRAMS = IlmImfTest

--- a/OpenEXR/IlmImfUtil/Makefile.am
+++ b/OpenEXR/IlmImfUtil/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 lib_LTLIBRARIES = libIlmImfUtil.la

--- a/OpenEXR/IlmImfUtilTest/Makefile.am
+++ b/OpenEXR/IlmImfUtilTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 check_PROGRAMS = IlmImfUtilTest

--- a/OpenEXR/Makefile.am
+++ b/OpenEXR/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # tell autoconf to include the m4 macros in the /m4 directory 

--- a/OpenEXR/OpenEXR.pc.in
+++ b/OpenEXR/OpenEXR.pc.in
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@

--- a/OpenEXR/bootstrap
+++ b/OpenEXR/bootstrap
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/OpenEXR/config/Makefile.am
+++ b/OpenEXR/config/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 configincludedir = $(includedir)/OpenEXR

--- a/OpenEXR/config/OpenEXRConfigInternal.h.in
+++ b/OpenEXR/config/OpenEXRConfigInternal.h.in
@@ -1,4 +1,9 @@
 //
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+//
 // Define and set to 1 if the target system supports a proc filesystem
 // compatible with the Linux kernel's proc filesystem.  Note that this
 // is only used by a program in the IlmImfTest test suite, it's not

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT(OpenEXR, 2.3.0)

--- a/OpenEXR/doc/Makefile.am
+++ b/OpenEXR/doc/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 EXTRA_DIST =  \
 	ReadingAndWritingImageFiles.pdf \
 	TechnicalIntroduction.pdf \

--- a/OpenEXR/exr2aces/Makefile.am
+++ b/OpenEXR/exr2aces/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exr2aces

--- a/OpenEXR/exrbuild/Makefile.am
+++ b/OpenEXR/exrbuild/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrbuild

--- a/OpenEXR/exrenvmap/Makefile.am
+++ b/OpenEXR/exrenvmap/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrenvmap

--- a/OpenEXR/exrheader/Makefile.am
+++ b/OpenEXR/exrheader/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrheader

--- a/OpenEXR/exrmakepreview/Makefile.am
+++ b/OpenEXR/exrmakepreview/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrmakepreview

--- a/OpenEXR/exrmaketiled/Makefile.am
+++ b/OpenEXR/exrmaketiled/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrmaketiled

--- a/OpenEXR/exrmultipart/Makefile.am
+++ b/OpenEXR/exrmultipart/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrmultipart

--- a/OpenEXR/exrmultiview/Makefile.am
+++ b/OpenEXR/exrmultiview/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrmultiview

--- a/OpenEXR/exrstdattr/Makefile.am
+++ b/OpenEXR/exrstdattr/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 bin_PROGRAMS = exrstdattr

--- a/OpenEXR/m4/path.pkgconfig.m4
+++ b/OpenEXR/m4/path.pkgconfig.m4
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 AC_DEFUN([AM_PATH_PKGCONFIG],
 [
 

--- a/OpenEXR/m4/threads.m4
+++ b/OpenEXR/m4/threads.m4
@@ -1,4 +1,7 @@
-
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl @synopsis ACX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
 dnl
 dnl Modified by Wojciech Jarosz (2005) to include check for POSIX

--- a/OpenEXR_Viewers/Makefile.am
+++ b/OpenEXR_Viewers/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 ACLOCAL_AMFLAGS = -I m4

--- a/OpenEXR_Viewers/bootstrap
+++ b/OpenEXR_Viewers/bootstrap
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/OpenEXR_Viewers/config/Makefile.am
+++ b/OpenEXR_Viewers/config/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 configincludedir = $(includedir)/OpenEXR

--- a/OpenEXR_Viewers/config/OpenEXR_ViewersConfig.h.in
+++ b/OpenEXR_Viewers/config/OpenEXR_ViewersConfig.h.in
@@ -1,4 +1,9 @@
 //
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+//
 // Define and set to 1 if the target system includes the NVIDIA Cg
 // runtime.  The exrdisplay program will use a fragment shader to
 // accelerate the display of OpenEXR images.

--- a/OpenEXR_Viewers/configure.ac
+++ b/OpenEXR_Viewers/configure.ac
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(OpenEXR_Viewers, 2.3.0)
 AC_SUBST(OPENEXR_VIEWERS_VERSION, 2.3.0)

--- a/OpenEXR_Viewers/doc/Makefile.am
+++ b/OpenEXR_Viewers/doc/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 EXTRA_DIST = OpenEXRViewers.odt OpenEXRViewers.pdf
 
 docdir=$(datadir)/doc/OpenEXR_Viewers-@OPENEXR_VIEWERS_VERSION@

--- a/OpenEXR_Viewers/exrdisplay/Makefile.am
+++ b/OpenEXR_Viewers/exrdisplay/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 if HAVE_FLTK

--- a/OpenEXR_Viewers/m4/compilelinkrun.m4
+++ b/OpenEXR_Viewers/m4/compilelinkrun.m4
@@ -1,4 +1,7 @@
 dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl
 dnl compilelinkrun.m4 - used to check whether a required package is properly 
 dnl installed.  Compiles, links and runs a c++ test program that uses the 

--- a/OpenEXR_Viewers/m4/path.cb.m4
+++ b/OpenEXR_Viewers/m4/path.cb.m4
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 
 dnl
 dnl Cg support

--- a/OpenEXR_Viewers/m4/path.fltk.m4
+++ b/OpenEXR_Viewers/m4/path.fltk.m4
@@ -1,4 +1,9 @@
 dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
+dnl
 dnl FLTK with GL support
 dnl
 

--- a/OpenEXR_Viewers/m4/path.gl.m4
+++ b/OpenEXR_Viewers/m4/path.gl.m4
@@ -1,4 +1,8 @@
 dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+dnl
 dnl Alternate OpenGL headers (e.g. for Nvidia headers)
 dnl
 

--- a/OpenEXR_Viewers/m4/path.pkgconfig.m4
+++ b/OpenEXR_Viewers/m4/path.pkgconfig.m4
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 AC_DEFUN([AM_PATH_PKGCONFIG],
 [
 

--- a/OpenEXR_Viewers/m4/threads.m4
+++ b/OpenEXR_Viewers/m4/threads.m4
@@ -1,4 +1,7 @@
-
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl @synopsis ACX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
 dnl
 dnl Modified by Wojciech Jarosz (2005) to include check for POSIX

--- a/OpenEXR_Viewers/playexr/Makefile.am
+++ b/OpenEXR_Viewers/playexr/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 if HAVE_CG

--- a/PyIlmBase/Makefile.am
+++ b/PyIlmBase/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # tell autoconf to include the m4 macros in the /m4 directory 

--- a/PyIlmBase/PyIex/Makefile.am
+++ b/PyIlmBase/PyIex/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 pyexec_LTLIBRARIES = iexmodule.la

--- a/PyIlmBase/PyIexTest/Makefile.am
+++ b/PyIlmBase/PyIexTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # check_PROGRAMS = pyIexTest

--- a/PyIlmBase/PyIlmBase.pc.in
+++ b/PyIlmBase/PyIlmBase.pc.in
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@

--- a/PyIlmBase/PyImath/Makefile.am
+++ b/PyIlmBase/PyImath/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 pyexec_LTLIBRARIES = imathmodule.la

--- a/PyIlmBase/PyImathNumpy/Makefile.am
+++ b/PyIlmBase/PyImathNumpy/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 pyexec_LTLIBRARIES = imathnumpymodule.la

--- a/PyIlmBase/PyImathNumpyTest/Makefile.am
+++ b/PyIlmBase/PyImathNumpyTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # check_PROGRAMS = pyImathNumpyTest

--- a/PyIlmBase/PyImathTest/Makefile.am
+++ b/PyIlmBase/PyImathTest/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 # check_PROGRAMS = pyImathTest

--- a/PyIlmBase/bootstrap
+++ b/PyIlmBase/bootstrap
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
 if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then

--- a/PyIlmBase/config/Makefile.am
+++ b/PyIlmBase/config/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 ## Process this file with automake to produce Makefile.in
 
 configincludedir = $(includedir)/OpenEXR

--- a/PyIlmBase/config/PyIlmBaseConfig.h.in
+++ b/PyIlmBase/config/PyIlmBaseConfig.h.in
@@ -1,4 +1,9 @@
 //
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+
+//
 // Define and set to 1 if the target system supports a proc filesystem
 // compatible with the Linux kernel's proc filesystem.  Note that this
 // is only used by a program in the IlmImfTest test suite, it's not

--- a/PyIlmBase/configure.ac
+++ b/PyIlmBase/configure.ac
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(PyIlmBase, 2.3.0)
 AC_SUBST(PYILMBASE_VERSION, 2.3.0)

--- a/PyIlmBase/doc/Makefile.am
+++ b/PyIlmBase/doc/Makefile.am
@@ -1,3 +1,8 @@
+##
+## SPDX-License-Identifier: BSD-3-Clause
+## Copyright Contributors to the OpenEXR Project.
+##
+
 EXTRA_DIST =  \
 
 docdir=$(datadir)/doc/OpenEXR-@OPENEXR_VERSION@

--- a/PyIlmBase/m4/compilelinkrun.m4
+++ b/PyIlmBase/m4/compilelinkrun.m4
@@ -1,4 +1,7 @@
 dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl
 dnl compilelinkrun.m4 - used to check whether a required package is properly 
 dnl installed.  Compiles, links and runs a c++ test program that uses the 

--- a/PyIlmBase/m4/path.pkgconfig.m4
+++ b/PyIlmBase/m4/path.pkgconfig.m4
@@ -1,3 +1,8 @@
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
+
 AC_DEFUN([AM_PATH_PKGCONFIG],
 [
 

--- a/PyIlmBase/m4/threads.m4
+++ b/PyIlmBase/m4/threads.m4
@@ -1,4 +1,7 @@
-
+dnl
+dnl SPDX-License-Identifier: BSD-3-Clause
+dnl Copyright Contributors to the OpenEXR Project.
+dnl
 dnl @synopsis ACX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
 dnl
 dnl Modified by Wojciech Jarosz (2005) to include check for POSIX


### PR DESCRIPTION
Missing copyright notices for autoconf configuration files HalfTest source files.

Signed-off-by: Cary Phillips <cary@ilm.com>