### PR TITLE
Fixes #139

### DIFF
--- a/IlmBase/bootstrap
+++ b/IlmBase/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ##
 ## SPDX-License-Identifier: BSD-3-Clause
@@ -7,7 +7,7 @@
 
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
-if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
+if [ "$HOSTTYPE" = "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
         LIBTOOLIZE=glibtoolize
 else
         LIBTOOLIZE=libtoolize

--- a/IlmBase/configure.ac
+++ b/IlmBase/configure.ac
@@ -51,19 +51,19 @@ AC_ARG_ENABLE(cxxstd,
                              [enable ISO c++ standard 11/14 [[default=auto]]]),
               [cxxstd="${enableval}"], [cxxstd=14])
 
-if test "${cxxstd}" == 17 ; then
+if test "${cxxstd}" = 17 ; then
     AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 	CXXFLAGS="$CXXFLAGS -std=c++17"
 else
-  if test "${cxxstd}" == 14 ; then
+  if test "${cxxstd}" = 14 ; then
       AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
   	CXXFLAGS="$CXXFLAGS -std=c++14"
   else
-    if test "${cxxstd}" == 11 ; then
+    if test "${cxxstd}" = 11 ; then
       AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
       CXXFLAGS="$CXXFLAGS -std=c++11"
     else
-      if test "${cxxstd}" == 03 ; then
+      if test "${cxxstd}" = 03 ; then
         AC_DEFINE(ILMBASE_FORCE_CXX03)
         CXXFLAGS="$CXXFLAGS -std=c++03"
       else
@@ -71,11 +71,11 @@ else
         AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
-        if test "$HAVE_CXX14" == 1 ; then
+        if test "$HAVE_CXX14" = 1 ; then
   	      CXXFLAGS="$CXXFLAGS -std=c++14"
           cxxstd = 14
         else
-          if test "$HAVE_CXX11" == 1 ; then
+          if test "$HAVE_CXX11" = 1 ; then
   	        CXXFLAGS="$CXXFLAGS -std=c++11"
             cxxstd = 11
           fi
@@ -263,7 +263,7 @@ AC_ARG_ENABLE(customusernamespace,
         [custom_public_namespace="${enableval}"], 
         [custom_public_namespace=no])
 
-if test "x${custom_public_namespace}" == xyes ; then
+if test "x${custom_public_namespace}" = xyes ; then
     AC_MSG_WARN([Enabling 'custom user namespace' requires an additional argument, reverting to default])
     AC_DEFINE(IMATH_NAMESPACE,     Imath)
     AC_DEFINE(IEX_NAMESPACE,       Iex)
@@ -271,7 +271,7 @@ if test "x${custom_public_namespace}" == xyes ; then
 
     public_namespace=""
     custom_public_namespace=no
-elif test "x${custom_public_namespace}" == xno ; then
+elif test "x${custom_public_namespace}" = xno ; then
     AC_DEFINE(IMATH_NAMESPACE,     Imath)
     AC_DEFINE(IEX_NAMESPACE,       Iex)
     AC_DEFINE(ILMTHREAD_NAMESPACE, IlmThread)
@@ -302,14 +302,12 @@ case "$host" in
 	      [osx_arch="${enableval}"], [osx_arch=default])
 
   if test "${osx_arch}" != default ; then
-     dnl Replace "a b c" with "-arch a -arch b -arch c". Should probably use an all-whitespace regexp rather than a single character for the search string.
-     osx_arch_flags="-arch ${osx_arch// / -arch }"
+     osx_arch_flags=$(printf ' -arch %s' ${osx_arch})
      CXXFLAGS="$CXXFLAGS $osx_arch_flags"
 
      dnl If multiple archs specified, make sure that --disable-dependency-tracking was also specified
      if test "$enable_dependency_tracking" != no ; then
-        osx_arch_array=( ${osx_arch} )
-        if test ${#osx_arch_array[@]} -gt 1 ; then
+        if echo "$osx_arch" | grep >/dev/null " " ; then
           AC_MSG_ERROR([building multiple OS X architectures requires --disable-dependency-tracking.
 Please re-run configure with these options:
   --enable-osx-arch="${osx_arch}" --disable-dependency-tracking

--- a/OpenEXR/bootstrap
+++ b/OpenEXR/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ##
 ## SPDX-License-Identifier: BSD-3-Clause
@@ -7,7 +7,7 @@
 
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
-if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
+if [ "$HOSTTYPE" = "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
         LIBTOOLIZE=glibtoolize
 else
 	LIBTOOLIZE=libtoolize

--- a/OpenEXR/configure.ac
+++ b/OpenEXR/configure.ac
@@ -76,30 +76,30 @@ AC_ARG_ENABLE(cxxstd,
                              [enable ISO c++ standard 11/14 [[default=auto]]]),
               [cxxstd="${enableval}"], [cxxstd=14])
 
-if test "${cxxstd}" == 17 ; then
+if test "${cxxstd}" = 17 ; then
     AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 	CXXFLAGS="$CXXFLAGS -std=c++17"
 else
-  if test "${cxxstd}" == 14 ; then
+  if test "${cxxstd}" = 14 ; then
       AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
   	CXXFLAGS="$CXXFLAGS -std=c++14"
   else
-    if test "${cxxstd}" == 11 ; then
+    if test "${cxxstd}" = 11 ; then
       AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
       CXXFLAGS="$CXXFLAGS -std=c++11"
     else
-      if test "${cxxstd}" == 03 ; then
+      if test "${cxxstd}" = 03 ; then
         CXXFLAGS="$CXXFLAGS -std=c++03"
       else
         dnl automatically determine...
         AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
-        if test "$HAVE_CXX14" == 1 ; then
+        if test "$HAVE_CXX14" = 1 ; then
   	      CXXFLAGS="$CXXFLAGS -std=c++14"
           cxxstd = 14
         else
-          if test "$HAVE_CXX11" == 1 ; then
+          if test "$HAVE_CXX11" = 1 ; then
   	        CXXFLAGS="$CXXFLAGS -std=c++11"
             cxxstd = 11
           fi
@@ -216,7 +216,7 @@ AC_COMPILE_IFELSE(
    [sysconf_nproc="no"]
 )
 AC_MSG_RESULT([$sysconf_nproc])
-if test "x${sysconf_nproc}" == xyes ; then
+if test "x${sysconf_nproc}" = xyes ; then
     AC_DEFINE([OPENEXR_IMF_HAVE_SYSCONF_NPROCESSORS_ONLN], [1], [Define if sysconf(_SC_NPROCESSORS_ONLN) can be used for CPU count])
 fi
 
@@ -297,14 +297,14 @@ LIB_SUFFIX=""
 lib_suffix_valid="no"
 
 lib_namespace="Imf"
-if test "x${library_namespace_versioning}" == xyes ; then
+if test "x${library_namespace_versioning}" = xyes ; then
     AC_DEFINE_UNQUOTED([OPENEXR_IMF_INTERNAL_NAMESPACE], [Imf_${OPENEXR_VERSION_API}], [OpenEXR])
     AC_DEFINE([OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM], [1], [OpenEXR])
 
     lib_namespace="Imf_${OPENEXR_VERSION_API}"
     LIB_SUFFIX="${OPENEXR_VERSION_API}"
     lib_suffix_valid="yes"
-elif test "x${library_namespace_versioning}" == xno ; then
+elif test "x${library_namespace_versioning}" = xno ; then
     AC_DEFINE_UNQUOTED([OPENEXR_IMF_INTERNAL_NAMESPACE], [Imf], [OpenEXR])
 
     lib_namespace="Imf"
@@ -318,7 +318,7 @@ else
 fi
 AC_SUBST(LIB_SUFFIX)
 
-if test "x${lib_suffix_valid}" == xyes ; then
+if test "x${lib_suffix_valid}" = xyes ; then
 AC_SUBST(LIB_SUFFIX_DASH,"-${LIB_SUFFIX}")
 AM_CONDITIONAL(LIB_SUFFIX_EXISTS,true)
 else
@@ -338,11 +338,11 @@ AC_ARG_ENABLE(customusernamespace,
         [custom_usr_namespace="${enableval}"], 
         [custom_usr_namespace=no])
 
-if test "x${custom_usr_namespace}" == xyes ; then
+if test "x${custom_usr_namespace}" = xyes ; then
     AC_MSG_WARN([Enabling 'custom user namespace' requires an additional argument, reverting to 'Imf'])
     AC_DEFINE_UNQUOTED([OPENEXR_IMF_NAMESPACE], [Imf], [OpenEXR])
     usr_namespace="Imf"
-elif test "x${custom_usr_namespace}" == xno ; then
+elif test "x${custom_usr_namespace}" = xno ; then
     AC_DEFINE_UNQUOTED([OPENEXR_IMF_NAMESPACE], [Imf], [OpenEXR])
     usr_namespace="Imf"
 else
@@ -386,7 +386,7 @@ enable large stack optimizations                $large_stack
 internal library namespace                      $lib_namespace
 user-client namespace                           $usr_namespace])
 
-if test "x$build_osxuniversal" == xyes; then
+if test "x$build_osxuniversal" = xyes; then
 AC_MSG_RESULT([
 build OS X universal binaries                   $build_osxuniversal])
 fi

--- a/OpenEXR_Viewers/bootstrap
+++ b/OpenEXR_Viewers/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ##
 ## SPDX-License-Identifier: BSD-3-Clause
@@ -7,7 +7,7 @@
 
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
-if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
+if [ "$HOSTTYPE" = "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
         LIBTOOLIZE=glibtoolize
 else
         LIBTOOLIZE=libtoolize

--- a/OpenEXR_Viewers/configure.ac
+++ b/OpenEXR_Viewers/configure.ac
@@ -89,30 +89,30 @@ AC_ARG_ENABLE(cxxstd,
                              [enable ISO c++ standard 11/14 [[default=auto]]]),
               [cxxstd="${enableval}"], [cxxstd=14])
 
-if test "${cxxstd}" == 17 ; then
+if test "${cxxstd}" = 17 ; then
     AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 	CXXFLAGS="$CXXFLAGS -std=c++17"
 else
-  if test "${cxxstd}" == 14 ; then
+  if test "${cxxstd}" = 14 ; then
       AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
   	CXXFLAGS="$CXXFLAGS -std=c++14"
   else
-    if test "${cxxstd}" == 11 ; then
+    if test "${cxxstd}" = 11 ; then
       AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
       CXXFLAGS="$CXXFLAGS -std=c++11"
     else
-      if test "${cxxstd}" == 03 ; then
+      if test "${cxxstd}" = 03 ; then
         CXXFLAGS="$CXXFLAGS -std=c++03"
       else
         dnl automatically determine...
         AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
-        if test "$HAVE_CXX14" == 1 ; then
+        if test "$HAVE_CXX14" = 1 ; then
   	      CXXFLAGS="$CXXFLAGS -std=c++14"
           cxxstd = 14
         else
-          if test "$HAVE_CXX11" == 1 ; then
+          if test "$HAVE_CXX11" = 1 ; then
   	        CXXFLAGS="$CXXFLAGS -std=c++11"
             cxxstd = 11
           fi
@@ -128,7 +128,7 @@ AC_ARG_ENABLE(threading,
                              [enable multi-threading [[default=yes]]]),
               [multithread="${enableval}"], [multithread=yes])
 
-if test x$PKG_CONFIG == xno && test "x${multithread}" != xno ; then
+if test x$PKG_CONFIG = xno && test "x${multithread}" != xno ; then
     ACX_PTHREAD(
     [
 	AC_DEFINE(HAVE_PTHREAD)
@@ -332,4 +332,3 @@ ctl support                                     $have_ctl
 ---------------------------------------------
   ])
 fi
-

--- a/PyIlmBase/bootstrap
+++ b/PyIlmBase/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ##
 ## SPDX-License-Identifier: BSD-3-Clause
@@ -7,7 +7,7 @@
 
 # If we're on OS X, use glibtoolize instead of toolize when available
 HOSTTYPE=`uname`
-if [ "$HOSTTYPE" == "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
+if [ "$HOSTTYPE" = "Darwin" ] && $(which glibtoolize > /dev/null 2>&1) ; then
         LIBTOOLIZE=glibtoolize
 else
         LIBTOOLIZE=libtoolize

--- a/PyIlmBase/configure.ac
+++ b/PyIlmBase/configure.ac
@@ -44,30 +44,30 @@ AC_ARG_ENABLE(cxxstd,
                              [enable ISO c++ standard 11/14 [[default=auto]]]),
               [cxxstd="${enableval}"], [cxxstd=14])
 
-if test "${cxxstd}" == 17 ; then
+if test "${cxxstd}" = 17 ; then
     AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 	CXXFLAGS="$CXXFLAGS -std=c++17"
 else
-  if test "${cxxstd}" == 14 ; then
+  if test "${cxxstd}" = 14 ; then
       AX_CXX_COMPILE_STDCXX([14], [noext], [mandatory])
   	CXXFLAGS="$CXXFLAGS -std=c++14"
   else
-    if test "${cxxstd}" == 11 ; then
+    if test "${cxxstd}" = 11 ; then
       AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
       CXXFLAGS="$CXXFLAGS -std=c++11"
     else
-      if test "${cxxstd}" == 03 ; then
+      if test "${cxxstd}" = 03 ; then
         CXXFLAGS="$CXXFLAGS -std=c++03"
       else
         dnl automatically determine...
         AX_CXX_COMPILE_STDCXX([11], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([14], [noext], [optional])
         AX_CXX_COMPILE_STDCXX([17], [noext], [optional])
-        if test "$HAVE_CXX14" == 1 ; then
+        if test "$HAVE_CXX14" = 1 ; then
   	      CXXFLAGS="$CXXFLAGS -std=c++14"
           cxxstd = 14
         else
-          if test "$HAVE_CXX11" == 1 ; then
+          if test "$HAVE_CXX11" = 1 ; then
   	        CXXFLAGS="$CXXFLAGS -std=c++11"
             cxxstd = 11
           fi
@@ -123,7 +123,7 @@ LIBS="$LIBS -lpython$PYTHON_VERSION"
 BOOST_PYTHON_CXXFLAGS="" 
 BOOST_PYTHON_LDFLAGS="" 
 BOOST_PYTHON_LIBS=""
-if test "${PYTHON_VER_MAJ}" == 3 ; then
+if test "${PYTHON_VER_MAJ}" = 3 ; then
   BOOST_PYTHON_LIBNAME="boost_python3"
 else
   BOOST_PYTHON_LIBNAME="boost_python"
@@ -246,4 +246,3 @@ Python version                                  $PYTHON_VERSION
 boost::python libname                           $BOOST_PYTHON_LIBNAME
 ---------------------------------------------
 ])
-


### PR DESCRIPTION
Removes bash-isms from the autoconf bootstrap / configure.ac files

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>