### PR TITLE
possible fix for #570: avoid writing NaNs into test images

### DIFF
--- a/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
+++ b/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
@@ -179,13 +179,19 @@ setupBuffer (const Header& hdr,       // header to grab datawindow from
     }
    
      const char * write_ptr = writing ? &writingBuffer[0] : &readingBuffer[0];
-     // fill with random halfs, casting to floats for float channels
+     // fill with random halfs, casting to floats for float channels - don't write NaN values
      size_t chan=0;
      for (size_t i=0;i<samples;i++)
      {
-         unsigned short int values = random_int(std::numeric_limits<unsigned short>::max());
+
          half v;
-         v.setBits(values);
+         do
+         {
+           unsigned short int values = random_int(std::numeric_limits<unsigned short>::max());
+           v.setBits(values);
+         }
+         while ( v.isNan() );
+
          if (pt==NULL || pt[chan]==IMF::HALF)
          {
              *(half*)write_ptr = half(v);


### PR DESCRIPTION
I couldn't get a 32bit x86 build working to reproduce #570. However, I think this change may be a fix. 

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>