### PR TITLE
suppress SonarCloud warnings about unhandled exceptions

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -348,7 +348,7 @@ reconstructLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
                 lineOffsets[lineOffsets.size() - i - 1] = lineOffset;
         }
     }
-    catch (...)
+    catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
     {
         //
         // Suppress all exceptions.  This functions is

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -1001,7 +1001,7 @@ DeepScanLineOutputFile::~DeepScanLineOutputFile ()
                 //
                 _data->_streamData->os->seekp (originalPosition);
             }
-            catch (...)
+            catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
             {
                 //
                 // We cannot safely throw any exceptions from here.

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -1273,7 +1273,7 @@ DeepTiledOutputFile::~DeepTiledOutputFile ()
                     //
                     _data->_streamData->os->seekp (originalPosition);
                 }
-                catch (...)
+                catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
                 {
                     //
                     // We cannot safely throw any exceptions from here.

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -683,7 +683,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
         }
         
     }
-    catch (...)
+    catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
     {
         //
         // Suppress all exceptions.  This functions is

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -871,7 +871,7 @@ OutputFile::~OutputFile ()
                     //
                     _data->_streamData->os->seekp (originalPosition);
                 }
-                catch (...)
+                catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
                 {
                     //
                     // We cannot safely throw any exceptions from here.

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -305,7 +305,7 @@ reconstructLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 		lineOffsets[lineOffsets.size() - i - 1] = lineOffset;
 	}
     }
-    catch (...)
+    catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
     {
 	//
 	// Suppress all exceptions.  This functions is

--- a/OpenEXR/IlmImf/ImfTileOffsets.cpp
+++ b/OpenEXR/IlmImf/ImfTileOffsets.cpp
@@ -187,7 +187,7 @@ TileOffsets::reconstructFromFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,bo
     {
 	findTiles (is,isMultiPart,isDeep,false);
     }
-    catch (...)
+    catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
     {
         //
         // Suppress all exceptions.  This function is called only to

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -1071,7 +1071,7 @@ TiledOutputFile::~TiledOutputFile ()
                     //
                     _streamData->os->seekp (originalPosition);
                 }
-                catch (...)
+                catch (...) //NOSONAR - suppress vulnerability reports from SonarCloud.
                 {
                     //
                     // We cannot safely throw any exceptions from here.


### PR DESCRIPTION
Add //NOSONAR to the "unhandled exception" catches that SonarCloud identifies as vulnerabilities, to suppress the warning. In each of these cases, a comment explains that no action is called for in the
catch, so it should not, in fact, be regarded as a bug or vulnerability.

Signed-off-by: Cary Phillips <cary@ilm.com>