### PR TITLE
Sonar fixes in IlmImf and IlmImfTest

### DIFF
--- a/OpenEXR/IlmImf/ImfTileOffsets.cpp
+++ b/OpenEXR/IlmImf/ImfTileOffsets.cpp
@@ -477,17 +477,14 @@ TileOffsets::operator () (int dx, int dy, int lx, int ly)
       case ONE_LEVEL:
 
         return _offsets[0][dy][dx];
-        break;
 
       case MIPMAP_LEVELS:
 
         return _offsets[lx][dy][dx];
-        break;
 
       case RIPMAP_LEVELS:
 
         return _offsets[lx + ly * _numXLevels][dy][dx];
-        break;
 
       default:
 
@@ -517,17 +514,14 @@ TileOffsets::operator () (int dx, int dy, int lx, int ly) const
       case ONE_LEVEL:
 
         return _offsets[0][dy][dx];
-        break;
 
       case MIPMAP_LEVELS:
 
         return _offsets[lx][dy][dx];
-        break;
 
       case RIPMAP_LEVELS:
 
         return _offsets[lx + ly * _numXLevels][dy][dx];
-        break;
 
       default:
 

--- a/OpenEXR/IlmImfTest/compareDwa.cpp
+++ b/OpenEXR/IlmImfTest/compareDwa.cpp
@@ -64,11 +64,9 @@ toNonlinear(half linear)
 
     if ( fabs( (float)linear ) <= 1.0f) {
         return (half)(sign * pow(fabs((float)linear), 1.f/2.2f));
-    } else {
-        return (half)(sign * ( log(fabs((float)linear)) / log(logBase) + 1.0f) );
-    }
+    } 
 
-    return (half)0.0f;
+    return (half)(sign * ( log(fabs((float)linear)) / log(logBase) + 1.0f) );
 }
 
 

--- a/OpenEXR/IlmImfTest/main.cpp
+++ b/OpenEXR/IlmImfTest/main.cpp
@@ -114,10 +114,11 @@
 
 using namespace std;
 
+#define TEST_STRING(x) #x
 #define TEST(x,y)                                                       \
-    if (argc < 2 || (!strcmp (argv[1], #x) || !strcmp (argv[1], y)))    \
+    if (argc < 2 || (!strcmp (argv[1], TEST_STRING(x)) || !strcmp (argv[1], y)))    \
     {                                                                   \
-        cout << "\n=======\nRunning " << #x <<endl;                     \
+        cout << "\n=======\nRunning " << TEST_STRING(x) <<endl;                     \
         x(tempDir);                                                     \
     }
 

--- a/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
+++ b/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
@@ -352,9 +352,9 @@ test (int testCount)
     for(int i = 0 ; i < testCount ; ++i )
     {
         FrameBuffer writeFrameBuf;
-        const char** channels=NULL;
-        switch( random_int(4)
-)        {
+        const char** channels=rgb;
+        switch( random_int(4))        
+        {
             case 0 : channels = rgb; break;
             case 1 : channels = rgba; break;
             case 2 : channels = rgbaz; break;


### PR DESCRIPTION
SonarCloud "bug" fixes in IlmImf and IlmImfTest:  
- remove unreachable 'break' statements.
- remove unreachable 'return' statement.
- edit macro to use a single instance of '#'
- fix static analysis warning about possible null pointer dereference.


