### PR TITLE
Add a missing break statement when determining compression in exr2aces

### DIFF
--- a/OpenEXR/exr2aces/main.cpp
+++ b/OpenEXR/exr2aces/main.cpp
@@ -137,6 +137,7 @@ exr2aces (const char inFileName[],
       case B44_COMPRESSION:
       case B44A_COMPRESSION:
 	h.compression() = B44A_COMPRESSION;
+	break;
 
       default:
 	h.compression() = PIZ_COMPRESSION;


### PR DESCRIPTION
Signed-off-by: Karl Hendrikse <karlhendrikse@gmail.com>