### PR TITLE
Switch from int to size_t to prevent overflow with huge images in exrdisplay (Fix for #610)

### DIFF
--- a/OpenEXR_Viewers/exrdisplay/ImageView.cpp
+++ b/OpenEXR_Viewers/exrdisplay/ImageView.cpp
@@ -106,7 +106,7 @@ ImageView::ImageView (int x, int y,
     _dy (dy),
     _zsize (zsize),
     _rgbaBox (rgbaBox),
-    _screenPixels (dw * dh * 3)
+    _screenPixels ( static_cast<Int64>(dw) * static_cast<Int64>(dh) * 3ul)
 {
     computeFogColor();
     updateScreenPixels();

--- a/OpenEXR_Viewers/exrdisplay/ImageView.cpp
+++ b/OpenEXR_Viewers/exrdisplay/ImageView.cpp
@@ -701,13 +701,13 @@ ImageView::updateScreenPixels ()
                    0.f, 255.f, 0.f, 0.f);
 
 
-    for (int y = 0; y < _dh; ++y)
+    for (size_t y = 0; y < _dh; ++y)
     {
-        int i = y * _dw;
+        size_t i = y * _dw;
 
-        for (int x = 0; x < _dw; ++x)
+        for (size_t x = 0; x < _dw; ++x)
         {
-            int j = i + x;
+            size_t j = i + x;
             const IMF::Rgba &rp = _rawPixels[j];
             unsigned char *sp = _screenPixels + j * 3;
             sp[0] = dither (rGamma (rp.r), x, y);

--- a/OpenEXR_Viewers/exrdisplay/loadImage.cpp
+++ b/OpenEXR_Viewers/exrdisplay/loadImage.cpp
@@ -101,14 +101,16 @@ loadImage (const char fileName[],
         int dx = dataWindow.min.x;
         int dy = dataWindow.min.y;
 
-        pixels.resizeErase (dw * dh);
-        memset (pixels, 0, (dw * dh) * (sizeof(Rgba)));
+        Int64 pixelCount = static_cast<Int64>(dw) * static_cast<Int64>(dh);
+         
+        pixels.resizeErase ( pixelCount );
+        memset (pixels, 0, pixelCount * (sizeof(Rgba)));
 
         size_t xs = 1 * sizeof (Rgba);
         size_t ys = dw * sizeof (Rgba);
 
         FrameBuffer fb;
-        Rgba *base = pixels - dx - dy * dw;
+        Rgba *base = pixels - static_cast<Int64>(dx) - (static_cast<Int64>(dy) * static_cast<Int64>(dw) );
 
         fb.insert ("R",
                    Slice (HALF,


### PR DESCRIPTION

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>