### PR TITLE
Makes building of fuzz test optional

### DIFF
--- a/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
@@ -1,23 +1,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-add_executable( IlmImfFuzzTest
-  fuzzFile.cpp
-  main.cpp
-  testFuzzDeepTiles.cpp
-  testFuzzDeepScanLines.cpp
-  testFuzzScanLines.cpp
-  testFuzzTiles.cpp
-)
-target_link_libraries(IlmImfFuzzTest OpenEXR::IlmImf)
-set_target_properties(IlmImfFuzzTest PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
 option(OPENEXR_RUN_FUZZ_TESTS  "Controls whether to include the fuzz tests (slow) in default test cases, there is a custom fuzz target" OFF)
 if(OPENEXR_RUN_FUZZ_TESTS)
+  add_executable( IlmImfFuzzTest
+    fuzzFile.cpp
+    main.cpp
+    testFuzzDeepTiles.cpp
+    testFuzzDeepScanLines.cpp
+    testFuzzScanLines.cpp
+    testFuzzTiles.cpp
+  )
+  target_link_libraries(IlmImfFuzzTest OpenEXR::IlmImf)
+  set_target_properties(IlmImfFuzzTest PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+  )
   add_test(NAME OpenEXR.ImfFuzz COMMAND $<TARGET_FILE:IlmImfFuzzTest>)
   set_tests_properties(OpenEXR.ImfFuzz PROPERTIES TIMEOUT 36000)
-endif()
 
-add_custom_target(fuzz ${CMAKE_CURRENT_BINARY_DIR}/IlmImfFuzzTest)
-add_dependencies(fuzz IlmImfFuzzTest)
+  add_custom_target(fuzz ${CMAKE_CURRENT_BINARY_DIR}/IlmImfFuzzTest)
+  add_dependencies(fuzz IlmImfFuzzTest)
+endif()


### PR DESCRIPTION
This further makes the fuzz test compilation dependent on whether you
want to include the fuzz test in the ctest "make test" rule. This is
mostly for sonar cloud such that it doesn't complain that the fuzz test
code isn't being run as a false positive (because it isn't included in
the test)

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>