### PR TITLE
"Rule of 5" copy/assign/move declarations

### DIFF
--- a/IlmBase/Iex/IexBaseExc.cpp
+++ b/IlmBase/Iex/IexBaseExc.cpp
@@ -99,18 +99,34 @@ BaseExc::BaseExc (std::stringstream &s) throw () :
     // empty
 }
 
-
-BaseExc::BaseExc (const BaseExc &be) throw () :
-    _message (be._message),
-    _stackTrace (be._stackTrace)
+BaseExc::BaseExc (const BaseExc &be) throw()
+    : _message (be._message),
+      _stackTrace (be._stackTrace)
 {
-    // empty
 }
-
 
 BaseExc::~BaseExc () throw ()
 {
-    // empty
+}
+
+BaseExc &
+BaseExc::operator = (const BaseExc& be) throw ()
+{
+    if (this != &be)
+    {
+        _message = be._message;
+        _stackTrace = be._stackTrace;
+    }
+}
+
+BaseExc &
+BaseExc::operator = (BaseExc&& be) throw ()
+{
+    if (this != &be)
+    {
+        _message = std::move (be._message);
+        _stackTrace = std::move (be._stackTrace);
+    }
 }
 
 const char *

--- a/IlmBase/Iex/IexBaseExc.cpp
+++ b/IlmBase/Iex/IexBaseExc.cpp
@@ -117,6 +117,8 @@ BaseExc::operator = (const BaseExc& be) throw ()
         _message = be._message;
         _stackTrace = be._stackTrace;
     }
+
+    return *this;
 }
 
 BaseExc &
@@ -127,6 +129,7 @@ BaseExc::operator = (BaseExc&& be) throw ()
         _message = std::move (be._message);
         _stackTrace = std::move (be._stackTrace);
     }
+    return *this;
 }
 
 const char *

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -72,7 +72,7 @@ class BaseExc: public std::exception
     IEX_EXPORT BaseExc (const BaseExc &be) throw();
     IEX_EXPORT virtual ~BaseExc () throw ();
 
-    IEX_EXPORT BaseExc & operator = (const BaseExc& be) throw () = delete;
+    IEX_EXPORT const BaseExc & operator = (const BaseExc& be) throw () = delete;
 
     //---------------------------------------------------
     // what() method -- e.what() returns _message.c_str()

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -65,15 +65,16 @@ class BaseExc: public std::exception
     // Constructors and destructor
     //----------------------------
 
-    IEX_EXPORT BaseExc (const char *s = 0) throw();     // std::string (s)
-    IEX_EXPORT BaseExc (const std::string &s) throw();  // std::string (s)
-    IEX_EXPORT BaseExc (std::stringstream &s) throw();  // std::string (s.str())
+    IEX_EXPORT BaseExc (const char *s = nullptr) throw();     // std::string (s)
+    IEX_EXPORT BaseExc (const std::string &s) throw();        // std::string (s)
+    IEX_EXPORT BaseExc (std::stringstream &s) throw();        // std::string (s.str())
 
     IEX_EXPORT BaseExc (const BaseExc &be) throw();
+    IEX_EXPORT BaseExc (BaseExc &&be) throw();
     IEX_EXPORT virtual ~BaseExc () throw ();
 
-    IEX_EXPORT BaseExc & operator = (const BaseExc& be) throw () = delete;
-    IEX_EXPORT BaseExc & operator = (const BaseExc&& be) throw () = delete;
+    IEX_EXPORT BaseExc & operator = (const BaseExc& be) throw ();
+    IEX_EXPORT BaseExc & operator = (BaseExc&& be) throw ();
 
     //---------------------------------------------------
     // what() method -- e.what() returns _message.c_str()
@@ -139,13 +140,22 @@ class BaseExc: public std::exception
         exp name (const char* text) throw();                        \
         exp name (const std::string &text) throw();                 \
         exp name (std::stringstream &text) throw();                 \
+        exp name (const name &other) throw();                       \
+        exp name (name &&other) throw();                            \
+        exp name& operator = (name &other) throw();                 \
+        exp name& operator = (name &&other) throw();                \
         exp ~name() throw();                                        \
     };
+
 #define DEFINE_EXC_EXP_IMPL(exp, name, base)                       \
 exp name::name () throw () : base () {}                            \
 exp name::name (const char* text) throw () : base (text) {}        \
 exp name::name (const std::string& text) throw () : base (text) {} \
 exp name::name (std::stringstream& text) throw () : base (text) {} \
+exp name::name (const name &other) throw() : base (other) {}       \
+exp name::name (name &&other) throw() : base (other) {}            \
+exp name& name::operator = (name &other) throw() { base::operator=(other); return *this; } \
+exp name& name::operator = (name &&other) throw() { base::operator=(other); return *this; } \
 exp name::~name () throw () {}
 
 // For backward compatibility.

--- a/IlmBase/Iex/IexBaseExc.h
+++ b/IlmBase/Iex/IexBaseExc.h
@@ -72,7 +72,8 @@ class BaseExc: public std::exception
     IEX_EXPORT BaseExc (const BaseExc &be) throw();
     IEX_EXPORT virtual ~BaseExc () throw ();
 
-    IEX_EXPORT const BaseExc & operator = (const BaseExc& be) throw () = delete;
+    IEX_EXPORT BaseExc & operator = (const BaseExc& be) throw () = delete;
+    IEX_EXPORT BaseExc & operator = (const BaseExc&& be) throw () = delete;
 
     //---------------------------------------------------
     // what() method -- e.what() returns _message.c_str()

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -143,7 +143,9 @@ class Thread
     std::thread _thread;
 
     Thread &operator= (const Thread& t) = delete;
+    Thread &operator= (const Thread&& t) = delete;
     Thread (const Thread& t) = delete;
+    Thread (const Thread&& t) = delete;
 #endif
 };
 

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -143,9 +143,9 @@ class Thread
     std::thread _thread;
 
     Thread &operator= (const Thread& t) = delete;
-    Thread &operator= (const Thread&& t) = delete;
+    Thread &operator= (Thread&& t) = delete;
     Thread (const Thread& t) = delete;
-    Thread (const Thread&& t) = delete;
+    Thread (Thread&& t) = delete;
 #endif
 };
 

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -91,6 +91,8 @@ struct ThreadPool::Data
     ~Data();
     Data (const Data&) = delete;
     Data &operator= (const Data&)  = delete;
+    Data (const Data&&) = delete;
+    Data &operator= (const Data&&)  = delete;
 
     struct SafeProvider
     {

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -91,8 +91,8 @@ struct ThreadPool::Data
     ~Data();
     Data (const Data&) = delete;
     Data &operator= (const Data&)  = delete;
-    Data (const Data&&) = delete;
-    Data &operator= (const Data&&)  = delete;
+    Data (Data&&) = delete;
+    Data &operator= (Data&&)  = delete;
 
     struct SafeProvider
     {

--- a/IlmBase/IlmThread/IlmThreadPool.h
+++ b/IlmBase/IlmThread/IlmThreadPool.h
@@ -217,6 +217,9 @@ class ILMTHREAD_EXPORT TaskGroup
     TaskGroup();
     ~TaskGroup();
 
+    TaskGroup (const TaskGroup& other) = delete;
+    const TaskGroup& operator = (const TaskGroup& other) = delete;
+    
     // marks one task as finished
     // should be used by the thread pool provider to notify
     // as it finishes tasks

--- a/IlmBase/IlmThread/IlmThreadPool.h
+++ b/IlmBase/IlmThread/IlmThreadPool.h
@@ -219,8 +219,8 @@ class ILMTHREAD_EXPORT TaskGroup
 
     TaskGroup (const TaskGroup& other) = delete;
     TaskGroup& operator = (const TaskGroup& other) = delete;
-    TaskGroup (const TaskGroup&& other) = delete;
-    TaskGroup& operator = (const TaskGroup&& other) = delete;
+    TaskGroup (TaskGroup&& other) = delete;
+    TaskGroup& operator = (TaskGroup&& other) = delete;
     
     // marks one task as finished
     // should be used by the thread pool provider to notify

--- a/IlmBase/IlmThread/IlmThreadPool.h
+++ b/IlmBase/IlmThread/IlmThreadPool.h
@@ -218,7 +218,9 @@ class ILMTHREAD_EXPORT TaskGroup
     ~TaskGroup();
 
     TaskGroup (const TaskGroup& other) = delete;
-    const TaskGroup& operator = (const TaskGroup& other) = delete;
+    TaskGroup& operator = (const TaskGroup& other) = delete;
+    TaskGroup (const TaskGroup&& other) = delete;
+    TaskGroup& operator = (const TaskGroup&& other) = delete;
     
     // marks one task as finished
     // should be used by the thread pool provider to notify

--- a/OpenEXR/IlmImf/ImfAcesFile.cpp
+++ b/OpenEXR/IlmImf/ImfAcesFile.cpp
@@ -72,6 +72,9 @@ class AcesOutputFile::Data
      Data();
     ~Data();
 
+    Data (const Data& other) = delete;
+    const Data operator = (const Data& other) = delete;
+
     RgbaOutputFile *	rgbaFile;
 };
 
@@ -337,6 +340,9 @@ class AcesInputFile::Data
 
      Data();
     ~Data();
+
+    Data (const Data& other) = delete;
+    const Data operator = (const Data& other) = delete;
 
     void		initColorConversion ();
 

--- a/OpenEXR/IlmImf/ImfAcesFile.cpp
+++ b/OpenEXR/IlmImf/ImfAcesFile.cpp
@@ -74,8 +74,8 @@ class AcesOutputFile::Data
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     RgbaOutputFile *	rgbaFile;
 };
@@ -345,8 +345,8 @@ class AcesInputFile::Data
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     void		initColorConversion ();
 

--- a/OpenEXR/IlmImf/ImfAcesFile.cpp
+++ b/OpenEXR/IlmImf/ImfAcesFile.cpp
@@ -73,7 +73,9 @@ class AcesOutputFile::Data
     ~Data();
 
     Data (const Data& other) = delete;
-    const Data operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     RgbaOutputFile *	rgbaFile;
 };
@@ -342,7 +344,9 @@ class AcesInputFile::Data
     ~Data();
 
     Data (const Data& other) = delete;
-    const Data operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     void		initColorConversion ();
 

--- a/OpenEXR/IlmImf/ImfAcesFile.h
+++ b/OpenEXR/IlmImf/ImfAcesFile.h
@@ -234,8 +234,8 @@ class AcesOutputFile
 
   private:
 
-    AcesOutputFile (const AcesOutputFile &);		  // not implemented
-    AcesOutputFile & operator = (const AcesOutputFile &); // not implemented
+    AcesOutputFile (const AcesOutputFile &) = delete;
+    const AcesOutputFile & operator = (const AcesOutputFile &) = delete;
 
     class Data;
 
@@ -343,8 +343,8 @@ class AcesInputFile
 
   private:
 
-    AcesInputFile (const AcesInputFile &);		  // not implemented
-    AcesInputFile & operator = (const AcesInputFile &);   // not implemented
+    AcesInputFile (const AcesInputFile &) = delete;
+    const AcesInputFile & operator = (const AcesInputFile &) = delete;
 
     class Data;
 

--- a/OpenEXR/IlmImf/ImfAcesFile.h
+++ b/OpenEXR/IlmImf/ImfAcesFile.h
@@ -235,7 +235,9 @@ class AcesOutputFile
   private:
 
     AcesOutputFile (const AcesOutputFile &) = delete;
-    const AcesOutputFile & operator = (const AcesOutputFile &) = delete;
+    AcesOutputFile & operator = (const AcesOutputFile &) = delete;
+    AcesOutputFile (const AcesOutputFile &&) = delete;
+    AcesOutputFile & operator = (const AcesOutputFile &&) = delete;
 
     class Data;
 
@@ -344,7 +346,9 @@ class AcesInputFile
   private:
 
     AcesInputFile (const AcesInputFile &) = delete;
-    const AcesInputFile & operator = (const AcesInputFile &) = delete;
+    AcesInputFile & operator = (const AcesInputFile &) = delete;
+    AcesInputFile (const AcesInputFile &&) = delete;
+    AcesInputFile & operator = (const AcesInputFile &&) = delete;
 
     class Data;
 

--- a/OpenEXR/IlmImf/ImfAcesFile.h
+++ b/OpenEXR/IlmImf/ImfAcesFile.h
@@ -236,8 +236,8 @@ class AcesOutputFile
 
     AcesOutputFile (const AcesOutputFile &) = delete;
     AcesOutputFile & operator = (const AcesOutputFile &) = delete;
-    AcesOutputFile (const AcesOutputFile &&) = delete;
-    AcesOutputFile & operator = (const AcesOutputFile &&) = delete;
+    AcesOutputFile (AcesOutputFile &&) = delete;
+    AcesOutputFile & operator = (AcesOutputFile &&) = delete;
 
     class Data;
 
@@ -347,8 +347,8 @@ class AcesInputFile
 
     AcesInputFile (const AcesInputFile &) = delete;
     AcesInputFile & operator = (const AcesInputFile &) = delete;
-    AcesInputFile (const AcesInputFile &&) = delete;
-    AcesInputFile & operator = (const AcesInputFile &&) = delete;
+    AcesInputFile (AcesInputFile &&) = delete;
+    AcesInputFile & operator = (AcesInputFile &&) = delete;
 
     class Data;
 

--- a/OpenEXR/IlmImf/ImfArray.h
+++ b/OpenEXR/IlmImf/ImfArray.h
@@ -120,8 +120,8 @@ class Array
 
   private:
 
-    Array (const Array &);		// Copying and assignment
-    Array & operator = (const Array &);	// are not implemented
+    Array (const Array &) = delete;
+    const Array & operator = (const Array &) = delete;
 
     long _size;
     T * _data;
@@ -176,8 +176,8 @@ class Array2D
 
   private:
 
-    Array2D (const Array2D &);			// Copying and assignment
-    Array2D & operator = (const Array2D &);	// are not implemented
+    Array2D (const Array2D &) = delete;
+    const Array2D & operator = (const Array2D &) = delete;
 
     long        _sizeX;
     long	_sizeY;

--- a/OpenEXR/IlmImf/ImfArray.h
+++ b/OpenEXR/IlmImf/ImfArray.h
@@ -122,8 +122,8 @@ class Array
 
     Array (const Array &) = delete;
     Array & operator = (const Array &) = delete;
-    Array (const Array &&) = delete;
-    Array & operator = (const Array &&) = delete;
+    Array (Array &&) = delete;
+    Array & operator = (Array &&) = delete;
 
     long _size;
     T * _data;
@@ -180,8 +180,8 @@ class Array2D
 
     Array2D (const Array2D &) = delete;
     Array2D & operator = (const Array2D &) = delete;
-    Array2D (const Array2D &&) = delete;
-    Array2D & operator = (const Array2D &&) = delete;
+    Array2D (Array2D &&) = delete;
+    Array2D & operator = (Array2D &&) = delete;
 
     long        _sizeX;
     long	_sizeY;

--- a/OpenEXR/IlmImf/ImfArray.h
+++ b/OpenEXR/IlmImf/ImfArray.h
@@ -121,7 +121,9 @@ class Array
   private:
 
     Array (const Array &) = delete;
-    const Array & operator = (const Array &) = delete;
+    Array & operator = (const Array &) = delete;
+    Array (const Array &&) = delete;
+    Array & operator = (const Array &&) = delete;
 
     long _size;
     T * _data;
@@ -177,7 +179,9 @@ class Array2D
   private:
 
     Array2D (const Array2D &) = delete;
-    const Array2D & operator = (const Array2D &) = delete;
+    Array2D & operator = (const Array2D &) = delete;
+    Array2D (const Array2D &&) = delete;
+    Array2D & operator = (const Array2D &&) = delete;
 
     long        _sizeX;
     long	_sizeY;

--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -151,6 +151,7 @@ class TypedAttribute: public Attribute
     TypedAttribute (const TypedAttribute<T> &other);
     virtual ~TypedAttribute ();
 
+    const TypedAttribute& operator = (const TypedAttribute& other) = delete;
 
     //--------------------------------
     // Access to the attribute's value

--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -142,18 +142,20 @@ class TypedAttribute: public Attribute
 {
   public:
 
-    //----------------------------
-    // Constructors and destructor
-    //------------_---------------
+    //------------------------------------------------------------
+    // Constructors and destructor: default behavior. This assumes
+    // that the type T is copyable/assignable/moveable.
+    //------------------------------------------------------------
 
-    TypedAttribute ();
+    TypedAttribute () = default;
     TypedAttribute (const T &value);
-    TypedAttribute (const TypedAttribute<T> &other);
-    virtual ~TypedAttribute ();
+    TypedAttribute (const TypedAttribute<T> &other) = default;
+    TypedAttribute (TypedAttribute<T> &&other) = default;
 
-    TypedAttribute& operator = (const TypedAttribute& other) = delete;
-    TypedAttribute (const TypedAttribute<T> &&other);
-    TypedAttribute& operator = (const TypedAttribute&& other) = delete;
+    virtual ~TypedAttribute () = default;
+
+    TypedAttribute& operator = (const TypedAttribute<T>& other) = default;
+    TypedAttribute& operator = (TypedAttribute<T>&& other) = default;
     
     //--------------------------------
     // Access to the attribute's value
@@ -247,14 +249,6 @@ class TypedAttribute: public Attribute
 //------------------------------------
 // Implementation of TypedAttribute<T>
 //------------------------------------
-template <class T>
-TypedAttribute<T>::TypedAttribute ():
-    Attribute (),
-    _value (T())
-{
-    // empty
-}
-
 
 template <class T>
 TypedAttribute<T>::TypedAttribute (const T & value):
@@ -263,23 +257,6 @@ TypedAttribute<T>::TypedAttribute (const T & value):
 {
     // empty
 }
-
-
-template <class T>
-TypedAttribute<T>::TypedAttribute (const TypedAttribute<T> &other):
-    Attribute (other),
-    _value ()
-{
-    copyValueFrom (other);
-}
-
-
-template <class T>
-TypedAttribute<T>::~TypedAttribute ()
-{
-    // empty
-}
-
 
 template <class T>
 inline T &

--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -151,8 +151,10 @@ class TypedAttribute: public Attribute
     TypedAttribute (const TypedAttribute<T> &other);
     virtual ~TypedAttribute ();
 
-    const TypedAttribute& operator = (const TypedAttribute& other) = delete;
-
+    TypedAttribute& operator = (const TypedAttribute& other) = delete;
+    TypedAttribute (const TypedAttribute<T> &&other);
+    TypedAttribute& operator = (const TypedAttribute&& other) = delete;
+    
     //--------------------------------
     // Access to the attribute's value
     //--------------------------------

--- a/OpenEXR/IlmImf/ImfAutoArray.h
+++ b/OpenEXR/IlmImf/ImfAutoArray.h
@@ -61,6 +61,9 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 	 AutoArray (): _data (new T [size]) { memset(_data, 0, size*sizeof(T)); }
 	~AutoArray () {delete [] _data;}
 
+        AutoArray (const AutoArray& other) = delete;
+        const AutoArray& operator = (const AutoArray& other) = delete;
+        
 	operator T * ()			{return _data;}
 	operator const T * () const	{return _data;}
       

--- a/OpenEXR/IlmImf/ImfAutoArray.h
+++ b/OpenEXR/IlmImf/ImfAutoArray.h
@@ -63,8 +63,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
         AutoArray (const AutoArray& other) = delete;
         AutoArray& operator = (const AutoArray& other) = delete;
-        AutoArray (const AutoArray&& other) = delete;
-        AutoArray& operator = (const AutoArray&& other) = delete;
+        AutoArray (AutoArray&& other) = delete;
+        AutoArray& operator = (AutoArray&& other) = delete;
         
 	operator T * ()			{return _data;}
 	operator const T * () const	{return _data;}

--- a/OpenEXR/IlmImf/ImfAutoArray.h
+++ b/OpenEXR/IlmImf/ImfAutoArray.h
@@ -62,7 +62,9 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 	~AutoArray () {delete [] _data;}
 
         AutoArray (const AutoArray& other) = delete;
-        const AutoArray& operator = (const AutoArray& other) = delete;
+        AutoArray& operator = (const AutoArray& other) = delete;
+        AutoArray (const AutoArray&& other) = delete;
+        AutoArray& operator = (const AutoArray&& other) = delete;
         
 	operator T * ()			{return _data;}
 	operator const T * () const	{return _data;}

--- a/OpenEXR/IlmImf/ImfB44Compressor.h
+++ b/OpenEXR/IlmImf/ImfB44Compressor.h
@@ -63,6 +63,9 @@ class B44Compressor: public Compressor
     IMF_EXPORT
     virtual ~B44Compressor ();
 
+    B44Compressor (const B44Compressor& other) = delete;
+    const B44Compressor& operator = (const B44Compressor& other) = delete;
+    
     IMF_EXPORT
     virtual int		numScanLines () const;
 

--- a/OpenEXR/IlmImf/ImfB44Compressor.h
+++ b/OpenEXR/IlmImf/ImfB44Compressor.h
@@ -64,7 +64,9 @@ class B44Compressor: public Compressor
     virtual ~B44Compressor ();
 
     B44Compressor (const B44Compressor& other) = delete;
-    const B44Compressor& operator = (const B44Compressor& other) = delete;
+    B44Compressor& operator = (const B44Compressor& other) = delete;
+    B44Compressor (const B44Compressor&& other) = delete;
+    B44Compressor& operator = (const B44Compressor&& other) = delete;
     
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfB44Compressor.h
+++ b/OpenEXR/IlmImf/ImfB44Compressor.h
@@ -65,8 +65,8 @@ class B44Compressor: public Compressor
 
     B44Compressor (const B44Compressor& other) = delete;
     B44Compressor& operator = (const B44Compressor& other) = delete;
-    B44Compressor (const B44Compressor&& other) = delete;
-    B44Compressor& operator = (const B44Compressor&& other) = delete;
+    B44Compressor (B44Compressor&& other) = delete;
+    B44Compressor& operator = (B44Compressor&& other) = delete;
     
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
@@ -143,8 +143,8 @@ class CompositeDeepScanLine
     private :  
       struct Data *_Data;
       
-      CompositeDeepScanLine(const CompositeDeepScanLine &); // not implemented
-      const CompositeDeepScanLine & operator=(const CompositeDeepScanLine &);  // not implemented
+      CompositeDeepScanLine(const CompositeDeepScanLine &) = delete;
+      const CompositeDeepScanLine & operator=(const CompositeDeepScanLine &) = delete;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
@@ -145,8 +145,8 @@ class CompositeDeepScanLine
       
     CompositeDeepScanLine(const CompositeDeepScanLine &) = delete;
     CompositeDeepScanLine & operator=(const CompositeDeepScanLine &) = delete;
-    CompositeDeepScanLine(const CompositeDeepScanLine &&) = delete;
-    CompositeDeepScanLine & operator=(const CompositeDeepScanLine &&) = delete;
+    CompositeDeepScanLine(CompositeDeepScanLine &&) = delete;
+    CompositeDeepScanLine & operator=(CompositeDeepScanLine &&) = delete;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.h
@@ -143,8 +143,10 @@ class CompositeDeepScanLine
     private :  
       struct Data *_Data;
       
-      CompositeDeepScanLine(const CompositeDeepScanLine &) = delete;
-      const CompositeDeepScanLine & operator=(const CompositeDeepScanLine &) = delete;
+    CompositeDeepScanLine(const CompositeDeepScanLine &) = delete;
+    CompositeDeepScanLine & operator=(const CompositeDeepScanLine &) = delete;
+    CompositeDeepScanLine(const CompositeDeepScanLine &&) = delete;
+    CompositeDeepScanLine & operator=(const CompositeDeepScanLine &&) = delete;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -261,6 +261,9 @@ struct DeepScanLineInputFile::Data: public Mutex
     Data (int numThreads);
     ~Data ();
 
+    Data (const Data& data) = delete;
+    const Data& operator = (const Data& data) = delete;
+    
     inline LineBuffer * getLineBuffer (int number); // hash function from line
                                                     // buffer indices into our
                                                     // vector of line buffers

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -263,8 +263,8 @@ struct DeepScanLineInputFile::Data: public Mutex
 
     Data (const Data& data) = delete;
     Data& operator = (const Data& data) = delete;
-    Data (const Data&& data) = delete;
-    Data& operator = (const Data&& data) = delete;
+    Data (Data&& data) = delete;
+    Data& operator = (Data&& data) = delete;
     
     inline LineBuffer * getLineBuffer (int number); // hash function from line
                                                     // buffer indices into our

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -262,7 +262,9 @@ struct DeepScanLineInputFile::Data: public Mutex
     ~Data ();
 
     Data (const Data& data) = delete;
-    const Data& operator = (const Data& data) = delete;
+    Data& operator = (const Data& data) = delete;
+    Data (const Data&& data) = delete;
+    Data& operator = (const Data&& data) = delete;
     
     inline LineBuffer * getLineBuffer (int number); // hash function from line
                                                     // buffer indices into our

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
@@ -69,6 +69,8 @@ class DeepScanLineInputFile : public GenericInputFile
                            int version, /*version field from file*/
                            int numThreads = globalThreadCount());
 
+    DeepScanLineInputFile (const DeepScanLineInputFile& other) = delete;
+    const DeepScanLineInputFile& operator = (const DeepScanLineInputFile& other) = delete;
 
     //-----------------------------------------
     // Destructor -- deallocates internal data

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
@@ -70,7 +70,9 @@ class DeepScanLineInputFile : public GenericInputFile
                            int numThreads = globalThreadCount());
 
     DeepScanLineInputFile (const DeepScanLineInputFile& other) = delete;
-    const DeepScanLineInputFile& operator = (const DeepScanLineInputFile& other) = delete;
+    DeepScanLineInputFile& operator = (const DeepScanLineInputFile& other) = delete;
+    DeepScanLineInputFile (const DeepScanLineInputFile&& other) = delete;
+    DeepScanLineInputFile& operator = (const DeepScanLineInputFile&& other) = delete;
 
     //-----------------------------------------
     // Destructor -- deallocates internal data

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
@@ -71,8 +71,8 @@ class DeepScanLineInputFile : public GenericInputFile
 
     DeepScanLineInputFile (const DeepScanLineInputFile& other) = delete;
     DeepScanLineInputFile& operator = (const DeepScanLineInputFile& other) = delete;
-    DeepScanLineInputFile (const DeepScanLineInputFile&& other) = delete;
-    DeepScanLineInputFile& operator = (const DeepScanLineInputFile&& other) = delete;
+    DeepScanLineInputFile (DeepScanLineInputFile&& other) = delete;
+    DeepScanLineInputFile& operator = (DeepScanLineInputFile&& other) = delete;
 
     //-----------------------------------------
     // Destructor -- deallocates internal data

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -234,6 +234,8 @@ struct DeepScanLineOutputFile::Data
     Data (int numThreads);
     ~Data ();
 
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
 
     inline LineBuffer *         getLineBuffer (int number);// hash function from line
                                                            // buffer indices into our

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -236,8 +236,8 @@ struct DeepScanLineOutputFile::Data
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     inline LineBuffer *         getLineBuffer (int number);// hash function from line
                                                            // buffer indices into our

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.cpp
@@ -235,7 +235,9 @@ struct DeepScanLineOutputFile::Data
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     inline LineBuffer *         getLineBuffer (int number);// hash function from line
                                                            // buffer indices into our

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
@@ -238,8 +238,8 @@ class DeepScanLineOutputFile : public GenericOutputFile
     //------------------------------------------------------------
     DeepScanLineOutputFile (const OutputPartData* part);
 
-    DeepScanLineOutputFile (const DeepScanLineOutputFile &);                    // not implemented
-    DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &);       // not implemented
+    DeepScanLineOutputFile (const DeepScanLineOutputFile &) = delete;
+    const DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &) = delete;
 
     void                initialize (const Header &header);
     void                initializeLineBuffer();

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
@@ -239,7 +239,9 @@ class DeepScanLineOutputFile : public GenericOutputFile
     DeepScanLineOutputFile (const OutputPartData* part);
 
     DeepScanLineOutputFile (const DeepScanLineOutputFile &) = delete;
-    const DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &) = delete;
+    DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &) = delete;
+    DeepScanLineOutputFile (const DeepScanLineOutputFile &&) = delete;
+    DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &&) = delete;
 
     void                initialize (const Header &header);
     void                initializeLineBuffer();

--- a/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineOutputFile.h
@@ -240,8 +240,8 @@ class DeepScanLineOutputFile : public GenericOutputFile
 
     DeepScanLineOutputFile (const DeepScanLineOutputFile &) = delete;
     DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &) = delete;
-    DeepScanLineOutputFile (const DeepScanLineOutputFile &&) = delete;
-    DeepScanLineOutputFile & operator = (const DeepScanLineOutputFile &&) = delete;
+    DeepScanLineOutputFile (DeepScanLineOutputFile &&) = delete;
+    DeepScanLineOutputFile & operator = (DeepScanLineOutputFile &&) = delete;
 
     void                initialize (const Header &header);
     void                initializeLineBuffer();

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -266,6 +266,9 @@ struct DeepTiledInputFile::Data: public Mutex
      Data (int numThreads);
     ~Data ();
 
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+    
     inline TileBuffer * getTileBuffer (int number);
                                                     // hash function from tile indices
                                                     // into our vector of tile buffers

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -267,7 +267,9 @@ struct DeepTiledInputFile::Data: public Mutex
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
     inline TileBuffer * getTileBuffer (int number);
                                                     // hash function from tile indices

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -268,8 +268,8 @@ struct DeepTiledInputFile::Data: public Mutex
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
     inline TileBuffer * getTileBuffer (int number);
                                                     // hash function from tile indices

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
@@ -440,8 +440,8 @@ class DeepTiledInputFile : public GenericInputFile
 
     DeepTiledInputFile (InputPartData* part);
 
-    DeepTiledInputFile (const DeepTiledInputFile &);              // not implemented
-    DeepTiledInputFile & operator = (const DeepTiledInputFile &); // not implemented
+    DeepTiledInputFile (const DeepTiledInputFile &) = delete;
+    const DeepTiledInputFile & operator = (const DeepTiledInputFile &) = delete;
 
     DeepTiledInputFile (const Header &header, OPENEXR_IMF_INTERNAL_NAMESPACE::IStream *is, int version,
                     int numThreads);

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
@@ -442,8 +442,8 @@ class DeepTiledInputFile : public GenericInputFile
 
     DeepTiledInputFile (const DeepTiledInputFile &) = delete;
     DeepTiledInputFile & operator = (const DeepTiledInputFile &) = delete;
-    DeepTiledInputFile (const DeepTiledInputFile &&) = delete;
-    DeepTiledInputFile & operator = (const DeepTiledInputFile &&) = delete;
+    DeepTiledInputFile (DeepTiledInputFile &&) = delete;
+    DeepTiledInputFile & operator = (DeepTiledInputFile &&) = delete;
 
     DeepTiledInputFile (const Header &header, OPENEXR_IMF_INTERNAL_NAMESPACE::IStream *is, int version,
                     int numThreads);

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.h
@@ -441,7 +441,9 @@ class DeepTiledInputFile : public GenericInputFile
     DeepTiledInputFile (InputPartData* part);
 
     DeepTiledInputFile (const DeepTiledInputFile &) = delete;
-    const DeepTiledInputFile & operator = (const DeepTiledInputFile &) = delete;
+    DeepTiledInputFile & operator = (const DeepTiledInputFile &) = delete;
+    DeepTiledInputFile (const DeepTiledInputFile &&) = delete;
+    DeepTiledInputFile & operator = (const DeepTiledInputFile &&) = delete;
 
     DeepTiledInputFile (const Header &header, OPENEXR_IMF_INTERNAL_NAMESPACE::IStream *is, int version,
                     int numThreads);

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -205,8 +205,8 @@ struct BufferedTile
 
     BufferedTile (const BufferedTile& other) = delete;
     BufferedTile& operator = (const BufferedTile& other) = delete;
-    BufferedTile (const BufferedTile&& other) = delete;
-    BufferedTile& operator = (const BufferedTile&& other) = delete;
+    BufferedTile (BufferedTile&& other) = delete;
+    BufferedTile& operator = (BufferedTile&& other) = delete;
 };
 
 
@@ -318,8 +318,8 @@ struct DeepTiledOutputFile::Data
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
     inline TileBuffer * getTileBuffer (int number);
                                                 // hash function from tile

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -204,7 +204,9 @@ struct BufferedTile
     }
 
     BufferedTile (const BufferedTile& other) = delete;
-    const BufferedTile& operator = (const BufferedTile& other) = delete;
+    BufferedTile& operator = (const BufferedTile& other) = delete;
+    BufferedTile (const BufferedTile&& other) = delete;
+    BufferedTile& operator = (const BufferedTile&& other) = delete;
 };
 
 
@@ -315,7 +317,9 @@ struct DeepTiledOutputFile::Data
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
     inline TileBuffer * getTileBuffer (int number);
                                                 // hash function from tile

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -311,6 +311,9 @@ struct DeepTiledOutputFile::Data
      Data (int numThreads);
     ~Data ();
 
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+    
     inline TileBuffer * getTileBuffer (int number);
                                                 // hash function from tile
                                                 // buffer coords into our

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.cpp
@@ -202,6 +202,9 @@ struct BufferedTile
         delete [] pixelData;
         delete [] sampleCountTableData;
     }
+
+    BufferedTile (const BufferedTile& other) = delete;
+    const BufferedTile& operator = (const BufferedTile& other) = delete;
 };
 
 

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
@@ -482,8 +482,8 @@ class DeepTiledOutputFile : public GenericOutputFile
     // ----------------------------------------------------------------
     DeepTiledOutputFile (const OutputPartData* part);
 
-    DeepTiledOutputFile (const DeepTiledOutputFile &);              // not implemented
-    DeepTiledOutputFile & operator = (const DeepTiledOutputFile &); // not implemented
+    DeepTiledOutputFile (const DeepTiledOutputFile &) = delete;
+    const DeepTiledOutputFile & operator = (const DeepTiledOutputFile &) = delete;
 
     void                initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
@@ -484,8 +484,8 @@ class DeepTiledOutputFile : public GenericOutputFile
 
     DeepTiledOutputFile (const DeepTiledOutputFile &) = delete;
     DeepTiledOutputFile & operator = (const DeepTiledOutputFile &) = delete;
-    DeepTiledOutputFile (const DeepTiledOutputFile &&) = delete;
-    DeepTiledOutputFile & operator = (const DeepTiledOutputFile &&) = delete;
+    DeepTiledOutputFile (DeepTiledOutputFile &&) = delete;
+    DeepTiledOutputFile & operator = (DeepTiledOutputFile &&) = delete;
 
     void                initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepTiledOutputFile.h
@@ -483,7 +483,9 @@ class DeepTiledOutputFile : public GenericOutputFile
     DeepTiledOutputFile (const OutputPartData* part);
 
     DeepTiledOutputFile (const DeepTiledOutputFile &) = delete;
-    const DeepTiledOutputFile & operator = (const DeepTiledOutputFile &) = delete;
+    DeepTiledOutputFile & operator = (const DeepTiledOutputFile &) = delete;
+    DeepTiledOutputFile (const DeepTiledOutputFile &&) = delete;
+    DeepTiledOutputFile & operator = (const DeepTiledOutputFile &&) = delete;
 
     void                initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfDwaCompressor.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.h
@@ -73,8 +73,8 @@ class DwaCompressor: public Compressor
 
     DwaCompressor (const DwaCompressor& other) = delete;
     DwaCompressor& operator = (const DwaCompressor& other) = delete;
-    DwaCompressor (const DwaCompressor&& other) = delete;
-    DwaCompressor& operator = (const DwaCompressor&& other) = delete;
+    DwaCompressor (DwaCompressor&& other) = delete;
+    DwaCompressor& operator = (DwaCompressor&& other) = delete;
     
     IMF_EXPORT
     virtual int numScanLines () const;

--- a/OpenEXR/IlmImf/ImfDwaCompressor.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.h
@@ -71,6 +71,7 @@ class DwaCompressor: public Compressor
     IMF_EXPORT
     virtual ~DwaCompressor ();
 
+    DwaCompressor (const DwaCompressor& other) = delete;
     const DwaCompressor& operator = (const DwaCompressor& other) = delete;
     
     IMF_EXPORT

--- a/OpenEXR/IlmImf/ImfDwaCompressor.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.h
@@ -71,6 +71,8 @@ class DwaCompressor: public Compressor
     IMF_EXPORT
     virtual ~DwaCompressor ();
 
+    const DwaCompressor& operator = (const DwaCompressor& other) = delete;
+    
     IMF_EXPORT
     virtual int numScanLines () const;
 

--- a/OpenEXR/IlmImf/ImfDwaCompressor.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.h
@@ -72,7 +72,9 @@ class DwaCompressor: public Compressor
     virtual ~DwaCompressor ();
 
     DwaCompressor (const DwaCompressor& other) = delete;
-    const DwaCompressor& operator = (const DwaCompressor& other) = delete;
+    DwaCompressor& operator = (const DwaCompressor& other) = delete;
+    DwaCompressor (const DwaCompressor&& other) = delete;
+    DwaCompressor& operator = (const DwaCompressor&& other) = delete;
     
     IMF_EXPORT
     virtual int numScanLines () const;

--- a/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
+++ b/OpenEXR/IlmImf/ImfDwaCompressorSimd.h
@@ -2166,7 +2166,7 @@ dctForward8x8 (float *data)
 
 #endif /* IMF_HAVE_SSE2 */
 
-} // anonymous namespace
+} // namespace
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 

--- a/OpenEXR/IlmImf/ImfFastHuf.h
+++ b/OpenEXR/IlmImf/ImfFastHuf.h
@@ -92,6 +92,9 @@ class FastHufDecoder
     IMF_EXPORT
     ~FastHufDecoder ();
 
+    FastHufDecoder (const FastHufDecoder& other) = delete;
+    const FastHufDecoder& operator = (const FastHufDecoder& other) = delete;
+
     IMF_EXPORT
     static bool enabled ();
 

--- a/OpenEXR/IlmImf/ImfFastHuf.h
+++ b/OpenEXR/IlmImf/ImfFastHuf.h
@@ -93,7 +93,9 @@ class FastHufDecoder
     ~FastHufDecoder ();
 
     FastHufDecoder (const FastHufDecoder& other) = delete;
-    const FastHufDecoder& operator = (const FastHufDecoder& other) = delete;
+    FastHufDecoder& operator = (const FastHufDecoder& other) = delete;
+    FastHufDecoder (const FastHufDecoder&& other) = delete;
+    FastHufDecoder& operator = (const FastHufDecoder&& other) = delete;
 
     IMF_EXPORT
     static bool enabled ();

--- a/OpenEXR/IlmImf/ImfFastHuf.h
+++ b/OpenEXR/IlmImf/ImfFastHuf.h
@@ -94,8 +94,8 @@ class FastHufDecoder
 
     FastHufDecoder (const FastHufDecoder& other) = delete;
     FastHufDecoder& operator = (const FastHufDecoder& other) = delete;
-    FastHufDecoder (const FastHufDecoder&& other) = delete;
-    FastHufDecoder& operator = (const FastHufDecoder&& other) = delete;
+    FastHufDecoder (FastHufDecoder&& other) = delete;
+    FastHufDecoder& operator = (FastHufDecoder&& other) = delete;
 
     IMF_EXPORT
     static bool enabled ();

--- a/OpenEXR/IlmImf/ImfIO.h
+++ b/OpenEXR/IlmImf/ImfIO.h
@@ -147,8 +147,8 @@ class IStream
 
   private:
 
-    IStream (const IStream &);			// not implemented
-    IStream & operator = (const IStream &);	// not implemented
+    IStream (const IStream &) = delete;
+    const IStream & operator = (const IStream &) = delete;
 
     std::string		_fileName;
 };
@@ -213,8 +213,8 @@ class OStream
 
   private:
 
-    OStream (const OStream &);			// not implemented
-    OStream & operator = (const OStream &);	// not implemented
+    OStream (const OStream &) = delete;
+    const OStream & operator = (const OStream &) = delete;
 
     std::string		_fileName;
 };

--- a/OpenEXR/IlmImf/ImfIO.h
+++ b/OpenEXR/IlmImf/ImfIO.h
@@ -148,7 +148,9 @@ class IStream
   private:
 
     IStream (const IStream &) = delete;
-    const IStream & operator = (const IStream &) = delete;
+    IStream & operator = (const IStream &) = delete;
+    IStream (const IStream &&) = delete;
+    IStream & operator = (const IStream &&) = delete;
 
     std::string		_fileName;
 };
@@ -214,7 +216,9 @@ class OStream
   private:
 
     OStream (const OStream &) = delete;
-    const OStream & operator = (const OStream &) = delete;
+    OStream & operator = (const OStream &) = delete;
+    OStream (const OStream &&) = delete;
+    OStream & operator = (const OStream &&) = delete;
 
     std::string		_fileName;
 };

--- a/OpenEXR/IlmImf/ImfIO.h
+++ b/OpenEXR/IlmImf/ImfIO.h
@@ -149,8 +149,8 @@ class IStream
 
     IStream (const IStream &) = delete;
     IStream & operator = (const IStream &) = delete;
-    IStream (const IStream &&) = delete;
-    IStream & operator = (const IStream &&) = delete;
+    IStream (IStream &&) = delete;
+    IStream & operator = (IStream &&) = delete;
 
     std::string		_fileName;
 };
@@ -217,8 +217,8 @@ class OStream
 
     OStream (const OStream &) = delete;
     OStream & operator = (const OStream &) = delete;
-    OStream (const OStream &&) = delete;
-    OStream & operator = (const OStream &&) = delete;
+    OStream (OStream &&) = delete;
+    OStream & operator = (OStream &&) = delete;
 
     std::string		_fileName;
 };

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -112,6 +112,9 @@ struct InputFile::Data : public Mutex
      Data (int numThreads);
     ~Data ();
 
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+
     void		deleteCachedBuffer();
 };
 

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -114,8 +114,8 @@ struct InputFile::Data : public Mutex
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     void		deleteCachedBuffer();
 };

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -113,7 +113,9 @@ struct InputFile::Data : public Mutex
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     void		deleteCachedBuffer();
 };

--- a/OpenEXR/IlmImf/ImfInputFile.h
+++ b/OpenEXR/IlmImf/ImfInputFile.h
@@ -256,8 +256,8 @@ class InputFile : public GenericInputFile
   private:
 
     InputFile (InputPartData* part);
-    InputFile (const InputFile &);			// not implemented
-    InputFile & operator = (const InputFile &);		// not implemented
+    InputFile (const InputFile &) = delete;
+    const InputFile & operator = (const InputFile &) = delete;
 
     void		initialize ();
     void                multiPartInitialize(InputPartData* part);

--- a/OpenEXR/IlmImf/ImfInputFile.h
+++ b/OpenEXR/IlmImf/ImfInputFile.h
@@ -256,8 +256,11 @@ class InputFile : public GenericInputFile
   private:
 
     InputFile (InputPartData* part);
+
     InputFile (const InputFile &) = delete;
-    const InputFile & operator = (const InputFile &) = delete;
+    InputFile & operator = (const InputFile &) = delete;
+    InputFile (const InputFile &&) = delete;
+    InputFile & operator = (const InputFile &&) = delete;
 
     void		initialize ();
     void                multiPartInitialize(InputPartData* part);

--- a/OpenEXR/IlmImf/ImfInputFile.h
+++ b/OpenEXR/IlmImf/ImfInputFile.h
@@ -259,8 +259,8 @@ class InputFile : public GenericInputFile
 
     InputFile (const InputFile &) = delete;
     InputFile & operator = (const InputFile &) = delete;
-    InputFile (const InputFile &&) = delete;
-    InputFile & operator = (const InputFile &&) = delete;
+    InputFile (InputFile &&) = delete;
+    InputFile & operator = (InputFile &&) = delete;
 
     void		initialize ();
     void                multiPartInitialize(InputPartData* part);

--- a/OpenEXR/IlmImf/ImfKeyCode.cpp
+++ b/OpenEXR/IlmImf/ImfKeyCode.cpp
@@ -79,14 +79,17 @@ KeyCode::KeyCode (const KeyCode &other)
 KeyCode &
 KeyCode::operator = (const KeyCode &other)
 {
-    _filmMfcCode = other._filmMfcCode;
-    _filmType = other._filmType;
-    _prefix = other._prefix;
-    _count = other._count;
-    _perfOffset = other._perfOffset;
-    _perfsPerFrame = other._perfsPerFrame;
-    _perfsPerCount = other._perfsPerCount;
-
+    if (this != &other)
+    {
+        _filmMfcCode = other._filmMfcCode;
+        _filmType = other._filmType;
+        _prefix = other._prefix;
+        _count = other._count;
+        _perfOffset = other._perfOffset;
+        _perfsPerFrame = other._perfsPerFrame;
+        _perfsPerCount = other._perfsPerCount;
+    }
+    
     return *this;
 }
 

--- a/OpenEXR/IlmImf/ImfKeyCode.h
+++ b/OpenEXR/IlmImf/ImfKeyCode.h
@@ -121,6 +121,8 @@ class KeyCode
     IMF_EXPORT
     KeyCode (const KeyCode &other);
     IMF_EXPORT
+    ~KeyCode() = default;
+    IMF_EXPORT
     KeyCode & operator = (const KeyCode &other);
 
 

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -118,6 +118,9 @@ struct MultiPartInputFile::Data: public InputStreamMutex
             delete parts[i];
     }
     
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+    
     template <class T>
     T*    createInputPartT(int partNumber)
     {

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -119,7 +119,9 @@ struct MultiPartInputFile::Data: public InputStreamMutex
     }
     
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
     template <class T>
     T*    createInputPartT(int partNumber)

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -120,8 +120,8 @@ struct MultiPartInputFile::Data: public InputStreamMutex
     
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
     template <class T>
     T*    createInputPartT(int partNumber)

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.h
@@ -97,7 +97,8 @@ class MultiPartInputFile : public GenericInputFile
   private:
     Data*                           _data;
 
-    MultiPartInputFile(const MultiPartInputFile &); // not implemented
+    MultiPartInputFile(const MultiPartInputFile &) = delete;
+    const MultiPartInputFile& operator = (const MultiPartInputFile &) = delete;
 
     
     //

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.h
@@ -98,7 +98,9 @@ class MultiPartInputFile : public GenericInputFile
     Data*                           _data;
 
     MultiPartInputFile(const MultiPartInputFile &) = delete;
-    const MultiPartInputFile& operator = (const MultiPartInputFile &) = delete;
+    MultiPartInputFile& operator = (const MultiPartInputFile &) = delete;
+    MultiPartInputFile(const MultiPartInputFile &&) = delete;
+    MultiPartInputFile& operator = (const MultiPartInputFile &&) = delete;
 
     
     //

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.h
@@ -99,8 +99,8 @@ class MultiPartInputFile : public GenericInputFile
 
     MultiPartInputFile(const MultiPartInputFile &) = delete;
     MultiPartInputFile& operator = (const MultiPartInputFile &) = delete;
-    MultiPartInputFile(const MultiPartInputFile &&) = delete;
-    MultiPartInputFile& operator = (const MultiPartInputFile &&) = delete;
+    MultiPartInputFile(MultiPartInputFile &&) = delete;
+    MultiPartInputFile& operator = (MultiPartInputFile &&) = delete;
 
     
     //

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
@@ -124,6 +124,10 @@ struct MultiPartOutputFile::Data: public OutputStreamMutex
             for (size_t i = 0; i < parts.size(); i++)
                 delete parts[i];
         }
+
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+    
 };
 
 void

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
@@ -127,8 +127,8 @@ struct MultiPartOutputFile::Data: public OutputStreamMutex
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
 };
 

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.cpp
@@ -126,7 +126,9 @@ struct MultiPartOutputFile::Data: public OutputStreamMutex
         }
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
 };
 

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
@@ -100,13 +100,14 @@ class MultiPartOutputFile : public GenericOutputFile
         IMF_EXPORT
         ~MultiPartOutputFile();
 
+        MultiPartOutputFile(const MultiPartOutputFile& other) = delete;
+        const MultiPartOutputFile& operator = (const MultiPartOutputFile& other) = delete;
+
         struct Data;
 
     private:
         Data*                           _data;
 
-        MultiPartOutputFile(const MultiPartOutputFile &); // not implemented
-        
         template<class T>         T*  getOutputPart(int partNumber);
 
     

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
@@ -102,8 +102,8 @@ class MultiPartOutputFile : public GenericOutputFile
 
         MultiPartOutputFile(const MultiPartOutputFile& other) = delete;
         MultiPartOutputFile& operator = (const MultiPartOutputFile& other) = delete;
-        MultiPartOutputFile(const MultiPartOutputFile&& other) = delete;
-        MultiPartOutputFile& operator = (const MultiPartOutputFile&& other) = delete;
+        MultiPartOutputFile(MultiPartOutputFile&& other) = delete;
+        MultiPartOutputFile& operator = (MultiPartOutputFile&& other) = delete;
 
         struct Data;
 

--- a/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartOutputFile.h
@@ -101,7 +101,9 @@ class MultiPartOutputFile : public GenericOutputFile
         ~MultiPartOutputFile();
 
         MultiPartOutputFile(const MultiPartOutputFile& other) = delete;
-        const MultiPartOutputFile& operator = (const MultiPartOutputFile& other) = delete;
+        MultiPartOutputFile& operator = (const MultiPartOutputFile& other) = delete;
+        MultiPartOutputFile(const MultiPartOutputFile&& other) = delete;
+        MultiPartOutputFile& operator = (const MultiPartOutputFile&& other) = delete;
 
         struct Data;
 

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -212,7 +212,9 @@ struct OutputFile::Data
      Data (int numThreads);
     ~Data ();
 
-
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+    
     inline LineBuffer *	getLineBuffer (int number); // hash function from line
     						    // buffer indices into our
 						    // vector of line buffers

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -213,7 +213,9 @@ struct OutputFile::Data
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
     inline LineBuffer *	getLineBuffer (int number); // hash function from line
     						    // buffer indices into our

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -214,8 +214,8 @@ struct OutputFile::Data
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
     inline LineBuffer *	getLineBuffer (int number); // hash function from line
     						    // buffer indices into our

--- a/OpenEXR/IlmImf/ImfOutputFile.h
+++ b/OpenEXR/IlmImf/ImfOutputFile.h
@@ -257,8 +257,8 @@ class OutputFile : public GenericOutputFile
     //------------------------------------------------------------
     OutputFile (const OutputPartData* part);
 
-    OutputFile (const OutputFile &);			// not implemented
-    OutputFile & operator = (const OutputFile &);	// not implemented
+    OutputFile (const OutputFile &) = delete;
+    const OutputFile & operator = (const OutputFile &) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfOutputFile.h
+++ b/OpenEXR/IlmImf/ImfOutputFile.h
@@ -259,8 +259,8 @@ class OutputFile : public GenericOutputFile
 
     OutputFile (const OutputFile &) = delete;
     OutputFile & operator = (const OutputFile &) = delete;
-    OutputFile (const OutputFile &&) = delete;
-    OutputFile & operator = (const OutputFile &&) = delete;
+    OutputFile (OutputFile &&) = delete;
+    OutputFile & operator = (OutputFile &&) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfOutputFile.h
+++ b/OpenEXR/IlmImf/ImfOutputFile.h
@@ -258,7 +258,9 @@ class OutputFile : public GenericOutputFile
     OutputFile (const OutputPartData* part);
 
     OutputFile (const OutputFile &) = delete;
-    const OutputFile & operator = (const OutputFile &) = delete;
+    OutputFile & operator = (const OutputFile &) = delete;
+    OutputFile (const OutputFile &&) = delete;
+    OutputFile & operator = (const OutputFile &&) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfPizCompressor.h
+++ b/OpenEXR/IlmImf/ImfPizCompressor.h
@@ -63,6 +63,9 @@ class PizCompressor: public Compressor
     IMF_EXPORT
     virtual ~PizCompressor ();
 
+    PizCompressor (const PizCompressor& other) = delete;
+    const PizCompressor& operator = (const PizCompressor& other) = delete;
+
     IMF_EXPORT
     virtual int		numScanLines () const;
 

--- a/OpenEXR/IlmImf/ImfPizCompressor.h
+++ b/OpenEXR/IlmImf/ImfPizCompressor.h
@@ -65,8 +65,8 @@ class PizCompressor: public Compressor
 
     PizCompressor (const PizCompressor& other) = delete;
     PizCompressor& operator = (const PizCompressor& other) = delete;
-    PizCompressor (const PizCompressor&& other) = delete;
-    PizCompressor& operator = (const PizCompressor&& other) = delete;
+    PizCompressor (PizCompressor&& other) = delete;
+    PizCompressor& operator = (PizCompressor&& other) = delete;
 
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfPizCompressor.h
+++ b/OpenEXR/IlmImf/ImfPizCompressor.h
@@ -64,7 +64,9 @@ class PizCompressor: public Compressor
     virtual ~PizCompressor ();
 
     PizCompressor (const PizCompressor& other) = delete;
-    const PizCompressor& operator = (const PizCompressor& other) = delete;
+    PizCompressor& operator = (const PizCompressor& other) = delete;
+    PizCompressor (const PizCompressor&& other) = delete;
+    PizCompressor& operator = (const PizCompressor&& other) = delete;
 
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfPreviewImage.cpp
+++ b/OpenEXR/IlmImf/ImfPreviewImage.cpp
@@ -88,15 +88,18 @@ PreviewImage::~PreviewImage ()
 PreviewImage &
 PreviewImage::operator = (const PreviewImage &other)
 {
-    delete [] _pixels;
+    if (this != &other)
+    {
+        delete [] _pixels;
 
-    _width = other._width;
-    _height = other._height;
-    _pixels = new PreviewRgba [other._width * other._height];
+        _width = other._width;
+        _height = other._height;
+        _pixels = new PreviewRgba [other._width * other._height];
 
-    for (unsigned int i = 0; i < _width * _height; ++i)
-	_pixels[i] = other._pixels[i];
-
+        for (unsigned int i = 0; i < _width * _height; ++i)
+            _pixels[i] = other._pixels[i];
+    }
+    
     return *this;
 }
 

--- a/OpenEXR/IlmImf/ImfPxr24Compressor.h
+++ b/OpenEXR/IlmImf/ImfPxr24Compressor.h
@@ -60,6 +60,9 @@ class Pxr24Compressor: public Compressor
     IMF_EXPORT
     virtual ~Pxr24Compressor ();
 
+    Pxr24Compressor (const Pxr24Compressor& other) = delete;
+    const Pxr24Compressor& operator = (const Pxr24Compressor& other) = delete;
+
     IMF_EXPORT
     virtual int		numScanLines () const;
 

--- a/OpenEXR/IlmImf/ImfPxr24Compressor.h
+++ b/OpenEXR/IlmImf/ImfPxr24Compressor.h
@@ -61,7 +61,9 @@ class Pxr24Compressor: public Compressor
     virtual ~Pxr24Compressor ();
 
     Pxr24Compressor (const Pxr24Compressor& other) = delete;
-    const Pxr24Compressor& operator = (const Pxr24Compressor& other) = delete;
+    Pxr24Compressor& operator = (const Pxr24Compressor& other) = delete;
+    Pxr24Compressor (const Pxr24Compressor&& other) = delete;
+    Pxr24Compressor& operator = (const Pxr24Compressor&& other) = delete;
 
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfPxr24Compressor.h
+++ b/OpenEXR/IlmImf/ImfPxr24Compressor.h
@@ -62,8 +62,8 @@ class Pxr24Compressor: public Compressor
 
     Pxr24Compressor (const Pxr24Compressor& other) = delete;
     Pxr24Compressor& operator = (const Pxr24Compressor& other) = delete;
-    Pxr24Compressor (const Pxr24Compressor&& other) = delete;
-    Pxr24Compressor& operator = (const Pxr24Compressor&& other) = delete;
+    Pxr24Compressor (Pxr24Compressor&& other) = delete;
+    Pxr24Compressor& operator = (Pxr24Compressor&& other) = delete;
 
     IMF_EXPORT
     virtual int		numScanLines () const;

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -196,6 +196,9 @@ class RgbaOutputFile::ToYca: public Mutex
      ToYca (OutputFile &outputFile, RgbaChannels rgbaChannels);
     ~ToYca ();
 
+    ToYca (const ToYca& other) = delete;
+    const ToYca& operator = (const ToYca& other) = delete;
+
     void		setYCRounding (unsigned int roundY,
 	    			       unsigned int roundC);
 
@@ -811,6 +814,9 @@ class RgbaInputFile::FromYca: public Mutex
 
      FromYca (InputFile &inputFile, RgbaChannels rgbaChannels);
     ~FromYca ();
+
+    FromYca (const FromYca& other) = delete;
+    const FromYca& operator = (const FromYca& other) = delete;
 
     void		setFrameBuffer (Rgba *base,
 					size_t xStride,

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -197,7 +197,9 @@ class RgbaOutputFile::ToYca: public Mutex
     ~ToYca ();
 
     ToYca (const ToYca& other) = delete;
-    const ToYca& operator = (const ToYca& other) = delete;
+    ToYca& operator = (const ToYca& other) = delete;
+    ToYca (const ToYca&& other) = delete;
+    ToYca& operator = (const ToYca&& other) = delete;
 
     void		setYCRounding (unsigned int roundY,
 	    			       unsigned int roundC);
@@ -816,7 +818,9 @@ class RgbaInputFile::FromYca: public Mutex
     ~FromYca ();
 
     FromYca (const FromYca& other) = delete;
-    const FromYca& operator = (const FromYca& other) = delete;
+    FromYca& operator = (const FromYca& other) = delete;
+    FromYca (const FromYca&& other) = delete;
+    FromYca& operator = (const FromYca&& other) = delete;
 
     void		setFrameBuffer (Rgba *base,
 					size_t xStride,

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -198,8 +198,8 @@ class RgbaOutputFile::ToYca: public Mutex
 
     ToYca (const ToYca& other) = delete;
     ToYca& operator = (const ToYca& other) = delete;
-    ToYca (const ToYca&& other) = delete;
-    ToYca& operator = (const ToYca&& other) = delete;
+    ToYca (ToYca&& other) = delete;
+    ToYca& operator = (ToYca&& other) = delete;
 
     void		setYCRounding (unsigned int roundY,
 	    			       unsigned int roundC);
@@ -819,8 +819,8 @@ class RgbaInputFile::FromYca: public Mutex
 
     FromYca (const FromYca& other) = delete;
     FromYca& operator = (const FromYca& other) = delete;
-    FromYca (const FromYca&& other) = delete;
-    FromYca& operator = (const FromYca&& other) = delete;
+    FromYca (FromYca&& other) = delete;
+    FromYca& operator = (FromYca&& other) = delete;
 
     void		setFrameBuffer (Rgba *base,
 					size_t xStride,

--- a/OpenEXR/IlmImf/ImfRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfRgbaFile.h
@@ -291,8 +291,8 @@ class RgbaOutputFile
 						char c);
   private:
 
-    RgbaOutputFile (const RgbaOutputFile &);		  // not implemented
-    RgbaOutputFile & operator = (const RgbaOutputFile &); // not implemented
+    RgbaOutputFile (const RgbaOutputFile &) = delete;
+    const RgbaOutputFile & operator = (const RgbaOutputFile &) = delete;
 
     class ToYca;
 
@@ -428,8 +428,8 @@ class RgbaInputFile
 
   private:
 
-    RgbaInputFile (const RgbaInputFile &);		  // not implemented
-    RgbaInputFile & operator = (const RgbaInputFile &);   // not implemented
+    RgbaInputFile (const RgbaInputFile &) = delete;
+    const RgbaInputFile & operator = (const RgbaInputFile &) = delete;
 
     class FromYca;
 

--- a/OpenEXR/IlmImf/ImfRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfRgbaFile.h
@@ -293,8 +293,8 @@ class RgbaOutputFile
 
     RgbaOutputFile (const RgbaOutputFile &) = delete;
     RgbaOutputFile & operator = (const RgbaOutputFile &) = delete;
-    RgbaOutputFile (const RgbaOutputFile &&) = delete;
-    RgbaOutputFile & operator = (const RgbaOutputFile &&) = delete;
+    RgbaOutputFile (RgbaOutputFile &&) = delete;
+    RgbaOutputFile & operator = (RgbaOutputFile &&) = delete;
 
     class ToYca;
 
@@ -432,8 +432,8 @@ class RgbaInputFile
 
     RgbaInputFile (const RgbaInputFile &) = delete;
     RgbaInputFile & operator = (const RgbaInputFile &) = delete;
-    RgbaInputFile (const RgbaInputFile &&) = delete;
-    RgbaInputFile & operator = (const RgbaInputFile &&) = delete;
+    RgbaInputFile (RgbaInputFile &&) = delete;
+    RgbaInputFile & operator = (RgbaInputFile &&) = delete;
 
     class FromYca;
 

--- a/OpenEXR/IlmImf/ImfRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfRgbaFile.h
@@ -292,7 +292,9 @@ class RgbaOutputFile
   private:
 
     RgbaOutputFile (const RgbaOutputFile &) = delete;
-    const RgbaOutputFile & operator = (const RgbaOutputFile &) = delete;
+    RgbaOutputFile & operator = (const RgbaOutputFile &) = delete;
+    RgbaOutputFile (const RgbaOutputFile &&) = delete;
+    RgbaOutputFile & operator = (const RgbaOutputFile &&) = delete;
 
     class ToYca;
 
@@ -429,7 +431,9 @@ class RgbaInputFile
   private:
 
     RgbaInputFile (const RgbaInputFile &) = delete;
-    const RgbaInputFile & operator = (const RgbaInputFile &) = delete;
+    RgbaInputFile & operator = (const RgbaInputFile &) = delete;
+    RgbaInputFile (const RgbaInputFile &&) = delete;
+    RgbaInputFile & operator = (const RgbaInputFile &&) = delete;
 
     class FromYca;
 

--- a/OpenEXR/IlmImf/ImfRleCompressor.h
+++ b/OpenEXR/IlmImf/ImfRleCompressor.h
@@ -58,6 +58,9 @@ class RleCompressor: public Compressor
     IMF_EXPORT
     virtual ~RleCompressor ();
 
+    RleCompressor (const RleCompressor& other) = delete;
+    const RleCompressor& operator = (const RleCompressor& other) = delete;
+
     IMF_EXPORT
     virtual int numScanLines () const;
 

--- a/OpenEXR/IlmImf/ImfRleCompressor.h
+++ b/OpenEXR/IlmImf/ImfRleCompressor.h
@@ -60,8 +60,8 @@ class RleCompressor: public Compressor
 
     RleCompressor (const RleCompressor& other) = delete;
     RleCompressor& operator = (const RleCompressor& other) = delete;
-    RleCompressor (const RleCompressor&& other) = delete;
-    RleCompressor& operator = (const RleCompressor&& other) = delete;
+    RleCompressor (RleCompressor&& other) = delete;
+    RleCompressor& operator = (RleCompressor&& other) = delete;
 
     IMF_EXPORT
     virtual int numScanLines () const;

--- a/OpenEXR/IlmImf/ImfRleCompressor.h
+++ b/OpenEXR/IlmImf/ImfRleCompressor.h
@@ -59,7 +59,9 @@ class RleCompressor: public Compressor
     virtual ~RleCompressor ();
 
     RleCompressor (const RleCompressor& other) = delete;
-    const RleCompressor& operator = (const RleCompressor& other) = delete;
+    RleCompressor& operator = (const RleCompressor& other) = delete;
+    RleCompressor (const RleCompressor&& other) = delete;
+    RleCompressor& operator = (const RleCompressor&& other) = delete;
 
     IMF_EXPORT
     virtual int numScanLines () const;

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -150,6 +150,9 @@ struct LineBuffer
     LineBuffer (Compressor * const comp);
     ~LineBuffer ();
 
+    LineBuffer (const LineBuffer& other) = delete;
+    const LineBuffer& operator = (const LineBuffer& other) = delete;
+
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
 

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -241,6 +241,9 @@ struct ScanLineInputFile::Data: public Mutex
     
     Data (int numThreads);
     ~Data ();
+
+    Data (const Data& other) = delete;
+    const Data operator = (const Data& other) = delete;
     
     inline LineBuffer * getLineBuffer (int number); // hash function from line
     						    // buffer indices into our

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -152,8 +152,8 @@ struct LineBuffer
 
     LineBuffer (const LineBuffer& other) = delete;
     LineBuffer& operator = (const LineBuffer& other) = delete;
-    LineBuffer (const LineBuffer&& other) = delete;
-    LineBuffer& operator = (const LineBuffer&& other) = delete;
+    LineBuffer (LineBuffer&& other) = delete;
+    LineBuffer& operator = (LineBuffer&& other) = delete;
 
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
@@ -246,8 +246,8 @@ struct ScanLineInputFile::Data: public Mutex
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
     
     inline LineBuffer * getLineBuffer (int number); // hash function from line
     						    // buffer indices into our

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -151,7 +151,9 @@ struct LineBuffer
     ~LineBuffer ();
 
     LineBuffer (const LineBuffer& other) = delete;
-    const LineBuffer& operator = (const LineBuffer& other) = delete;
+    LineBuffer& operator = (const LineBuffer& other) = delete;
+    LineBuffer (const LineBuffer&& other) = delete;
+    LineBuffer& operator = (const LineBuffer&& other) = delete;
 
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
@@ -243,7 +245,9 @@ struct ScanLineInputFile::Data: public Mutex
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
     
     inline LineBuffer * getLineBuffer (int number); // hash function from line
     						    // buffer indices into our

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.h
@@ -75,6 +75,9 @@ class ScanLineInputFile : public GenericInputFile
     IMF_EXPORT
     virtual ~ScanLineInputFile ();
 
+    ScanLineInputFile (const ScanLineInputFile& other) = delete;
+    const ScanLineInputFile& operator = (const ScanLineInputFile& other) = delete;
+
 
     //------------------------
     // Access to the file name

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.h
@@ -77,8 +77,8 @@ class ScanLineInputFile : public GenericInputFile
 
     ScanLineInputFile (const ScanLineInputFile& other) = delete;
     ScanLineInputFile& operator = (const ScanLineInputFile& other) = delete;
-    ScanLineInputFile (const ScanLineInputFile&& other) = delete;
-    ScanLineInputFile& operator = (const ScanLineInputFile&& other) = delete;
+    ScanLineInputFile (ScanLineInputFile&& other) = delete;
+    ScanLineInputFile& operator = (ScanLineInputFile&& other) = delete;
 
 
     //------------------------

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.h
@@ -76,7 +76,9 @@ class ScanLineInputFile : public GenericInputFile
     virtual ~ScanLineInputFile ();
 
     ScanLineInputFile (const ScanLineInputFile& other) = delete;
-    const ScanLineInputFile& operator = (const ScanLineInputFile& other) = delete;
+    ScanLineInputFile& operator = (const ScanLineInputFile& other) = delete;
+    ScanLineInputFile (const ScanLineInputFile&& other) = delete;
+    ScanLineInputFile& operator = (const ScanLineInputFile&& other) = delete;
 
 
     //------------------------

--- a/OpenEXR/IlmImf/ImfStandardAttributes.cpp
+++ b/OpenEXR/IlmImf/ImfStandardAttributes.cpp
@@ -47,27 +47,27 @@
 #define IMF_STD_ATTRIBUTE_IMP(name,suffix,type)				 \
 									 \
     void								 \
-    add##suffix (Header &header, const type &value)			 \
+    IMF_ADD_SUFFIX(suffix) (Header &header, const type &value)          \
     {									 \
 	header.insert (IMF_STRING (name), TypedAttribute<type> (value)); \
     }									 \
 									 \
     bool								 \
-    has##suffix (const Header &header)					 \
+    IMF_HAS_SUFFIX(suffix) (const Header &header)                       \
     {									 \
 	return header.findTypedAttribute <TypedAttribute <type> >	 \
 		(IMF_STRING (name)) != 0;				 \
     }									 \
 									 \
     const TypedAttribute<type> &					 \
-    name##Attribute (const Header &header)				 \
+    IMF_NAME_ATTRIBUTE(name) (const Header &header)                    \
     {									 \
 	return header.typedAttribute <TypedAttribute <type> >		 \
 		(IMF_STRING (name));					 \
     }									 \
 									 \
     TypedAttribute<type> &						 \
-    name##Attribute (Header &header)					 \
+    IMF_NAME_ATTRIBUTE(name) (Header &header)                      \
     {									 \
 	return header.typedAttribute <TypedAttribute <type> >		 \
 		(IMF_STRING (name));					 \
@@ -76,13 +76,13 @@
     const type &							 \
     name (const Header &header)						 \
     {									 \
-	return name##Attribute(header).value();				 \
+	return IMF_NAME_ATTRIBUTE(name) (header).value();           \
     }									 \
 									 \
     type &								 \
     name (Header &header)						 \
     {									 \
-	return name##Attribute(header).value();				 \
+	return IMF_NAME_ATTRIBUTE(name) (header).value();           \
     }
 
 #include "ImfNamespace.h"

--- a/OpenEXR/IlmImf/ImfStandardAttributes.h
+++ b/OpenEXR/IlmImf/ImfStandardAttributes.h
@@ -70,15 +70,19 @@
 #include "ImfNamespace.h"
 #include "ImfExport.h"
 
+#define IMF_ADD_SUFFIX(suffix) add##suffix
+#define IMF_HAS_SUFFIX(suffix) has##suffix
+#define IMF_NAME_ATTRIBUTE(name) name##Attribute
+
 #define IMF_STD_ATTRIBUTE_DEF(name,suffix,object)                            \
                                                                              \
     OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER                              \
-    IMF_EXPORT void           add##suffix (Header &header, const object &v); \
-    IMF_EXPORT bool           has##suffix (const Header &header);            \
+    IMF_EXPORT void           IMF_ADD_SUFFIX(suffix) (Header &header, const object &v); \
+    IMF_EXPORT bool           IMF_HAS_SUFFIX(suffix) (const Header &header);     \
     IMF_EXPORT const TypedAttribute<object> &                                \
-                              name##Attribute (const Header &header);        \
+                              IMF_NAME_ATTRIBUTE(name) (const Header &header); \
     IMF_EXPORT TypedAttribute<object> &                                      \
-                              name##Attribute (Header &header);              \
+                              IMF_NAME_ATTRIBUTE(name) (Header &header);     \
     IMF_EXPORT const object &                                                \
                               name (const Header &header);                   \
     IMF_EXPORT object &       name (Header &header);                         \

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -149,6 +149,9 @@ struct TileBuffer
      TileBuffer (Compressor * const comp);
     ~TileBuffer ();
 
+    TileBuffer (const TileBuffer& other) = delete;
+    const TileBuffer& operator = (const TileBuffer& other) = delete;
+
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
 
@@ -242,6 +245,9 @@ struct TiledInputFile::Data: public Mutex
 
      Data (int numThreads);
     ~Data ();
+
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
 
     inline TileBuffer * getTileBuffer (int number);
 					    // hash function from tile indices

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -150,7 +150,9 @@ struct TileBuffer
     ~TileBuffer ();
 
     TileBuffer (const TileBuffer& other) = delete;
-    const TileBuffer& operator = (const TileBuffer& other) = delete;
+    TileBuffer& operator = (const TileBuffer& other) = delete;
+    TileBuffer (const TileBuffer&& other) = delete;
+    TileBuffer& operator = (const TileBuffer&& other) = delete;
 
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
@@ -247,7 +249,9 @@ struct TiledInputFile::Data: public Mutex
     ~Data ();
 
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     inline TileBuffer * getTileBuffer (int number);
 					    // hash function from tile indices

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -151,8 +151,8 @@ struct TileBuffer
 
     TileBuffer (const TileBuffer& other) = delete;
     TileBuffer& operator = (const TileBuffer& other) = delete;
-    TileBuffer (const TileBuffer&& other) = delete;
-    TileBuffer& operator = (const TileBuffer&& other) = delete;
+    TileBuffer (TileBuffer&& other) = delete;
+    TileBuffer& operator = (TileBuffer&& other) = delete;
 
     inline void		wait () {_sem.wait();}
     inline void		post () {_sem.post();}
@@ -250,8 +250,8 @@ struct TiledInputFile::Data: public Mutex
 
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     inline TileBuffer * getTileBuffer (int number);
 					    // hash function from tile indices

--- a/OpenEXR/IlmImf/ImfTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.h
@@ -93,6 +93,9 @@ class TiledInputFile : public GenericInputFile
     IMF_EXPORT
     virtual ~TiledInputFile ();
 
+    TiledInputFile (const TiledInputFile& other) = delete;
+    const TiledInputFile& operator = (const TiledInputFile& other) = delete;
+
 
     //------------------------
     // Access to the file name
@@ -398,9 +401,6 @@ class TiledInputFile : public GenericInputFile
     friend class MultiPartInputFile;
 
     TiledInputFile (InputPartData* part);
-
-    TiledInputFile (const TiledInputFile &);		  // not implemented
-    TiledInputFile & operator = (const TiledInputFile &); // not implemented
 
     TiledInputFile (const Header &header, OPENEXR_IMF_INTERNAL_NAMESPACE::IStream *is, int version,
                     int numThreads);

--- a/OpenEXR/IlmImf/ImfTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.h
@@ -95,8 +95,8 @@ class TiledInputFile : public GenericInputFile
 
     TiledInputFile (const TiledInputFile& other) = delete;
     TiledInputFile& operator = (const TiledInputFile& other) = delete;
-    TiledInputFile (const TiledInputFile&& other) = delete;
-    TiledInputFile& operator = (const TiledInputFile&& other) = delete;
+    TiledInputFile (TiledInputFile&& other) = delete;
+    TiledInputFile& operator = (TiledInputFile&& other) = delete;
 
 
     //------------------------

--- a/OpenEXR/IlmImf/ImfTiledInputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.h
@@ -94,7 +94,9 @@ class TiledInputFile : public GenericInputFile
     virtual ~TiledInputFile ();
 
     TiledInputFile (const TiledInputFile& other) = delete;
-    const TiledInputFile& operator = (const TiledInputFile& other) = delete;
+    TiledInputFile& operator = (const TiledInputFile& other) = delete;
+    TiledInputFile (const TiledInputFile&& other) = delete;
+    TiledInputFile& operator = (const TiledInputFile&& other) = delete;
 
 
     //------------------------

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -187,6 +187,9 @@ struct BufferedTile
     {
 	delete [] pixelData;
     }
+
+    BufferedTile (const BufferedTile& other) = delete;
+    const BufferedTile& operator = (const BufferedTile& other) = delete;
 };
 
 
@@ -278,6 +281,9 @@ struct TiledOutputFile::Data
      Data (int numThreads);
     ~Data ();
     
+    Data (const Data& other) = delete;
+    const Data& operator = (const Data& other) = delete;
+
     inline TileBuffer *	getTileBuffer (int number);
     						// hash function from tile
 						// buffer coords into our

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -190,8 +190,8 @@ struct BufferedTile
 
     BufferedTile (const BufferedTile& other) = delete;
     BufferedTile& operator = (const BufferedTile& other) = delete;
-    BufferedTile (const BufferedTile&& other) = delete;
-    BufferedTile& operator = (const BufferedTile&& other) = delete;
+    BufferedTile (BufferedTile&& other) = delete;
+    BufferedTile& operator = (BufferedTile&& other) = delete;
 };
 
 
@@ -285,8 +285,8 @@ struct TiledOutputFile::Data
     
     Data (const Data& other) = delete;
     Data& operator = (const Data& other) = delete;
-    Data (const Data&& other) = delete;
-    Data& operator = (const Data&& other) = delete;
+    Data (Data&& other) = delete;
+    Data& operator = (Data&& other) = delete;
 
     inline TileBuffer *	getTileBuffer (int number);
     						// hash function from tile

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -189,7 +189,9 @@ struct BufferedTile
     }
 
     BufferedTile (const BufferedTile& other) = delete;
-    const BufferedTile& operator = (const BufferedTile& other) = delete;
+    BufferedTile& operator = (const BufferedTile& other) = delete;
+    BufferedTile (const BufferedTile&& other) = delete;
+    BufferedTile& operator = (const BufferedTile&& other) = delete;
 };
 
 
@@ -282,7 +284,9 @@ struct TiledOutputFile::Data
     ~Data ();
     
     Data (const Data& other) = delete;
-    const Data& operator = (const Data& other) = delete;
+    Data& operator = (const Data& other) = delete;
+    Data (const Data&& other) = delete;
+    Data& operator = (const Data&& other) = delete;
 
     inline TileBuffer *	getTileBuffer (int number);
     						// hash function from tile

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.h
@@ -503,8 +503,8 @@ class TiledOutputFile : public GenericOutputFile
     // ----------------------------------------------------------------
     TiledOutputFile (const OutputPartData* part);
 
-    TiledOutputFile (const TiledOutputFile &);		    // not implemented
-    TiledOutputFile & operator = (const TiledOutputFile &); // not implemented
+    TiledOutputFile (const TiledOutputFile &) = delete;
+    const TiledOutputFile & operator = (const TiledOutputFile &) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.h
@@ -504,7 +504,9 @@ class TiledOutputFile : public GenericOutputFile
     TiledOutputFile (const OutputPartData* part);
 
     TiledOutputFile (const TiledOutputFile &) = delete;
-    const TiledOutputFile & operator = (const TiledOutputFile &) = delete;
+    TiledOutputFile & operator = (const TiledOutputFile &) = delete;
+    TiledOutputFile (const TiledOutputFile &&) = delete;
+    TiledOutputFile & operator = (const TiledOutputFile &&) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.h
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.h
@@ -505,8 +505,8 @@ class TiledOutputFile : public GenericOutputFile
 
     TiledOutputFile (const TiledOutputFile &) = delete;
     TiledOutputFile & operator = (const TiledOutputFile &) = delete;
-    TiledOutputFile (const TiledOutputFile &&) = delete;
-    TiledOutputFile & operator = (const TiledOutputFile &&) = delete;
+    TiledOutputFile (TiledOutputFile &&) = delete;
+    TiledOutputFile & operator = (TiledOutputFile &&) = delete;
 
     void		initialize (const Header &header);
 

--- a/OpenEXR/IlmImf/ImfTiledRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfTiledRgbaFile.h
@@ -316,8 +316,8 @@ class TiledRgbaOutputFile
     // Copy constructor and assignment are not implemented
     //
 
-    TiledRgbaOutputFile (const TiledRgbaOutputFile &);	
-    TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &);
+    TiledRgbaOutputFile (const TiledRgbaOutputFile &) = delete;	
+    const TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &) = delete;
 
     class ToYa;
 
@@ -539,8 +539,8 @@ class TiledRgbaInputFile
     // Copy constructor and assignment are not implemented
     //
 
-    TiledRgbaInputFile (const TiledRgbaInputFile &);
-    TiledRgbaInputFile & operator = (const TiledRgbaInputFile &);
+    TiledRgbaInputFile (const TiledRgbaInputFile &) = delete;
+    const TiledRgbaInputFile & operator = (const TiledRgbaInputFile &) = delete;
 
     class FromYa;
 

--- a/OpenEXR/IlmImf/ImfTiledRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfTiledRgbaFile.h
@@ -317,7 +317,9 @@ class TiledRgbaOutputFile
     //
 
     TiledRgbaOutputFile (const TiledRgbaOutputFile &) = delete;	
-    const TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &) = delete;
+    TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &) = delete;
+    TiledRgbaOutputFile (const TiledRgbaOutputFile &&) = delete;	
+    TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &&) = delete;
 
     class ToYa;
 
@@ -540,7 +542,9 @@ class TiledRgbaInputFile
     //
 
     TiledRgbaInputFile (const TiledRgbaInputFile &) = delete;
-    const TiledRgbaInputFile & operator = (const TiledRgbaInputFile &) = delete;
+    TiledRgbaInputFile & operator = (const TiledRgbaInputFile &) = delete;
+    TiledRgbaInputFile (const TiledRgbaInputFile &&) = delete;
+    TiledRgbaInputFile & operator = (const TiledRgbaInputFile &&) = delete;
 
     class FromYa;
 

--- a/OpenEXR/IlmImf/ImfTiledRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfTiledRgbaFile.h
@@ -318,8 +318,8 @@ class TiledRgbaOutputFile
 
     TiledRgbaOutputFile (const TiledRgbaOutputFile &) = delete;	
     TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &) = delete;
-    TiledRgbaOutputFile (const TiledRgbaOutputFile &&) = delete;	
-    TiledRgbaOutputFile & operator = (const TiledRgbaOutputFile &&) = delete;
+    TiledRgbaOutputFile (TiledRgbaOutputFile &&) = delete;	
+    TiledRgbaOutputFile & operator = (TiledRgbaOutputFile &&) = delete;
 
     class ToYa;
 
@@ -543,8 +543,8 @@ class TiledRgbaInputFile
 
     TiledRgbaInputFile (const TiledRgbaInputFile &) = delete;
     TiledRgbaInputFile & operator = (const TiledRgbaInputFile &) = delete;
-    TiledRgbaInputFile (const TiledRgbaInputFile &&) = delete;
-    TiledRgbaInputFile & operator = (const TiledRgbaInputFile &&) = delete;
+    TiledRgbaInputFile (TiledRgbaInputFile &&) = delete;
+    TiledRgbaInputFile & operator = (TiledRgbaInputFile &&) = delete;
 
     class FromYa;
 

--- a/OpenEXR/IlmImf/ImfTimeCode.cpp
+++ b/OpenEXR/IlmImf/ImfTimeCode.cpp
@@ -114,8 +114,11 @@ TimeCode::TimeCode (const TimeCode &other)
 TimeCode &
 TimeCode::operator = (const TimeCode &other)
 {
-    _time = other._time;
-    _user = other._user;
+    if (&other != this)
+    {
+        _time = other._time;
+        _user = other._user;
+    }
     return *this;
 }
 

--- a/OpenEXR/IlmImf/ImfTimeCode.h
+++ b/OpenEXR/IlmImf/ImfTimeCode.h
@@ -167,6 +167,8 @@ class TimeCode
     IMF_EXPORT
     TimeCode (const TimeCode &other);
 
+    ~TimeCode () = default;
+
     IMF_EXPORT
     TimeCode & operator = (const TimeCode &other);
 

--- a/OpenEXR/IlmImf/ImfZip.h
+++ b/OpenEXR/IlmImf/ImfZip.h
@@ -53,6 +53,9 @@ class Zip
         IMF_EXPORT
         ~Zip();
 
+        Zip (const Zip& other) = delete;
+        const Zip& operator = (const Zip& other) = delete;
+
         IMF_EXPORT
         size_t maxRawSize();
         IMF_EXPORT
@@ -76,9 +79,6 @@ class Zip
     private:
         size_t _maxRawSize;
         char  *_tmpBuffer;
-
-        Zip();
-        Zip(const Zip&);
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/OpenEXR/IlmImf/ImfZip.h
+++ b/OpenEXR/IlmImf/ImfZip.h
@@ -54,7 +54,9 @@ class Zip
         ~Zip();
 
         Zip (const Zip& other) = delete;
-        const Zip& operator = (const Zip& other) = delete;
+        Zip& operator = (const Zip& other) = delete;
+        Zip (const Zip&& other) = delete;
+        Zip& operator = (const Zip&& other) = delete;
 
         IMF_EXPORT
         size_t maxRawSize();

--- a/OpenEXR/IlmImf/ImfZip.h
+++ b/OpenEXR/IlmImf/ImfZip.h
@@ -55,8 +55,8 @@ class Zip
 
         Zip (const Zip& other) = delete;
         Zip& operator = (const Zip& other) = delete;
-        Zip (const Zip&& other) = delete;
-        Zip& operator = (const Zip&& other) = delete;
+        Zip (Zip&& other) = delete;
+        Zip& operator = (Zip&& other) = delete;
 
         IMF_EXPORT
         size_t maxRawSize();

--- a/OpenEXR/IlmImf/dwaLookups.cpp
+++ b/OpenEXR/IlmImf/dwaLookups.cpp
@@ -108,6 +108,9 @@ namespace {
             {
             }
 
+            LutHeaderWorker(const LutHeaderWorker& other) = delete;
+            const LutHeaderWorker& operator = (const LutHeaderWorker& other) = delete;
+
             ~LutHeaderWorker()
             {
                 delete[] _offset;

--- a/OpenEXR/IlmImf/dwaLookups.cpp
+++ b/OpenEXR/IlmImf/dwaLookups.cpp
@@ -109,7 +109,9 @@ namespace {
             }
 
             LutHeaderWorker(const LutHeaderWorker& other) = delete;
-            const LutHeaderWorker& operator = (const LutHeaderWorker& other) = delete;
+            LutHeaderWorker& operator = (const LutHeaderWorker& other) = delete;
+            LutHeaderWorker(const LutHeaderWorker&& other) = delete;
+            LutHeaderWorker& operator = (const LutHeaderWorker&& other) = delete;
 
             ~LutHeaderWorker()
             {

--- a/OpenEXR/IlmImf/dwaLookups.cpp
+++ b/OpenEXR/IlmImf/dwaLookups.cpp
@@ -110,8 +110,8 @@ namespace {
 
             LutHeaderWorker(const LutHeaderWorker& other) = delete;
             LutHeaderWorker& operator = (const LutHeaderWorker& other) = delete;
-            LutHeaderWorker(const LutHeaderWorker&& other) = delete;
-            LutHeaderWorker& operator = (const LutHeaderWorker&& other) = delete;
+            LutHeaderWorker(LutHeaderWorker&& other) = delete;
+            LutHeaderWorker& operator = (LutHeaderWorker&& other) = delete;
 
             ~LutHeaderWorker()
             {

--- a/OpenEXR/IlmImfTest/testAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testAttributes.cpp
@@ -578,12 +578,229 @@ print_type(const OPENEXR_IMF_NAMESPACE::TypedAttribute<T> & object)
     cout << object.typeName() << endl;
 }
 
+//
+// Test to confirm that the copy/move constructors are implemented
+// properly.
+//
+
+static int default_constructor;
+static int destructor;
+static int copy_constructor;
+static int assignment_operator;
+static int move_constructor;
+static int move_assignment_operator;
+
+struct TestType 
+{
+    TestType() 
+    {
+        default_constructor++;
+    }
+
+    ~TestType() 
+    {
+        destructor++;
+    }
+    
+    TestType (const TestType& other) 
+        : _f (other._f)
+    {
+        copy_constructor++;
+    }
+
+    TestType& operator = (const TestType& other)
+    {
+        assignment_operator++;
+        _f = other._f;
+        return *this;
+    }
+
+    TestType (TestType&& other) 
+        : _f (std::move (other._f))
+    {
+        move_constructor++;
+    }
+
+    TestType& operator = (TestType&& other)
+    {
+        move_assignment_operator++;
+        _f = std::move (other._f);
+        return *this;
+    }
+
+    static TestType func()
+    {
+        TestType t;
+        return t;
+    }
+    
+    static TestType arg (TestType a)
+    {
+        return a;
+    }
+    
+    int _f;
+    
+    static void assert_count (int dc, int d, int cc, int ao, int mc, int mao)
+    {
+        assert (dc == default_constructor);
+        assert (d == destructor);
+        assert (cc == copy_constructor);
+        assert (ao == assignment_operator);
+        assert (mc == move_constructor);
+        assert (mao == move_assignment_operator);
+    }
+        
+    static void reset()
+    {
+        default_constructor = 0;
+        destructor = 0;
+        copy_constructor = 0;
+        assignment_operator = 0;
+        move_constructor = 0;
+        move_assignment_operator = 0;
+    }
+
+    static std::string str()
+    {
+        std::stringstream s;
+        if (default_constructor)
+            s << "default_constructor=" << default_constructor << std::endl;        
+        if (destructor)
+            s << "destructor=" << destructor << std::endl;        
+
+        if (copy_constructor)
+            s << "copy_constructor=" << copy_constructor << std::endl;        
+
+        if (assignment_operator)
+            s << "assignment_operator=" << assignment_operator << std::endl;        
+        if (move_constructor)
+            s << "move_constructor=" << move_constructor << std::endl;        
+
+        if (move_assignment_operator)
+            s << "move_assignment_operator=" << move_assignment_operator << std::endl;        
+        return s.str();
+    }
+};
+
+typedef Imf::TypedAttribute<TestType> TestTypedAttribute;
+
+template <>
+const char *
+TestTypedAttribute::staticTypeName ()
+{
+    return "test";
+}
+
+template <>
+void
+TestTypedAttribute::writeValueTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, int version) const
+{
+}
+
+template <>
+void
+TestTypedAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int size, int version)
+{
+}
+
+TestType
+testTypeFunc()
+{
+    return TestType();
+}
+
+TestTypedAttribute
+testFunc()
+{
+    TestTypedAttribute a;
+    return a;
+}
+
+TestTypedAttribute
+testArg (TestTypedAttribute a)
+{
+    return a;
+}
+
+void
+testTypedAttribute()
+{
+    std::cout << "running testTypedAttribute()\n";
+    
+    //
+    // Validate the test type
+    //
+    
+    TestType A;
+    TestType::assert_count (1, 0, 0, 0, 0, 0);
+    TestType::reset();
+
+    TestType B (A);
+    TestType::assert_count (0, 0, 1, 0, 0, 0);
+    TestType::reset();
+
+    B = A;
+    TestType::assert_count (0, 0, 0, 1, 0, 0);
+    TestType::reset();
+
+    A = std::move (B);
+    TestType::assert_count (0, 0, 0, 0, 0, 1);
+    TestType::reset();
+
+    A = TestType::func();
+    TestType::assert_count (1, 1, 0, 0, 0, 1);
+    TestType::reset();
+
+    A = TestType::arg(B);
+    TestType::assert_count (0, 2, 1, 0, 1, 1);
+    TestType::reset();
+
+    //
+    // Test the attribute type
+    //
+    
+    TestTypedAttribute a;
+    TestType::assert_count (1, 0, 0, 0, 0, 0);
+    TestType::reset();
+
+    {
+        TestType x;
+    }
+    TestType::assert_count (1, 1, 0, 0, 0, 0);
+    TestType::reset();
+    
+    TestTypedAttribute b(a);
+    TestType::assert_count (0, 0, 1, 0, 0, 0);
+    TestType::reset();
+
+    a = b;
+    TestType::assert_count (0, 0, 0, 1, 0, 0);
+    TestType::reset();
+
+    a = std::move (b);
+    TestType::assert_count (0, 0, 0, 0, 0, 1);
+    TestType::reset();
+
+    a = testFunc();
+    TestType::assert_count (1, 1, 0, 0, 0, 1);
+    TestType::reset();
+
+    a = testArg(b);
+    TestType::assert_count (0, 2, 1, 0, 1, 1);
+    TestType::reset();
+
+    std::cout << "ok." << std::endl;
+}
+
 void
 testAttributes (const std::string &tempDir)
 {
     try
     {
 	cout << "Testing built-in attributes" << endl;
+
+        testTypedAttribute();
 
 	const int W = 217;
 	const int H = 197;

--- a/OpenEXR/IlmImfTest/testAttributes.cpp
+++ b/OpenEXR/IlmImfTest/testAttributes.cpp
@@ -578,6 +578,8 @@ print_type(const OPENEXR_IMF_NAMESPACE::TypedAttribute<T> & object)
     cout << object.typeName() << endl;
 }
 
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
 //
 // Test to confirm that the copy/move constructors are implemented
 // properly.
@@ -723,10 +725,15 @@ testArg (TestTypedAttribute a)
     return a;
 }
 
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+
 void
 testTypedAttribute()
 {
     std::cout << "running testTypedAttribute()\n";
+    
+    using namespace OPENEXR_IMF_INTERNAL_NAMESPACE;
     
     //
     // Validate the test type

--- a/OpenEXR/IlmImfTest/testInputPart.cpp
+++ b/OpenEXR/IlmImfTest/testInputPart.cpp
@@ -58,7 +58,7 @@
 #include <ImfInputPart.h>
 #include <ImfTiledOutputPart.h>
 #include <ImfPartType.h>
-#include <ImfMisc.h>
+//#include <ImfMisc.h>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -65,7 +65,7 @@
 #include <ImfDeepTiledInputPart.h>
 #include <ImfDeepScanLineInputPart.h>
 #include <ImfPartType.h>
-#include <ImfMisc.h>
+//#include <ImfMisc.h>
 #include <ImfSystemSpecific.h>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;

--- a/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartFileMixingBasic.cpp
@@ -65,7 +65,7 @@
 #include <ImfDeepTiledInputPart.h>
 #include <ImfDeepScanLineInputPart.h>
 #include <ImfPartType.h>
-//#include <ImfMisc.h>
+#include <ImfMisc.h>
 #include <ImfSystemSpecific.h>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;

--- a/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
@@ -103,6 +103,9 @@ class DeepImageChannel: public ImageChannel
     IMFUTIL_EXPORT DeepImageChannel (DeepImageLevel &level, bool pLinear);
     IMFUTIL_EXPORT virtual ~DeepImageChannel();
 
+    DeepImageChannel (const DeepImageChannel& other) = delete;
+    const DeepImageChannel& operator = (const DeepImageChannel& other) = delete;
+
     virtual void setSamplesToZero
                         (size_t i,
                          unsigned int oldNumSamples,

--- a/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
@@ -104,7 +104,9 @@ class DeepImageChannel: public ImageChannel
     IMFUTIL_EXPORT virtual ~DeepImageChannel();
 
     DeepImageChannel (const DeepImageChannel& other) = delete;
-    const DeepImageChannel& operator = (const DeepImageChannel& other) = delete;
+    DeepImageChannel& operator = (const DeepImageChannel& other) = delete;
+    DeepImageChannel (const DeepImageChannel&& other) = delete;
+    DeepImageChannel& operator = (const DeepImageChannel&& other) = delete;
 
     virtual void setSamplesToZero
                         (size_t i,
@@ -194,7 +196,9 @@ class TypedDeepImageChannel: public DeepImageChannel
     virtual ~TypedDeepImageChannel ();
 
     TypedDeepImageChannel (const TypedDeepImageChannel& other) = delete;
-    const TypedDeepImageChannel& operator = (const TypedDeepImageChannel& other) = delete;    
+    TypedDeepImageChannel& operator = (const TypedDeepImageChannel& other) = delete;    
+    TypedDeepImageChannel (const TypedDeepImageChannel&& other) = delete;
+    TypedDeepImageChannel& operator = (const TypedDeepImageChannel&& other) = delete;    
 
     virtual void setSamplesToZero
                             (size_t i,

--- a/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
@@ -193,6 +193,9 @@ class TypedDeepImageChannel: public DeepImageChannel
     TypedDeepImageChannel (DeepImageLevel &level, bool pLinear);
     virtual ~TypedDeepImageChannel ();
 
+    TypedDeepImageChannel (const TypedDeepImageChannel& other) = delete;
+    const TypedDeepImageChannel& operator = (const TypedDeepImageChannel& other) = delete;    
+
     virtual void setSamplesToZero
                             (size_t i,
                              unsigned int oldNumSamples,

--- a/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfDeepImageChannel.h
@@ -105,8 +105,8 @@ class DeepImageChannel: public ImageChannel
 
     DeepImageChannel (const DeepImageChannel& other) = delete;
     DeepImageChannel& operator = (const DeepImageChannel& other) = delete;
-    DeepImageChannel (const DeepImageChannel&& other) = delete;
-    DeepImageChannel& operator = (const DeepImageChannel&& other) = delete;
+    DeepImageChannel (DeepImageChannel&& other) = delete;
+    DeepImageChannel& operator = (DeepImageChannel&& other) = delete;
 
     virtual void setSamplesToZero
                         (size_t i,
@@ -197,8 +197,8 @@ class TypedDeepImageChannel: public DeepImageChannel
 
     TypedDeepImageChannel (const TypedDeepImageChannel& other) = delete;
     TypedDeepImageChannel& operator = (const TypedDeepImageChannel& other) = delete;    
-    TypedDeepImageChannel (const TypedDeepImageChannel&& other) = delete;
-    TypedDeepImageChannel& operator = (const TypedDeepImageChannel&& other) = delete;    
+    TypedDeepImageChannel (TypedDeepImageChannel&& other) = delete;
+    TypedDeepImageChannel& operator = (TypedDeepImageChannel&& other) = delete;    
 
     virtual void setSamplesToZero
                             (size_t i,

--- a/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
@@ -102,6 +102,9 @@ class FlatImageChannel: public ImageChannel
     IMFUTIL_EXPORT
     virtual ~FlatImageChannel();
 
+    FlatImageChannel (const FlatImageChannel& other) = delete;
+    const FlatImageChannel& operator = (const FlatImageChannel& other) = delete;
+
     IMFUTIL_EXPORT
     virtual void            resize ();
 

--- a/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
@@ -103,7 +103,9 @@ class FlatImageChannel: public ImageChannel
     virtual ~FlatImageChannel();
 
     FlatImageChannel (const FlatImageChannel& other) = delete;
-    const FlatImageChannel& operator = (const FlatImageChannel& other) = delete;
+    FlatImageChannel& operator = (const FlatImageChannel& other) = delete;
+    FlatImageChannel (const FlatImageChannel&& other) = delete;
+    FlatImageChannel& operator = (const FlatImageChannel&& other) = delete;
 
     IMFUTIL_EXPORT
     virtual void            resize ();
@@ -178,7 +180,9 @@ class TypedFlatImageChannel: public FlatImageChannel
     virtual ~TypedFlatImageChannel ();
 
     TypedFlatImageChannel (const TypedFlatImageChannel& other) = delete;
-    const TypedFlatImageChannel& operator = (const TypedFlatImageChannel& other) = delete;    
+    TypedFlatImageChannel& operator = (const TypedFlatImageChannel& other) = delete;    
+    TypedFlatImageChannel (const TypedFlatImageChannel&& other) = delete;
+    TypedFlatImageChannel& operator = (const TypedFlatImageChannel&& other) = delete;    
 
     virtual void        resize ();
 

--- a/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
@@ -104,8 +104,8 @@ class FlatImageChannel: public ImageChannel
 
     FlatImageChannel (const FlatImageChannel& other) = delete;
     FlatImageChannel& operator = (const FlatImageChannel& other) = delete;
-    FlatImageChannel (const FlatImageChannel&& other) = delete;
-    FlatImageChannel& operator = (const FlatImageChannel&& other) = delete;
+    FlatImageChannel (FlatImageChannel&& other) = delete;
+    FlatImageChannel& operator = (FlatImageChannel&& other) = delete;
 
     IMFUTIL_EXPORT
     virtual void            resize ();
@@ -181,8 +181,8 @@ class TypedFlatImageChannel: public FlatImageChannel
 
     TypedFlatImageChannel (const TypedFlatImageChannel& other) = delete;
     TypedFlatImageChannel& operator = (const TypedFlatImageChannel& other) = delete;    
-    TypedFlatImageChannel (const TypedFlatImageChannel&& other) = delete;
-    TypedFlatImageChannel& operator = (const TypedFlatImageChannel&& other) = delete;    
+    TypedFlatImageChannel (TypedFlatImageChannel&& other) = delete;
+    TypedFlatImageChannel& operator = (TypedFlatImageChannel&& other) = delete;    
 
     virtual void        resize ();
 

--- a/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfFlatImageChannel.h
@@ -177,6 +177,9 @@ class TypedFlatImageChannel: public FlatImageChannel
 
     virtual ~TypedFlatImageChannel ();
 
+    TypedFlatImageChannel (const TypedFlatImageChannel& other) = delete;
+    const TypedFlatImageChannel& operator = (const TypedFlatImageChannel& other) = delete;    
+
     virtual void        resize ();
 
     virtual void        resetBasePointer ();

--- a/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
@@ -224,6 +224,9 @@ class SampleCountChannel : public ImageChannel
          IMFUTIL_EXPORT
         ~Edit ();
 
+        Edit (const Edit& other) = delete;
+        const Edit& operator = (const Edit& other) = delete;
+
         //
         // Access to the writable sample count array.
         //

--- a/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
@@ -226,8 +226,8 @@ class SampleCountChannel : public ImageChannel
 
         Edit (const Edit& other) = delete;
         Edit& operator = (const Edit& other) = delete;
-        Edit (const Edit&& other) = delete;
-        Edit& operator = (const Edit&& other) = delete;
+        Edit (Edit&& other) = delete;
+        Edit& operator = (Edit&& other) = delete;
 
         //
         // Access to the writable sample count array.

--- a/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
+++ b/OpenEXR/IlmImfUtil/ImfSampleCountChannel.h
@@ -225,7 +225,9 @@ class SampleCountChannel : public ImageChannel
         ~Edit ();
 
         Edit (const Edit& other) = delete;
-        const Edit& operator = (const Edit& other) = delete;
+        Edit& operator = (const Edit& other) = delete;
+        Edit (const Edit&& other) = delete;
+        Edit& operator = (const Edit&& other) = delete;
 
         //
         // Access to the writable sample count array.

--- a/OpenEXR/exrmaketiled/Image.h
+++ b/OpenEXR/exrmaketiled/Image.h
@@ -114,6 +114,9 @@ class Image
     Image (const IMATH_NAMESPACE::Box2i &dataWindow);
    ~Image ();
 
+    Image (const Image& other) = delete;
+    const Image & operator = (const Image& other) = delete;
+    
     const IMATH_NAMESPACE::Box2i &	dataWindow () const;
     void			resize (const IMATH_NAMESPACE::Box2i &dataWindow);
 

--- a/OpenEXR/exrmaketiled/Image.h
+++ b/OpenEXR/exrmaketiled/Image.h
@@ -115,7 +115,9 @@ class Image
    ~Image ();
 
     Image (const Image& other) = delete;
-    const Image & operator = (const Image& other) = delete;
+    Image & operator = (const Image& other) = delete;
+    Image (const Image&& other) = delete;
+    Image & operator = (const Image&& other) = delete;
     
     const IMATH_NAMESPACE::Box2i &	dataWindow () const;
     void			resize (const IMATH_NAMESPACE::Box2i &dataWindow);

--- a/OpenEXR/exrmaketiled/Image.h
+++ b/OpenEXR/exrmaketiled/Image.h
@@ -116,8 +116,8 @@ class Image
 
     Image (const Image& other) = delete;
     Image & operator = (const Image& other) = delete;
-    Image (const Image&& other) = delete;
-    Image & operator = (const Image&& other) = delete;
+    Image (Image&& other) = delete;
+    Image & operator = (Image&& other) = delete;
     
     const IMATH_NAMESPACE::Box2i &	dataWindow () const;
     void			resize (const IMATH_NAMESPACE::Box2i &dataWindow);

--- a/OpenEXR/exrmaketiled/makeTiled.cpp
+++ b/OpenEXR/exrmaketiled/makeTiled.cpp
@@ -56,7 +56,7 @@
 #include "ImfStandardAttributes.h"
 #include "ImathFun.h"
 #include "Iex.h"
-#include "ImfMisc.h"
+//#include "ImfMisc.h"
 
 #include <map>
 #include <algorithm>

--- a/OpenEXR/exrmaketiled/makeTiled.cpp
+++ b/OpenEXR/exrmaketiled/makeTiled.cpp
@@ -56,7 +56,7 @@
 #include "ImfStandardAttributes.h"
 #include "ImathFun.h"
 #include "Iex.h"
-//#include "ImfMisc.h"
+#include "ImfMisc.h"
 
 #include <map>
 #include <algorithm>

--- a/OpenEXR/exrmultiview/Image.h
+++ b/OpenEXR/exrmultiview/Image.h
@@ -115,6 +115,9 @@ class Image
     Image (const IMATH_NAMESPACE::Box2i &dataWindow);
    ~Image ();
 
+    Image (const Image& other) = delete;
+    const Image & operator = (const Image& other) = delete;
+
    const IMATH_NAMESPACE::Box2i &		dataWindow () const;
    void				resize (const IMATH_NAMESPACE::Box2i &dataWindow);
    

--- a/OpenEXR/exrmultiview/Image.h
+++ b/OpenEXR/exrmultiview/Image.h
@@ -116,7 +116,9 @@ class Image
    ~Image ();
 
     Image (const Image& other) = delete;
-    const Image & operator = (const Image& other) = delete;
+    Image & operator = (const Image& other) = delete;
+    Image (const Image&& other) = delete;
+    Image & operator = (const Image&& other) = delete;
 
    const IMATH_NAMESPACE::Box2i &		dataWindow () const;
    void				resize (const IMATH_NAMESPACE::Box2i &dataWindow);

--- a/OpenEXR/exrmultiview/Image.h
+++ b/OpenEXR/exrmultiview/Image.h
@@ -117,8 +117,8 @@ class Image
 
     Image (const Image& other) = delete;
     Image & operator = (const Image& other) = delete;
-    Image (const Image&& other) = delete;
-    Image & operator = (const Image&& other) = delete;
+    Image (Image&& other) = delete;
+    Image & operator = (Image&& other) = delete;
 
    const IMATH_NAMESPACE::Box2i &		dataWindow () const;
    void				resize (const IMATH_NAMESPACE::Box2i &dataWindow);

--- a/PyIlmBase/PyIex/PyIexTypeTranslator.h
+++ b/PyIlmBase/PyIex/PyIexTypeTranslator.h
@@ -61,6 +61,9 @@ class TypeTranslator
      TypeTranslator (const std::string &typeName, const std::string &moduleName, PyObject *typeObject);
     ~TypeTranslator ();
 
+    TypeTranslator (const TypeTranslator& other) = delete;
+    const TypeTranslator& operator = (const TypeTranslator& other) = delete;
+
     PyObject *	typeObject (const BaseClass *ptr) const;
     PyObject *	baseTypeObject () const;
 
@@ -80,6 +83,9 @@ class TypeTranslator
 		   const ClassDesc *baseClass);
 
 	virtual ~ClassDesc ();
+
+        ClassDesc (const ClassDesc& other) = delete;
+        const ClassDesc& operator = (const ClassDesc& other) = delete;
 
 	virtual bool		typeMatches (const BaseClass *ptr) const = 0;
 

--- a/PyIlmBase/PyIex/PyIexTypeTranslator.h
+++ b/PyIlmBase/PyIex/PyIexTypeTranslator.h
@@ -62,7 +62,9 @@ class TypeTranslator
     ~TypeTranslator ();
 
     TypeTranslator (const TypeTranslator& other) = delete;
-    const TypeTranslator& operator = (const TypeTranslator& other) = delete;
+    TypeTranslator& operator = (const TypeTranslator& other) = delete;
+    TypeTranslator (const TypeTranslator&& other) = delete;
+    TypeTranslator& operator = (const TypeTranslator&& other) = delete;
 
     PyObject *	typeObject (const BaseClass *ptr) const;
     PyObject *	baseTypeObject () const;
@@ -85,7 +87,9 @@ class TypeTranslator
 	virtual ~ClassDesc ();
 
         ClassDesc (const ClassDesc& other) = delete;
-        const ClassDesc& operator = (const ClassDesc& other) = delete;
+        ClassDesc& operator = (const ClassDesc& other) = delete;
+        ClassDesc (const ClassDesc&& other) = delete;
+        ClassDesc& operator = (const ClassDesc&& other) = delete;
 
 	virtual bool		typeMatches (const BaseClass *ptr) const = 0;
 

--- a/PyIlmBase/PyIex/PyIexTypeTranslator.h
+++ b/PyIlmBase/PyIex/PyIexTypeTranslator.h
@@ -63,8 +63,8 @@ class TypeTranslator
 
     TypeTranslator (const TypeTranslator& other) = delete;
     TypeTranslator& operator = (const TypeTranslator& other) = delete;
-    TypeTranslator (const TypeTranslator&& other) = delete;
-    TypeTranslator& operator = (const TypeTranslator&& other) = delete;
+    TypeTranslator (TypeTranslator&& other) = delete;
+    TypeTranslator& operator = (TypeTranslator&& other) = delete;
 
     PyObject *	typeObject (const BaseClass *ptr) const;
     PyObject *	baseTypeObject () const;
@@ -88,8 +88,8 @@ class TypeTranslator
 
         ClassDesc (const ClassDesc& other) = delete;
         ClassDesc& operator = (const ClassDesc& other) = delete;
-        ClassDesc (const ClassDesc&& other) = delete;
-        ClassDesc& operator = (const ClassDesc&& other) = delete;
+        ClassDesc (ClassDesc&& other) = delete;
+        ClassDesc& operator = (ClassDesc&& other) = delete;
 
 	virtual bool		typeMatches (const BaseClass *ptr) const = 0;
 

--- a/PyIlmBase/PyImath/PyImathFixedVArray.cpp
+++ b/PyIlmBase/PyImath/PyImathFixedVArray.cpp
@@ -153,7 +153,7 @@ FixedVArray<T>::FixedVArray(FixedVArray<T>& other, const FixedArray<int>& mask)
     {
         if (mask[i])
         {
-            _indices[j] = i;
+            _indices[j] = i; // NOSONAR - suppress SonarCloud warning.
             j++;
         }
     }

--- a/PyIlmBase/PyImath/PyImathStringTable.h
+++ b/PyIlmBase/PyImath/PyImathStringTable.h
@@ -64,7 +64,9 @@ struct StringTableIndex
     
     const StringTableIndex & operator = (const StringTableIndex &si)
     { 
-        _index = si._index; // NOSONAR - suppress SonarCloud warning
+        if (&si != this)
+            _index = si._index;
+        
         return *this;
     }
 
@@ -133,7 +135,7 @@ class StringTableDetailT {
     > StringTableContainer;
 };
 
-} // namespace PyImath
+} // namespace
 
 typedef StringTableDetailT<std::string> StringTableDetail;
 typedef StringTableDetailT<std::wstring> WStringTableDetail;

--- a/PyIlmBase/PyImath/PyImathStringTable.h
+++ b/PyIlmBase/PyImath/PyImathStringTable.h
@@ -112,7 +112,7 @@ struct StringTableEntry
     T                s;
 };
 
-namespace PyImath {
+namespace {
 
 using boost::multi_index_container;
 using namespace boost::multi_index;

--- a/PyIlmBase/PyImath/PyImathStringTable.h
+++ b/PyIlmBase/PyImath/PyImathStringTable.h
@@ -60,10 +60,12 @@ struct StringTableIndex
     StringTableIndex() : _index(0) {}
     StringTableIndex (const StringTableIndex &si) : _index (si._index) {}
     explicit StringTableIndex (index_type i) : _index (i) {}
-
+    ~StringTableIndex() = default;
+    
     const StringTableIndex & operator = (const StringTableIndex &si)
     { 
-        _index = si._index; return *this;
+        _index = si._index; // NOSONAR - suppress SonarCloud warning
+        return *this;
     }
 
     bool operator == (const StringTableIndex &si) const
@@ -110,7 +112,7 @@ struct StringTableEntry
     T                s;
 };
 
-namespace {
+namespace PyImath {
 
 using boost::multi_index_container;
 using namespace boost::multi_index;
@@ -131,7 +133,7 @@ class StringTableDetailT {
     > StringTableContainer;
 };
 
-} // namespace
+} // namespace PyImath
 
 typedef StringTableDetailT<std::string> StringTableDetail;
 typedef StringTableDetailT<std::wstring> WStringTableDetail;

--- a/PyIlmBase/PyImath/PyImathUtil.h
+++ b/PyIlmBase/PyImath/PyImathUtil.h
@@ -68,7 +68,7 @@ class PyAcquireLock
 
     PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
     PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock&& other) = delete;
+    PYIMATH_EXPORT PyAcquireLock(PyAcquireLock&& other) = delete;
     PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
     
   private:
@@ -92,7 +92,7 @@ class PyReleaseLock
     PYIMATH_EXPORT ~PyReleaseLock();
     PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
     PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock&& other) = delete;
+    PYIMATH_EXPORT PyReleaseLock(PyReleaseLock&& other) = delete;
     PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
 
   private:

--- a/PyIlmBase/PyImath/PyImathUtil.h
+++ b/PyIlmBase/PyImath/PyImathUtil.h
@@ -65,8 +65,11 @@ class PyAcquireLock
   public:
     PYIMATH_EXPORT PyAcquireLock();
     PYIMATH_EXPORT ~PyAcquireLock();
+
     PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT const PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock&& other) = delete;
+    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock&& other) = delete;
     
   private:
     PyGILState_STATE _gstate;
@@ -88,7 +91,9 @@ class PyReleaseLock
     PYIMATH_EXPORT PyReleaseLock();
     PYIMATH_EXPORT ~PyReleaseLock();
     PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT const PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+    PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock&& other) = delete;
+    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock&& other) = delete;
 
   private:
     PyThreadState *_save;

--- a/PyIlmBase/PyImath/PyImathUtil.h
+++ b/PyIlmBase/PyImath/PyImathUtil.h
@@ -65,6 +65,9 @@ class PyAcquireLock
   public:
     PYIMATH_EXPORT PyAcquireLock();
     PYIMATH_EXPORT ~PyAcquireLock();
+    PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
+    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    
   private:
     PyGILState_STATE _gstate;
 };
@@ -84,6 +87,9 @@ class PyReleaseLock
   public:
     PYIMATH_EXPORT PyReleaseLock();
     PYIMATH_EXPORT ~PyReleaseLock();
+    PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
+    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+
   private:
     PyThreadState *_save;
 

--- a/PyIlmBase/PyImath/PyImathUtil.h
+++ b/PyIlmBase/PyImath/PyImathUtil.h
@@ -66,7 +66,7 @@ class PyAcquireLock
     PYIMATH_EXPORT PyAcquireLock();
     PYIMATH_EXPORT ~PyAcquireLock();
     PYIMATH_EXPORT PyAcquireLock(const PyAcquireLock& other) = delete;
-    PYIMATH_EXPORT PyAcquireLock & operator = (PyAcquireLock& other) = delete;
+    PYIMATH_EXPORT const PyAcquireLock & operator = (PyAcquireLock& other) = delete;
     
   private:
     PyGILState_STATE _gstate;
@@ -88,7 +88,7 @@ class PyReleaseLock
     PYIMATH_EXPORT PyReleaseLock();
     PYIMATH_EXPORT ~PyReleaseLock();
     PYIMATH_EXPORT PyReleaseLock(const PyReleaseLock& other) = delete;
-    PYIMATH_EXPORT PyReleaseLock & operator = (PyReleaseLock& other) = delete;
+    PYIMATH_EXPORT const PyReleaseLock & operator = (PyReleaseLock& other) = delete;
 
   private:
     PyThreadState *_save;


### PR DESCRIPTION
- Added =delete constructor/operator=/move to all internal classes (declared inside a .cpp)
- Added =delete constructor/operator=/move to all external classes (in .h files) for which the operation is not trivial (i.e. class has dynamically-allocated fields), and is currently not needed.
- Added =default constructor/operator=/move to TypedAttribute<T> class, since that behavior is reasonable.
- added if(this!=&other) in operator=
- restructured IMF_STD_ATTRIBUTE