### PR TITLE
Add NOSONAR comments to PyImath to suppress "self==self" bug reports.

### DIFF
--- a/PyIlmBase/PyImath/PyImathBox.cpp
+++ b/PyIlmBase/PyImath/PyImathBox.cpp
@@ -356,8 +356,8 @@ register_Box2()
         .def_readwrite("max",&Box<T>::max)
         .def("min", &boxMin<T>)
         .def("max", &boxMax<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__repr__", &Box2_repr<T>)
         .def("makeEmpty",&Box<T>::makeEmpty,"makeEmpty() make the box empty")
         .def("makeInfinite",&Box<T>::makeInfinite,"makeInfinite() make the box cover all space")
@@ -416,8 +416,8 @@ register_Box3()
         .def("__init__", make_constructor(boxConstructor<T, IMATH_NAMESPACE::V3i>))
         .def_readwrite("min",&Box<T>::min)
         .def_readwrite("max",&Box<T>::max)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__mul__", &mulM44<T, float>)
         .def("__mul__", &mulM44<T, double>)
         .def("__imul__", &imulM44<T, float>,return_internal_reference<>())

--- a/PyIlmBase/PyImath/PyImathColor3.cpp
+++ b/PyIlmBase/PyImath/PyImathColor3.cpp
@@ -593,8 +593,8 @@ register_Color3()
         .def_readwrite("b", &Color3<T>::z)
         .def("__str__", &color3_str<T>)
         .def("__repr__", &color3_repr<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__iadd__", &iadd<T>,return_internal_reference<>())
         .def("__add__", &add<T>)
         .def("__add__", &addTuple<T>)

--- a/PyIlmBase/PyImath/PyImathColor4.cpp
+++ b/PyIlmBase/PyImath/PyImathColor4.cpp
@@ -592,8 +592,8 @@ register_Color4()
         .def_readwrite("a", &Color4<T>::a)
         .def("__str__", &color4_str<T>)
         .def("__repr__", &color4_repr<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__iadd__", &iadd<T>,return_internal_reference<>())
         .def("__add__", &add<T>)
         .def("__add__", &addTuple<T>)

--- a/PyIlmBase/PyImath/PyImathFrustum.cpp
+++ b/PyIlmBase/PyImath/PyImathFrustum.cpp
@@ -306,8 +306,8 @@ register_Frustum()
         .def(init<>("Frustum() default construction"))
         .def(init<T,T,T,T,T,T,bool>("Frustum(nearPlane,farPlane,left,right,top,bottom,ortho) construction"))
         .def(init<T,T,T,T,T>("Frustum(nearPlane,farPlane,fovx,fovy,aspect) construction"))
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__repr__",&Frustum_repr<T>)
         .def("set", set1,
         	 "F.set(nearPlane, farPlane, left, right, top, bottom, "

--- a/PyIlmBase/PyImath/PyImathMatrix33.cpp
+++ b/PyIlmBase/PyImath/PyImathMatrix33.cpp
@@ -905,8 +905,8 @@ register_Matrix33()
         .def("minorOf",&Matrix33<T>::minorOf,"minorOf() return the matrix minor of the (row,col) element of this matrix")
         .def("fastMinor",&Matrix33<T>::fastMinor,"fastMinor() return the matrix minor using the specified rows and columns of this matrix")
         .def("determinant",&Matrix33<T>::determinant,"determinant() return the determinant of this matrix")
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__iadd__", &iadd33<T, float>,return_internal_reference<>())
         .def("__iadd__", &iadd33<T, double>,return_internal_reference<>())
         .def("__iadd__", &iadd33T<T>,return_internal_reference<>())

--- a/PyIlmBase/PyImath/PyImathMatrix44.cpp
+++ b/PyIlmBase/PyImath/PyImathMatrix44.cpp
@@ -1004,8 +1004,8 @@ register_Matrix44()
         .def("inverse",&inverse44<T>,inverse44_overloads("inverse() return a inverted copy of this matrix"))
         .def("gjInvert",&gjInvert44<T>,gjInvert44_overloads("gjInvert() invert this matrix")[return_internal_reference<>()])
         .def("gjInverse",&gjInverse44<T>,gjInverse44_overloads("gjInverse() return a inverted copy of this matrix"))
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__iadd__", &iadd44<T, float>,return_internal_reference<>())
         .def("__iadd__", &iadd44<T, double>,return_internal_reference<>())
         .def("__iadd__", &iadd44T<T>,return_internal_reference<>())

--- a/PyIlmBase/PyImath/PyImathQuat.cpp
+++ b/PyIlmBase/PyImath/PyImathQuat.cpp
@@ -524,8 +524,8 @@ register_Quat()
         .def ("__itruediv__", &idivT<T>, return_internal_reference<>())
         .def ("__iadd__", &iadd<T>, return_internal_reference<>())
         .def ("__isub__", &isub<T>, return_internal_reference<>())
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def ("__rmul__", &rmulM33<T>)
         .def ("__mul__", &mulM33<T>)
         .def ("__mul__", &mul<T>)

--- a/PyIlmBase/PyImath/PyImathShear.cpp
+++ b/PyIlmBase/PyImath/PyImathShear.cpp
@@ -533,8 +533,8 @@ register_Shear()
         .def("__div__",&divT<T>)
         .def("__truediv__",&div<T>)
         .def("__truediv__",&divT<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__str__",&Shear_str<T>)
         .def("__repr__",&Shear_repr<T>)
         .def("setValue", setValue1)

--- a/PyIlmBase/PyImath/PyImathStringArray.cpp
+++ b/PyIlmBase/PyImath/PyImathStringArray.cpp
@@ -304,10 +304,10 @@ void register_StringArrays()
         .def("__setitem__", &StringArray::setitem_string_vector)
         .def("__setitem__", &StringArray::setitem_string_vector_mask)
         .def("__len__",&StringArray::len)
-        .def(self == self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
         .def(self == other<std::string>())
         .def(other<std::string>() == self)
-        .def(self != self)
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def(self != other<std::string>())
         .def(other<std::string>() != self)
         ;
@@ -324,10 +324,10 @@ void register_StringArrays()
         .def("__setitem__", &WstringArray::setitem_string_vector)
         .def("__setitem__", &WstringArray::setitem_string_vector_mask)
         .def("__len__",&WstringArray::len)
-        .def(self == self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
         .def(self == other<std::wstring>())
         .def(other<std::wstring>() == self)
-        .def(self != self)
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def(self != other<std::wstring>())
         .def(other<std::wstring>() != self)
         ;


### PR DESCRIPTION
SonarCloud doesn't like expressions of the form "a == a", but this
construction occurs in the boost::python .def() template
instantiations in PyImath. This comment will suppress the bug report.

Signed-off-by: Cary Phillips <cary@ilm.com>