### PR TITLE
fix testB44ExpLogTable and testDwaLookups, and Makefile.am

### DIFF
--- a/OpenEXR/IlmImfTest/Makefile.am
+++ b/OpenEXR/IlmImfTest/Makefile.am
@@ -60,7 +60,7 @@ IlmImfTest_SOURCES = main.cpp tmpDir.h testAttributes.cpp testChannels.cpp \
 	             testRle.cpp testRle.h \
 	             testB44ExpLogTable.cpp testB44ExpLogTable.h \
 	             testDwaLookups.cpp testDwaLookups.h \
-		     bswap_32.h
+		     bswap_32.h random.cpp
 
 AM_CPPFLAGS = -DILM_IMF_TEST_IMAGEDIR=\"$(srcdir)/\"
 

--- a/OpenEXR/IlmImfTest/testB44ExpLogTable.cpp
+++ b/OpenEXR/IlmImfTest/testB44ExpLogTable.cpp
@@ -20,8 +20,7 @@ using namespace std;
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-extern const unsigned short expTable[];
-extern const unsigned short logTable[];
+#include "b44ExpLogTable.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT
 

--- a/OpenEXR/IlmImfTest/testDwaLookups.cpp
+++ b/OpenEXR/IlmImfTest/testDwaLookups.cpp
@@ -26,6 +26,7 @@
 #include <IlmThreadSemaphore.h>
 #include <ImfIO.h>
 #include <ImfXdr.h>
+#include "dwaLookups.h"
 #include "ImfNamespace.h"
 
 //
@@ -38,11 +39,7 @@ using namespace OPENEXR_IMF_NAMESPACE;
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-extern const unsigned short dwaCompressorNoOp[];
-extern const unsigned short dwaCompressorToLinear[];
-extern const unsigned short dwaCompressorToNonlinear[];
-extern const unsigned short closestData[];
-extern const unsigned int closestDataOffset[];
+#include "dwaLookups.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT
 
@@ -373,7 +370,7 @@ testToNonlinear()
 
     printf("test dwaCompressorToNonlinear[]\n");
     for (int i=0; i<65536; ++i)
-        assert (toNonLinear[i] == OPENEXR_IMF_INTERNAL_NAMESPACE::dwaCompressorToNonLinear[i]);
+        assert (toNonlinear[i] == OPENEXR_IMF_INTERNAL_NAMESPACE::dwaCompressorToNonlinear[i]);
 }
 
 //


### PR DESCRIPTION
There was apparently a typo in one of the tests. Also, the 'generated' header files are in anonymous namespaces, not in the Imf internal namespace, so aren't visible to the test. I worked around that by re-including the header files in the test, rather than picking up the compiled version from the IlmImf library. An alternative solution would be to move the headers into the Imf internal namespace to make the symbols visible.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>