### PR TITLE
Replace use of rand()/srand() with the C++11 <random>

### DIFF
--- a/IlmBase/HalfTest/testError.cpp
+++ b/IlmBase/HalfTest/testError.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <assert.h>
-
+#include <random>
 
 using namespace std;
 
@@ -21,7 +21,10 @@ namespace {
 float
 drand()
 {
-    return static_cast<float> (rand()/(RAND_MAX+1.0f));
+    static std::default_random_engine generator;
+    static std::uniform_real_distribution<float> distribution (0.0f, 1.0f);
+    float r = distribution (generator);
+    return r;
 }
 
 } // namespace

--- a/OpenEXR/IlmImfTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfTest/CMakeLists.txt
@@ -60,7 +60,7 @@ add_executable(IlmImfTest
   testXdr.cpp
   testYca.cpp
   testLargeDataWindowOffsets.cpp
-  random
+  random.cpp
 )
 target_compile_definitions(IlmImfTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
 target_link_libraries(IlmImfTest OpenEXR::IlmImf)

--- a/OpenEXR/IlmImfTest/CMakeLists.txt
+++ b/OpenEXR/IlmImfTest/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(IlmImfTest
   testXdr.cpp
   testYca.cpp
   testLargeDataWindowOffsets.cpp
+  random
 )
 target_compile_definitions(IlmImfTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
 target_link_libraries(IlmImfTest OpenEXR::IlmImf)

--- a/OpenEXR/IlmImfTest/random.cpp
+++ b/OpenEXR/IlmImfTest/random.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+#include "random.h"
+#include <random>
+#include <assert.h>
+
+static std::default_random_engine generator;
+
+void
+random_reseed (int s)
+{
+    generator.seed (s);
+}
+
+//
+// Return an integer in the range [0,range), so that 0 <= i < range
+//
+int
+random_int (int range)
+{
+    std::uniform_int_distribution<int> distribution (0, range-1);
+    int i = distribution (generator);
+    assert (0 <= i && i < range);
+    return i;
+}
+
+//
+// Return a float in the range [0, range), so that 0 <= f < range
+//
+
+float
+random_float (float range)
+{
+    std::uniform_real_distribution<float> distribution (0, range);
+    float f = distribution (generator);
+    assert (0 <= f && f < range);
+    return f;
+}
+
+    

--- a/OpenEXR/IlmImfTest/random.h
+++ b/OpenEXR/IlmImfTest/random.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+#pragma once
+
+#include <limits>
+
+extern int   random_int(int range = std::numeric_limits<int>::max());
+extern float random_float(float range = std::numeric_limits<float>::max());
+extern void  random_reseed (int s);
+
+
+
+
+

--- a/OpenEXR/IlmImfTest/testCompositeDeepScanLine.cpp
+++ b/OpenEXR/IlmImfTest/testCompositeDeepScanLine.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "testCompositeDeepScanLine.h"
+#include "random.h"
 
 #include <vector>
 #include <string>
@@ -251,8 +252,8 @@ class data
             
             for(size_t s=0;s<_samples[i].size();s++)
             {
-              int part = rand()% parts.size();
-              parts[part]._samples[i].push_back(_samples[i][s]);
+                int part = random_int(parts.size());
+                parts[part]._samples[i].push_back(_samples[i][s]);
             }
         }
     }
@@ -522,10 +523,10 @@ write_file(const char * filename, const data<T> & master, int number_of_parts)
     // all headers are the same in this test
     headers[0].displayWindow().max.x=164;
     headers[0].displayWindow().max.y=216;
-    headers[0].dataWindow().min.x=rand()%400 - 200;
-    headers[0].dataWindow().max.x=headers[0].dataWindow().min.x+40+rand()%400;
-    headers[0].dataWindow().min.y=rand()%400 - 200;
-    headers[0].dataWindow().max.y=headers[0].dataWindow().min.y+40+rand()%400;
+    headers[0].dataWindow().min.x=random_int(400) - 200;
+    headers[0].dataWindow().max.x=headers[0].dataWindow().min.x+40+random_int(400);
+    headers[0].dataWindow().min.y=random_int(400) - 200;
+    headers[0].dataWindow().max.y=headers[0].dataWindow().min.y+40+random_int(400);
     cout << "data window: " << headers[0].dataWindow().min.x << ',' << headers[0].dataWindow().min.y << ' ' << 
     headers[0].dataWindow().max.x << ',' << headers[0].dataWindow().max.y << endl;
     headers[0].setType(DEEPSCANLINE);
@@ -616,7 +617,7 @@ test_parts (int pattern_number,
            int low = comp.dataWindow().min.y;
            while(low<comp.dataWindow().max.y)
            {
-               int high = low + rand()%64;
+               int high = low + random_int(64);
                if(high>comp.dataWindow().max.y) 
                    high = comp.dataWindow().max.y;
                comp.readPixels(low,high);
@@ -647,7 +648,7 @@ test_parts (int pattern_number,
              int low = dataWindow.min.y;
              while(low<dataWindow.max.y)
              {
-                 int high = low + rand()%64;
+                 int high = low + random_int(64);
                  if(high>dataWindow.max.y) 
                      high = dataWindow.max.y;
                  file.readPixels(low,high);
@@ -674,8 +675,7 @@ void testCompositeDeepScanLine (const std::string & tempDir)
             passes=1;
     }
   
-
-    srand(1);
+    random_reseed(1);
     
     for(int pass=0;pass<2;pass++)
     {

--- a/OpenEXR/IlmImfTest/testCopyDeepScanLine.cpp
+++ b/OpenEXR/IlmImfTest/testCopyDeepScanLine.cpp
@@ -39,7 +39,7 @@
 #endif
 
 #include "testCopyDeepScanLine.h"
-
+#include "random.h"
 
 #include <assert.h>
 #include <string.h>
@@ -99,7 +99,7 @@ void generateRandomFile (const std::string & source_filename,
 
     for (int i = 0; i < channelCount; i++)
     {
-        int type = rand() % 3;
+        int type = random_int(3);
         stringstream ss;
         ss << i;
         string str = ss.str();
@@ -174,7 +174,7 @@ void generateRandomFile (const std::string & source_filename,
 
             for (int j = 0; j < width; j++)
             {
-                sampleCount[i][j] = rand() % 10 + 1;
+                sampleCount[i][j] = random_int(10) + 1;
                 for (int k = 0; k < channelCount; k++)
                 {
                     if (channelTypes[k] == 0)
@@ -419,7 +419,7 @@ void testCopyDeepScanLine (const std::string &tempDir)
     {
         cout << "\n\nTesting raw data copy in DeepScanLineInput/OutputFile:\n" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testCopyDeepTiled.cpp
+++ b/OpenEXR/IlmImfTest/testCopyDeepTiled.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "testCopyDeepTiled.h"
+#include "random.h"
 
 
 #include <assert.h>
@@ -100,7 +101,7 @@ generateRandomFile (int channelCount,
 
     for (int i = 0; i < channelCount; i++)
     {
-        int type = rand() % 3;
+        int type = random_int(3);
         stringstream ss;
         ss << i;
         string str = ss.str();
@@ -115,7 +116,7 @@ generateRandomFile (int channelCount,
 
     header.setType(DEEPTILE);
     header.setTileDescription(
-        TileDescription(rand() % width + 1, rand() % height + 1, RIPMAP_LEVELS));
+        TileDescription(random_int(width) + 1, random_int(height) + 1, RIPMAP_LEVELS));
 
     Array<Array2D< void* > > data(channelCount);
     for (int i = 0; i < channelCount; i++)
@@ -203,7 +204,7 @@ generateRandomFile (int channelCount,
                             {
                                 int dwy = y - dataWindowL.min.y;
                                 int dwx = x - dataWindowL.min.x;
-                                sampleCount[dwy][dwx] = rand() % 10 + 1;
+                                sampleCount[dwy][dwx] = random_int(10) + 1;
                                 sampleCountWhole[ly][lx][dwy][dwx] = sampleCount[dwy][dwx];
                                 for (int k = 0; k < channelCount; k++)
                                 {
@@ -504,7 +505,7 @@ void testCopyDeepTiled  (const std::string & tempDir)
     {
         cout << "Testing raw copy in DeepTiledInput/OutputFile " << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(2);

--- a/OpenEXR/IlmImfTest/testCopyMultiPartFile.cpp
+++ b/OpenEXR/IlmImfTest/testCopyMultiPartFile.cpp
@@ -47,6 +47,7 @@
 
 #include "tmpDir.h"
 #include "testCopyMultiPartFile.h"
+#include "random.h"
 
 #include <IlmThreadPool.h>
 #include <ImfMultiPartInputFile.h>
@@ -242,8 +243,8 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
                        INCREASING_Y, 
                        ZIPS_COMPRESSION);
                    
-        int pixelType = rand() % 3;
-        int partType = rand() % 4;
+        int pixelType = random_int(3);
+        int partType = random_int(4);
         
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
@@ -286,9 +287,9 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         int levelMode;
         if (partType == 1 || partType == 3)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm  = NUM_LEVELMODES;
             switch (levelMode)
@@ -307,11 +308,11 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         }
 
  
-        int order = rand() % NUM_LINEORDERS;
+        int order = random_int(NUM_LINEORDERS);
         if(partType==0 || partType ==2)
         {
             // can't write random scanlines
-            order = rand() % (NUM_LINEORDERS-1);
+            order = random_int(NUM_LINEORDERS-1);
         }
         LineOrder l = NUM_LINEORDERS;
         switch(order)
@@ -704,8 +705,8 @@ readWholeFiles (const std::string & cpyFn)
         shuffledPartNumber.push_back(i);
     for (int i = 0; i < nHeaders; i++)
     {
-        int a = rand() % nHeaders;
-        int b = rand() % nHeaders;
+        int a = random_int(nHeaders);
+        int b = random_int(nHeaders);
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -966,7 +967,7 @@ void testCopyMultiPartFile (const std::string & tempDir)
     {
         cout << "Testing copying multi-part files" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
+++ b/OpenEXR/IlmImfTest/testDeepScanLineBasic.cpp
@@ -37,7 +37,7 @@
 #endif
 
 #include "testDeepScanLineBasic.h"
-
+#include "random.h"
 
 #include <assert.h>
 #include <string.h>
@@ -96,7 +96,7 @@ void generateRandomFile (const std::string filename,
 
     for (int i = 0; i < channelCount; i++)
     {
-        int type = rand() % 3;
+        int type = random_int(3);
         stringstream ss;
         ss << i;
         string str = ss.str();
@@ -174,7 +174,7 @@ void generateRandomFile (const std::string filename,
 
             for (int j = 0; j < width; j++)
             {
-                sampleCount[i][j] = rand() % 10 + 1;
+                sampleCount[i][j] = random_int(10) + 1;
                 for (int k = 0; k < channelCount; k++)
                 {
                     if (channelTypes[k] == 0)
@@ -209,7 +209,7 @@ void generateRandomFile (const std::string filename,
 
             for (int j = 0; j < width; j++)
             {
-                sampleCount[i][j] = rand() % 10 + 1;
+                sampleCount[i][j] = random_int(10) + 1;
                 for (int k = 0; k < channelCount; k++)
                 {
                     if (channelTypes[k] == 0)
@@ -278,7 +278,7 @@ void readFile (const std::string & filename,
     
         
     // also test filling channels. Generate up to 2 extra channels
-    int fillChannels=rand()%3;
+    int fillChannels=random_int(3);
     
     Array<Array2D< void* > > data(channelCount+fillChannels);
     for (int i = 0; i < channelCount+fillChannels; i++)
@@ -302,7 +302,7 @@ void readFile (const std::string & filename,
     {
         if(randomChannels)
         {
-	     read_channel[i] = rand() % 2;
+	     read_channel[i] = random_int(2);
 	     
         }
         if(!randomChannels || read_channel[i]==1)
@@ -614,7 +614,7 @@ void testDeepScanLineBasic (const std::string &tempDir)
     {
         cout << "\n\nTesting the DeepScanLineInput/OutputFile for basic use:\n" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testDeepScanLineHuge.cpp
+++ b/OpenEXR/IlmImfTest/testDeepScanLineHuge.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "testDeepScanLineBasic.h"
+#include "random.h"
 
 #include "ImfDeepScanLineInputFile.h"
 #include "ImfDeepScanLineOutputFile.h"
@@ -102,7 +103,7 @@ generateRandomFile (int channelCount,
 
     for (int i = 0; i < channelCount; i++)
     {
-        int type = rand() % 3;
+        int type = random_int(3);
         stringstream ss;
         ss << i;
         string str = ss.str();
@@ -189,7 +190,7 @@ generateRandomFile (int channelCount,
     {
             for (int j = 0; j < width; j++)
             {
-                sampleCount[i][j] = (rand() % 4000) + (samples_per_pixel-2000);
+                sampleCount[i][j] = random_int(4000) + (samples_per_pixel-2000);
                 total_number_of_samples += sampleCount[i][j];
             }
     }
@@ -235,11 +236,11 @@ generateRandomFile (int channelCount,
                         for (unsigned int l = 0; l < sampleCount[i][j]; l++)
                         {
                             if (channelTypes[k] == 0)
-                                ((unsigned int*)data[k][i][j])[l] = rand();
+                                ((unsigned int*)data[k][i][j])[l] = random_int();
                             if (channelTypes[k] == 1)
-                                ((half*)data[k][i][j])[l] = rand()/RAND_MAX;
+                                ((half*)data[k][i][j])[l] = random_float();
                             if (channelTypes[k] == 2)
-                                ((float*)data[k][i][j])[l] = rand()/RAND_MAX;
+                                ((float*)data[k][i][j])[l] = random_float();
                         }
                     }
                     else
@@ -423,7 +424,7 @@ void testDeepScanLineHuge (const std::string & tempDir)
     {
         cout << "\n\nTesting the DeepScanLineInput/OutputFile for huge scanlines:\n" << endl;
 
-        srand(1);
+        random_reseed(1);
         std::string fn = tempDir + "imf_test_deep_scanline_huge.exr";
 
         readWriteTest (10, 5 , false, fn);

--- a/OpenEXR/IlmImfTest/testDeepScanLineMultipleRead.cpp
+++ b/OpenEXR/IlmImfTest/testDeepScanLineMultipleRead.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "testCompositeDeepScanLine.h"
+#include "random.h"
 
 #include <ImfDeepScanLineOutputFile.h>
 #include <ImfDeepScanLineInputFile.h>
@@ -148,7 +149,7 @@ static void read_file(const char * filename)
     
     for(int count=0;count<4000;count++)
     {
-        int row = rand() % height + y_offset;
+        int row = random_int(height) + y_offset;
         
         //
         // read row y (at random)
@@ -220,7 +221,7 @@ testDeepScanLineMultipleRead(const std::string & tempDir)
     cout << "\n\nTesting random re-reads from deep scanline file:\n" << endl;
     
     std::string source_filename = tempDir + "imf_test_multiple_read";
-    srand(1);
+    random_reseed(1);
     
     make_file(source_filename.c_str());
     read_file(source_filename.c_str());

--- a/OpenEXR/IlmImfTest/testDeepTiledBasic.cpp
+++ b/OpenEXR/IlmImfTest/testDeepTiledBasic.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "testDeepTiledBasic.h"
+#include "random.h"
 
 #include <assert.h>
 #include <string.h>
@@ -98,7 +99,7 @@ void generateRandomFile (int channelCount,
 
     for (int i = 0; i < channelCount; i++)
     {
-        int type = rand() % 3;
+        int type = random_int(3);
         stringstream ss;
         ss << i;
         string str = ss.str();
@@ -113,7 +114,7 @@ void generateRandomFile (int channelCount,
 
     header.setType(DEEPTILE);
     header.setTileDescription(
-        TileDescription(rand() % width + 1, rand() % height + 1, RIPMAP_LEVELS));
+        TileDescription(random_int(width) + 1, random_int(height) + 1, RIPMAP_LEVELS));
 
 
     //
@@ -222,7 +223,7 @@ void generateRandomFile (int channelCount,
                             {
                                 int dwy = y - dataWindowL.min.y;
                                 int dwx = x - dataWindowL.min.x;
-                                sampleCount[dwy][dwx] = rand() % 10 + 1;
+                                sampleCount[dwy][dwx] = random_int(10) + 1;
                                 sampleCountWhole[ly][lx][dwy][dwx] = sampleCount[dwy][dwx];
                                 for (int k = 0; k < channelCount; k++)
                                 {
@@ -266,7 +267,7 @@ void generateRandomFile (int channelCount,
                                 {
                                     int dwy = y - dataWindowL.min.y;
                                     int dwx = x - dataWindowL.min.x;
-                                    sampleCount[dwy][dwx] = rand() % 10 + 1;
+                                    sampleCount[dwy][dwx] = random_int(10) + 1;
                                     sampleCountWhole[ly][lx][dwy][dwx] = sampleCount[dwy][dwx];
                                     for (int k = 0; k < channelCount; k++)
                                     {
@@ -309,7 +310,7 @@ void generateRandomFile (int channelCount,
                                     int dwx = x - dataWindowL.min.x;
                                     int ty = y - box.min.y;
                                     int tx = x - box.min.x;
-                                    sampleCount[ty][tx] = rand() % 10 + 1;
+                                    sampleCount[ty][tx] = random_int(10) + 1;
                                     sampleCountWhole[ly][lx][dwy][dwx] = sampleCount[ty][tx];
                                     for (int k = 0; k < channelCount; k++)
                                     {
@@ -437,7 +438,7 @@ void readFile (int channelCount,
     localSampleCount.resizeErase(height, width);
     
     // also test filling channels. Generate up to 2 extra channels
-    int fillChannels=rand()%3;
+    int fillChannels=random_int(3);
     
     Array<Array2D< void* > > data(channelCount+fillChannels);
     for (int i = 0; i < channelCount+fillChannels; i++)
@@ -466,7 +467,7 @@ void readFile (int channelCount,
     {
          if(randomChannels)
         {
-	     read_channel[i] = rand() % 2;
+	     read_channel[i] = random_int(2);
 	     
         }
         if(!randomChannels || read_channel[i]==1)
@@ -830,7 +831,7 @@ void testDeepTiledBasic (const std::string & tempDir)
     {
         cout << "Testing the DeepTiledInput/OutputFile for basic use" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(2);

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -49,6 +49,7 @@
 #include "tmpDir.h"
 #include "testFutureProofing.h"
 #include "testMultiPartFileMixingBasic.h"
+#include "random.h"
 
 #include <IlmThreadPool.h>
 #include <ImfMultiPartInputFile.h>
@@ -290,8 +291,8 @@ generateRandomHeaders (int partCount, vector<Header>& headers)
                        INCREASING_Y, 
                        ZIPS_COMPRESSION);
                    
-        int pixelType = rand() % 3;
-        int partType = rand() % 4;
+        int pixelType = random_int(3);
+        int partType = random_int(4);
         
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
@@ -334,9 +335,9 @@ generateRandomHeaders (int partCount, vector<Header>& headers)
         int levelMode;
         if (partType == 1 || partType == 3)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm  = NUM_LEVELMODES;
             switch (levelMode)
@@ -355,11 +356,11 @@ generateRandomHeaders (int partCount, vector<Header>& headers)
         }
 
  
-        int order = rand() % NUM_LINEORDERS;
+        int order = random_int(NUM_LINEORDERS);
         if(partType==0 || partType ==2)
         {
             // can't write random scanlines
-            order = rand() % (NUM_LINEORDERS-1);
+            order = random_int(NUM_LINEORDERS-1);
         }
         LineOrder l = NUM_LINEORDERS;
         switch(order)
@@ -777,8 +778,8 @@ readWholeFiles (int modification)
         shuffledPartNumber.push_back(i);
     for (size_t i = 0; i < shuffledPartNumber.size(); i++)
     {
-        size_t a = rand() % shuffledPartNumber.size();
-        size_t b = rand() % shuffledPartNumber.size();
+        size_t a = random_int(shuffledPartNumber.size());
+        size_t b = random_int(shuffledPartNumber.size());
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -987,8 +988,8 @@ readFirstPart()
         case 0:
         {
         int l1, l2;
-        l1 = rand() % height;
-        l2 = rand() % height;
+        l1 = random_int(height);
+        l2 = random_int(height);
         if (l1 > l2) swap(l1, l2);
 
         InputFile part(filename.c_str());
@@ -1025,8 +1026,8 @@ readFirstPart()
         int numXLevels = part.numXLevels();
         int numYLevels = part.numYLevels();
 
-        lx = rand() % numXLevels;
-        ly = rand() % numYLevels;
+        lx = random_int(numXLevels);
+        ly = random_int(numYLevels);
         if (levelMode == 1) ly = lx;
 
         int w = part.levelWidth(lx);
@@ -1034,10 +1035,10 @@ readFirstPart()
 
         int numXTiles = part.numXTiles(lx);
         int numYTiles = part.numYTiles(ly);
-        tx1 = rand() % numXTiles;
-        tx2 = rand() % numXTiles;
-        ty1 = rand() % numYTiles;
-        ty2 = rand() % numYTiles;
+        tx1 = random_int(numXTiles);
+        tx2 = random_int(numXTiles);
+        ty1 = random_int(numYTiles);
+        ty2 = random_int(numYTiles);
         if (tx1 > tx2) swap(tx1, tx2);
         if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1087,8 +1088,8 @@ readFirstPart()
         part.setFrameBuffer(frameBuffer);
 
         int l1, l2;
-        l1 = rand() % height;
-        l2 = rand() % height;
+        l1 = random_int(height);
+        l2 = random_int(height);
         if (l1 > l2) swap(l1, l2);
 
         part.readPixelSampleCounts(l1, l2);
@@ -1124,8 +1125,8 @@ readFirstPart()
 
         int tx1, tx2, ty1, ty2;
         int lx, ly;
-        lx = rand() % numXLevels;
-        ly = rand() % numYLevels;
+        lx = random_int(numXLevels);
+        ly = random_int(numYLevels);
         if (levelMode == 1) ly = lx;
 
         int w = part.levelWidth(lx);
@@ -1133,10 +1134,10 @@ readFirstPart()
 
         int numXTiles = part.numXTiles(lx);
         int numYTiles = part.numYTiles(ly);
-        tx1 = rand() % numXTiles;
-        tx2 = rand() % numXTiles;
-        ty1 = rand() % numYTiles;
-        ty2 = rand() % numYTiles;
+        tx1 = random_int(numXTiles);
+        tx2 = random_int(numXTiles);
+        ty1 = random_int(numYTiles);
+        ty2 = random_int(numYTiles);
         if (tx1 > tx2) swap(tx1, tx2);
         if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1382,7 +1383,7 @@ testFutureProofing (const std::string & tempDir)
     {
         cout << "Testing reading future-files" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testInputPart.cpp
+++ b/OpenEXR/IlmImfTest/testInputPart.cpp
@@ -47,6 +47,7 @@
 
 #include "tmpDir.h"
 #include "testInputPart.h"
+#include "random.h"
 
 #include <IlmThreadPool.h>
 #include <ImfMultiPartInputFile.h>
@@ -237,8 +238,8 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
                        INCREASING_Y, 
                        ZIPS_COMPRESSION);
                    
-        int pixelType = rand() % 3;
-        int partType = rand() % 2;
+        int pixelType = random_int(3);
+        int partType = random_int(2);
         
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
@@ -275,9 +276,9 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         int levelMode;
         if (partType == 1)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm  = NUM_LEVELMODES;
             switch (levelMode)
@@ -296,11 +297,11 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         }
 
  
-        int order = rand() % NUM_LINEORDERS;
+        int order = random_int(NUM_LINEORDERS);
         if(partType==0 || partType ==2)
         {
             // can't write random scanlines
-            order = rand() % (NUM_LINEORDERS-1);
+            order = random_int(NUM_LINEORDERS-1);
         }
         LineOrder l = NUM_LINEORDERS;
         switch(order)
@@ -541,8 +542,8 @@ readWholeFiles (const std::string & fn)
         shuffledPartNumber.push_back(i);
     for (int i = 0; i < nHeaders; i++)
     {
-        int a = rand() % nHeaders;
-        int b = rand() % nHeaders;
+        int a = random_int(nHeaders);
+        int b = random_int(nHeaders);
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -602,8 +603,8 @@ readFirstPart (const std::string & fn)
     //int levelMode = levelModes[0];
 
     int l1, l2;
-    l1 = rand() % height;
-    l2 = rand() % height;
+    l1 = random_int(height);
+    l2 = random_int(height);
     if (l1 > l2) swap(l1, l2);
 
     InputFile part(fn.c_str());
@@ -647,14 +648,14 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
     for (int i = 0; i < randomReadCount; i++)
     {
-        int partNumber = rand() % file.parts();
+        int partNumber = random_int(file.parts());
         //int partType = partTypes[partNumber];
         int pixelType = pixelTypes[partNumber];
         //int levelMode = levelModes[partNumber];
 
         int l1, l2;
-        l1 = rand() % height;
-        l2 = rand() % height;
+        l1 = random_int(height);
+        l2 = random_int(height);
         
         if (l1 > l2) swap(l1, l2);
 
@@ -716,7 +717,7 @@ void testInputPart (const std::string & tempDir)
     {
         cout << "Testing reading multipart tiles and scanlines with InputPart" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testMultiPartApi.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartApi.cpp
@@ -45,6 +45,7 @@
 
 #include "tmpDir.h"
 #include "testMultiPartApi.h"
+#include "random.h"
 
 #include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
@@ -134,8 +135,8 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Task>&
     for (int i = 0; i < partCount; i++)
     {
         Header header(width, height);
-        int pixelType = rand() % 3;
-        int partType = rand() % 2;
+        int pixelType = random_int(3);
+        int partType = random_int(2);
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
 
@@ -171,9 +172,9 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Task>&
         int levelMode = 0;
         if (partType == 1)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm = NUM_LEVELMODES;
             switch (levelMode)
@@ -349,8 +350,8 @@ generateRandomFile (int partCount, const std::string & fn)
     for (int i = 0; i < taskListSize; i++)
     {
         int a, b;
-        a = rand() % taskListSize;
-        b = rand() % taskListSize;
+        a = random_int(taskListSize);
+        b = random_int(taskListSize);
         swap(taskList[a], taskList[b]);
     }
 
@@ -517,8 +518,8 @@ readWholeFiles (const std::string & fn)
         shuffledPartNumber.push_back(i);
     for (int i = 0; i < nHeaders; i++)
     {
-        int a = rand() % nHeaders;
-        int b = rand() % nHeaders;
+        int a = random_int(nHeaders);
+        int b = random_int(nHeaders);
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -611,7 +612,7 @@ readPartialFiles (int randomReadCount, const std::string & fn)
     //const vector<Header>& headers = file.parts();
     for (int i = 0; i < randomReadCount; i++)
     {
-        int partNumber = rand() % headers.size();
+        int partNumber = random_int(headers.size());
         int partType = partTypes[partNumber];
         int pixelType = pixelTypes[partNumber];
         int levelMode = levelModes[partNumber];
@@ -619,8 +620,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
         if (partType == 0)
         {
             int l1, l2;
-            l1 = rand() % height;
-            l2 = rand() % height;
+            l1 = random_int(height);
+            l2 = random_int(height);
             if (l1 > l2) swap(l1, l2);
 
             InputPart part(file, partNumber);
@@ -655,8 +656,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
             int numXLevels = part.numXLevels();
             int numYLevels = part.numYLevels();
 
-            lx = rand() % numXLevels;
-            ly = rand() % numYLevels;
+            lx = random_int(numXLevels);
+            ly = random_int(numYLevels);
             if (levelMode == 1) ly = lx;
 
             int w = part.levelWidth(lx);
@@ -664,10 +665,10 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
             int numXTiles = part.numXTiles(lx);
             int numYTiles = part.numYTiles(ly);
-            tx1 = rand() % numXTiles;
-            tx2 = rand() % numXTiles;
-            ty1 = rand() % numYTiles;
-            ty2 = rand() % numYTiles;
+            tx1 = random_int(numXTiles);
+            tx2 = random_int(numXTiles);
+            ty1 = random_int(numYTiles);
+            ty2 = random_int(numYTiles);
             if (tx1 > tx2) swap(tx1, tx2);
             if (ty1 > ty2) swap(ty1, ty2);
 
@@ -731,7 +732,7 @@ void testMultiPartApi (const std::string & tempDir)
     {
         cout << "Testing the multi part APIs for normal use" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         testWriteRead ( 1, 2,   5, tempDir);
         testWriteRead ( 2, 5,  10, tempDir);

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -49,6 +49,7 @@
 
 #include "tmpDir.h"
 #include "testMultiPartFileMixingBasic.h"
+#include "random.h"
 
 #include <IlmThreadPool.h>
 #include <ImfMultiPartInputFile.h>
@@ -243,8 +244,8 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
                        INCREASING_Y, 
                        ZIPS_COMPRESSION);
                    
-        int pixelType = rand() % 3;
-        int partType = rand() % 4;
+        int pixelType = random_int(3);
+        int partType = random_int(4);
         
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
@@ -287,9 +288,9 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         int levelMode;
         if (partType == 1 || partType == 3)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm = NUM_LEVELMODES;
             switch (levelMode)
@@ -308,11 +309,11 @@ void generateRandomHeaders(int partCount, vector<Header>& headers)
         }
 
  
-        int order = rand() % NUM_LINEORDERS;
+        int order = random_int(NUM_LINEORDERS);
         if(partType==0 || partType ==2)
         {
             // can't write random scanlines
-            order = rand() % (NUM_LINEORDERS-1);
+            order = random_int(NUM_LINEORDERS-1);
         }
         LineOrder l = NUM_LINEORDERS;
         switch(order)
@@ -705,8 +706,8 @@ readWholeFiles (const std::string & fn)
         shuffledPartNumber.push_back(i);
     for (int i = 0; i < nHeaders; i++)
     {
-        int a = rand() % nHeaders;
-        int b = rand() % nHeaders;
+        int a = random_int(nHeaders);
+        int b = random_int(nHeaders);
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -913,8 +914,8 @@ readFirstPart (const std::string & fn)
             InputFile part (fn.c_str());
 
             int l1, l2;
-            l1 = rand() % height;
-            l2 = rand() % height;
+            l1 = random_int(height);
+            l2 = random_int(height);
             if (l1 > l2) swap(l1, l2);
 
             FrameBuffer frameBuffer;
@@ -950,8 +951,8 @@ readFirstPart (const std::string & fn)
             int numXLevels = part.numXLevels();
             int numYLevels = part.numYLevels();
 
-            lx = rand() % numXLevels;
-            ly = rand() % numYLevels;
+            lx = random_int(numXLevels);
+            ly = random_int(numYLevels);
             if (levelMode == 1) ly = lx;
 
             int w = part.levelWidth(lx);
@@ -959,10 +960,10 @@ readFirstPart (const std::string & fn)
 
             int numXTiles = part.numXTiles(lx);
             int numYTiles = part.numYTiles(ly);
-            tx1 = rand() % numXTiles;
-            tx2 = rand() % numXTiles;
-            ty1 = rand() % numYTiles;
-            ty2 = rand() % numYTiles;
+            tx1 = random_int(numXTiles);
+            tx2 = random_int(numXTiles);
+            ty1 = random_int(numYTiles);
+            ty2 = random_int(numYTiles);
             if (tx1 > tx2) swap(tx1, tx2);
             if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1012,8 +1013,8 @@ readFirstPart (const std::string & fn)
             part.setFrameBuffer(frameBuffer);
 
             int l1, l2;
-            l1 = rand() % height;
-            l2 = rand() % height;
+            l1 = random_int(height);
+            l2 = random_int(height);
             if (l1 > l2) swap(l1, l2);
 
             part.readPixelSampleCounts(l1, l2);
@@ -1049,8 +1050,8 @@ readFirstPart (const std::string & fn)
 
             int tx1, tx2, ty1, ty2;
             int lx, ly;
-            lx = rand() % numXLevels;
-            ly = rand() % numYLevels;
+            lx = random_int(numXLevels);
+            ly = random_int(numYLevels);
             if (levelMode == 1) ly = lx;
 
             int w = part.levelWidth(lx);
@@ -1058,10 +1059,10 @@ readFirstPart (const std::string & fn)
 
             int numXTiles = part.numXTiles(lx);
             int numYTiles = part.numYTiles(ly);
-            tx1 = rand() % numXTiles;
-            tx2 = rand() % numXTiles;
-            ty1 = rand() % numYTiles;
-            ty2 = rand() % numYTiles;
+            tx1 = random_int(numXTiles);
+            tx2 = random_int(numXTiles);
+            ty1 = random_int(numYTiles);
+            ty2 = random_int(numYTiles);
             if (tx1 > tx2) swap(tx1, tx2);
             if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1132,7 +1133,7 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
     for (int i = 0; i < randomReadCount; i++)
     {
-        int partNumber = rand() % file.parts();
+        int partNumber = random_int(file.parts());
         int partType = partTypes[partNumber];
         int pixelType = pixelTypes[partNumber];
         int levelMode = levelModes[partNumber];
@@ -1142,8 +1143,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
             case 0:
             {
                 int l1, l2;
-                l1 = rand() % height;
-                l2 = rand() % height;
+                l1 = random_int(height);
+                l2 = random_int(height);
                 if (l1 > l2) swap(l1, l2);
 
                 InputPart part(file, partNumber);
@@ -1180,8 +1181,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
                 int numXLevels = part.numXLevels();
                 int numYLevels = part.numYLevels();
 
-                lx = rand() % numXLevels;
-                ly = rand() % numYLevels;
+                lx = random_int(numXLevels);
+                ly = random_int(numYLevels);
                 if (levelMode == 1) ly = lx;
 
                 int w = part.levelWidth(lx);
@@ -1189,10 +1190,10 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
                 int numXTiles = part.numXTiles(lx);
                 int numYTiles = part.numYTiles(ly);
-                tx1 = rand() % numXTiles;
-                tx2 = rand() % numXTiles;
-                ty1 = rand() % numYTiles;
-                ty2 = rand() % numYTiles;
+                tx1 = random_int(numXTiles);
+                tx2 = random_int(numXTiles);
+                ty1 = random_int(numYTiles);
+                ty2 = random_int(numYTiles);
                 if (tx1 > tx2) swap(tx1, tx2);
                 if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1242,8 +1243,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
                 part.setFrameBuffer(frameBuffer);
 
                 int l1, l2;
-                l1 = rand() % height;
-                l2 = rand() % height;
+                l1 = random_int(height);
+                l2 = random_int(height);
                 if (l1 > l2) swap(l1, l2);
 
                 part.readPixelSampleCounts(l1, l2);
@@ -1279,8 +1280,8 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
                 int tx1, tx2, ty1, ty2;
                 int lx, ly;
-                lx = rand() % numXLevels;
-                ly = rand() % numYLevels;
+                lx = random_int(numXLevels);
+                ly = random_int(numYLevels);
                 if (levelMode == 1) ly = lx;
 
                 int w = part.levelWidth(lx);
@@ -1288,10 +1289,10 @@ readPartialFiles (int randomReadCount, const std::string & fn)
 
                 int numXTiles = part.numXTiles(lx);
                 int numYTiles = part.numYTiles(ly);
-                tx1 = rand() % numXTiles;
-                tx2 = rand() % numXTiles;
-                ty1 = rand() % numYTiles;
-                ty2 = rand() % numYTiles;
+                tx1 = random_int(numXTiles);
+                tx2 = random_int(numXTiles);
+                ty1 = random_int(numYTiles);
+                ty2 = random_int(numYTiles);
                 if (tx1 > tx2) swap(tx1, tx2);
                 if (ty1 > ty2) swap(ty1, ty2);
 
@@ -1472,7 +1473,7 @@ void testMultiPartFileMixingBasic (const std::string & tempDir)
         cout << "Testing the mixed (ScanLine, Tiled, DeepScanLine and DeepTiled)"
                 " multi-part file" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(4);

--- a/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartSharedAttributes.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include "testMultiPartSharedAttributes.h"
+#include "random.h"
 
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
@@ -88,8 +89,8 @@ generateRandomHeaders (int partCount, vector<Header> & headers)
     for (int i = 0; i < partCount; i++)
     {
         Header header(width, height);
-        int pixelType = rand() % 3;
-        int partType = rand() % 2;
+        int pixelType = random_int(3);
+        int partType = random_int(2);
 
         stringstream ss;
         ss << i;
@@ -123,9 +124,9 @@ generateRandomHeaders (int partCount, vector<Header> & headers)
         int levelMode;
         if (partType == 1)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             LevelMode lm = NUM_LEVELMODES;
             switch (levelMode)
             {
@@ -514,6 +515,8 @@ testMultiPartSharedAttributes (const std::string & tempDir)
     try
     {
         cout << "Testing multi part APIs : shared attributes, header... " << endl;
+
+        random_reseed(1);
 
         std::string fn = tempDir +  "imf_test_multipart_shared_attrs.exr";
 

--- a/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
@@ -45,6 +45,7 @@
 
 #include "tmpDir.h"
 #include "testMultiPartThreading.h"
+#include "random.h"
 
 #include <ImfPartType.h>
 #include <ImfMultiPartInputFile.h>
@@ -262,7 +263,7 @@ class RandomReadingTask : public Task
 
         void execute()
         {
-            int partNumber = rand() % headers.size();
+            int partNumber = random_int(headers.size());
             int partType = partTypes[partNumber];
             int pixelType = pixelTypes[partNumber];
             int levelMode = levelModes[partNumber];
@@ -273,8 +274,8 @@ class RandomReadingTask : public Task
             if (partType == 0)
             {
                 int l1, l2;
-                l1 = rand() % height;
-                l2 = rand() % height;
+                l1 = random_int(height);
+                l2 = random_int(height);
                 if (l1 > l2) swap(l1, l2);
 
                 InputPart part(*file, partNumber);
@@ -319,8 +320,8 @@ class RandomReadingTask : public Task
                 int numXLevels = part.numXLevels();
                 int numYLevels = part.numYLevels();
 
-                lx = rand() % numXLevels;
-                ly = rand() % numYLevels;
+                lx = random_int(numXLevels);
+                ly = random_int(numYLevels);
                 if (levelMode == 1) ly = lx;
 
                 int w = part.levelWidth(lx);
@@ -328,10 +329,10 @@ class RandomReadingTask : public Task
 
                 int numXTiles = part.numXTiles(lx);
                 int numYTiles = part.numYTiles(ly);
-                tx1 = rand() % numXTiles;
-                tx2 = rand() % numXTiles;
-                ty1 = rand() % numYTiles;
-                ty2 = rand() % numYTiles;
+                tx1 = random_int(numXTiles);
+                tx2 = random_int(numXTiles);
+                ty1 = random_int(numYTiles);
+                ty2 = random_int(numYTiles);
                 if (tx1 > tx2) swap(tx1, tx2);
                 if (ty1 > ty2) swap(ty1, ty2);
 
@@ -373,8 +374,8 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Writin
     for (int i = 0; i < partCount; i++)
     {
         Header header(width, height);
-        int pixelType = rand() % 3;
-        int partType = rand() % 2;
+        int pixelType = random_int(3);
+        int partType = random_int(2);
         pixelTypes[i] = pixelType;
         partTypes[i] = partType;
 
@@ -410,9 +411,9 @@ void generateRandomHeaders(int partCount, vector<Header>& headers, vector<Writin
         int levelMode = 0;
         if (partType == 1)
         {
-            tileX = rand() % width + 1;
-            tileY = rand() % height + 1;
-            levelMode = rand() % 3;
+            tileX = random_int(width) + 1;
+            tileY = random_int(height) + 1;
+            levelMode = random_int(3);
             levelModes[i] = levelMode;
             LevelMode lm = NUM_LEVELMODES;
             switch (levelMode)
@@ -519,8 +520,8 @@ generateRandomFile (int partCount, const std::string & fn)
     for (int i = 0; i < taskListSize; i++)
     {
         int a, b;
-        a = rand() % taskListSize;
-        b = rand() % taskListSize;
+        a = random_int(taskListSize);
+        b = random_int(taskListSize);
         swap(taskList[a], taskList[b]);
     }
 
@@ -681,8 +682,8 @@ readWholeFiles (const std::string & fn)
         shuffledPartNumber.push_back(i);
     for (int i = 0; i < nHeaders; i++)
     {
-        int a = rand() % nHeaders;
-        int b = rand() % nHeaders;
+        int a = random_int(nHeaders);
+        int b = random_int(nHeaders);
         swap (shuffledPartNumber[a], shuffledPartNumber[b]);
     }
 
@@ -810,7 +811,7 @@ void testMultiPartThreading (const std::string & tempDir)
     {
         cout << "Testing the multi part APIs for multi-thread use" << endl;
 
-        srand(1);
+        random_reseed(1);
 
         int numThreads = ThreadPool::globalThreadPool().numThreads();
         ThreadPool::globalThreadPool().setNumThreads(32);

--- a/OpenEXR/IlmImfTest/testOptimizedInterleavePatterns.cpp
+++ b/OpenEXR/IlmImfTest/testOptimizedInterleavePatterns.cpp
@@ -49,6 +49,7 @@
 #include <ImathBox.h>
 
 #include "tmpDir.h"
+#include "random.h"
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;
@@ -369,7 +370,7 @@ setupBuffer (const Header& hdr,       // header to grab datawindow from
      int chan=0;
      for (int i=0;i<samples;i++)
      {
-         unsigned short int values = (unsigned short int) floor((double(rand())/double(RAND_MAX))*65535.0);
+         unsigned short int values = random_int(std::numeric_limits<unsigned short>::max());
          half v;
          v.setBits(values);
          if (pt==NULL || pt[chan]==IMF::HALF)
@@ -493,22 +494,22 @@ Box2i writefile(Schema & scheme,FrameBuffer& buf,bool tiny)
     Header hdr(width,height,1);
     
     
-    //min values in range (-100,100)
-    hdr.dataWindow().min.x = int(200.0*double(rand())/double(RAND_MAX)-100.0);
-    hdr.dataWindow().min.y = int(200.0*double(rand())/double(RAND_MAX)-100.0);
+    //min values in range [-100,100]
+    hdr.dataWindow().min.x = random_int(201)-100;
+    hdr.dataWindow().min.y = random_int(201)-100;
     
     
     // in tiny mode, make image up to 14*14 pixels (less than two SSE instructions)
     if (tiny)
     {
-        hdr.dataWindow().max.x = hdr.dataWindow().min.x + 1+int(13*double(rand())/double(RAND_MAX));
-        hdr.dataWindow().max.y = hdr.dataWindow().min.y + 1+int(13*double(rand())/double(RAND_MAX));
+        hdr.dataWindow().max.x = hdr.dataWindow().min.x + 1 + random_int(14);
+        hdr.dataWindow().max.y = hdr.dataWindow().min.y + 1 + random_int(14);
     }
     else
     {
         // in normal mode, make chunky images
-        hdr.dataWindow().max.x = hdr.dataWindow().min.x + 64+int(400*double(rand())/double(RAND_MAX));
-        hdr.dataWindow().max.y = hdr.dataWindow().min.y + 64+int(400*double(rand())/double(RAND_MAX));
+        hdr.dataWindow().max.x = hdr.dataWindow().min.x + 64 + random_int(400);
+        hdr.dataWindow().max.y = hdr.dataWindow().min.y + 64 + random_int(400);
     }
     
     hdr.compression()=ZIPS_COMPRESSION;
@@ -603,7 +604,7 @@ test (Schema writeScheme, Schema readScheme, bool nonfatal, bool tiny)
 
 void runtests(bool nonfatal,bool tiny)
 {
-    srand(1);
+    random_reseed(1);
     int i=0;
     int skipped=0;
     


### PR DESCRIPTION
SonarCloud reports use of rand() as a "bug" and recommends the new
generator/distribution mechanism. The new "random.{h,cpp}" defines
random_int() and random_float(), which take the place of "rand() % N",
etc.

Signed-off-by: Cary Phillips <cary@ilm.com>