### PR TITLE
Updated Azure MacOS job to install Boost python and numpy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ jobs:
       cxxCompiler: $(cxxCompiler)
       cCompiler: $(cCompiler)
       cmakeOpts: -- -j4
+      excludeTests: 'PyIlmBase.*'
 
   - task: PublishTestResults@2
     condition: succeededOrFailed()
@@ -120,20 +121,20 @@ jobs:
   steps:
   - template: share/ci/templates/checkout.yml
   - bash: |
-      share/ci/scripts/macos/install.sh
       share/ci/scripts/macos/install_python.sh 2.7.16
+      share/ci/scripts/macos/install_python.sh 3.7.4
+      share/ci/scripts/macos/install.sh
     displayName: Install dependencies
 
   - template: share/ci/templates/configure.yml
     parameters:
-      cmakeOpts: |
-        -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 \
-        -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib \
-        -DPYTHON_EXECUTABLE=$(which python2)
+      cmakeOpts: ''
 
   - template: share/ci/templates/build.yml
     parameters:
       cmakeOpts: -- -j4
+      excludeTests: ''
+
 
 # ------------------------------------------------------------------------------
 # Windows

--- a/share/ci/scripts/macos/install.sh
+++ b/share/ci/scripts/macos/install.sh
@@ -3,4 +3,7 @@
 set -ex
 
 brew update
-brew install glew
+brew install boost
+brew install boost-python
+brew install boost-python3
+pip3 install numpy

--- a/share/ci/templates/build.yml
+++ b/share/ci/templates/build.yml
@@ -6,6 +6,7 @@ parameters:
   cxxCompiler: ''
   cCompiler: ''
   cmakeOpts: ''
+  excludeTests: ''
 
 steps:
 - bash: |
@@ -23,6 +24,8 @@ steps:
   workingDirectory: _build
   displayName: Build OpenEXR
 
-- template: test.yml
+- template: test.yml 
+  parameters:
+    excludeTests: ${{ parameters.excludeTests }}
 
 

--- a/share/ci/templates/test.yml
+++ b/share/ci/templates/test.yml
@@ -1,8 +1,11 @@
 # azure-pipelines template file
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops
 
+parameters:
+  excludeTests: ''
+
 steps:
 - bash: |
-    ctest -T Test -E PyIlmBase.* --output-on-failure -VV
+    ctest -T Test -E ${{ parameters.excludeTests }} --output-on-failure -VV
   workingDirectory: _build
   displayName: Test OpenEXR


### PR DESCRIPTION
This installs boost, boost-python and numpy so the MacOS job can build PyIlmBase. 

Signed-off-by: Christina Tempelaar-Lietz <xlietz@gmail.com>