### PR TITLE
Create a "holder" object to fix stale reference to array

### DIFF
--- a/PyIlmBase/PyImathNumpy/imathnumpymodule.cpp
+++ b/PyIlmBase/PyImathNumpy/imathnumpymodule.cpp
@@ -60,7 +60,6 @@ template <typename T>
 static void
 setBaseObject (PyObject* nparr, T& arr)
 {
-    using converter_type = typename reference_existing_object::apply<T*>::type;
     using holder         = Holder<T>;
 
     holder* ph = new holder (arr);


### PR DESCRIPTION
we were creating a reference to an int array, but then that object no
longer was existing, so was being deleted, but we are still trying to
use it. This uses the python capsule mechanism to stash off the array
and then clean it up

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>