### PR TITLE
Fix #246, add type traits check

### DIFF
--- a/IlmBase/HalfTest/testClassification.cpp
+++ b/IlmBase/HalfTest/testClassification.cpp
@@ -17,7 +17,9 @@ using namespace std;
 
 namespace {
 
+#if __cplusplus >= 201402L
 static_assert(std::is_trivially_default_constructible<half>::value, "half is trivial and default constructible");
+#endif
 
 void
 testClass (half h,

--- a/IlmBase/HalfTest/testClassification.cpp
+++ b/IlmBase/HalfTest/testClassification.cpp
@@ -11,11 +11,13 @@
 #include "half.h"
 #include <iostream>
 #include <assert.h>
-
+#include <type_traits>
 
 using namespace std;
 
 namespace {
+
+static_assert(std::is_trivially_default_constructible<half>::value, "half is trivial and default constructible");
 
 void
 testClass (half h,


### PR DESCRIPTION
previous cleanup did most of the work, but add an explicit test that
half is now trivial and default constructible

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>