### PR TITLE
Disable the debug postfix for the python modules

### DIFF
--- a/PyIlmBase/PyImathNumpy/CMakeLists.txt
+++ b/PyIlmBase/PyImathNumpy/CMakeLists.txt
@@ -22,6 +22,7 @@ if(TARGET Python2::Python AND
   set_target_properties(imathnumpy_python2 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python${Python2_VERSION_MAJOR}_${Python2_VERSION_MINOR}/"
     LIBRARY_OUTPUT_NAME "imathnumpy"
+    DEBUG_POSTFIX ""
   )
 endif()
 
@@ -46,5 +47,6 @@ if(TARGET Python3::Python AND
   set_target_properties(imathnumpy_python3 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR}/"
     LIBRARY_OUTPUT_NAME "imathnumpy"
+    DEBUG_POSTFIX ""
   )
 endif()

--- a/PyIlmBase/config/ModuleDefine.cmake
+++ b/PyIlmBase/config/ModuleDefine.cmake
@@ -117,6 +117,7 @@ function(PYILMBASE_DEFINE_MODULE modname)
     set_target_properties(${modname}_python2 PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python${Python2_VERSION_MAJOR}_${Python2_VERSION_MINOR}/"
       LIBRARY_OUTPUT_NAME "${modname}"
+      DEBUG_POSTFIX ""
     )
     #### TODO: Define installation rules
   endif()
@@ -142,6 +143,7 @@ function(PYILMBASE_DEFINE_MODULE modname)
     set_target_properties(${modname}_python3 PROPERTIES
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/python${Python3_VERSION_MAJOR}_${Python3_VERSION_MINOR}/"
       LIBRARY_OUTPUT_NAME "${modname}"
+      DEBUG_POSTFIX ""
     )
     #### TODO: Define installation rules
   endif()


### PR DESCRIPTION
If we are building a debug configuration, make the python modules still
output their base name instead of imath_d.so or whatever, otherwise
import does not work.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>