### PR TITLE
Fix #457, (unused) policy tag only in 3.13+ of cmake, no longer needed

### DIFF
--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -1,9 +1,6 @@
 # "More Modern" CMake version
 cmake_minimum_required(VERSION 3.12)
 
-# this is for target_sources, new policy converts relative paths to absolute
-cmake_policy(SET CMP0076 NEW)
-
 # we include this first to parse configure.ac and extract the version
 # numbers
 include(config/ParseConfigure.cmake)

--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -1,9 +1,6 @@
 # "More Modern" CMake version
 cmake_minimum_required(VERSION 3.12)
 
-# this is for target_sources, new policy converts relative paths to absolute
-cmake_policy(SET CMP0076 NEW)
-
 # we include this first to parse configure.ac and extract the version
 # numbers
 include(config/ParseConfigure.cmake)

--- a/OpenEXR_Viewers/CMakeLists.txt
+++ b/OpenEXR_Viewers/CMakeLists.txt
@@ -1,9 +1,6 @@
 # "More Modern" CMake version
 cmake_minimum_required(VERSION 3.12)
 
-# this is for target_sources, new policy converts relative paths to absolute
-cmake_policy(SET CMP0076 NEW)
-
 set(OPENEXR_VIEWERS_VERSION 2.3.0)
 
 project(OpenEXR_Viewers VERSION ${OPENEXR_VIEWERS_VERSION})
@@ -31,6 +28,19 @@ IF(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 ENDIF()
 
 PROJECT (openexr_viewers VERSION ${OPENEXR_VERSION})
+
+if(OPENEXR_BUILD_VIEWERS)
+  message(WARNING "Viewers are currently out of order. Building anyway")
+  SET (FLTK_SKIP_FLUID 1)
+  find_package(FLTK)
+  if(NOT FLTK_FOUND)
+    message(WARNING "FLTK not found, exrdisplay will not be built")
+  endif()
+  find_package(OpenGL)
+  if(NOT OpenGL_FOUND)
+    message(WARNING "OpenGL not found, exrdisplay will not be built")
+  endif()
+endif()
 
 IF(OPENEXR_VIEWERS_STANDALONE)
   INCLUDE(OpenEXRSettings)

--- a/PyIlmBase/CMakeLists.txt
+++ b/PyIlmBase/CMakeLists.txt
@@ -1,9 +1,6 @@
 # "More Modern" CMake version
 cmake_minimum_required(VERSION 3.12)
 
-# this is for target_sources, new policy converts relative paths to absolute
-cmake_policy(SET CMP0076 NEW)
-
 # we include this first to parse configure.ac and extract the version
 # numbers
 include(config/ParseConfigure.cmake)


### PR DESCRIPTION
This removes a policy tag that was previously needed for cmake 3.13+ when using the target_sources function, however, with new help function, no longer needed