### PR TITLE
changed AP_CPPFLAGS to AM_CPPFLAGS in PyImathNumpy/Makefile.am.

### DIFF
--- a/PyIlmBase/PyImathNumpy/Makefile.am
+++ b/PyIlmBase/PyImathNumpy/Makefile.am
@@ -13,8 +13,8 @@ imathnumpymodule_la_LIBADD  = $(top_builddir)/PyImath/libPyImath.la @BOOST_PYTHO
 
 noinst_HEADERS = 
 
-AP_CPPFLAGS = @ILMBASE_CXXFLAGS@      \
-           @NUMPY_CXXFLAGS@        \
-           -I$(top_srcdir)/PyImath \
-	       -I$(top_builddir)       \
-	       -I$(top_srcdir)/config
+AM_CPPFLAGS = @ILMBASE_CXXFLAGS@      \
+              @NUMPY_CXXFLAGS@        \
+              -I$(top_srcdir)/PyImath \
+	      -I$(top_builddir)       \
+	      -I$(top_srcdir)/config


### PR DESCRIPTION
What this a typo? The automake-generated Makefiles expect 'AM', which
was leading to a failure to find PyImath.h.

Signed-off-by: Cary Phillips <cary@ilm.com>