### PR TITLE
add missing IMF_EXPORT to ImfOpenInputFile for dllexport

### DIFF
--- a/OpenEXR/IlmImf/ImfCRgbaFile.h
+++ b/OpenEXR/IlmImf/ImfCRgbaFile.h
@@ -443,6 +443,7 @@ int	       	ImfTiledOutputLevelRoundingMode
 struct ImfInputFile;
 typedef struct ImfInputFile ImfInputFile;
 
+IMF_EXPORT
 ImfInputFile *		ImfOpenInputFile (const char name[]);
 
 IMF_EXPORT 


### PR DESCRIPTION
add missing IMF_EXPORT to ImfOpenInputFile in order to be able to use it from a windows dll
Function is used by exrtools, so this fix is needed to compile for windows using shared libraries.
Regards, Laurens.