### PR TITLE
Normalize library naming between cmake and autoconf

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,10 +90,10 @@ If you are building dynamic libraries, once you have configured, built,
 and installed the libraries, you should see the following pattern of
 symlinks and files in the install lib folder:
 
-    libHalf.so -> libHalf-LIB_SUFFIX.so
-    libHalf-LIB_SUFFIX.so -> libHalf-LIB_SUFFIX.so.SO_MAJOR_VERSION
-    libHalf-LIB_SUFFIX.so.SO_MAJOR_VERSION -> libHalf-LIB_SUFFIX.so.SO_FULL_VERSION
-    libHalf-LIB_SUFFIX.so.SO_FULL_VERSION (actual file)
+    libHalf.so -> libHalf-$LIB_SUFFIX.so
+    libHalf-$LIB_SUFFIX.so -> libHalf-$LIB_SUFFIX.so.$SO_MAJOR_VERSION
+    libHalf-$LIB_SUFFIX.so.$SO_MAJOR_VERSION -> libHalf-$LIB_SUFFIX.so.$SO_FULL_VERSION
+    libHalf-$LIB_SUFFIX.so.$SO_FULL_VERSION (actual file)
 
 You can configure the LIB_SUFFIX, although it defaults to the library
 major and minor version, so in the case of a 2.3 library, it would default

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,6 +76,31 @@ can specify a local install directory to cmake via the
 
     % cmake .. -DCMAKE_INSTALL_PREFIX=$install_directory
 
+## Library Names
+
+Using either cmake or autoconf based configuration mechanisms described
+in this document, by default the installed libraries follow a pattern
+for how they are named. This is done to enable multiple versions of the
+library to be installed and targeted by different builds depending on
+the needs of the project. A simple example of this would be to have
+different versions of the library installed to allow for applications
+targeting different VFX Platform years to co-exist.
+
+If you are building dynamic libraries, once you have configured, built,
+and installed the libraries, you should see the following pattern of
+symlinks and files in the install lib folder:
+
+    libHalf.so -> libHalf-LIB_SUFFIX.so
+    libHalf-LIB_SUFFIX.so -> libHalf-LIB_SUFFIX.so.SO_MAJOR_VERSION
+    libHalf-LIB_SUFFIX.so.SO_MAJOR_VERSION -> libHalf-LIB_SUFFIX.so.SO_FULL_VERSION
+    libHalf-LIB_SUFFIX.so.SO_FULL_VERSION (actual file)
+
+You can configure the LIB_SUFFIX, although it defaults to the library
+major and minor version, so in the case of a 2.3 library, it would default
+to 2_3. You would then link your programs against this versioned library
+to have maximum safety (i.e. `-lHalf-2_3`), and the pkg-config and cmake
+configuration files included with find_package should set this up.
+
 ## Sub-Modules
 
 OpenEXR consists of four separate sub-modules - IlmBase, PyIlmBase,
@@ -190,11 +215,11 @@ You can customize these options three ways:
 
 * **ILMBASE\_LIB\_SUFFIX**
 
-  Append the given string to the end of all the llmBase libraries. Default is ``-<major>_<minor>`` version string.
+  Append the given string to the end of all the llmBase libraries. Default is ``-<major>_<minor>`` version string. Please see the section on library names
 
 * **OPENEXR\_LIB\_SUFFIX**
 
-  Append the given string to the end of all the llmBase libraries. Default is ``-<major>_<minor>`` version string.
+  Append the given string to the end of all the llmBase libraries. Default is ``-<major>_<minor>`` version string. Please see the section on library names
 
 ### Namespace Options:
 
@@ -324,9 +349,3 @@ As an alternative to CMake on Linux systems, the OpenEXR build can be configured
     % make install
 
 Run ``./configure --help`` for a complete set of configuration options.
-
-
-
-
-
-

--- a/IlmBase/Half/Makefile.am
+++ b/IlmBase/Half/Makefile.am
@@ -12,6 +12,9 @@ lib_LTLIBRARIES = libHalf.la
 libHalf_la_SOURCES = half.cpp half.h halfFunction.h halfLimits.h
 
 libHalf_la_LDFLAGS = -version-info @LIBTOOL_VERSION@ -no-undefined
+if LIB_SUFFIX_EXISTS
+libHalf_la_LDFLAGS += -release @LIB_SUFFIX@
+endif
 
 libHalfincludedir = $(includedir)/OpenEXR
 

--- a/IlmBase/IlmBase.pc.in
+++ b/IlmBase/IlmBase.pc.in
@@ -7,7 +7,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-libsuffix=@LIB_SUFFIX@
+libsuffix=@LIB_SUFFIX_DASH@
 Name: IlmBase
 Description: Base math and exception libraries
 Version: @ILMBASE_VERSION@

--- a/IlmBase/bootstrap
+++ b/IlmBase/bootstrap
@@ -59,7 +59,15 @@ if [ -d /usr/local/share/aclocal ]; then
 fi	
 
 run_cmd aclocal -I m4 $ACLOCAL_INCLUDE
+# Injects an additional naming scheme so we have
+# libFoo.so -> libFoo-SUFFIX.so
+# libFoo-SUFFIX.so -> libFoo-SUFFIX.so.MAJ
+# libFoo-SUFFIX.so.MAJ -> libFoo-SUFFIX.so.FULL_SO_VERSION
+# (or short cut from libFoo-SUFFIX to FULL_SO_VERSION depending
+# on libtool, but link file names are the same.
+sed -e 's/shared_ext\$major \$libname\$shared_ext/shared_ext\$major \$libname\$release\$shared_ext \$libname\$shared_ext/' -i aclocal.m4
 run_cmd $LIBTOOLIZE --automake --copy
+sed -e 's/shared_ext\$major \$libname\$shared_ext/shared_ext\$major \$libname\$release\$shared_ext \$libname\$shared_ext/' -i m4/libtool.m4
 run_cmd automake --add-missing --copy --foreign
 run_cmd autoconf
 echo

--- a/IlmBase/config/CMakeLists.txt
+++ b/IlmBase/config/CMakeLists.txt
@@ -5,7 +5,6 @@ include(CheckIncludeFiles)
 include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(CheckStructHasMember)
-include(CMakeDependentOption)
 
 check_include_files(ucontext.h ILMBASE_HAVE_UCONTEXT_H)
 if(ILMBASE_HAVE_UCONTEXT_H)
@@ -73,7 +72,6 @@ install(
 install(TARGETS IlmBaseConfig EXPORT ${PROJECT_NAME})
 add_library(IlmBase::Config ALIAS IlmBaseConfig)
 
-cmake_dependent_option(ILMBASE_INSTALL_PKG_CONFIG "Install IlmBase.pc file" ON "WIN32" OFF)
 if(ILMBASE_INSTALL_PKG_CONFIG)
   # use a helper function to avoid variable pollution, but pretty simple
   function(ilmbase_pkg_config_help pcinfile)
@@ -81,7 +79,7 @@ if(ILMBASE_INSTALL_PKG_CONFIG)
     set(exec_prefix ${CMAKE_INSTALL_BINDIR})
     set(libdir ${CMAKE_INSTALL_LIBDIR})
     set(includedir ${CMAKE_INSTALL_INCLUDEDIR})
-    set(LIB_SUFFIX ${ILMBASE_LIB_SUFFIX})
+    set(LIB_SUFFIX_DASH ${ILMBASE_LIB_SUFFIX})
     if(TARGET Threads::Threads)
       # hrm, can't use properties as they end up as generator expressions
       # which don't seem to evaluate
@@ -98,6 +96,8 @@ if(ILMBASE_INSTALL_PKG_CONFIG)
     )
   endfunction()
   ilmbase_pkg_config_help(../IlmBase.pc.in)
+else()
+  message(NOTICE "-- WARNING pkg-config generation disabled")
 endif()
 
 # The main export of the configuration - This is the

--- a/IlmBase/config/IlmBaseSetup.cmake
+++ b/IlmBase/config/IlmBaseSetup.cmake
@@ -30,6 +30,13 @@ set(ILMBASE_IEX_NAMESPACE "Iex" CACHE STRING "Public namespace alias for Iex")
 set(ILMBASE_ILMTHREAD_NAMESPACE "IlmThread" CACHE STRING "Public namespace alias for IlmThread")
 set(ILMBASE_PACKAGE_NAME "IlmBase ${ILMBASE_VERSION}" CACHE STRING "Public string / label for displaying package")
 
+# Whether to generate and install a pkg-config file IlmBase.pc on
+if(WIN32)
+option(ILMBASE_INSTALL_PKG_CONFIG "Install IlmBase.pc file" OFF)
+else()
+option(ILMBASE_INSTALL_PKG_CONFIG "Install IlmBase.pc file" ON)
+endif()
+
 ########################
 ## Build related options
 

--- a/IlmBase/config/LibraryDefine.cmake
+++ b/IlmBase/config/LibraryDefine.cmake
@@ -24,10 +24,14 @@ function(ILMBASE_DEFINE_LIBRARY libname)
 
   if(use_objlib)
     set(objlib ${libname}_Object)
-    add_library(${objlib} OBJECT ${ILMBASE_CURLIB_SOURCES})
+    add_library(${objlib} OBJECT
+      ${ILMBASE_CURLIB_HEADERS}
+      ${ILMBASE_CURLIB_SOURCES})
   else()
     set(objlib ${libname})
-    add_library(${objlib} ${ILMBASE_CURLIB_SOURCES})
+    add_library(${objlib}
+      ${ILMBASE_CURLIB_HEADERS}
+      ${ILMBASE_CURLIB_SOURCES})
   endif()
 
   target_compile_features(${objlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})

--- a/IlmBase/config/LibraryDefine.cmake
+++ b/IlmBase/config/LibraryDefine.cmake
@@ -88,6 +88,14 @@ function(ILMBASE_DEFINE_LIBRARY libname)
     PUBLIC_HEADER
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${ILMBASE_OUTPUT_SUBDIR}
   )
+  if(BUILD_SHARED_LIBS AND (NOT "${ILMBASE_LIB_SUFFIX}" STREQUAL ""))
+    set(verlibname ${CMAKE_SHARED_LIBRARY_PREFIX}${libname}${ILMBASE_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(baselibname ${CMAKE_SHARED_LIBRARY_PREFIX}${libname}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_INSTALL_FULL_LIBDIR} ${CMAKE_COMMAND} -E create_symlink ${verlibname} ${baselibname})")
+    install(CODE "message(\"-- Creating symlink in ${CMAKE_INSTALL_FULL_LIBDIR} ${baselibname} -> ${verlibname}\")")
+    set(verlibname)
+    set(baselibname)
+  endif()
 
   if(ILMBASE_BUILD_BOTH_STATIC_SHARED)
     if(use_objlib)

--- a/OpenEXR/OpenEXR.pc.in
+++ b/OpenEXR/OpenEXR.pc.in
@@ -8,7 +8,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 OpenEXR_includedir=@includedir@/OpenEXR
-libsuffix=@LIB_SUFFIX@
+libsuffix=@LIB_SUFFIX_DASH@
 
 Name: OpenEXR
 Description: OpenEXR image library

--- a/OpenEXR/bootstrap
+++ b/OpenEXR/bootstrap
@@ -58,7 +58,15 @@ if [ -d /usr/local/share/aclocal ]; then
 fi	
 
 run_cmd aclocal -I m4 $ACLOCAL_INCLUDE
+# Injects an additional naming scheme so we have
+# libFoo.so -> libFoo-SUFFIX.so
+# libFoo-SUFFIX.so -> libFoo-SUFFIX.so.MAJ
+# libFoo-SUFFIX.so.MAJ -> libFoo-SUFFIX.so.FULL_SO_VERSION
+# (or short cut from libFoo-SUFFIX to FULL_SO_VERSION depending
+# on libtool, but link file names are the same.
+sed -e 's/shared_ext\$major \$libname\$shared_ext/shared_ext\$major \$libname\$release\$shared_ext \$libname\$shared_ext/' -i aclocal.m4
 run_cmd $LIBTOOLIZE --automake --copy
+sed -e 's/shared_ext\$major \$libname\$shared_ext/shared_ext\$major \$libname\$release\$shared_ext \$libname\$shared_ext/' -i m4/libtool.m4
 run_cmd automake --add-missing --copy --foreign
 run_cmd autoconf
 echo

--- a/OpenEXR/config/CMakeLists.txt
+++ b/OpenEXR/config/CMakeLists.txt
@@ -87,7 +87,6 @@ install(
 install(TARGETS IlmImfConfig EXPORT ${PROJECT_NAME})
 add_library(${PROJECT_NAME}::Config ALIAS IlmImfConfig)
 
-option(OPENEXR_INSTALL_PKG_CONFIG "Install OpenEXR.pc file" ON)
 if(OPENEXR_INSTALL_PKG_CONFIG)
   # use a helper function to avoid variable pollution, but pretty simple
   function(openexr_pkg_config_help pcinfile)
@@ -95,7 +94,7 @@ if(OPENEXR_INSTALL_PKG_CONFIG)
     set(exec_prefix ${CMAKE_INSTALL_BINDIR})
     set(libdir ${CMAKE_INSTALL_LIBDIR})
     set(includedir ${CMAKE_INSTALL_INCLUDEDIR})
-    set(LIB_SUFFIX ${OPENEXR_LIB_SUFFIX})
+    set(LIB_SUFFIX_DASH ${OPENEXR_LIB_SUFFIX})
     if(TARGET Threads::Threads)
       # hrm, can't use properties as they end up as generator expressions
       # which don't seem to evaluate

--- a/OpenEXR/config/LibraryDefine.cmake
+++ b/OpenEXR/config/LibraryDefine.cmake
@@ -87,6 +87,14 @@ function(OPENEXR_DEFINE_LIBRARY libname)
     PUBLIC_HEADER
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${OPENEXR_OUTPUT_SUBDIR}
   )
+  if(BUILD_SHARED_LIBS AND (NOT "${OPENEXR_LIB_SUFFIX}" STREQUAL ""))
+    set(verlibname ${CMAKE_SHARED_LIBRARY_PREFIX}${libname}${OPENEXR_LIB_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(baselibname ${CMAKE_SHARED_LIBRARY_PREFIX}${libname}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_INSTALL_FULL_LIBDIR} ${CMAKE_COMMAND} -E create_symlink ${verlibname} ${baselibname})")
+    install(CODE "message(\"-- Creating symlink in ${CMAKE_INSTALL_FULL_LIBDIR} ${baselibname} -> ${verlibname}\")")
+    set(verlibname)
+    set(baselibname)
+  endif()
 
   if(OPENEXR_BUILD_BOTH_STATIC_SHARED)
     if(use_objlib)

--- a/OpenEXR/config/LibraryDefine.cmake
+++ b/OpenEXR/config/LibraryDefine.cmake
@@ -24,10 +24,14 @@ function(OPENEXR_DEFINE_LIBRARY libname)
 
   if(use_objlib)
     set(objlib ${libname}_Object)
-    add_library(${objlib} OBJECT ${OPENEXR_CURLIB_SOURCES})
+    add_library(${objlib} OBJECT
+      ${OPENEXR_CURLIB_HEADERS}
+      ${OPENEXR_CURLIB_SOURCES})
   else()
     set(objlib ${libname})
-    add_library(${objlib} ${OPENEXR_CURLIB_SOURCES})
+    add_library(${objlib}
+      ${OPENEXR_CURLIB_HEADERS}
+      ${OPENEXR_CURLIB_SOURCES})
   endif()
 
   target_compile_features(${objlib} PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})

--- a/OpenEXR/config/OpenEXRSetup.cmake
+++ b/OpenEXR/config/OpenEXRSetup.cmake
@@ -20,6 +20,13 @@ set(OPENEXR_INTERNAL_IMF_NAMESPACE "Imf_${OPENEXR_VERSION_API}" CACHE STRING "Re
 set(OPENEXR_IMF_NAMESPACE "Imf" CACHE STRING "Public namespace alias for Imath")
 set(OPENEXR_PACKAGE_NAME "IlmBase ${ILMBASE_VERSION}" CACHE STRING "Public string / label for displaying package")
 
+# Whether to generate and install a pkg-config file OpenEXR.pc
+if (WIN32)
+option(OPENEXR_INSTALL_PKG_CONFIG "Install OpenEXR.pc file" OFF)
+else()
+option(OPENEXR_INSTALL_PKG_CONFIG "Install OpenEXR.pc file" ON)
+endif()
+
 ########################
 ## Build related options
 


### PR DESCRIPTION
installed libraries should follow the following basic pattern:
(-> indicates a symlink)

libFoo.so -> libFoo-LIB_SUFFIX.so
libFoo-LIB_SUFFIX.so -> libFoo-LIB_SUFFIX.so.MAJ_SO_VERSION
libFoo-LIB_SUFFIX.so.MAJ_SO_VERSION ->
libFoo-LIB_SUFFIX.so.FULL_SO_VERSION

so with a concrete example of 2.3 lib w/ so version of 24

libFoo.so -> libFoo-2_3.so
libFoo-2_3.so -> libFoo-2_3.so.24
libFoo-2_3.so.24 -> libFoo-2_3.so.24.0.0
libFoo-2_3.so.24.0.0.0 <--- actual file

(there may be slight variations in the link destinations based on
differences in libtool and cmake, but the file names available should
all be there)

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>