### PR TITLE
Force the python binding libraries to shared

### DIFF
--- a/PyIlmBase/CMakeLists.txt
+++ b/PyIlmBase/CMakeLists.txt
@@ -140,6 +140,10 @@ include(config/ModuleDefine.cmake)
 ##########################
 add_subdirectory(config)
 
+if(NOT BUILD_SHARED_LIBS)
+  message(WARNING "Forcing python bindings to be built with dynamic libraries")
+endif()
+
 add_subdirectory( PyIex )
 add_subdirectory( PyImath )
 if(TARGET Python2::IlmBaseNumPy OR TARGET Python3::IlmBaseNumPy)

--- a/PyIlmBase/config/ModuleDefine.cmake
+++ b/PyIlmBase/config/ModuleDefine.cmake
@@ -8,15 +8,17 @@ function(PYILMBASE_ADD_LIBRARY_PRIV libname)
   cmake_parse_arguments(PYILMBASE_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
 
-  # let the default behaviour BUILD_SHARED_LIBS control the
-  # disposition of the default library...
-  add_library(${libname} ${PYILMBASE_CURLIB_SOURCE})
-  if(BUILD_SHARED_LIBS)
-    set_target_properties(${libname} PROPERTIES
-    SOVERSION ${PYILMBASE_SOVERSION}
-    VERSION ${PYILMBASE_LIB_VERSION}
-    )
-  endif()
+  # Currently, the python bindings REQUIRE a shared library for
+  # the Iex stuff to be initialized correctly. As such, force that
+  # here
+  # TODO Change this back when these bindings are refactored
+  add_library(${libname} SHARED ${PYILMBASE_CURLIB_SOURCE})
+  #if(BUILD_SHARED_LIBS)
+  set_target_properties(${libname} PROPERTIES
+  SOVERSION ${PYILMBASE_SOVERSION}
+  VERSION ${PYILMBASE_LIB_VERSION}
+  )
+  #endif()
   set_target_properties(${libname} PROPERTIES
     OUTPUT_NAME "${PYILMBASE_OUTPUT_OUTROOT}${libname}${PYILMBASE_LIB_SUFFIX}"
   )


### PR DESCRIPTION
Currently, the python binding helper libraries require shared objects so
(at least) the Iex registration table is shared. Force that until we can
refactor the python bindings

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>