### PR TITLE
More SonarCloud "bug" fixes in Imath

### DIFF
--- a/IlmBase/Imath/ImathEuler.h
+++ b/IlmBase/Imath/ImathEuler.h
@@ -226,6 +226,12 @@ class Euler : public Vec3<T>
     Euler(const Matrix33<T> &, Order o = Default);
     Euler(const Matrix44<T> &, Order o = Default);
 
+    //-------------
+    //  Destructor
+    //-------------
+	
+	~Euler() = default;
+
     //---------------------------------
     //  Algebraic functions/ Operators
     //---------------------------------
@@ -746,14 +752,14 @@ Quat<T> Euler<T>::toQuat() const
     if ( _initialRepeated )
     {
 	a[i]	= cj*(cs + sc);
-	a[j]	= sj*(cc + ss) * parity,
+	a[j]	= sj*(cc + ss) * parity, // NOSONAR - suppress SonarCloud bug report.
 	a[k]	= sj*(cs - sc);
 	q.r	= cj*(cc - ss);
     }
     else
     {
 	a[i]	= cj*sc - sj*cs,
-	a[j]	= (cj*ss + sj*cc) * parity,
+	a[j]	= (cj*ss + sj*cc) * parity, // NOSONAR - suppress SonarCloud bug report.
 	a[k]	= cj*cs - sj*sc;
 	q.r	= cj*cc + sj*ss;
     }

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -119,6 +119,12 @@ template <class T> class Matrix33
     const Matrix33 &    operator = (T a);
 
 
+    //------------
+    // Destructor
+    //------------
+
+    ~Matrix33 () = default;
+	
     //----------------------
     // Compatibility with Sb
     //----------------------
@@ -474,6 +480,11 @@ template <class T> class Matrix44
                                 // r r r 0
                                 // t t t 1
 
+    //------------
+    // Destructor
+    //------------
+
+    ~Matrix44 () = default;
 
     //--------------------------------
     // Copy constructor and assignment

--- a/IlmBase/Imath/ImathQuat.h
+++ b/IlmBase/Imath/ImathQuat.h
@@ -78,7 +78,7 @@ class Quat
 
 
     //-----------------------------------------------------
-    //	Constructors - default constructor is identity quat
+    // Constructors - default constructor is identity quat
     //-----------------------------------------------------
 
     Quat ();
@@ -92,6 +92,17 @@ class Quat
 
     static Quat<T> identity ();
 
+    //-------------------
+    // Copy constructor
+    //-------------------
+
+    Quat (const Quat &q);
+
+    //-------------
+    // Destructor
+    //-------------
+
+    ~Quat () = default;
 
     //-------------------------------------------------
     //	Basic Algebra - Operators and Methods
@@ -258,6 +269,12 @@ Quat<T>::Quat (T s, Vec3<T> d): r (s), v (d)
     // empty
 }
 
+template<class T>
+inline
+Quat<T>::Quat(const Quat<T> &q)
+{
+	operator=(q);
+}
 
 template<class T>
 inline Quat<T>

--- a/IlmBase/Imath/ImathShear.h
+++ b/IlmBase/Imath/ImathShear.h
@@ -91,6 +91,11 @@ template <class T> class Shear6
     template <class S> 
 	const Shear6 &	operator = (const Vec3<S> &v);
 
+    //------------
+    // Destructor
+    //------------
+
+	~Shear6() = default;
 
     //----------------------
     // Compatibility with Sb
@@ -251,14 +256,14 @@ template <class T>
 inline T &
 Shear6<T>::operator [] (int i)
 {
-    return (&xy)[i];
+    return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 inline const T &
 Shear6<T>::operator [] (int i) const
 {
-    return (&xy)[i];
+    return (&xy)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>

--- a/IlmBase/Imath/ImathVec.h
+++ b/IlmBase/Imath/ImathVec.h
@@ -98,6 +98,11 @@ template <class T> class Vec2
 
     const Vec2 &	operator = (const Vec2 &v);
 
+    //------------
+    // Destructor
+    //------------
+	
+    ~Vec2 () = default;
 
     //----------------------
     // Compatibility with Sb
@@ -296,6 +301,11 @@ template <class T> class Vec3
 
     const Vec3 &	operator = (const Vec3 &v);
 
+    //-----------
+    // Destructor
+    //-----------
+	
+    ~Vec3 () = default;
 
     //---------------------------------------------------------
     // Vec4 to Vec3 conversion, divides x, y and z by w:
@@ -509,6 +519,11 @@ template <class T> class Vec4
 
     const Vec4 &    operator = (const Vec4 &v);
 
+    //-----------
+    // Destructor
+    //-----------
+	
+    ~Vec4 () = default;
 
     //-------------------------------------
     // Vec3 to Vec4 conversion, sets w to 1
@@ -853,14 +868,14 @@ template <class T>
 inline T &
 Vec2<T>::operator [] (int i)
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 inline const T &
 Vec2<T>::operator [] (int i) const
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
@@ -1274,14 +1289,14 @@ template <class T>
 inline T &
 Vec3<T>::operator [] (int i)
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 inline const T &
 Vec3<T>::operator [] (int i) const
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
@@ -1768,14 +1783,14 @@ template <class T>
 inline T &
 Vec4<T>::operator [] (int i)
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>
 inline const T &
 Vec4<T>::operator [] (int i) const
 {
-    return (&x)[i];
+    return (&x)[i]; // NOSONAR - suppress SonarCloud bug report.
 }
 
 template <class T>

--- a/OpenEXR/IlmImf/ImfIO.cpp
+++ b/OpenEXR/IlmImf/ImfIO.cpp
@@ -70,7 +70,6 @@ IStream::readMemoryMapped (int n)
 {
     throw IEX_NAMESPACE::InputExc ("Attempt to perform a memory-mapped read "
 			 "on a file that is not memory mapped.");
-    return 0;
 }
 
 


### PR DESCRIPTION
Various SonarCloud bug fixes:
- added explicit destructors.
- added explicit copy constructor.
- added NOSONAR exceptions for array index operators in math primitive classes, current method of accessing is proven and fast.
- removed unreachable return statement.