### PR TITLE
Fix missing #include <cmath> for std::isnormal

### DIFF
--- a/OpenEXR/IlmImf/ImfHeader.cpp
+++ b/OpenEXR/IlmImf/ImfHeader.cpp
@@ -73,6 +73,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <time.h>
+#include <cmath>
 #include "ImfTiledMisc.h"
 #include "ImfNamespace.h"
 


### PR DESCRIPTION
fixes compile regression on macos + clang-6