### PR TITLE
Fix fuzz pseudo target

### DIFF
--- a/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfFuzzTest/CMakeLists.txt
@@ -18,6 +18,6 @@ if(OPENEXR_RUN_FUZZ_TESTS)
   add_test(NAME OpenEXR.ImfFuzz COMMAND $<TARGET_FILE:IlmImfFuzzTest>)
   set_tests_properties(OpenEXR.ImfFuzz PROPERTIES TIMEOUT 36000)
 
-  add_custom_target(fuzz ${CMAKE_CURRENT_BINARY_DIR}/IlmImfFuzzTest)
+  add_custom_target(fuzz $<TARGET_FILE:IlmImfFuzzTest>)
   add_dependencies(fuzz IlmImfFuzzTest)
 endif()


### PR DESCRIPTION
The fuzz pseudo target didn't receive the generator update when switching
to have all the binaries output to a single folder

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>