### PR TITLE
Project documentation edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@
 Thank you for your interest in contributing to OpenEXR. This document
 explains our contribution process and procedures:
 
-* [Getting Information](#Getting Information)
-* [Legal Requirements](#Legal Requirements)
-* [Development Workflow](#Development Workflow)
-* [Coding Style](#Coding Style)
-* [Versioning Policy](#Versioning Policy)
-* [Creating a Release](#Creating a Release)
+* [Getting Information](#Getting-Information)
+* [Legal Requirements](#Legal-Requirements)
+* [Development Workflow](#Development-Workflow)
+* [Coding Style](#Coding-Style)
+* [Versioning Policy](#Versioning-Policy)
+* [Creating a Release](#Creating-a-Release)
 
 For a description of the roles and responsibilities of the various
 members of the OpenEXR community, see [GOVERNANCE](GOVERNANCE.md), and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,41 @@
 # Contributing to OpenEXR
 
 Thank you for your interest in contributing to OpenEXR. This document
-explains our contribution process and procedures
+explains our contribution process and procedures:
+
+* [Getting Information](#Getting Information)
+* [Legal Requirements](#Legal Requirements)
+* [Development Workflow](#Development Workflow)
+* [Coding Style](#Coding Style)
+* [Versioning Policy](#Versioning Policy)
+* [Creating a Release](#Creating a Release)
+
+For a description of the roles and responsibilities of the various
+members of the OpenEXR community, see [GOVERNANCE](GOVERNANCE.md), and
+for further details, see the project's [Technical
+Charter](ASWF/charter/OpenEXR-Technical-Charter.md). Briefly,
+Contributors are anyone who submits content to the project, Committers
+review and approve such submissions, and the Technical Steering
+Committee provides general project oversight.
 
 ## Getting Information
 
 There are two primary ways to connect with the OpenEXR project:
 
 * The [openexr-dev](https://lists.aswf.io/g/openexr-dev) mail list:
-This is a development focused mail list with a deep history of
-technical conversations and decisions that have shaped the project.
+  This is a development focused mail list with a deep history of
+  technical conversations and decisions that have shaped the project.
 
 * [GitHub Issues](https://github.com/openexr/openexr/issues): GitHub
-**issues** are used both to track bugs and to discuss feature requests.
+  Issues are used both to track bugs and to discuss feature requests.
 
 ### How to Ask for Help
 
-If you have trouble installing, building, or using the library, but there's not yet reason to suspect you've encountered a genuine bug, start by posting a question to the [openexr-dev](http://lists.aswf.io/openexr-dev) mailing list. This is the place for question such has "How do I...".
+If you have trouble installing, building, or using the library, but
+there's not yet reason to suspect you've encountered a genuine bug,
+start by posting a question to the
+[openexr-dev](http://lists.aswf.io/openexr-dev) mailing list. This is
+the place for question such has "How do I...".
 
 ### How to Report a Bug
 
@@ -52,19 +71,27 @@ an investigation.
 
 ### How to Contribute a Bug Fix or Change
 
-To contribute code to the project, you'll need:
+To contribute code to the project, first read over the [GOVERNANCE](GOVERNANCE.md) page to understand the roles involved. You'll need:
 
 * A good knowledge of git.
-* A fork of the GitHub repo.
-* An understanding of the project's development workflow
-* Legal Authorization
 
-See below for details.
+* A fork of the GitHub repo.
+
+* An understanding of the project's development workflow.
+
+* Legal authorization, that is, you need to have signed a Contributor
+  License Agreement. See below for details.
 
 ## Legal Requirements
 
-OpenEXR is owned by the Academy Software Foundation and follows the
+OpenEXR is a project of the Academy Software Foundation and follows the
 open source software best practice policies of the Linux Foundation.
+
+### License
+
+OpenEXR is licensed under the [BSD-3-Clause](LICENSE.md)
+license. Contributions to the library should abide by that standard
+license.
 
 ### Contributor License Agreements
 
@@ -72,18 +99,16 @@ Developers who wish to contribute code to be considered for inclusion
 in the OpenEXR distribution must first complete a **Contributor
 License Agreement**.
 
-Trivial changes (such as an alteration to the Makefiles, a one-line
-bug fix, etc.) may be accepted without a CLA, at the sole discretion of the
-project leader, but anything complex requires a CLA. 
-
 * If you are an individual writing the code on your own time and
-you're SURE you are the sole owner of any intellectual property you
-contribute, use the [Individual Contributor License Agreement](http://www.openexr.com/downloads/OpenEXRIndividualContributorLicenseAgreement.docx).
+  you're SURE you are the sole owner of any intellectual property you
+  contribute, use the [Individual Contributor License
+  Agreement](http://www.openexr.com/downloads/OpenEXRIndividualContributorLicenseAgreement.docx).
 
 * If you are writing the code as part of your job, or if there is any
-possibility that your employers might think they own any intellectual
-property you create, then you should use the [Corporate Contributor
-Licence Agreement](http://www.openexr.com/downloads/OpenEXRCorporateContributorLicenseAgreement.docx).
+  possibility that your employers might think they own any
+  intellectual property you create, then you should use the [Corporate
+  Contributor Licence
+  Agreement](http://www.openexr.com/downloads/OpenEXRCorporateContributorLicenseAgreement.docx).
 
 Download the appropriate CLA from the links above (or find them in the
 src/doc directory of the software distribution), print, sign, and
@@ -287,6 +312,8 @@ Incoming new issues are labeled promptly by the TSC using GitHub labels.
 
 The labels include:
 
+* **Autotools** - A problem with the autoconf configuration setup.
+
 * **Bug** - A bug in the source code. Something appears to be
     functioning improperly: a compile error, a crash, unexpected behavior, etc. 
 
@@ -301,19 +328,29 @@ The labels include:
 
 * **CVE** - A security vulnerability bug.
 
-* **Documentation** - The project documentation: developer or user guide, web site, project policies, etc. 
+* **Documentation** - The project documentation: developer or user
+    guide, web site, project policies, etc.
 
-* **Feature Request** - A suggested change or addition of functionality to the library.
-
-* **MinGW** - An issue specific to MinGW
+* **Feature Request** - A suggested change or addition of
+    functionality to the library.
 
 * **Mac OS** - A build issue specific to Mac OS.
 
-* **Pending merge to master**
+* **MinGW** - An issue specific to MinGW
 
-* **Question/Problem/Help** - A request for help or further investigation, possibly just user error or misunderstanding.
+* **Modification** - A modification to the code, refactoring or
+    optimization without significant additional behavior
 
-* **Test Failure** - One of the automated tests is failing, or an analysis tool is reporting problematic behavior.
+* **Needs Info** - Issue is waiting for more information from the
+    submitter.
+
+* **Question/Problem/Help** - A request for help or further
+    investigation, possibly just user error or misunderstanding.
+
+* **Test Failure** - One of the automated tests is failing, or an
+    analysis tool is reporting problematic behavior.
+
+* **TSC** - To be discussed in the technical steering committee.
 
 * **Windows** - A build issue specific to Windows
 
@@ -453,8 +490,9 @@ To create a new release from the master branch:
 
 1. Update the release notes in ``CHANGES.md``.
 
-   Write a high-level summary of the features and improvements. Include the summary in
-   ``CHANGES.md`` and also in the Release comments.
+   Write a high-level summary of the features and
+   improvements. Include the summary in ``CHANGES.md`` and also in the
+   Release comments.
 
    Include the log of all changes since the last release, via:
 
@@ -470,9 +508,6 @@ To create a new release from the master branch:
 
 4. Download and sign the release tarball, as described
 [here](https://wiki.debian.org/Creating%20signed%20GitHub%20releases),
-via:
-
-        git diff --stat v2.2.1
 
 5. Attach the detached ``.asc`` signature file to the GitHub release as a
 binary file.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,65 +1,71 @@
-# OpenEXR Project Governance
+# OpenEXR Project Roles and Responsibilities
 
-The OpenEXR project is owned by the Academy Software Foundation and is
-governed by its Committers, including a Technical Steering Committee
-(TSC) which is responsible for high-level guidance of the project.
+OpenEXR is a project of the Academy Software Foundation and relies on
+the ASWF governance policies, supported by the Linux Foundation.
+
+There are three primary project roles: Contributors submit code to the
+project; Committers approve code to be included into the project; and
+the Technical Steering Committee (TSC) provides overall high-level
+project guidance.
+
+* [Contributors](#Contributors)
+* [Committers](#Committers)
+* [Technical Steering Committee](#Technical Steering Committee)
 
 ## Contributors
 
-The OpenEXR project grows and thrives from assistance from Contributors.
-Contributors include anyone in the community that contributes code,
-documentation, or other technical artifacts that have been incorporated into the
-projects repository.
+The OpenEXR project grows and thrives from assistance from
+Contributors.  Contributors include anyone in the community that
+submits code, documentation, or other technical artifacts to the
+project. However, such contributions must be approved by a project
+Committer before they become a part of the project.  
+
+Anyone can be a Contributor. You need no formal approval from the
+project, beyond the legal forms.
+
+### How to Become a Contributor
+
+* Review the coding standards to ensure your contribution is in line
+  with the project's coding and styling guidelines.
+
+* Sign the Individual CLA, or have your organization sign the Corporate CLA.
+
+* Submit your code as a PR with the appropriate DCO sign-off.
 
 ## Committers
 
-The OpenEXR GitHub repository is maintained by OpenEXR Committers. Committers
-are Contributors who have earned the ability to modify source code,
-documentation, or other technical artifacts to the project. Upon becoming
-Committers, they become members of the OpenEXR leadership team.
+Project Committers have merge access on the OpenEXR GitHub repository
+and are responsible for approving submissions by Contributors.
 
-Their privileges include, but are not limited to:
-
-* Commit access to the OpenEXR repository
-* Moderator status on all communication channels
-
-### Committer Activities
+### Committer Responsibilities
 
 Typical activities of a Committer include:
 
-* Helping users and novice contributors
-* Ensuring a response to questions posted to the openexr-dev alias
-* Contributing code and documentation changes that improve the project
-* Reviewing and commenting on issues and pull requests
-* Participation in working groups
-* Merging pull requests
+* Helping users and novice contributors.
 
-The TSC periodically reviews the Committer list to identify inactive Committers.
-Past Committers are typically given Emeritus status. Emeriti may request that
-the TSC restore them to active Committer status.
+* Ensuring a response to questions posted to the
+  openexr-dev@lists.aswf.io mailing list.
 
-### Committer Nominations
+* Contributing code and documentation changes that improve the
+  project.
 
-Any existing Committer can nominate an individual making significant and
-valuable contributions to the OpenEXR project to become a new Committer.
+* Reviewing and commenting on issues and pull requests.
 
-To nominate a new Committer, open an issue in the OpenEXR repository, with a
-summary of the nominee's contributions.
+* Ensuring that changes and new code meet acceptable standards and are
+  in the long-term interest of the project.
 
-If there are no objections raised by any Committers two weeks after the issue is
-opened, the nomination will be considered as accepted. Should there be any
-objections against the nomination, the TSC is responsible for working with the
-individuals involved and finding a resolution. The nomination must be approved
-by the TSC, which is assumed when there are no objections from any TSC members.
+* Participation in working groups.
 
-Prior to the public nomination, the Committer initiating it may seek feedback
-from other Committers in private channels and work with the nominee to improve
-the nominee's contribution profile, in order to make the nomination as
-frictionless as possible.
+* Merging pull requests.
 
-If individuals making valuable contributions do not believe they have been
-considered for a nomination, they may log an issue or contact a Committer
-directly.
+### How to Become a Committer
+
+Any existing Committer can nominate an individual making significant
+and valuable contributions to the OpenEXR project to become a new
+Committer.  New committers are approved by vote of the TSC.
+
+If you are interested in becomming a Committer, contact the TSC at
+info@openexr.com.
 
 ## Technical Steering Committee
 
@@ -70,31 +76,34 @@ charter defines the TSC member terms and succession policies.
 
 The responsibilities of the TSC include:
 
-* Coordinating technical direction of the Project
-* Project governance and process (including this policy)
-* Contribution policy
-* GitHub repository hosting
-* Conduct guidelines
-* Maintaining the list of additional Committers
-* Appointing representatives to work with other open source or open standards
-communities
-* Discussions, seeking consensus, and where necessary, voting on technical
-matters relating to the code base that affect multiple projects
-* Coordinating any marketing, events, or communications regarding the project
+* Coordinating technical direction of the project.
 
-The TSC elects a Chair person, who acts as the project manager, organizing meetings and
-providing oversight to project administration. The Chair is elected by the TSC.
-The Chair also serves as the OpenEXR representative on the Academy Software Foundation (ASWF) Technical
-Advisory Council (TAC). The chair represents the
-project at all ASWF TAC meetings.
+* Project governance and contribution policy.
 
-### TSC Leaders
+* GitHub repository administration.
 
-* Chair: Cary Phillips
+* Maintaining the list of additional Committers.
 
-### TSC Members
+* Appointing representatives to work with other open source or open
+  standards communities.
 
-* Cary Phillips - Industrial Light & Magic
+* Discussions, seeking consensus, and where necessary, voting on
+  technical matters relating to the code base that affect multiple
+  projects.
+
+* Coordinating any marketing, events, or communications regarding the
+  project.
+
+The TSC elects a Chair person, who acts as the project manager,
+organizing meetings and providing oversight to project
+administration. The Chair is elected by the TSC.  The Chair also
+serves as the OpenEXR representative on the Academy Software
+Foundation (ASWF) Technical Advisory Council (TAC). The chair
+represents the project at ASWF TAC meetings.
+
+### Current TSC Members
+
+* Cary Phillips (chair) - Industrial Light & Magic
 * Rod Bogart - Epic Games
 * Larry Gritz - Sony Pictures ImageWorks
 * Peter Hillman - Weta Digital, Ltd.
@@ -112,18 +121,19 @@ each Thursday at 1pm Pacific Time via Zoom video conference.  The TSC
 Chair moderates the meeting, or appoints another TSC member to
 moderate in his or her absence.
 
-Items are added to the TSC agenda which are considered contentious or are
-modifications of governance, contribution policy, TSC membership, or release
-process, in addition to topics involving the high-level technical direction of
-the project.
+Items are added to the TSC agenda which are considered contentious or
+are modifications of governance, contribution policy, TSC membership,
+or release process, in addition to topics involving the high-level
+technical direction of the project.
 
-The intention of the agenda is not to approve or review all patches. That should
-happen continuously on GitHub and be handled by the larger group of Committers.
+The intention of the agenda is not to approve or review all
+patches. That should happen continuously on GitHub and be handled by
+the larger group of Committers.
 
 Any community member or Contributor can ask that something be reviewed
 by the TSC at the meeting by logging a GitHub issue. Any Committer,
 TSC member, or the meeting chair can bring the issue to the TSC's
-attention by applying the `tsc-review` label.
+attention by applying the `TSC` label.
 
 Prior to each TSC meeting, the meeting chair will share the agenda with members
 of the TSC. TSC members can also add items to the agenda at the beginning of
@@ -134,29 +144,7 @@ The TSC may invite additional persons to participate in a non-voting capacity.
 The meeting chair is responsible for archiving the minutes, stored at 
 https://github.com/openexr/openexr/tree/master/ASWF/tsc-meetings.
 
-Due to the challenges of scheduling a global meeting with participants in
-several time zones, the TSC will seek to resolve as many agenda items as
-possible outside of meetings on the public mailing list.
+Due to the challenges of scheduling a global meeting with participants
+in several time zones, the TSC will seek to resolve as many agenda
+items as possible outside of meetings on the public mailing list.
 
-### TSC Nomination
-
-Any proposal for additional members of the TSC may be submitted by Committers
-and/or TSC members by opening an issue outlining their case. Formal consensus
-should be reached by the existing TSC members. No objections raised by any TSC
-members two weeks after the issue is opened does not imply acceptance, if
-general consensus cannot be reached by this time a formal vote is required.
-
-Should there be any objections against the nomination, the TSC is responsible
-for working with the individuals involved and finding a resolution.
-
-### TSC Succession
-
-A voting member of the TSC may nominate a successor in the event that such
-voting member decides to leave the TSC, and the TSC, including the departing
-member, shall confirm or reject such nomination by a vote.
-
-In the event that the departing member’s nomination for successor is rejected by
-vote of the TSC, the departing member shall be entitled to continue nominating
-successors until one such successor is confirmed by vote of the TSC. If the
-departing member fails or is unable to nominate a successor, the TSC may
-nominate one on the departing member’s behalf.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,7 +10,7 @@ project guidance.
 
 * [Contributors](#Contributors)
 * [Committers](#Committers)
-* [Technical Steering Committee](#Technical Steering Committee)
+* [Technical Steering Committee](#Technical-Steering-Committee)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,14 @@ OpenEXR builds on:
 
 The Python bindings in PyIlmBase support Python 2 and Python 3.
 
+## Developer Quick Start
+
+See [INSTALL](INSTALL.md) for instructions on downloading and building OpenEXR
+from source.
+
 ## Resources
 
-* Main web page: http:://www.openexr.com
+* Website: http:://www.openexr.com
 
 * GitHub repository: http://www.github.com/openexr/openexr
 
@@ -83,7 +88,7 @@ There are two primary ways to connect with the OpenEXR project:
 
 * The openexr-dev@lists.aswf.io mail list: This is a development
   focused mail list with a deep history of technical conversations and
-  decisions that have shaped the project. Subscribe a
+  decisions that have shaped the project. Subscribe at
   [openexr-dev@lists.aswf.io](https://lists.aswf.io/g/openexr-dev).
 
 * GitHub Issues: GitHub issues are used both to track bugs and to
@@ -91,14 +96,10 @@ There are two primary ways to connect with the OpenEXR project:
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
-## Developer Quick Start
+### Getting Involved
 
-See [INSTALL](INSTALL.md) for instructions on downloading and building OpenEXR
-from source.
-
-## Contributing
-
-See [CONTRIBUTING](CONTRIBUTING.md) for more information about
+OpenEXR welcomes contributions to the project. See
+[CONTRIBUTING](CONTRIBUTING.md) for more information about
 contributing to OpenEXR.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,20 +2,14 @@
 
 [![License](https://img.shields.io/badge/License-BSD%203%20Clause-blue.svg)](LICENSE.md)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2799/badge)](https://bestpractices.coreinfrastructure.org/projects/2799)
+[![Build Status](https://dev.azure.com/openexr/OpenEXR/_apis/build/status/openexr.openexr?branchName=master)](https://dev.azure.com/openexr/OpenEXR/_build/latest?definitionId=1&branchName=master)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=openexr_openexr&metric=alert_status)](https://sonarcloud.io/dashboard?id=openexr_openexr)
 
 ![openexr](/OpenEXR/doc/images/windowExample1.png)
 
-**OpenEXR** is a high dynamic-range (HDR) image file format originally
-developed by Industrial Light & Magic (ILM) in 2003 for use in
+**OpenEXR** is a high dynamic-range (HDR) image file format for use in
 computer imaging applications. It supports stereoscopic and deep
-images.  Weta Digital, Walt Disney Animation Studios, Sony Pictures
-Imageworks, Pixar Animation Studios, DreamWorks, and other studios,
-companies, and individuals have made contributions to the code
-base. OpenEXR is now maintained by the [Academy Software
-Foundation](https://www.aswf.io). The file format has seen wide
-adoption in a number of industries.
-
-OpenEXR's features include:
+images. OpenEXR's features include:
 
 * Higher dynamic range and color precision than existing 8- and 10-bit
   image file formats.
@@ -45,7 +39,14 @@ OpenEXR's features include:
   namespaces to provide protection when using multiple versions of the
   library in the same process space.
 
-## OpenEXR Sub-modules
+OpenEXR is a project of the [Academy Software
+Foundation](https://www.aswf.io).  It was originally developed by
+Industrial Light & Magic (ILM) in 2003.  Weta Digital, Walt Disney
+Animation Studios, Sony Pictures Imageworks, Pixar Animation Studios,
+DreamWorks, and other studios, companies, and individuals have made
+contributions to the code base. 
+
+## OpenEXR Sub-Modules
 
 The OpenEXR distribution consists of the following sub-modules:
 
@@ -60,7 +61,7 @@ https://github.com/openexr/openexr-images.
 
 ## Supported Platforms
 
-The OpenEXR codebase can be built with any of the following:
+OpenEXR builds on:
 
 * Linux
 * macOS
@@ -68,34 +69,37 @@ The OpenEXR codebase can be built with any of the following:
 
 The Python bindings in PyIlmBase support Python 2 and Python 3.
 
-## Dependencies
+## Resources
 
-* OpenEXR depends on [zlib](https://zlib.net).
-
-* PyIlmBase depends on [boost-python](https://github.com/boostorg/python) and
-optionally on [numpy](http://www.numpy.org).
-
-* In OpenEXR_Viewers:
-
-  * **exrdisplay** depends on [fltk](http://www.fltk.org/index.php)
-  * **playexr** depends on [Cg](https://developer.nvidia.com/cg-toolkit)
-
-See [INSTALL](INSTALL.md) for more details.
-
-## Web Resources
-
-* Main web page: http:://www.openexr.org
+* Main web page: http:://www.openexr.com
 
 * GitHub repository: http://www.github.com/openexr/openexr
 
 * Documentation: http://www.openexr.com/documentation.html.
 
-* Developer discussion mailing list: [openexr-dev@lists.aswf.io](https://lists.aswf.io/g/openexr-dev)
+### Getting Help
+
+There are two primary ways to connect with the OpenEXR project:
+
+* The openexr-dev@lists.aswf.io mail list: This is a development
+  focused mail list with a deep history of technical conversations and
+  decisions that have shaped the project. Subscribe a
+  [openexr-dev@lists.aswf.io](https://lists.aswf.io/g/openexr-dev).
+
+* GitHub Issues: GitHub issues are used both to track bugs and to
+  discuss feature requests.
+
+See [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## Developer Quick Start
 
 See [INSTALL](INSTALL.md) for instructions on downloading and building OpenEXR
 from source.
+
+## Contributing
+
+See [CONTRIBUTING](CONTRIBUTING.md) for more information about
+contributing to OpenEXR.
 
 ## License
 
@@ -108,32 +112,11 @@ include a “Signed-off-by” line indicating that the committer wrote the
 code and has the right to release it under the BSD-3-Clause
 license. See http://developercertificate.org/ for more information.
 
-## Contributing
-
-See [CONTRIBUTING](CONTRIBUTING.md) for more information about
-contributing to OpenEXR.
-
 ## Project Goverance
 
 OpenEXR is governed by the Academy Software Foundation. See
-[GOVERNANCE](GOVERNANCE.md) for more infomation.
-
-## Documentation
-
-Technical documentation is available at
-http://www.openexr.com/documentation.html, or:
-
-* [Technical Introduction](/OpenEXR/doc/TechnicalIntroduction.pdf)
-
-* [Reading and Writing Image Files](/OpenEXR/doc/ReadingAndWritingImageFiles.pdf)
-
-* [OpenEXR File Layout](/OpenEXR/doc/OpenEXRFileLayout.pdf)
-
-* [Multi-View OpenEXR](/OpenEXR/doc/MultiViewOpenEXR.pdf)
-
-* [Interpreting OpenEXR Deep Pixels](/OpenEXR/doc/InterpretingDeepPixels.pdf)
-
-* [The Theory Of OpenEXR Deep Samples](/OpenEXR/doc/InterpretingDeepPixels.pdf)
+[GOVERNANCE](GOVERNANCE.md) for more infomation about how the project
+operates.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Edits to README, CONTRIBUTING, GOVERNANCE.  Tighten up the intros, removed some section that were redundant with the charter, clarified roles and responsibilities, rearranged some sections for better clarity.  The main page has badges for Azure and Sonar.