### PR TITLE
Use previously-built native generators when building with CMake.

### DIFF
--- a/IlmBase/Half/CMakeLists.txt
+++ b/IlmBase/Half/CMakeLists.txt
@@ -1,21 +1,44 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-add_executable(eLut eLut.cpp)
-target_compile_features(eLut PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+check_include_files(${CMAKE_CURRENT_BINARY_DIR}/eLut.h HAVE_ELUT_H)
+check_include_files(${CMAKE_CURRENT_BINARY_DIR}/toFloat.h HAVE_TOFLOAT_H)
 
-
-add_executable(toFloat toFloat.cpp)
-target_compile_features(toFloat PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
-
-add_custom_command(
-  OUTPUT
-    ${CMAKE_CURRENT_BINARY_DIR}/toFloat.h
-    ${CMAKE_CURRENT_BINARY_DIR}/eLut.h
-  COMMAND $<TARGET_FILE:toFloat> ARGS > ${CMAKE_CURRENT_BINARY_DIR}/toFloat.h
-  COMMAND $<TARGET_FILE:eLut> ARGS > ${CMAKE_CURRENT_BINARY_DIR}/eLut.h
-  DEPENDS eLut toFloat
-)
+if((NOT HAVE_ELUT_H) OR (NOT HAVE_TOFLOAT_H))
+  if(CMAKE_CROSSCOMPILING)
+    message(STATUS "We're cross-compiling; will use native executables from a previous build to generate toFloat.h and eLut.h")
+    set(NATIVE_ILMBASE_BUILD_DIR "NATIVE_ILMBASE-NOTFOUND" CACHE FILEPATH "Point it to the build folder of a native build.")
+    if (NATIVE_ILMBASE_BUILD_DIR)
+      set (toFloat_PATH "${NATIVE_ILMBASE_BUILD_DIR}/bin/toFloat")
+      set (eLut_PATH "${NATIVE_ILMBASE_BUILD_DIR}/bin/eLut")
+    else()
+      message(FATAL_ERROR "Missing path to native build directory.")
+    endif()
+   else()
+    add_executable(eLut eLut.cpp)
+    target_compile_features(eLut PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+    set_target_properties(eLut PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+    
+    add_executable(toFloat toFloat.cpp)
+    target_compile_features(toFloat PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+    set_target_properties(toFloat PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+    set (toFloat_PATH "$<TARGET_FILE:toFloat>")
+    set (eLut_PATH "$<TARGET_FILE:eLut>")
+   endif()
+    add_custom_command(
+      OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/toFloat.h
+        ${CMAKE_CURRENT_BINARY_DIR}/eLut.h
+      COMMAND "${toFloat_PATH}" ARGS > "${CMAKE_CURRENT_BINARY_DIR}/toFloat.h"
+      COMMAND "${eLut_PATH}" ARGS > "${CMAKE_CURRENT_BINARY_DIR}/eLut.h"
+      DEPENDS $<$<NOT:$<BOOL:${CMAKE_CROSSCOMPILING}>>:eLut>
+      DEPENDS $<$<NOT:$<BOOL:${CMAKE_CROSSCOMPILING}>>:toFloat>
+    )
+endif()
 
 ### Now define the real library
 

--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -1,30 +1,47 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
-add_executable(b44ExpLogTable b44ExpLogTable.cpp)
-target_link_libraries(b44ExpLogTable PRIVATE OpenEXR::Config IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
-set_target_properties(b44ExpLogTable PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-# TODO: Old file had logic to skip these if the file already exists
-add_custom_command(
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
-  COMMAND $<TARGET_FILE:b44ExpLogTable> > ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
-  DEPENDS b44ExpLogTable
-)
+check_include_files(${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h HAVE_B44_EXP_LOG_TABLE_H)
+check_include_files(${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h HAVE_DWA_LOOKUPS_H)
 
+if((NOT HAVE_B44_EXP_LOG_TABLE_H) OR (NOT HAVE_DWA_LOOKUPS_H))
+  if(CMAKE_CROSSCOMPILING)
+    message(STATUS "We're cross-compiling; will use native executables from a previous build to generate b44ExpLogTable.h and dwaLookups.h")
+    set(NATIVE_OPENEXR_BUILD_DIR "NATIVE_OPENEXR-NOTFOUND" CACHE FILEPATH "Point it to the build folder of a native build.")
+    if (NATIVE_OPENEXR_BUILD_DIR)
+      set (b44ExpLogTable_PATH "${NATIVE_OPENEXR_BUILD_DIR}/bin/b44ExpLogTable")
+      set (dwaLookups_PATH "${NATIVE_OPENEXR_BUILD_DIR}/bin/dwaLookups")
+    else()
+      message(FATAL_ERROR "Missing path to native build directory.")
+    endif()
+   else()
+    add_executable(b44ExpLogTable b44ExpLogTable.cpp)
+    target_link_libraries(b44ExpLogTable PRIVATE OpenEXR::Config IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
+    set_target_properties(b44ExpLogTable PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+    target_compile_features(b44ExpLogTable PUBLIC cxx_std_${OPENEXR_CXX_STANDARD})
+    
+    add_executable(dwaLookups dwaLookups.cpp)
+    target_link_libraries(dwaLookups PRIVATE OpenEXR::Config IlmBase::Imath IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
+    set_target_properties(dwaLookups PROPERTIES
+     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+    
+    set (b44ExpLogTable_PATH "$<TARGET_FILE:b44ExpLogTable>")
+    set (dwaLookups_PATH "$<TARGET_FILE:dwaLookups>")
+   endif()
+    add_custom_command(
+      OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h
+        ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
+      COMMAND "${b44ExpLogTable_PATH}" ARGS > "${CMAKE_CURRENT_BINARY_DIR}/b44ExpLogTable.h"
+      COMMAND "${dwaLookups_PATH}" ARGS > "${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h"
+      DEPENDS $<$<NOT:$<BOOL:${CMAKE_CROSSCOMPILING}>>:b44ExpLogTable>
+      DEPENDS $<$<NOT:$<BOOL:${CMAKE_CROSSCOMPILING}>>:dwaLookups>
+    )
+endif()
 
-add_executable(dwaLookups dwaLookups.cpp)
-target_link_libraries(dwaLookups PRIVATE OpenEXR::Config IlmBase::Imath IlmBase::Half IlmBase::IlmThread IlmBase::Iex)
-set_target_properties(dwaLookups PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
-)
-# TODO: Old file had logic to skip these if the file already exists
-add_custom_command(
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
-  COMMAND $<TARGET_FILE:dwaLookups> > ${CMAKE_CURRENT_BINARY_DIR}/dwaLookups.h
-  DEPENDS dwaLookups
-)
 
 openexr_define_library(IlmImf
   PRIV_EXPORT ILMIMF_EXPORTS


### PR DESCRIPTION
Just split this off from #591 as requested.