### PR TITLE
Put all runtime artefacts in a single folder to help win32 find dlls

### DIFF
--- a/IlmBase/HalfTest/CMakeLists.txt
+++ b/IlmBase/HalfTest/CMakeLists.txt
@@ -13,4 +13,7 @@ add_executable(HalfTest
 )
 
 target_link_libraries(HalfTest IlmBase::Half)
+set_target_properties(HalfTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 add_test(NAME IlmBase.Half COMMAND $<TARGET_FILE:HalfTest>)

--- a/IlmBase/IexTest/CMakeLists.txt
+++ b/IlmBase/IexTest/CMakeLists.txt
@@ -7,4 +7,7 @@ add_executable(IexTest
 )
 
 target_link_libraries(IexTest IlmBase::Iex)
+set_target_properties(IexTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 add_test(NAME IlmBase.Iex COMMAND $<TARGET_FILE:IexTest>)

--- a/IlmBase/ImathTest/CMakeLists.txt
+++ b/IlmBase/ImathTest/CMakeLists.txt
@@ -28,4 +28,7 @@ add_executable(ImathTest
 )
 
 target_link_libraries(ImathTest IlmBase::Imath)
+set_target_properties(ImathTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 add_test(NAME IlmBase.Imath COMMAND $<TARGET_FILE:ImathTest>)

--- a/IlmBase/config/LibraryDefine.cmake
+++ b/IlmBase/config/LibraryDefine.cmake
@@ -72,9 +72,12 @@ function(ILMBASE_DEFINE_LIBRARY libname)
     set_target_properties(${libname} PROPERTIES
       SOVERSION ${ILMBASE_SOVERSION}
       VERSION ${ILMBASE_LIB_VERSION}
-      OUTPUT_NAME "${libname}${ILMBASE_LIB_SUFFIX}"
     )
   endif()
+  set_target_properties(${libname} PROPERTIES
+      OUTPUT_NAME "${libname}${ILMBASE_LIB_SUFFIX}"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  )
   add_library(${PROJECT_NAME}::${libname} ALIAS ${libname})
 
   install(TARGETS ${libname}

--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -3,6 +3,9 @@
 
 add_executable(b44ExpLogTable b44ExpLogTable.cpp)
 target_link_libraries(b44ExpLogTable PRIVATE OpenEXR::Config IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
+set_target_properties(b44ExpLogTable PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 # TODO: Old file had logic to skip these if the file already exists
 add_custom_command(
   OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
@@ -13,6 +16,9 @@ add_custom_command(
 
 add_executable(dwaLookups dwaLookups.cpp)
 target_link_libraries(dwaLookups PRIVATE OpenEXR::Config IlmBase::Imath IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
+set_target_properties(dwaLookups PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 # TODO: Old file had logic to skip these if the file already exists
 add_custom_command(
   OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h

--- a/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
@@ -10,6 +10,9 @@ add_executable( IlmImfFuzzTest
   testFuzzTiles.cpp
 )
 target_link_libraries(IlmImfFuzzTest OpenEXR::IlmImf)
+set_target_properties(IlmImfFuzzTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 option(OPENEXR_RUN_FUZZ_TESTS  "Controls whether to include the fuzz tests (slow) in default test cases, there is a custom fuzz target" OFF)
 if(OPENEXR_RUN_FUZZ_TESTS)
   add_test(NAME OpenEXR.ImfFuzz COMMAND $<TARGET_FILE:IlmImfFuzzTest>)

--- a/OpenEXR/IlmImfTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfTest/CMakeLists.txt
@@ -62,4 +62,7 @@ add_executable(IlmImfTest
 )
 target_compile_definitions(IlmImfTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
 target_link_libraries(IlmImfTest OpenEXR::IlmImf)
+set_target_properties(IlmImfTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 add_test(NAME OpenEXR.IlmImf COMMAND $<TARGET_FILE:IlmImfTest>)

--- a/OpenEXR/IlmImfUtilTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfUtilTest/CMakeLists.txt
@@ -8,4 +8,7 @@ add_executable(IlmImfUtilTest
   testIO.cpp
  )
 target_link_libraries(IlmImfUtilTest OpenEXR::IlmImfUtil)
+set_target_properties(IlmImfUtilTest PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 add_test(NAME OpenEXR.IlmImfUtil COMMAND $<TARGET_FILE:IlmImfUtilTest>)

--- a/OpenEXR/config/LibraryDefine.cmake
+++ b/OpenEXR/config/LibraryDefine.cmake
@@ -71,9 +71,12 @@ function(OPENEXR_DEFINE_LIBRARY libname)
     set_target_properties(${libname} PROPERTIES
       SOVERSION ${OPENEXR_SOVERSION}
       VERSION ${OPENEXR_LIB_VERSION}
-      OUTPUT_NAME "${libname}${OPENEXR_LIB_SUFFIX}"
     )
   endif()
+  set_target_properties(${libname} PROPERTIES
+      OUTPUT_NAME "${libname}${OPENEXR_LIB_SUFFIX}"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  )
   add_library(${PROJECT_NAME}::${libname} ALIAS ${libname})
 
   install(TARGETS ${libname}

--- a/OpenEXR/exr2aces/CMakeLists.txt
+++ b/OpenEXR/exr2aces/CMakeLists.txt
@@ -3,4 +3,7 @@
 
 add_executable(exr2aces main.cpp)
 target_link_libraries(exr2aces OpenEXR::IlmImf)
+set_target_properties(exr2aces PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exr2aces DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrenvmap/CMakeLists.txt
+++ b/OpenEXR/exrenvmap/CMakeLists.txt
@@ -12,4 +12,7 @@ add_executable( exrenvmap
 )
 
 target_link_libraries(exrenvmap OpenEXR::IlmImf)
+set_target_properties(exrenvmap PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrenvmap DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrheader/CMakeLists.txt
+++ b/OpenEXR/exrheader/CMakeLists.txt
@@ -3,4 +3,7 @@
 
 add_executable(exrheader main.cpp)
 target_link_libraries(exrheader OpenEXR::IlmImf)
+set_target_properties(exrheader PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrheader DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrmakepreview/CMakeLists.txt
+++ b/OpenEXR/exrmakepreview/CMakeLists.txt
@@ -6,4 +6,7 @@ add_executable(exrmakepreview
   makePreview.cpp
 )
 target_link_libraries(exrmakepreview OpenEXR::IlmImf)
+set_target_properties(exrmakepreview PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrmakepreview DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrmaketiled/CMakeLists.txt
+++ b/OpenEXR/exrmaketiled/CMakeLists.txt
@@ -7,4 +7,7 @@ add_executable(exrmaketiled
   Image.cpp
 )
 target_link_libraries(exrmaketiled OpenEXR::IlmImf)
+set_target_properties(exrmaketiled PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrmaketiled DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrmultipart/CMakeLists.txt
+++ b/OpenEXR/exrmultipart/CMakeLists.txt
@@ -3,4 +3,7 @@
 
 add_executable(exrmultipart exrmultipart.cpp)
 target_link_libraries(exrmultipart OpenEXR::IlmImf)
+set_target_properties(exrmultipart PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrmultipart DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrmultiview/CMakeLists.txt
+++ b/OpenEXR/exrmultiview/CMakeLists.txt
@@ -7,4 +7,7 @@ add_executable(exrmultiview
   Image.cpp
 )
 target_link_libraries(exrmultiview OpenEXR::IlmImf)
+set_target_properties(exrmultiview PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrmultiview DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR/exrstdattr/CMakeLists.txt
+++ b/OpenEXR/exrstdattr/CMakeLists.txt
@@ -3,4 +3,7 @@
 
 add_executable(exrstdattr main.cpp)
 target_link_libraries(exrstdattr OpenEXR::IlmImf)
+set_target_properties(exrstdattr PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 install(TARGETS exrstdattr DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR_Viewers/exrdisplay/CMakeLists.txt
+++ b/OpenEXR_Viewers/exrdisplay/CMakeLists.txt
@@ -20,5 +20,8 @@ target_link_libraries(exrdisplay
   OpenGL::GL
   OpenEXR::IlmImf
 )
+set_target_properties(exrdisplay PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 
 install(TARGETS exrdisplay DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OpenEXR_Viewers/playexr/CMakeLists.txt
+++ b/OpenEXR_Viewers/playexr/CMakeLists.txt
@@ -26,5 +26,8 @@ target_link_libraries(playexr
   OpenGL::GLU
   OpenEXR::IlmImf
 )
+set_target_properties(playexr PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
 
 install(TARGETS playexr DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This will (hopefully) fix issues with compiling ilmbase as a dll and
using that to generate and compile openexr

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>