### PR TITLE
Fix warnings when _FORTIFY_SOURCE set

### DIFF
--- a/OpenEXR/IlmImf/ImfSystemSpecific.h
+++ b/OpenEXR/IlmImf/ImfSystemSpecific.h
@@ -61,7 +61,12 @@ EXRAllocAligned (size_t size, size_t alignment)
     return _mm_malloc (size, alignment);
 #elif defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L)
     void* ptr = 0;
-    posix_memalign (&ptr, alignment, size);
+    // With fortify_source on, just doing the (void) cast trick
+    // doesn't remove the unused result warning but we expect the
+    // other mallocs to return null and to check the return value
+    // of this function
+    if ( posix_memalign (&ptr, alignment, size) )
+        ptr = 0;
     return ptr;
 #else
     return malloc(size);

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -1243,7 +1243,8 @@ modifyType (bool modify_version)
             //length of attribute
             size_t nr = fread (&length,4,1,f);
             if ( nr != 1 )
-                throw std::runtime_error ("unable to read length of attribute");
+                throw IEX_NAMESPACE::IoExc (
+                    "unable to read length of attribute");
             if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
             {
         	length = bswap_32(length);

--- a/OpenEXR/IlmImfTest/testFutureProofing.cpp
+++ b/OpenEXR/IlmImfTest/testFutureProofing.cpp
@@ -1241,7 +1241,9 @@ modifyType (bool modify_version)
             
             
             //length of attribute
-            fread(&length,4,1,f);
+            size_t nr = fread (&length,4,1,f);
+            if ( nr != 1 )
+                throw std::runtime_error ("unable to read length of attribute");
             if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
             {
         	length = bswap_32(length);

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -1393,7 +1393,9 @@ killOffsetTables (const std::string & fn)
             
             
             //length of attribute
-            fread(&length,4,1,f);
+            size_t nr = fread(&length,4,1,f);
+            if (nr != 1)
+                throw std::runtime_error ("Unable to read attribute length");
     	    if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
     	    {
     		length = bswap_32(length);

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -1395,8 +1395,9 @@ killOffsetTables (const std::string & fn)
             //length of attribute
             size_t nr = fread(&length,4,1,f);
             if (nr != 1)
-                throw std::runtime_error ("Unable to read attribute length");
-    	    if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
+                throw IEX_NAMESPACE::IoExc (
+                    "Unable to read attribute length");
+            if (!GLOBAL_SYSTEM_LITTLE_ENDIAN)
     	    {
     		length = bswap_32(length);
     	    }


### PR DESCRIPTION
This fixes a couple of warnings when compiling the tree with fortify
source enabled, which is the default on some systems.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>