### PR TITLE
More fixes for SonarCloud bugs

### DIFF
--- a/OpenEXR/IlmImfTest/testTiledCompression.cpp
+++ b/OpenEXR/IlmImfTest/testTiledCompression.cpp
@@ -145,7 +145,7 @@ fillPixels4 (Array2D<unsigned int> &pi,
             {
                 ph[y][x].setBits (rand.nexti());
             }
-            while (ph[y][x].isNan());
+            while (ph[y][x].isNan() || ph[y][x].isInfinity());
 
             union {int i; float f;} u;
 
@@ -154,7 +154,7 @@ fillPixels4 (Array2D<unsigned int> &pi,
                 u.i = rand.nexti();
                 pf[y][x] = u.f;
             }
-            while (pf[y][x] != pf[y][x]);
+            while (isnan(pf[y][x]) || isinf(pf[y][x]));
         }
 }
 

--- a/PyIlmBase/PyImath/PyImathVec3Impl.h
+++ b/PyIlmBase/PyImath/PyImathVec3Impl.h
@@ -994,8 +994,8 @@ register_Vec3()
         .def("__itruediv__", &Vec3_idivObj<T>,return_internal_reference<>())
         .def("__xor__", &Vec3_dot<T>)
         .def("__mod__", &Vec3_cross<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__add__", &Vec3_add<T>)
         .def("__add__", &Vec3_addV<T, int>)
         .def("__add__", &Vec3_addV<T, float>)

--- a/PyIlmBase/PyImath/PyImathVec4Impl.h
+++ b/PyIlmBase/PyImath/PyImathVec4Impl.h
@@ -973,8 +973,8 @@ register_Vec4()
         .def("__idiv__", &Vec4_idivObj<T>,return_internal_reference<>())
         .def("__itruediv__", &Vec4_idivObj<T>,return_internal_reference<>())
         .def("__xor__", &Vec4_dot<T>)
-        .def(self == self)
-        .def(self != self)
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
         .def("__add__", &Vec4_add<T>)
         .def("__add__", &Vec4_addV<T, int>)
         .def("__add__", &Vec4_addV<T, float>)


### PR DESCRIPTION
SonarCloud bug fixes:
- suppress warnings for PyBind defs
- change nan check from 'a!=a' to std::isnan() and add infinity checks