### PR TITLE
Remove last vestiges of old ifdef for windows

### DIFF
--- a/IlmBase/Iex/IexBaseExc.cpp
+++ b/IlmBase/Iex/IexBaseExc.cpp
@@ -44,7 +44,7 @@
 #include "IexBaseExc.h"
 #include "IexMacros.h"
 
-#ifdef PLATFORM_WINDOWS
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -193,7 +193,7 @@ BaseExc::stackTrace () const
 IEX_INTERNAL_NAMESPACE_SOURCE_EXIT
 
 
-#ifdef PLATFORM_WINDOWS
+#ifdef _WIN32
 
 #pragma optimize("", off)
 void

--- a/IlmBase/Iex/IexThrowErrnoExc.cpp
+++ b/IlmBase/Iex/IexThrowErrnoExc.cpp
@@ -46,7 +46,7 @@
 #include <string.h>
 #include <errno.h>
 
-#ifdef PLATFORM_WINDOWS
+#ifdef _WIN32
 #include <windows.h>
 #endif
 
@@ -55,7 +55,7 @@ IEX_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 void throwErrnoExc (const std::string &text, int errnum)
 {
-#ifdef PLATFORM_WINDOWS
+#ifdef _WIN32
     if (0 != getenv("IEXDEBUGTHROW"))
         DebugBreak();
 #endif

--- a/OpenEXR/IlmImfFuzzTest/tmpDir.h
+++ b/OpenEXR/IlmImfFuzzTest/tmpDir.h
@@ -33,7 +33,7 @@
 ///////////////////////////////////////////////////////////////////////////
 
 
-#if defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__) || defined(__ANDROID__)
+#if defined(_WIN32) || defined(_WIN64) || defined(__ANDROID__)
     #define IMF_TMP_DIR ""
 #else
     #define IMF_TMP_DIR "/var/tmp/"

--- a/OpenEXR/IlmImfTest/tmpDir.h
+++ b/OpenEXR/IlmImfTest/tmpDir.h
@@ -36,7 +36,7 @@
 #if defined(ANDROID) || defined(__ANDROID_API__)
     #define IMF_TMP_DIR "/sdcard/"
     #define IMF_PATH_SEPARATOR "/"
-#elif defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__)
+#elif defined(_WIN32) || defined(_WIN64)
     #define IMF_TMP_DIR ""  // TODO: get this from GetTempPath() or env var $TEMP or $TMP
     #define IMF_PATH_SEPARATOR "\\"
     #include <direct.h> // for _mkdir, _rmdir

--- a/OpenEXR/IlmImfUtilTest/tmpDir.h
+++ b/OpenEXR/IlmImfUtilTest/tmpDir.h
@@ -36,7 +36,7 @@
 #if defined(ANDROID) || defined(__ANDROID_API__)
     #define IMF_TMP_DIR "/sdcard/"
     #define IMF_PATH_SEPARATOR "/"
-#elif defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__)
+#elif defined(_WIN32) || defined(_WIN64)
     #define IMF_TMP_DIR ""  // TODO: get this from GetTempPath() or env var $TEMP or $TMP
     #define IMF_PATH_SEPARATOR "\\"
     #include <direct.h> // for _mkdir, _rmdir

--- a/OpenEXR/exrmultipart/exrmultipart.cpp
+++ b/OpenEXR/exrmultipart/exrmultipart.cpp
@@ -85,7 +85,7 @@ using namespace OPENEXR_IMF_NAMESPACE;
 
 #if defined(ANDROID) || defined(__ANDROID_API__)
     #define IMF_PATH_SEPARATOR "/"
-#elif defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__)
+#elif defined(_WIN32) || defined(_WIN64)
     #define IMF_PATH_SEPARATOR "\\"
 #else
     #define IMF_PATH_SEPARATOR "/"

--- a/OpenEXR/exrmultipart/exrmultipart.cpp
+++ b/OpenEXR/exrmultipart/exrmultipart.cpp
@@ -85,7 +85,7 @@ using namespace OPENEXR_IMF_NAMESPACE;
 
 #if defined(ANDROID) || defined(__ANDROID_API__)
     #define IMF_PATH_SEPARATOR "/"
-#elif defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__) || defined(PLATFORM_WINDOWS)
+#elif defined(_WIN32) || defined(_WIN64) || defined(__MWERKS__)
     #define IMF_PATH_SEPARATOR "\\"
 #else
     #define IMF_PATH_SEPARATOR "/"
@@ -827,4 +827,3 @@ main (int argc, char * argv[])
 
     return 0;
 }
-

--- a/OpenEXR_Viewers/exrdisplay/ImageView.cpp
+++ b/OpenEXR_Viewers/exrdisplay/ImageView.cpp
@@ -51,7 +51,7 @@
 #include <algorithm>
 #include <stdio.h>
 
-#if defined PLATFORM_WINDOWS || defined _WIN32
+#if defined _WIN32
     #include <windows.h>
     #include <FL/Fl.H>
     #include <GL/gl.h>


### PR DESCRIPTION
Previously PLATFORM_WINDOWS was used to conditionally include things,
but that had been removed elsewhere, and a few spots missed.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>