### PR TITLE
exrdisplay: limit maximum image size based on available screen res

### DIFF
--- a/OpenEXR_Viewers/exrdisplay/main.cpp
+++ b/OpenEXR_Viewers/exrdisplay/main.cpp
@@ -283,6 +283,11 @@ makeMainWindow (const char imageFile[],
     int zsize;
 
     //
+    // limit maximum size to twice screen resolution
+    //
+    Header::setMaxImageSize(Fl::w()*2 , Fl::h()*2);
+    
+    //
     //pass 0 as partnum for the first load
     //
     loadImage (imageFile,


### PR DESCRIPTION
As discussed in #610 , `exrdisplay` doesn't handle large images well. It will always try to match the window resolution to the image size. It doesn't have the ability to resize the window, zoom out, or pan around an image, making it impractical to use with images that are larger than the screen size.  Very large images may create windows which are too large for window managers, and `exrdisplay` will allocate excessive amounts of memory to load them.

This change simply aborts loading early with images that are more than twice as wide or high as the screen.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>