### PR TITLE
Fix #491, issue with part number range check reconstructing chunk off…

### DIFF
--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -571,7 +571,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
             
             
             
-            if(partNumber<0 || partNumber> static_cast<int>(parts.size()))
+            if(partNumber<0 || partNumber>= static_cast<int>(parts.size()))
             {
                 throw IEX_NAMESPACE::IoExc("part number out of range");
             }


### PR DESCRIPTION
…set table

The chunk offset was incorrectly testing for a part number that was the
same size (i.e. an invalid index)

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>