### PR TITLE
Fix #555

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,14 @@
 
 # We require this to get object library link library support and
 # combined python 2 + 3 support
-cmake_minimum_required(VERSION 3.12)
+if(OPENEXR_BUILD_BOTH_STATIC_SHARED OR ILMBASE_BUILD_BOTH_STATIC_SHARED)
+  if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    message(FATAL_ERROR "CMake 3.12 or newer is required for object library support when building both static and shared libraries")
+  endif()
+  cmake_minimum_required(VERSION 3.12)
+else()
+  cmake_minimum_required(VERSION 3.10)
+endif()
 
 # Hint: This can be set to enable custom find_package
 # search paths, probably best to set it when configuring
@@ -62,7 +69,11 @@ add_subdirectory(OpenEXR)
 # is found and warn otherwise? or error out?
 option(PYILMBASE_ENABLE "Enables configuration of the PyIlmBase module" ON)
 if(PYILMBASE_ENABLE)
-  add_subdirectory(PyIlmBase)
+  if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    message(WARNING ": CMake version ${CMAKE_VERSION} detected, PyIlmBase uses newer features of cmake (>= 3.12), disabling")
+  else()
+    add_subdirectory(PyIlmBase)
+  endif()
 endif()
 
 option(OPENEXR_VIEWERS_ENABLE "Enables configuration of the viewers module" ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,7 +30,8 @@ directory of the source code tree as ``$source_directory``.
 
 Make sure these are installed on your system before building OpenEXR:
 
-* OpenEXR requires CMake version 3.12 or newer (or autoconf on Linux systems).
+* OpenEXR requires CMake version 3.10 or newer (or autoconf on Linux systems).
+  - NB: CMake 3.12 is required for current PyIlmBase support
 * C++ compiler that supports C++11
 * Zlib
 * Python and boost-python if building the PyIlmBase module.

--- a/IlmBase/CMakeLists.txt
+++ b/IlmBase/CMakeLists.txt
@@ -3,7 +3,14 @@
 
 # We require this to get object library link library support and
 # combined python 2 + 3 support
-cmake_minimum_required(VERSION 3.12)
+if(ILMBASE_BUILD_BOTH_STATIC_SHARED)
+  if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    message(FATAL_ERROR "CMake 3.12 or newer is required for object library support when building both static and shared libraries")
+  endif()
+  cmake_minimum_required(VERSION 3.12)
+else()
+  cmake_minimum_required(VERSION 3.10)
+endif()
 
 # we include this first to parse configure.ac and extract the version
 # numbers

--- a/IlmBase/config/CMakeLists.txt
+++ b/IlmBase/config/CMakeLists.txt
@@ -19,13 +19,8 @@ if(ILMBASE_HAVE_UCONTEXT_H)
   endif()
 endif()
 
-# so we know how to link / use...
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_package(Threads)
 ###check_include_files(pthread.h ILMBASE_HAVE_PTHREAD)
 if(Threads_FOUND)
-  set_target_properties(Threads::Threads PROPERTIES IMPORTED_GLOBAL TRUE)
   if(CMAKE_HAVE_PTHREAD_H OR CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREAD_INIT)
     set(ILMBASE_HAVE_PTHREAD ON)
     # TODO: remove this once we cleanly have ILMBASE_ prefix on all #defines

--- a/IlmBase/config/IlmBaseSetup.cmake
+++ b/IlmBase/config/IlmBaseSetup.cmake
@@ -124,3 +124,17 @@ if(OPENEXR_USE_CLANG_TIDY)
     -checks=*;
   )
 endif()
+
+###############################
+# Dependent libraries
+
+# so we know how to link / use threads and don't have to have a -pthread
+# everywhere...
+if(NOT TARGET Threads::Threads)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads)
+  if(NOT Threads_FOUND)
+    message(FATAL_ERROR "Unable to find a threading library which is required for IlmThread")
+  endif()
+endif()

--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -3,7 +3,14 @@
 
 # We require this to get object library link library support and
 # combined python 2 + 3 support
-cmake_minimum_required(VERSION 3.12)
+if(OPENEXR_BUILD_BOTH_STATIC_SHARED)
+  if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    message(FATAL_ERROR "CMake 3.12 or newer is required for object library support when building both static and shared libraries")
+  endif()
+  cmake_minimum_required(VERSION 3.12)
+else()
+  cmake_minimum_required(VERSION 3.10)
+endif()
 
 # we include this first to parse configure.ac and extract the version
 # numbers

--- a/OpenEXR/config/CMakeLists.txt
+++ b/OpenEXR/config/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${PROJECT_NAME}ConfigVersion.cmake"
   VERSION ${OPENEXR_VERSION}
-  COMPATIBILITY SameMinorVersion
+  COMPATIBILITY SameMajorVersion
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}

--- a/OpenEXR/config/CMakeLists.txt
+++ b/OpenEXR/config/CMakeLists.txt
@@ -52,22 +52,6 @@ endif()
 find_package(ZLIB REQUIRED)
 set_target_properties(ZLIB::ZLIB PROPERTIES IMPORTED_GLOBAL TRUE)
 
-# so we know how to link / use...
-if(NOT TARGET Threads::Threads)
-  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads)
-  ###check_include_files(pthread.h OPENEXR_HAVE_PTHREAD)
-  if(Threads_FOUND)
-    set_target_properties(Threads::Threads PROPERTIES IMPORTED_GLOBAL TRUE)
-    if(CMAKE_HAVE_PTHREAD_H OR CMAKE_USE_PTHREADS_INIT OR CMAKE_HP_PTHREAD_INIT)
-      set(OPENEXR_HAVE_PTHREAD ON)
-      # TODO: remove this once we cleanly have OPENEXR_ prefix on all #defines
-      set(HAVE_PTHREAD ON)
-    endif()
-  endif()
-endif()
-
 configure_file(OpenEXRConfig.h.in_cmake ${CMAKE_CURRENT_BINARY_DIR}/OpenEXRConfig.h)
 configure_file(OpenEXRConfigInternal.h.in_cmake ${CMAKE_CURRENT_BINARY_DIR}/OpenEXRConfigInternal.h)
 

--- a/OpenEXR/config/CMakeLists.txt
+++ b/OpenEXR/config/CMakeLists.txt
@@ -49,9 +49,6 @@ if(APPLE)
   set(OPENEXR_IMF_HAVE_DARWIN TRUE)
 endif()
 
-find_package(ZLIB REQUIRED)
-set_target_properties(ZLIB::ZLIB PROPERTIES IMPORTED_GLOBAL TRUE)
-
 configure_file(OpenEXRConfig.h.in_cmake ${CMAKE_CURRENT_BINARY_DIR}/OpenEXRConfig.h)
 configure_file(OpenEXRConfigInternal.h.in_cmake ${CMAKE_CURRENT_BINARY_DIR}/OpenEXRConfigInternal.h)
 

--- a/OpenEXR/config/OpenEXRSetup.cmake
+++ b/OpenEXR/config/OpenEXRSetup.cmake
@@ -132,3 +132,8 @@ if(NOT TARGET Threads::Threads)
     message(FATAL_ERROR "Unable to find a threading library which is required for OpenEXR")
   endif()
 endif()
+
+find_package(ZLIB REQUIRED)
+if(NOT TARGET ZLIB::ZLIB)
+  message(FATAL_ERROR "Unable to find zlib library target which is required for OpenEXR")
+endif()

--- a/OpenEXR/config/OpenEXRSetup.cmake
+++ b/OpenEXR/config/OpenEXRSetup.cmake
@@ -118,3 +118,17 @@ if(OPENEXR_USE_CLANG_TIDY)
     -checks=*;
   )
 endif()
+
+###############################
+# Dependent libraries
+
+# so we know how to add the thread stuff to the pkg-config package
+# which is the only (but good) reason.
+if(NOT TARGET Threads::Threads)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads)
+  if(NOT Threads_FOUND)
+    message(FATAL_ERROR "Unable to find a threading library which is required for OpenEXR")
+  endif()
+endif()

--- a/OpenEXR_Viewers/CMakeLists.txt
+++ b/OpenEXR_Viewers/CMakeLists.txt
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-# We require this to get object library link library support and
-# combined python 2 + 3 support
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 # we include this first to parse configure.ac and extract the version
 # numbers
@@ -25,6 +23,8 @@ include(config/OpenEXRViewersSetup.cmake)
 find_package(IlmBase ${OPENEXR_VIEWERS_VERSION} EXACT REQUIRED CONFIG)
 find_package(OpenEXR ${OPENEXR_VIEWERS_VERSION} EXACT REQUIRED CONFIG)
 
+# This is for newer cmake versions who know about vendor versions
+set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL)
 
 set(FLTK_SKIP_FLUID 1)


### PR DESCRIPTION
This fixes issue #555 as well as enabling IlmBase and OpenEXR to compile by default under Ubuntu 18.04 which has an older cmake by default