### PR TITLE
Address issues with mingw and win32 wide filenames

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -80,7 +80,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ifstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -75,7 +75,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -81,7 +81,6 @@ using IMATH_NAMESPACE::Box2i;
 using IMATH_NAMESPACE::V2i;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::map;
 using std::min;
 using std::max;

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -77,7 +77,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::min;
 using std::max;
 using ILMTHREAD_NAMESPACE::Mutex;

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -73,7 +73,6 @@ using IMATH_NAMESPACE::divp;
 using IMATH_NAMESPACE::modp;
 using std::string;
 using std::vector;
-using std::ifstream;
 using std::min;
 using std::max;
 using std::sort;

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -79,7 +79,6 @@ using IMATH_NAMESPACE::Box2i;
 using IMATH_NAMESPACE::V2i;
 using std::string;
 using std::vector;
-using std::ofstream;
 using std::map;
 using std::min;
 using std::max;

--- a/OpenEXR/IlmImfFuzzTest/fuzzFile.cpp
+++ b/OpenEXR/IlmImfFuzzTest/fuzzFile.cpp
@@ -45,6 +45,7 @@
 
 #include <iostream>
 #include <fstream>
+#include "../IlmImfTest/TestUtilFStream.h"
 
 // Handle the case when the custom namespace is not exposed
 #include <OpenEXRConfig.h>
@@ -58,7 +59,9 @@ namespace {
 Int64
 lengthOfFile (const char fileName[])
 {
-    ifstream ifs (fileName, ios_base::binary);
+    ifstream ifs;
+    testutil::OpenStreamWithUTF8Name (
+        ifs, fileName, ios::in | ios_base::binary);
 
     if (!ifs)
 	return 0;
@@ -80,7 +83,9 @@ fuzzFile (const char goodFile[],
     // Read the input file.
     //
 
-    ifstream ifs (goodFile, ios_base::binary);
+    ifstream ifs;
+    testutil::OpenStreamWithUTF8Name (
+        ifs, goodFile, ios::in | ios_base::binary);
 
     if (!ifs)
 	THROW_ERRNO ("Cannot open file " << goodFile << " (%T).");
@@ -110,7 +115,9 @@ fuzzFile (const char goodFile[],
     // Save the damaged file contents in the output file.
     //
 
-    ofstream ofs (brokenFile, ios_base::binary);
+    ofstream ofs;
+    testutil::OpenStreamWithUTF8Name (
+        ofs, brokenFile, ios::out | ios_base::binary);
 
     if (!ofs)
 	THROW_ERRNO ("Cannot open file " << brokenFile << " (%T)." << endl);

--- a/OpenEXR/IlmImfTest/TestUtilFStream.h
+++ b/OpenEXR/IlmImfTest/TestUtilFStream.h
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+#pragma once
+
+#ifndef INCLUDE_TestUtilFStream_h_
+#define INCLUDE_TestUtilFStream_h_ 1
+
+#include <fstream>
+#include <string>
+
+#ifdef _WIN32
+# define VC_EXTRALEAN
+# include <string.h>
+# include <windows.h>
+# include <io.h>
+# include <fcntl.h>
+# include <sys/types.h>
+# include <sys/stat.h>
+# include <share.h>
+#endif
+
+namespace testutil
+{
+#ifdef _WIN32
+inline std::wstring
+WidenFilename (const char* filename)
+{
+    std::wstring ret;
+    int          fnlen = static_cast<int> (strlen (filename));
+    int len = MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, NULL, 0);
+    if (len > 0)
+    {
+        ret.resize (len);
+        MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, &ret[0], len);
+    }
+    return ret;
+}
+
+// This is a big work around mechanism for compiling using mingw / gcc under windows
+// until mingw 9 where they add the wide filename version of open
+# if (defined(__GLIBCXX__) && !(defined(_GLIBCXX_HAVE_WFOPEN) && defined(_GLIBCXX_USE_WCHAR_T)))
+#  define USE_WIDEN_FILEBUF 1
+template <typename CharT, typename TraitsT>
+class WidenFilebuf : public std::basic_filebuf<CharT, TraitsT>
+{
+    inline int mode_to_flags (std::ios_base::openmode mode)
+    {
+        int flags = 0;
+        if (mode & std::ios_base::in) flags |= _O_RDONLY;
+        if (mode & std::ios_base::out)
+        {
+            flags |= _O_WRONLY;
+            flags |= _O_CREAT;
+            if (mode & std::ios_base::app) flags |= _O_APPEND;
+            if (mode & std::ios_base::trunc) flags |= _O_TRUNC;
+        }
+        if (mode & std::ios_base::binary)
+            flags |= _O_BINARY;
+        else
+            flags |= _O_TEXT;
+        return flags;
+    }
+
+public:
+    using base_filebuf = std::basic_filebuf<CharT, TraitsT>;
+    inline base_filebuf* wide_open (std::wstring& fn, std::ios_base::openmode m)
+    {
+        if (this->is_open () || fn.empty ())
+            return nullptr;
+
+        int     fd;
+        errno_t e = _wsopen_s (
+            &fd,
+            fn.c_str (),
+            mode_to_flags (m),
+            _SH_DENYNO,
+            _S_IREAD | _S_IWRITE);
+        if (e != 0)
+            return nullptr;
+
+        // sys_open will do an fdopen internally which will then clean up the fd upon close
+        this->_M_file.sys_open (fd, m);
+        if (this->is_open ())
+        {
+            // reset the internal state, these members are consistent between gcc versions 4.3 - 9
+            // but at 9, the wfopen stuff should become available, such that this will no longer be
+            // active
+            this->_M_allocate_internal_buffer ();
+            this->_M_mode    = m;
+            this->_M_reading = false;
+            this->_M_writing = false;
+            this->_M_set_buffer (-1);
+            this->_M_state_last = this->_M_state_cur = this->_M_state_beg;
+
+            if ((m & std::ios_base::ate) &&
+                this->seekoff (0, std::ios_base::end, m) ==
+                    static_cast<typename base_filebuf::pos_type> (-1))
+            {
+                this->close ();
+                return nullptr;
+            }
+        }
+        return this;
+    }
+};
+# endif // __GLIBCXX__
+#endif     // _WIN32
+
+template <typename StreamType>
+inline void
+OpenStreamWithUTF8Name (
+    StreamType& is, const char* filename, std::ios_base::openmode mode)
+{
+#ifdef _WIN32
+    std::wstring wfn = WidenFilename (filename);
+# ifdef USE_WIDEN_FILEBUF
+    using CharT   = typename StreamType::char_type;
+    using TraitsT = typename StreamType::traits_type;
+    using wbuf    = WidenFilebuf<CharT, TraitsT>;
+    if (!static_cast<wbuf*> (is.rdbuf ())->wide_open (wfn, mode))
+        is.setstate (std::ios_base::failbit);
+    else
+        is.clear ();
+# else
+    is.rdbuf ()->open (wfn.c_str (), mode);
+# endif
+#else
+    is.rdbuf ()->open (filename, mode);
+#endif
+}
+
+} // namespace testutil
+
+#endif // INCLUDE_TestUtilFStream_h_

--- a/OpenEXR/IlmImfTest/main.cpp
+++ b/OpenEXR/IlmImfTest/main.cpp
@@ -105,10 +105,12 @@
 #include <string.h>
 #include <time.h>
 
-#if defined(OPENEXR_IMF_HAVE_LINUX_PROCFS) || defined(OPENEXR_IMF_HAVE_DARWIN)
-    #include <unistd.h>
-    #include <sstream>
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <unistd.h>
 #endif
+#include <sstream>
 
 using namespace std;
 
@@ -131,8 +133,21 @@ main (int argc, char *argv[])
 
     while (true)
     {
+#ifdef _WIN32
+        char  tmpbuf[4096];
+        DWORD len = GetTempPathA (4096, tmpbuf);
+        if (len == 0 || len > 4095)
+        {
+            cerr << "Cannot retrieve temporary directory" << endl;
+            return 1;
+        }
+        tempDir = tmpbuf;
+        // windows does this automatically
+        // tempDir += IMF_PATH_SEPARATOR;
+        tempDir += "IlmImfTest_";
+#else
         tempDir = IMF_TMP_DIR "IlmImfTest_";
-
+#endif
         for (int i = 0; i < 8; ++i)
             tempDir += ('A' + rand48.nexti() % 26);
 
@@ -210,15 +225,15 @@ main (int argc, char *argv[])
 
     //#ifdef ENABLE_IMFHUGETEST
     // defined via configure with --enable-imfhugetest=yes/no
-    #if 0
+#if 0
         TEST (testDeepScanLineHuge, "deep");
-    #endif    
+#endif    
 
 
     std::cout << "removing temp dir " << tempDir << std::endl;
     rmdir (tempDir.c_str());
 
-    #ifdef OPENEXR_IMF_HAVE_LINUX_PROCFS
+#ifdef OPENEXR_IMF_HAVE_LINUX_PROCFS
 
         //
         // Allow the user to check for file descriptor leaks
@@ -236,7 +251,7 @@ main (int argc, char *argv[])
 
         std::cout << std::endl;
 
-    #endif
+#endif
 
     return 0;
 }

--- a/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
+++ b/OpenEXR/IlmImfTest/testBackwardCompatibility.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "testBackwardCompatibility.h"
+#include "TestUtilFStream.h"
 
 #include <ImfArray.h>
 #include <ImfHeader.h>
@@ -104,8 +105,9 @@ const int H = 197;
 void
 diffImageFiles (const char * fn1, const char * fn2)
 {
-    ifstream i1 (fn1, ios::binary);
-    ifstream i2 (fn2, ios::binary);
+    ifstream i1, i2;
+    testutil::OpenStreamWithUTF8Name (i1, fn1, ios::in | ios::binary);
+    testutil::OpenStreamWithUTF8Name (i2, fn2, ios::in | ios::binary);
 
     if(!i1.good()){THROW (IEX_NAMESPACE::BaseExc, string("cannot open ") + string(fn1));}
     if(!i2.good()){THROW (IEX_NAMESPACE::BaseExc, string("cannot open ") + string(fn2));}

--- a/OpenEXR/IlmImfTest/testExistingStreams.cpp
+++ b/OpenEXR/IlmImfTest/testExistingStreams.cpp
@@ -54,6 +54,7 @@
 #include <vector>
 #include <ImfChannelList.h>
 
+#include "TestUtilFStream.h"
 
 using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
@@ -139,7 +140,9 @@ MMIFStream::MMIFStream (const char fileName[]):
     _length (0),
     _pos (0)
 {
-    std::ifstream ifs (fileName, ios_base::binary);
+    std::ifstream ifs;
+    testutil::OpenStreamWithUTF8Name (
+        ifs, fileName, ios::in | ios_base::binary);
 
     //
     // Get length of file
@@ -229,19 +232,23 @@ writeReadScanLines (const char fileName[],
 
     {
         cout << "writing";
-	remove (fileName);
-	std::ofstream os (fileName, ios_base::binary);
-	StdOFStream ofs (os, fileName);
-	RgbaOutputFile out (ofs, header, WRITE_RGBA);
-	out.setFrameBuffer (&p1[0][0], 1, width);
-	out.writePixels (height);
+        remove (fileName);
+        std::ofstream os;
+        testutil::OpenStreamWithUTF8Name (
+            os, fileName, ios::out | ios_base::binary);
+        StdOFStream ofs (os, fileName);
+        RgbaOutputFile out (ofs, header, WRITE_RGBA);
+        out.setFrameBuffer (&p1[0][0], 1, width);
+        out.writePixels (height);
     }
 
     {
         cout << ", reading";
-	std::ifstream is (fileName, ios_base::binary);
-	StdIFStream ifs (is, fileName);
-	RgbaInputFile in (ifs);
+        std::ifstream is;
+        testutil::OpenStreamWithUTF8Name (
+            is, fileName, ios::in | ios_base::binary);
+        StdIFStream ifs (is, fileName);
+        RgbaInputFile in (ifs);
 
 	const Box2i &dw = in.dataWindow();
 	int w = dw.max.x - dw.min.x + 1;
@@ -333,7 +340,9 @@ writeReadMultiPart (const char fileName[],
     {
         cout << "writing";
         remove (fileName);
-        std::ofstream os (fileName, ios_base::binary);
+        std::ofstream os;
+        testutil::OpenStreamWithUTF8Name (
+            os, fileName, ios::out | ios_base::binary);
         StdOFStream ofs (os, fileName);
         MultiPartOutputFile out (ofs, &headers[0],2);
         FrameBuffer f;
@@ -352,7 +361,9 @@ writeReadMultiPart (const char fileName[],
                         
     {
         cout << ", reading";
-        std::ifstream is (fileName, ios_base::binary);
+        std::ifstream is;
+        testutil::OpenStreamWithUTF8Name (
+            is, fileName, ios::in | ios_base::binary);
         StdIFStream ifs (is, fileName);
         MultiPartInputFile in (ifs);
         
@@ -464,19 +475,23 @@ writeReadTiles (const char fileName[],
 
     {
         cout << "writing";
-	remove (fileName);
-	std::ofstream os (fileName, ios_base::binary);
-	StdOFStream ofs (os, fileName);
-	TiledRgbaOutputFile out (ofs, header, WRITE_RGBA, 20, 20, ONE_LEVEL);
-	out.setFrameBuffer (&p1[0][0], 1, width);
+        remove (fileName);
+        std::ofstream os;
+        testutil::OpenStreamWithUTF8Name (
+            os, fileName, ios_base::out | ios_base::binary);
+        StdOFStream ofs (os, fileName);
+        TiledRgbaOutputFile out (ofs, header, WRITE_RGBA, 20, 20, ONE_LEVEL);
+        out.setFrameBuffer (&p1[0][0], 1, width);
         out.writeTiles (0, out.numXTiles() - 1, 0, out.numYTiles() - 1);
     }
 
     {
         cout << ", reading";
-	std::ifstream is (fileName, ios_base::binary);
-	StdIFStream ifs (is, fileName);
-	TiledRgbaInputFile in (ifs);
+        std::ifstream is;
+        testutil::OpenStreamWithUTF8Name (
+            is, fileName, ios::in | ios_base::binary);
+        StdIFStream ifs (is, fileName);
+        TiledRgbaInputFile in (ifs);
 
 	const Box2i &dw = in.dataWindow();
 	int w = dw.max.x - dw.min.x + 1;

--- a/OpenEXR/IlmImfTest/testMagic.cpp
+++ b/OpenEXR/IlmImfTest/testMagic.cpp
@@ -44,6 +44,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "TestUtilFStream.h"
+
 #ifndef ILM_IMF_TEST_IMAGEDIR
     #define ILM_IMF_TEST_IMAGEDIR
 #endif
@@ -60,7 +62,8 @@ testFile1 (const char fileName[], bool isImfFile)
 {
     cout << fileName << " " << flush;
 
-    ifstream f (fileName, ios_base::binary);
+    ifstream f;
+    testutil::OpenStreamWithUTF8Name (f, fileName, ios::in | ios_base::binary);
     assert (!!f);
 
     char bytes[4];

--- a/OpenEXR/IlmImfTest/testPreviewImage.cpp
+++ b/OpenEXR/IlmImfTest/testPreviewImage.cpp
@@ -42,6 +42,7 @@
 #include <fstream>
 #include <stdio.h>
 #include <assert.h>
+#include "TestUtilFStream.h"
 
 #ifndef ILM_IMF_TEST_IMAGEDIR
     #define ILM_IMF_TEST_IMAGEDIR
@@ -179,20 +180,23 @@ readWriteFiles (const char fileName1[],
     cout << "comparing files " << fileName2 << " and " << fileName3 << endl;
 
     {
-	ifstream file2 (fileName2, std::ios_base::binary);
-	ifstream file3 (fileName3, std::ios_base::binary);
+        ifstream file2, file3;
+        testutil::OpenStreamWithUTF8Name (
+            file2, fileName2, std::ios_base::in | std::ios_base::binary);
+        testutil::OpenStreamWithUTF8Name (
+            file3, fileName3, std::ios_base::in | std::ios_base::binary);
 
-	while (true)
-	{
-	    int c2 = file2.get();
-	    int c3 = file3.get();
+        while (true)
+        {
+            int c2 = file2.get();
+            int c3 = file3.get();
 
-	    if (file2.eof())
-		break;
+            if (file2.eof())
+                break;
 
-	    assert (c2 == c3);
-	    assert (!!file2 && !!file3);
-	}
+            assert (c2 == c3);
+            assert (!!file2 && !!file3);
+        }
     }
 
     remove (fileName2);

--- a/OpenEXR/IlmImfUtilTest/main.cpp
+++ b/OpenEXR/IlmImfUtilTest/main.cpp
@@ -51,8 +51,10 @@
 #include <cstring>
 #include <time.h>
 
-#if defined(OPENEXR_IMF_HAVE_LINUX_PROCFS) || defined(OPENEXR_IMF_HAVE_DARWIN)
-    #include <unistd.h>
+#ifdef _WIN32
+# include <windows.h>
+#else
+# include <unistd.h>
 #endif
 
 using namespace std;
@@ -74,8 +76,21 @@ main (int argc, char *argv[])
 
     while (true)
     {
+#ifdef _WIN32
+        char tmpbuf[4096];
+        DWORD len = GetTempPathA(4096, tmpbuf);
+        if ( len == 0 || len > 4095 )
+        {
+            cerr << "Cannot retrieve temporary directory" << endl;
+            return 1;
+        }
+        tempDir = tmpbuf;
+        // windows does this automatically
+        // tempDir += IMF_PATH_SEPARATOR;
+        tempDir += "IlmImfTest_";
+#else
         tempDir = IMF_TMP_DIR "IlmImfTest_";
-
+#endif
         for (int i = 0; i < 8; ++i)
             tempDir += ('A' + rand48.nexti() % 26);
 

--- a/OpenEXR/IlmImfUtilTest/testDeepImage.cpp
+++ b/OpenEXR/IlmImfUtilTest/testDeepImage.cpp
@@ -595,8 +595,9 @@ testCropping (const string &fileName)
     verifyPixelsAreEqual <half> (img3.level(0).channel ("A"),
                                  img1.level(0).channel ("A"),
                                  0, 0);
-}
 
+    remove (fileName.c_str ());
+}
 
 void
 testRenameChannel ()

--- a/OpenEXR/IlmImfUtilTest/testFlatImage.cpp
+++ b/OpenEXR/IlmImfUtilTest/testFlatImage.cpp
@@ -495,8 +495,8 @@ testCropping (const string &fileName)
     verifyPixelsAreEqual <half> (img3.level(0).channel ("A"),
                                  img1.level(0).channel ("A"),
                                  0, 0);
+    remove (fileName.c_str ());
 }
-
 
 void
 testRenameChannel ()

--- a/OpenEXR/IlmImfUtilTest/testIO.cpp
+++ b/OpenEXR/IlmImfUtilTest/testIO.cpp
@@ -250,4 +250,5 @@ testIO (const string &tempDir)
 	cerr << "ERROR -- caught exception: " << e.what() << endl;
 	assert (false);
     }
+    remove ((tempDir + "io.exr").c_str());
 }


### PR DESCRIPTION
This cleans up the internals of ImfStdIO.cpp to use wide filenames under win32 so as to handle when compiling with mingw, where older versions do not correctly implement the MSVC extension to take a wide filename in to the filename. This does that, and then adds a similar mechanism to the locations in the various test programs that were creating i/o fstreams.

Further, it fixes issues accessing the temp folder for the IlmImfTest and UtilTest programs under win32, and cleans up files.

The default "make test" now passes when cross compiling for windows using mingw from linux, running under wine.