### PR TITLE
Fix #455 by not using object libraries under apple

### DIFF
--- a/IlmBase/config/LibraryDefine.cmake
+++ b/IlmBase/config/LibraryDefine.cmake
@@ -9,8 +9,27 @@ function(ILMBASE_DEFINE_LIBRARY libname)
   set(multiValueArgs SOURCES HEADERS DEPENDENCIES PRIVATE_DEPS)
   cmake_parse_arguments(ILMBASE_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  set(objlib ${libname}_Object)
-  add_library(${objlib} OBJECT ${ILMBASE_CURLIB_SOURCES})
+  # only do the object library mechanism in a few cases:
+  # - xcode doesn't handle "empty" targets (i.e. add_library with
+  #   an object lib only)
+  # - under windows, we don't want the static library targets to
+  #   have the export tags
+  # - if we're not compiling both, don't add the extra layer to prevent
+  #   extra compiles since we aren't doing that anyway
+  if(ILMBASE_BUILD_BOTH_STATIC_SHARED AND NOT (APPLE OR WIN32))
+    set(use_objlib TRUE)
+  else()
+    set(use_objlib)
+  endif()
+
+  if(use_objlib)
+    set(objlib ${libname}_Object)
+    add_library(${objlib} OBJECT ${ILMBASE_CURLIB_SOURCES})
+  else()
+    set(objlib ${libname})
+    add_library(${objlib} ${ILMBASE_CURLIB_SOURCES})
+  endif()
+
   target_compile_features(${objlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
   if(ILMBASE_CURLIB_PRIV_EXPORT AND BUILD_SHARED_LIBS)
     target_compile_definitions(${objlib} PRIVATE ${ILMBASE_CURLIB_PRIV_EXPORT})
@@ -35,16 +54,20 @@ function(ILMBASE_DEFINE_LIBRARY libname)
   )
   set_property(TARGET ${objlib} PROPERTY PUBLIC_HEADER ${ILMBASE_CURLIB_HEADERS})
 
-  install(TARGETS ${objlib}
-    EXPORT ${PROJECT_NAME}
-    PUBLIC_HEADER
-      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ILMBASE_OUTPUT_SUBDIR}
-  )
+  if(use_objlib)
+    install(TARGETS ${objlib}
+      EXPORT ${PROJECT_NAME}
+      PUBLIC_HEADER
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ILMBASE_OUTPUT_SUBDIR}
+    )
+  endif()
 
   # let the default behaviour BUILD_SHARED_LIBS control the
   # disposition of the default library...
-  add_library(${libname} $<TARGET_OBJECTS:${objlib}>)
-  target_link_libraries(${libname} PUBLIC ${objlib})
+  if(use_objlib)
+    add_library(${libname} $<TARGET_OBJECTS:${objlib}>)
+    target_link_libraries(${libname} PUBLIC ${objlib})
+  endif()
   if(BUILD_SHARED_LIBS)
     set_target_properties(${libname} PROPERTIES
       SOVERSION ${ILMBASE_SOVERSION}
@@ -66,12 +89,36 @@ function(ILMBASE_DEFINE_LIBRARY libname)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ILMBASE_OUTPUT_SUBDIR}
   )
 
   if(ILMBASE_BUILD_BOTH_STATIC_SHARED)
-    add_library(${libname}_static STATIC $<TARGET_OBJECTS:${objlib}>)
-    target_link_libraries(${libname}_static INTERFACE ${objlib})
+    if(use_objlib)
+      add_library(${libname}_static STATIC $<TARGET_OBJECTS:${objlib}>)
+      target_link_libraries(${libname}_static INTERFACE ${objlib})
+    else()
+      # have to build multiple times... but have different flags anyway (i.e. no dll)
+      set(curlib ${libname}_static)
+      add_library(${curlib} STATIC ${ILMBASE_CURLIB_SOURCES})
+      target_compile_features(${curlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+      if(ILMBASE_CURLIB_CURDIR)
+        target_include_directories(${curlib} INTERFACE $<BUILD_INTERFACE:${ILMBASE_CURLIB_CURDIR}>)
+      endif()
+      if(ILMBASE_CURLIB_CURBINDIR)
+        target_include_directories(${curlib} PRIVATE $<BUILD_INTERFACE:${ILMBASE_CURLIB_CURBINDIR}>)
+      endif()
+      target_link_libraries(${curlib} PUBLIC ${PROJECT_NAME}::Config ${ILMBASE_CURLIB_DEPENDENCIES})
+      if(ILMBASE_CURLIB_PRIVATE_DEPS)
+        target_link_libraries(${curlib} PRIVATE ${ILMBASE_CURLIB_PRIVATE_DEPS})
+      endif()
+      set(curlib)
+    endif()
+
     set_target_properties(${libname}_static PROPERTIES
+      CXX_STANDARD_REQUIRED ON
+      CXX_EXTENSIONS OFF
+      POSITION_INDEPENDENT_CODE ON
       SOVERSION ${ILMBASE_SOVERSION}
       VERSION ${ILMBASE_LIB_VERSION}
       OUTPUT_NAME "${libname}${ILMBASE_LIB_SUFFIX}${ILMBASE_STATIC_LIB_SUFFIX}"

--- a/OpenEXR/config/LibraryDefine.cmake
+++ b/OpenEXR/config/LibraryDefine.cmake
@@ -9,8 +9,27 @@ function(OPENEXR_DEFINE_LIBRARY libname)
   set(multiValueArgs SOURCES HEADERS DEPENDENCIES PRIVATE_DEPS)
   cmake_parse_arguments(OPENEXR_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-  set(objlib ${libname}_Object)
-  add_library(${objlib} OBJECT ${OPENEXR_CURLIB_SOURCES})
+  # only do the object library mechanism in a few cases:
+  # - xcode doesn't handle "empty" targets (i.e. add_library with
+  #   an object lib only)
+  # - under windows, we don't want the static library targets to
+  #   have the export tags
+  # - if we're not compiling both, don't add the extra layer to prevent
+  #   extra compiles since we aren't doing that anyway
+  if(OPENEXR_BUILD_BOTH_STATIC_SHARED AND NOT (APPLE OR WIN32))
+    set(use_objlib TRUE)
+  else()
+    set(use_objlib)
+  endif()
+
+  if(use_objlib)
+    set(objlib ${libname}_Object)
+    add_library(${objlib} OBJECT ${OPENEXR_CURLIB_SOURCES})
+  else()
+    set(objlib ${libname})
+    add_library(${objlib} ${OPENEXR_CURLIB_SOURCES})
+  endif()
+
   target_compile_features(${objlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
   if(OPENEXR_CURLIB_PRIV_EXPORT AND BUILD_SHARED_LIBS)
     target_compile_definitions(${objlib} PRIVATE ${OPENEXR_CURLIB_PRIV_EXPORT})
@@ -35,16 +54,19 @@ function(OPENEXR_DEFINE_LIBRARY libname)
   )
   set_property(TARGET ${objlib} PROPERTY PUBLIC_HEADER ${OPENEXR_CURLIB_HEADERS})
 
-  install(TARGETS ${objlib}
-    EXPORT ${PROJECT_NAME}
-    PUBLIC_HEADER
-      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENEXR_OUTPUT_SUBDIR}
-  )
+  if(use_objlib)
+    install(TARGETS ${objlib}
+      EXPORT ${PROJECT_NAME}
+      PUBLIC_HEADER
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENEXR_OUTPUT_SUBDIR}
+    )
 
-  # let the default behaviour BUILD_SHARED_LIBS control the
-  # disposition of the default library...
-  add_library(${libname} $<TARGET_OBJECTS:${objlib}>)
-  target_link_libraries(${libname} PUBLIC ${objlib})
+    # let the default behaviour BUILD_SHARED_LIBS control the
+    # disposition of the default library...
+    add_library(${libname} $<TARGET_OBJECTS:${objlib}>)
+    target_link_libraries(${libname} PUBLIC ${objlib})
+  endif()
+
   if(BUILD_SHARED_LIBS)
     set_target_properties(${libname} PROPERTIES
       SOVERSION ${OPENEXR_SOVERSION}
@@ -66,11 +88,32 @@ function(OPENEXR_DEFINE_LIBRARY libname)
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENEXR_OUTPUT_SUBDIR}
   )
 
   if(OPENEXR_BUILD_BOTH_STATIC_SHARED)
-    add_library(${libname}_static STATIC $<TARGET_OBJECTS:${objlib}>)
-    target_link_libraries(${libname}_static INTERFACE ${objlib})
+    if(use_objlib)
+      add_library(${libname}_static STATIC $<TARGET_OBJECTS:${objlib}>)
+      target_link_libraries(${libname}_static INTERFACE ${objlib})
+    else()
+      # have to build multiple times... but have different flags anyway (i.e. no dll)
+      set(curlib ${libname}_static)
+      add_library(${curlib} STATIC ${OPENEXR_CURLIB_SOURCES})
+      target_compile_features(${curlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+      if(OPENEXR_CURLIB_CURDIR)
+        target_include_directories(${curlib} INTERFACE $<BUILD_INTERFACE:${OPENEXR_CURLIB_CURDIR}>)
+      endif()
+      if(OPENEXR_CURLIB_CURBINDIR)
+        target_include_directories(${curlib} PRIVATE $<BUILD_INTERFACE:${OPENEXR_CURLIB_CURBINDIR}>)
+      endif()
+      target_link_libraries(${curlib} PUBLIC ${PROJECT_NAME}::Config ${OPENEXR_CURLIB_DEPENDENCIES})
+      if(OPENEXR_CURLIB_PRIVATE_DEPS)
+        target_link_libraries(${curlib} PRIVATE ${OPENEXR_CURLIB_PRIVATE_DEPS})
+      endif()
+      set(curlib)
+    endif()
+
     set_target_properties(${libname}_static PROPERTIES
       SOVERSION ${OPENEXR_SOVERSION}
       VERSION ${OPENEXR_LIB_VERSION}


### PR DESCRIPTION
Per the docs, add_library calls with only object library dependencies
are not yet handled properly by Xcode and similar. Disable the use of
object libraries as a compilation speedup mechanism as a result.
Similarly, disable under win32 when building both types of libs to avoid
exported symbols in the static libs. Finally, use same mechanism to
avoid extra layer of libs in generated exports when only building one
config on all platforms

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>