### PR TITLE
Added generation of PyIlmBase/config/PyIlmBaseConfigInternal.h to aut…

### DIFF
--- a/OpenEXR/config/Makefile.am
+++ b/OpenEXR/config/Makefile.am
@@ -7,9 +7,13 @@
 
 configincludedir = $(includedir)/OpenEXR
 
-nodist_configinclude_HEADERS = OpenEXRConfig.h
+nodist_configinclude_HEADERS = OpenEXRConfig.h OpenEXRConfigInternal.h
 
-EXTRA_DIST = OpenEXRConfig.h.in OpenEXRConfig.h.in_cmake \
- OpenEXRConfigInternal.h.in OpenEXRConfigInternal.h.in_cmake \
- CMakeLists.txt OpenEXRSetup.cmake LibraryDefine.cmake \
- ParseConfigure.cmake
+EXTRA_DIST = OpenEXRConfig.h.in \
+	     OpenEXRConfig.h.in_cmake \
+	     OpenEXRConfigInternal.h.in \
+	     OpenEXRConfigInternal.h.in_cmake \
+	     OpenEXRSetup.cmake \
+             LibraryDefine.cmake \
+             ParseConfigure.cmake \
+             CMakeLists.txt 

--- a/PyIlmBase/config/Makefile.am
+++ b/PyIlmBase/config/Makefile.am
@@ -7,8 +7,13 @@
 
 configincludedir = $(includedir)/OpenEXR
 
-nodist_configinclude_HEADERS = PyIlmBaseConfig.h
+nodist_configinclude_HEADERS = PyIlmBaseConfig.h PyIlmBaseConfigInternal.h
 
-EXTRA_DIST = PyIlmBaseConfig.h.in ModuleDefine.cmake \
- NumPyLocate.cmake ParseConfigure.cmake PyIlmBaseSetup.cmake \
- CMakeLists.txt
+EXTRA_DIST = PyIlmBaseConfig.h.in \
+             PyIlmBaseConfigInternal.h.in \
+             PyIlmBaseConfigInternal.h.in_cmake \
+             PyIlmBaseSetup.cmake \
+	     NumPyLocate.cmake \
+	     ModuleDefine.cmake \
+	     ParseConfigure.cmake \
+             CMakeLists.txt

--- a/PyIlmBase/configure.ac
+++ b/PyIlmBase/configure.ac
@@ -4,11 +4,12 @@ dnl Copyright Contributors to the OpenEXR Project.
 dnl
 
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(PyIlmBase, 2.3.0)
-AC_SUBST(PYILMBASE_VERSION, 2.3.0)
+AC_INIT(PyIlmBase, 2.4.0)
+AC_SUBST(PYILMBASE_VERSION, 2.4.0)
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR(PyIex/iexmodule.cpp)
-AC_CONFIG_HEADER(config/PyIlmBaseConfig.h)
+AC_CONFIG_HEADERS([config/PyIlmBaseConfig.h])
+AC_CONFIG_HEADERS([config/PyIlmBaseConfigInternal.h])
 AM_INIT_AUTOMAKE(1.6.3)  dnl Require automake 1.6.3 or better
 AM_MAINTAINER_MODE
 dnl static python modules make no sense - disable static


### PR DESCRIPTION
…omake

PyIlmBase/configure.ac failed to mention PyIlmBaseConfigInternal.h, so
./configure was failing to generate it. Also, the Internal.h files
should be included in the nodist list in the Makefile.am

Signed-off-by: Cary Phillips <cary@ilm.com>