### PR TITLE
No longer install ImfMisc.h

### DIFF
--- a/OpenEXR/IlmImf/CMakeLists.txt
+++ b/OpenEXR/IlmImf/CMakeLists.txt
@@ -206,7 +206,6 @@ openexr_define_library(IlmImf
     ImfDeepCompositing.h
     ImfCompositeDeepScanLine.h
     ImfNamespace.h
-    ImfMisc.h
     ImfDeepImageState.h
     ImfDeepImageStateAttribute.h
     ImfFloatVectorAttribute.h

--- a/OpenEXR/IlmImf/Makefile.am
+++ b/OpenEXR/IlmImf/Makefile.am
@@ -36,7 +36,7 @@ libIlmImf_la_SOURCES = ImfForward.h ImfAttribute.cpp ImfBoxAttribute.cpp ImfCRgb
 		       ImfName.h ImfPixelType.h ImfVersion.h ImfXdr.h \
 		       ImfCompressor.h ImfRleCompressor.h ImfZipCompressor.h \
 		       ImfPizCompressor.h ImfDwaCompressor.h \
-	               ImfDwaCompressorSimd.h ImfMisc.h ImfAutoArray.h \
+	               ImfDwaCompressorSimd.h ImfAutoArray.h \
 		       ImfConvert.cpp ImfConvert.h ImfPreviewImage.cpp \
 		       ImfPreviewImage.h ImfPreviewImageAttribute.cpp \
 		       ImfPreviewImageAttribute.h ImfVersion.cpp \
@@ -165,7 +165,6 @@ libIlmImfinclude_HEADERS = ImfForward.h ImfAttribute.h ImfBoxAttribute.h \
 			   ImfDeepFrameBuffer.h \
 			   ImfDeepCompositing.h ImfCompositeDeepScanLine.h \
 			   ImfNamespace.h ImfForward.h ImfExport.h \
-			   ImfMisc.h          \
 			   ImfPartHelper.h \
 			   ImfDeepImageState.h \
 			   ImfDeepImageStateAttribute.h


### PR DESCRIPTION
ImfMisc.h is for internal use only. The functions declared in it
should not be used in application code.

Signed-off-by: Cary Phillips <cary@ilm.com>