### PR TITLE
Force exception handling / unwind disposition under msvc

### DIFF
--- a/IlmBase/config/LibraryDefine.cmake
+++ b/IlmBase/config/LibraryDefine.cmake
@@ -21,7 +21,9 @@ function(ILMBASE_DEFINE_LIBRARY libname)
   else()
     set(use_objlib)
   endif()
-
+  if (MSVC)
+    set(_ilmbase_extra_flags "/EHsc")
+  endif()
   if(use_objlib)
     set(objlib ${libname}_Object)
     add_library(${objlib} OBJECT
@@ -56,6 +58,9 @@ function(ILMBASE_DEFINE_LIBRARY libname)
     CXX_EXTENSIONS OFF
     POSITION_INDEPENDENT_CODE ON
   )
+  if (_ilmbase_extra_flags)
+    target_compile_options(${objlib} PUBLIC ${_ilmbase_extra_flags})
+  endif()
   set_property(TARGET ${objlib} PROPERTY PUBLIC_HEADER ${ILMBASE_CURLIB_HEADERS})
 
   if(use_objlib)


### PR DESCRIPTION
msvc seems to default to exceptions off, and cmake does not
explicitly turn it on. Force it on as a public option so any
users of IlmBase will inherit that option. Otherwise, if an
exception occurs, mutex unlocks and such do not happen.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>