### PR TITLE
Add missing symbol export to Slice::Make

### DIFF
--- a/OpenEXR/IlmImf/ImfAcesFile.h
+++ b/OpenEXR/IlmImf/ImfAcesFile.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2007, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -41,33 +41,33 @@
 //-----------------------------------------------------------------------------
 //
 //	ACES image file I/O.
-//	
+//
 //	This header file declares two classes that directly support
 //	image file input and output according to the Academy Image
 //	Interchange Framework.
-//	
+//
 //	The Academy Image Interchange file format is a subset of OpenEXR:
-//	
+//
 //	    - Images are stored as scanlines.  Tiles are not allowed.
-//	
+//
 //	    - Images contain three color channels, either
 //		    R, G, B (red, green, blue) or
 //		    Y, RY, BY (luminance, sub-sampled chroma)
-//	
+//
 //	    - Images may optionally contain an alpha channel.
-//	
+//
 //	    - Only three compression types are allowed:
 //		    - NO_COMPRESSION (file is not compressed)
 //		    - PIZ_COMPRESSION (lossless)
 //		    - B44A_COMPRESSION (lossy)
-//	
+//
 //	    - The "chromaticities" header attribute must specify
 //	      the ACES RGB primaries and white point.
-//	
+//
 //	class AcesOutputFile writes an OpenEXR file, enforcing the
 //	restrictions listed above.  Pixel data supplied by application
 //	software must already be in the ACES RGB space.
-//	
+//
 //	class AcesInputFile reads an OpenEXR file.  Pixel data delivered
 //	to application software is guaranteed to be in the ACES RGB space.
 //	If the RGB space of the file is not the same as the ACES space,
@@ -194,8 +194,10 @@ class AcesOutputFile
     // The pixels are assumed to contain ACES RGB data.
     //-------------------------------------------------
 
-    void			writePixels (int numScanLines = 1);
-    int				currentScanLine () const;
+    IMF_EXPORT
+    void            writePixels (int numScanLines = 1);
+    IMF_EXPORT
+    int             currentScanLine () const;
 
 
     //--------------------------

--- a/OpenEXR/IlmImf/ImfFrameBuffer.h
+++ b/OpenEXR/IlmImf/ImfFrameBuffer.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2002, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -101,7 +101,7 @@ struct Slice
 
     //--------------------------------------------
     // Subsampling: pixel (x, y) is present in the
-    // slice only if 
+    // slice only if
     //
     //  x % xSampling == 0 && y % ySampling == 0
     //
@@ -117,7 +117,7 @@ struct Slice
     //----------------------------------------------------------
 
     double              fillValue;
-    
+
 
     //-------------------------------------------------------
     // For tiled files, the xTileCoords and yTileCoords flags
@@ -155,6 +155,7 @@ struct Slice
     //
     // if xStride == 0, assumes sizeof(pixeltype)
     // if yStride == 0, assumes xStride * ( w / xSampling )
+    IMF_EXPORT
     static Slice Make(PixelType type,
                       const void *ptr,
                       const IMATH_NAMESPACE::V2i &origin,
@@ -169,6 +170,7 @@ struct Slice
                       bool yTileCoords = false);
     // same as above, just computes w and h for you
     // from a data window
+    IMF_EXPORT
     static Slice Make(PixelType type,
                       const void *ptr,
                       const IMATH_NAMESPACE::Box2i &dataWindow,

--- a/OpenEXR/exrstdattr/main.cpp
+++ b/OpenEXR/exrstdattr/main.cpp
@@ -361,20 +361,20 @@ isDate (const char attrName[], const char str[])
 
 void
 getFloat (const char attrName[],
-          int argc,
-          char **argv,
-          int &i,
+	  int argc,
+	  char **argv,
+	  int &i,
           int part,
-          SetAttrVector &attrs,
-          void (*check) (const char attrName[], float f) = 0)
+	  SetAttrVector &attrs,
+	  void (*check) (const char attrName[], float f) = 0)
 {
     if (i > argc - 2)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     float f = static_cast<float>(strtod (argv[i + 1], 0));
 
     if (check)
-        check (attrName, f);
+	check (attrName, f);
 
     attrs.push_back (SetAttr (attrName, part, new FloatAttribute (f)));
     i += 2;
@@ -383,31 +383,31 @@ getFloat (const char attrName[],
 
 void
 getPosFloatOrInf (const char attrName[],
-                 int argc,
-                 char **argv,
-                 int &i,
-                 int part,
-                 SetAttrVector &attrs)
+	          int argc,
+		  char **argv,
+		  int &i,
+                  int part,
+		  SetAttrVector &attrs)
 {
     if (i > argc - 2)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     float f;
 
     if (!strcmp (argv[i + 1], "inf") || !strcmp (argv[i + 1], "infinity"))
     {
-        f = float (half::posInf());
+	f = float (half::posInf());
     }
     else
     {
-        f = static_cast<float>(strtod (argv[i + 1], 0));
+	f = static_cast<float>(strtod (argv[i + 1], 0));
 
-        if (f <= 0)
-        {
-            cerr << "The value for the " << attrName << " attribute "
-                    "must be greater than zero, or \"infinity\"." << endl;
-            exit (1);
-        }
+	if (f <= 0)
+	{
+	    cerr << "The value for the " << attrName << " attribute "
+		    "must be greater than zero, or \"infinity\"." << endl;
+	    exit (1);
+	}
     }
 
     attrs.push_back (SetAttr (attrName, part, new FloatAttribute (f)));
@@ -417,21 +417,21 @@ getPosFloatOrInf (const char attrName[],
 
 void
 getV2f (const char attrName[],
-        int argc,
-        char **argv,
-        int &i,
+	int argc,
+	char **argv,
+	int &i,
         int part,
-        SetAttrVector &attrs,
-        void (*check) (const char attrName[], const V2f &v) = 0)
+	SetAttrVector &attrs,
+	void (*check) (const char attrName[], const V2f &v) = 0)
 {
     if (i > argc - 3)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     V2f v (static_cast<float>(strtod (argv[i + 1], 0)),
            static_cast<float>(strtod (argv[i + 2], 0)));
 
     if (check)
-        check (attrName, v);
+	check (attrName, v);
 
     attrs.push_back (SetAttr (attrName, part, new V2fAttribute (v)));
     i += 3;
@@ -440,20 +440,20 @@ getV2f (const char attrName[],
 
 void
 getRational (const char attrName[],
-            int argc,
-            char **argv,
-            int &i,
-            int part,
-            SetAttrVector &attrs,
-            void (*check) (const char attrName[], const Rational &r) = 0)
+	     int argc,
+	     char **argv,
+	     int &i,
+             int part,
+	     SetAttrVector &attrs,
+	     void (*check) (const char attrName[], const Rational &r) = 0)
 {
     if (i > argc - 3)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     Rational r (strtol (argv[i + 1], 0, 0), strtol (argv[i + 2], 0, 0));
 
     if (check)
-        check (attrName, r);
+	check (attrName, r);
 
     attrs.push_back (SetAttr (attrName, part, new RationalAttribute (r)));
     i += 3;
@@ -501,13 +501,13 @@ getNameAndString (int argc,
 
 void
 getNameAndFloat (int argc,
-                 char **argv,
-                 int &i,
+		 char **argv,
+		 int &i,
                  int part,
-                 SetAttrVector &attrs)
+		 SetAttrVector &attrs)
 {
     if (i > argc - 3)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     const char *attrName = argv[i + 1];
     float f = static_cast<float>(strtod (argv[i + 2], 0));
@@ -518,10 +518,10 @@ getNameAndFloat (int argc,
 
 void
 getNameAndInt (int argc,
-               char **argv,
-               int &i,
+	       char **argv,
+	       int &i,
                int part,
-               SetAttrVector &attrs)
+	       SetAttrVector &attrs)
 {
     if (i > argc - 3)
 	usageMessage (argv[0]);
@@ -535,14 +535,14 @@ getNameAndInt (int argc,
 
 void
 getChromaticities (const char attrName[],
-                   int argc,
-                   char **argv,
-                   int &i,
+		   int argc,
+	           char **argv,
+		   int &i,
                    int part,
-                   SetAttrVector &attrs)
+		   SetAttrVector &attrs)
 {
     if (i > argc - 9)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     ChromaticitiesAttribute *a = new ChromaticitiesAttribute;
     attrs.push_back (SetAttr (attrName, part, a));
@@ -561,31 +561,31 @@ getChromaticities (const char attrName[],
 
 void
 getEnvmap (const char attrName[],
-           int argc,
-           char **argv,
-           int &i,
+	   int argc,
+	   char **argv,
+	   int &i,
            int part,
-           SetAttrVector &attrs)
+	   SetAttrVector &attrs)
 {
     if (i > argc - 2)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     char *str = argv[i + 1];
     Envmap type;
 
     if (!strcmp (str, "latlong") || !strcmp (str, "LATLONG"))
     {
-        type = ENVMAP_LATLONG;
+	type = ENVMAP_LATLONG;
     }
     else if (!strcmp (str, "cube") || !strcmp (str, "CUBE"))
     {
-        type = ENVMAP_CUBE;
+	type = ENVMAP_CUBE;
     }
     else
     {
-        cerr << "The value for the " << attrName << " attribute "
-                "must be either LATLONG or CUBE." << endl;
-        exit (1);
+	cerr << "The value for the " << attrName << " attribute "
+	        "must be either LATLONG or CUBE." << endl;
+	exit (1);
     }
 
     attrs.push_back (SetAttr (attrName, part, new EnvmapAttribute (type)));
@@ -595,14 +595,14 @@ getEnvmap (const char attrName[],
 
 void
 getKeyCode (const char attrName[],
-            int argc,
-            char **argv,
-            int &i,
+	    int argc,
+	    char **argv,
+	    int &i,
             int part,
-            SetAttrVector &attrs)
+	    SetAttrVector &attrs)
 {
     if (i > argc - 8)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     KeyCodeAttribute *a = new KeyCodeAttribute;
     attrs.push_back (SetAttr (attrName, part, a));
@@ -646,7 +646,7 @@ getPart (const char attrName[],
          int &part)
 {
     if (i > argc - 2)
-        usageMessage (argv[0]);
+	usageMessage (argv[0]);
 
     if (!strcmp (argv[i + 1], "any"))
         part = -1;
@@ -665,18 +665,18 @@ main(int argc, char **argv)
     //
 
     if (argc < 2)
-        usageMessage (argv[0], true);
+	usageMessage (argv[0], true);
 
     int exitStatus = 0;
 
     try
     {
-        const char *inFileName = 0;
-        const char *outFileName = 0;
+	const char *inFileName = 0;
+	const char *outFileName = 0;
 
-        SetAttrVector attrs;
-        int part = -1;
-        int i = 1;
+	SetAttrVector attrs;
+	int part = -1;
+	int i = 1;
 
 	while (i < argc)
 	{

--- a/OpenEXR/exrstdattr/main.cpp
+++ b/OpenEXR/exrstdattr/main.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2004-2014, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -248,7 +248,7 @@ struct SetAttr
     string      name;
     int         part;
     Attribute * attr;
-    
+
     SetAttr (const string &name, int part, Attribute *attr):
         name (name), part (part), attr (attr) {}
 };
@@ -361,20 +361,20 @@ isDate (const char attrName[], const char str[])
 
 void
 getFloat (const char attrName[],
-	  int argc,
-	  char **argv,
-	  int &i,
+          int argc,
+          char **argv,
+          int &i,
           int part,
-	  SetAttrVector &attrs,
-	  void (*check) (const char attrName[], float f) = 0)
+          SetAttrVector &attrs,
+          void (*check) (const char attrName[], float f) = 0)
 {
     if (i > argc - 2)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
-    float f = strtod (argv[i + 1], 0);
+    float f = static_cast<float>(strtod (argv[i + 1], 0));
 
     if (check)
-	check (attrName, f);
+        check (attrName, f);
 
     attrs.push_back (SetAttr (attrName, part, new FloatAttribute (f)));
     i += 2;
@@ -383,31 +383,31 @@ getFloat (const char attrName[],
 
 void
 getPosFloatOrInf (const char attrName[],
-	          int argc,
-		  char **argv,
-		  int &i,
-                  int part,
-		  SetAttrVector &attrs)
+                 int argc,
+                 char **argv,
+                 int &i,
+                 int part,
+                 SetAttrVector &attrs)
 {
     if (i > argc - 2)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     float f;
-    
+
     if (!strcmp (argv[i + 1], "inf") || !strcmp (argv[i + 1], "infinity"))
     {
-	f = float (half::posInf());
+        f = float (half::posInf());
     }
     else
     {
-	f = strtod (argv[i + 1], 0);
+        f = static_cast<float>(strtod (argv[i + 1], 0));
 
-	if (f <= 0)
-	{
-	    cerr << "The value for the " << attrName << " attribute "
-		    "must be greater than zero, or \"infinity\"." << endl;
-	    exit (1);
-	}
+        if (f <= 0)
+        {
+            cerr << "The value for the " << attrName << " attribute "
+                    "must be greater than zero, or \"infinity\"." << endl;
+            exit (1);
+        }
     }
 
     attrs.push_back (SetAttr (attrName, part, new FloatAttribute (f)));
@@ -417,20 +417,21 @@ getPosFloatOrInf (const char attrName[],
 
 void
 getV2f (const char attrName[],
-	int argc,
-	char **argv,
-	int &i,
+        int argc,
+        char **argv,
+        int &i,
         int part,
-	SetAttrVector &attrs,
-	void (*check) (const char attrName[], const V2f &v) = 0)
+        SetAttrVector &attrs,
+        void (*check) (const char attrName[], const V2f &v) = 0)
 {
     if (i > argc - 3)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
-    V2f v (strtod (argv[i + 1], 0), strtod (argv[i + 2], 0));
+    V2f v (static_cast<float>(strtod (argv[i + 1], 0)),
+           static_cast<float>(strtod (argv[i + 2], 0)));
 
     if (check)
-	check (attrName, v);
+        check (attrName, v);
 
     attrs.push_back (SetAttr (attrName, part, new V2fAttribute (v)));
     i += 3;
@@ -439,20 +440,20 @@ getV2f (const char attrName[],
 
 void
 getRational (const char attrName[],
-	     int argc,
-	     char **argv,
-	     int &i,
-             int part,
-	     SetAttrVector &attrs,
-	     void (*check) (const char attrName[], const Rational &r) = 0)
+            int argc,
+            char **argv,
+            int &i,
+            int part,
+            SetAttrVector &attrs,
+            void (*check) (const char attrName[], const Rational &r) = 0)
 {
     if (i > argc - 3)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     Rational r (strtol (argv[i + 1], 0, 0), strtol (argv[i + 2], 0, 0));
 
     if (check)
-	check (attrName, r);
+        check (attrName, r);
 
     attrs.push_back (SetAttr (attrName, part, new RationalAttribute (r)));
     i += 3;
@@ -500,16 +501,16 @@ getNameAndString (int argc,
 
 void
 getNameAndFloat (int argc,
-		 char **argv,
-		 int &i,
+                 char **argv,
+                 int &i,
                  int part,
-		 SetAttrVector &attrs)
+                 SetAttrVector &attrs)
 {
     if (i > argc - 3)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     const char *attrName = argv[i + 1];
-    float f = strtod (argv[i + 2], 0);
+    float f = static_cast<float>(strtod (argv[i + 2], 0));
     attrs.push_back (SetAttr (attrName, part, new FloatAttribute (f)));
     i += 3;
 }
@@ -517,10 +518,10 @@ getNameAndFloat (int argc,
 
 void
 getNameAndInt (int argc,
-	       char **argv,
-	       int &i,
+               char **argv,
+               int &i,
                int part,
-	       SetAttrVector &attrs)
+               SetAttrVector &attrs)
 {
     if (i > argc - 3)
 	usageMessage (argv[0]);
@@ -534,57 +535,57 @@ getNameAndInt (int argc,
 
 void
 getChromaticities (const char attrName[],
-		   int argc,
-	           char **argv,
-		   int &i,
+                   int argc,
+                   char **argv,
+                   int &i,
                    int part,
-		   SetAttrVector &attrs)
+                   SetAttrVector &attrs)
 {
     if (i > argc - 9)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     ChromaticitiesAttribute *a = new ChromaticitiesAttribute;
     attrs.push_back (SetAttr (attrName, part, a));
 
-    a->value().red.x   = strtod (argv[i + 1], 0);
-    a->value().red.y   = strtod (argv[i + 2], 0);
-    a->value().green.x = strtod (argv[i + 3], 0);
-    a->value().green.y = strtod (argv[i + 4], 0);
-    a->value().blue.x  = strtod (argv[i + 5], 0);
-    a->value().blue.y  = strtod (argv[i + 6], 0);
-    a->value().white.x = strtod (argv[i + 7], 0);
-    a->value().white.y = strtod (argv[i + 8], 0);
+    a->value().red.x   = static_cast<float>(strtod (argv[i + 1], 0));
+    a->value().red.y   = static_cast<float>(strtod (argv[i + 2], 0));
+    a->value().green.x = static_cast<float>(strtod (argv[i + 3], 0));
+    a->value().green.y = static_cast<float>(strtod (argv[i + 4], 0));
+    a->value().blue.x  = static_cast<float>(strtod (argv[i + 5], 0));
+    a->value().blue.y  = static_cast<float>(strtod (argv[i + 6], 0));
+    a->value().white.x = static_cast<float>(strtod (argv[i + 7], 0));
+    a->value().white.y = static_cast<float>(strtod (argv[i + 8], 0));
     i += 9;
 }
 
 
 void
 getEnvmap (const char attrName[],
-	   int argc,
-	   char **argv,
-	   int &i,
+           int argc,
+           char **argv,
+           int &i,
            int part,
-	   SetAttrVector &attrs)
+           SetAttrVector &attrs)
 {
     if (i > argc - 2)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     char *str = argv[i + 1];
     Envmap type;
 
     if (!strcmp (str, "latlong") || !strcmp (str, "LATLONG"))
     {
-	type = ENVMAP_LATLONG;
+        type = ENVMAP_LATLONG;
     }
     else if (!strcmp (str, "cube") || !strcmp (str, "CUBE"))
     {
-	type = ENVMAP_CUBE;
+        type = ENVMAP_CUBE;
     }
     else
     {
-	cerr << "The value for the " << attrName << " attribute "
-	        "must be either LATLONG or CUBE." << endl;
-	exit (1);
+        cerr << "The value for the " << attrName << " attribute "
+                "must be either LATLONG or CUBE." << endl;
+        exit (1);
     }
 
     attrs.push_back (SetAttr (attrName, part, new EnvmapAttribute (type)));
@@ -594,14 +595,14 @@ getEnvmap (const char attrName[],
 
 void
 getKeyCode (const char attrName[],
-	    int argc,
-	    char **argv,
-	    int &i,
+            int argc,
+            char **argv,
+            int &i,
             int part,
-	    SetAttrVector &attrs)
+            SetAttrVector &attrs)
 {
     if (i > argc - 8)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     KeyCodeAttribute *a = new KeyCodeAttribute;
     attrs.push_back (SetAttr (attrName, part, a));
@@ -645,7 +646,7 @@ getPart (const char attrName[],
          int &part)
 {
     if (i > argc - 2)
-	usageMessage (argv[0]);
+        usageMessage (argv[0]);
 
     if (!strcmp (argv[i + 1], "any"))
         part = -1;
@@ -664,18 +665,18 @@ main(int argc, char **argv)
     //
 
     if (argc < 2)
-	usageMessage (argv[0], true);
+        usageMessage (argv[0], true);
 
     int exitStatus = 0;
 
     try
     {
-	const char *inFileName = 0;
-	const char *outFileName = 0;
+        const char *inFileName = 0;
+        const char *outFileName = 0;
 
-	SetAttrVector attrs;
-	int part = -1;
-	int i = 1;
+        SetAttrVector attrs;
+        int part = -1;
+        int i = 1;
 
 	while (i < argc)
 	{


### PR DESCRIPTION
This fixes the exrstdattr build failure, allowing the Windows build to complete successfully. This change also corrects the narrowing warnings on strtod, and some whitespace cleanup snuck in.