### PR TITLE
support reloading broken files with IlmImfFuzzTest

### DIFF
--- a/OpenEXR/IlmImfFuzzTest/main.cpp
+++ b/OpenEXR/IlmImfFuzzTest/main.cpp
@@ -53,7 +53,7 @@
     #include <sstream>
 #endif
 
-#define TEST(x) if (argc < 2 || !strcmp (argv[1], #x)) x();
+#define TEST(x) if (argc < 2 || !strcmp (argv[1], #x)) x(argc==3 ? argv[2] : nullptr);
 
 int
 main (int argc, char *argv[])

--- a/OpenEXR/IlmImfFuzzTest/main.cpp
+++ b/OpenEXR/IlmImfFuzzTest/main.cpp
@@ -46,36 +46,82 @@
 
 #include <stdlib.h>
 #include <iostream>
+#include <set>
 #include <string.h>
+#include <string>
 
 #ifdef OPENEXR_IMF_HAVE_LINUX_PROCFS
     #include <unistd.h>
     #include <sstream>
 #endif
 
-#define TEST(x) if (argc < 2 || !strcmp (argv[1], #x)) x(argc==3 ? argv[2] : nullptr);
+
+using std::set;
+using std::string;
+using std::cout;
+using std::endl;
+
+#define TEST(x) if (helpMode) tests.insert(string(#x)); else if (argc < 2 || !strcmp (argv[1], #x)) x(argc==3 ? argv[2] : nullptr);
 
 int
 main (int argc, char *argv[])
 {
+    bool helpMode = false;
+    if( argc==2 && (strcmp(argv[1],"--help")==0 || strcmp(argv[1],"-h")==0))
+    {
+	    helpMode = true;
+    }
+    set<string> tests;
+
+
     TEST (testFuzzScanLines);
     TEST (testFuzzTiles);
     TEST (testFuzzDeepScanLines);
     TEST (testFuzzDeepTiles);
-    
+   
+
+    if(helpMode)
+    {
+       cout << "IlmImfFuzzTest tests how resilient the IlmImf library is with\n"
+	       "respect to broken input files: the program first damages\n"
+	       "OpenEXR files by partially overwriting them with random data;\n"
+	       "then it tries to read the damaged files.  If all goes well,\n"
+	       "then the program doesn't crash.\n";
+       cout << "\n";
+       cout << "If IlmImfFuzzTest does crash, it will leave a file in the current\n"
+	       "directory, or /var/tmp. Running 'IlmImfFuzzTest test file' will\n"
+	       "usually quickly reproduce the issue by attempting to reload the file,\n"
+	       "(without running the normal tests) and is useful for debugging\n"
+	       "the exact cause of the crash or confirming a bug is fixed.\n";
+       cout << "\n";
+       cout << "usage:\n";
+       cout << " IlmImfFuzzTest             : with no arguments, run all tests\n";
+       cout << " IlmImfFuzzTest TEST        : run specific TEST only\n";
+       cout << " IlmImfFuzzTest TEST file   : try to read 'file' with given TEST\n";
+       cout << "\n";
+       cout << "TEST can be one of the following:\n";
+       for ( auto i = tests.begin() ; i!= tests.end() ; ++i )
+       {
+	       cout << ' ' << *i << endl;
+       }
+
+    }
+    else
+    {
+
 #ifdef OPENEXR_IMF_HAVE_LINUX_PROCFS
 
     //
     // Allow the user to check for file descriptor leaks
     //
 
-    std::cout << "open file descriptors:" << std::endl;
+    cout << "open file descriptors:" << endl;
 
     std::stringstream ss;
     ss << "ls -lG /proc/" << getpid() << "/fd";
 
     system (ss.str().c_str());
 #endif
-
+    }
     return 0;
 }

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.cpp
@@ -408,21 +408,29 @@ fuzzDeepScanLines (int numThreads, Rand48 &random)
 
 
 void
-testFuzzDeepScanLines ()
+testFuzzDeepScanLines (const char* file)
 {
     try
     {
-	cout << "Testing deep scanline-based files "
-		"with randomly inserted errors" << endl;
+        if(file)
+        {
+            readFile(file);
+        }
+        else
+        {
 
-	Rand48 random (1);
+            cout << "Testing deep scanline-based files "
+                    "with randomly inserted errors" << endl;
 
-	fuzzDeepScanLines (0, random);
+            Rand48 random (1);
 
-	if (ILMTHREAD_NAMESPACE::supportsThreads())
-	    fuzzDeepScanLines (2, random);
+            fuzzDeepScanLines (0, random);
 
-	cout << "ok\n" << endl;
+            if (ILMTHREAD_NAMESPACE::supportsThreads())
+                fuzzDeepScanLines (2, random);
+
+            cout << "ok\n" << endl;
+        }
     }
     catch (const std::exception &e)
     {

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.h
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepScanLines.h
@@ -35,5 +35,5 @@
 
 
 
-void testFuzzDeepScanLines ();
+void testFuzzDeepScanLines (const char* file);
 

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.cpp
@@ -219,7 +219,7 @@ void generateRandomFile(const char filename[], int channelCount, int parts , Com
                     {
                         for(int x=0;x<data[k].width();x++)
                         {
-                            delete reinterpret_cast<char *>( data[k][y][x] );
+                            delete [] reinterpret_cast<char *>( data[k][y][x] );
                             data[k][y][x]=0;
                         }
                     }
@@ -503,23 +503,30 @@ fuzzDeepTiles (int numThreads, Rand48 &random)
 
 
 void
-testFuzzDeepTiles ()
+testFuzzDeepTiles (const char* file)
 {
     
     
     try
     {
-	cout << "Testing deep tile-based files "
-		"with randomly inserted errors" << endl;
+        if(file)
+        {
+            readFile(file);
+        }
+        else
+        {
+            cout << "Testing deep tile-based files "
+                    "with randomly inserted errors" << endl;
 
-	Rand48 random (1);
+            Rand48 random (1);
 
-	fuzzDeepTiles (0, random);
+            fuzzDeepTiles (0, random);
 
-	if (ILMTHREAD_NAMESPACE::supportsThreads())
-	    fuzzDeepTiles (2, random);
+            if (ILMTHREAD_NAMESPACE::supportsThreads())
+                fuzzDeepTiles (2, random);
 
-	cout << "ok\n" << endl;
+            cout << "ok\n" << endl;
+        }
     }
     catch (const std::exception &e)
     {

--- a/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.h
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzDeepTiles.h
@@ -35,5 +35,5 @@
 
 
 
-void testFuzzDeepTiles ();
+void testFuzzDeepTiles (const char* file);
 

--- a/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.cpp
@@ -252,21 +252,28 @@ fuzzScanLines (int numThreads, Rand48 &random)
 
 
 void
-testFuzzScanLines ()
+testFuzzScanLines (const char* file)
 {
     try
     {
-	cout << "Testing scanline-based files "
-		"with randomly inserted errors" << endl;
+        if(file)
+        {
+            readImage(file);
+        }
+        else
+        {
+            cout << "Testing scanline-based files "
+                    "with randomly inserted errors" << endl;
 
-	Rand48 random (1);
+            Rand48 random (1);
 
-	fuzzScanLines (0, random);
+            fuzzScanLines (0, random);
 
-	if (ILMTHREAD_NAMESPACE::supportsThreads())
-	    fuzzScanLines (2, random);
+            if (ILMTHREAD_NAMESPACE::supportsThreads())
+                fuzzScanLines (2, random);
 
-	cout << "ok\n" << endl;
+            cout << "ok\n" << endl;
+        }
     }
     catch (const std::exception &e)
     {

--- a/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.h
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzScanLines.h
@@ -35,5 +35,5 @@
 
 
 
-void testFuzzScanLines ();
+void testFuzzScanLines (const char* file);
 

--- a/OpenEXR/IlmImfFuzzTest/testFuzzTiles.cpp
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzTiles.cpp
@@ -406,21 +406,30 @@ fuzzTiles (int numThreads, Rand48 &random)
 
 
 void
-testFuzzTiles ()
+testFuzzTiles (const char* file)
 {
     try
     {
-	cout << "Testing tile-based files "
-		"with randomly inserted errors" << endl;
+        if(file)
+        {
+            readImageONE(file);
+            readImageMIP(file);
+            readImageRIP(file);
+        }
+        else
+        {
+            cout << "Testing tile-based files "
+                    "with randomly inserted errors" << endl;
 
-	Rand48 random (5);
+            Rand48 random (5);
 
-	fuzzTiles (0, random);
+            fuzzTiles (0, random);
 
-	if (ILMTHREAD_NAMESPACE::supportsThreads())
-	    fuzzTiles (2, random);
+            if (ILMTHREAD_NAMESPACE::supportsThreads())
+                fuzzTiles (2, random);
 
-	cout << "ok\n" << endl;
+            cout << "ok\n" << endl;
+        }
     }
     catch (const std::exception &e)
     {

--- a/OpenEXR/IlmImfFuzzTest/testFuzzTiles.h
+++ b/OpenEXR/IlmImfFuzzTest/testFuzzTiles.h
@@ -35,5 +35,5 @@
 
 
 
-void testFuzzTiles ();
+void testFuzzTiles (const char* file);
 

--- a/OpenEXR/IlmImfTest/main.cpp
+++ b/OpenEXR/IlmImfTest/main.cpp
@@ -107,6 +107,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <set>
+
 #ifdef _WIN32
 #    include <windows.h>
 #else
@@ -118,22 +120,23 @@ using namespace std;
 
 #define TEST_STRING(x) #x
 #define TEST(x,y)                                                       \
-    if (argc < 2 || (!strcmp (argv[1], TEST_STRING(x)) || !strcmp (argv[1], y)))    \
+    if (helpMode)\
+    {\
+	tests.insert(string(TEST_STRING(x)));\
+	suites.insert(string(y));\
+    }\
+    else if (argc < 2 || (!strcmp (argv[1], TEST_STRING(x)) || !strcmp (argv[1], y)))    \
     {                                                                   \
         cout << "\n=======\nRunning " << TEST_STRING(x) <<endl;                     \
         x(tempDir);                                                     \
     }
 
-int
-main (int argc, char *argv[])
+
+string makeTempDir()
 {
-    // Create temporary files in a uniquely named private temporary
-    // subdirectory of IMF_TMP_DIR to avoid colliding with other
-    // running instances of this program.
+    string tempDir;
 
     IMATH_NAMESPACE::Rand48 rand48 (time ((time_t*)0) );
-    std::string tempDir;
-
     while (true)
     {
 #ifdef _WIN32
@@ -142,7 +145,7 @@ main (int argc, char *argv[])
         if (len == 0 || len > 4095)
         {
             cerr << "Cannot retrieve temporary directory" << endl;
-            return 1;
+            exit(1);
         }
         tempDir = tmpbuf;
         // windows does this automatically
@@ -168,8 +171,35 @@ main (int argc, char *argv[])
         {
             std::cerr << "ERROR -- mkdir(" << tempDir << ") failed: "
                          "errno = " << errno << std::endl;
-            return 1;
+            exit(1);
         }
+    }
+
+    return tempDir;
+
+}
+
+int
+main (int argc, char *argv[])
+{
+    // Create temporary files in a uniquely named private temporary
+    // subdirectory of IMF_TMP_DIR to avoid colliding with other
+    // running instances of this program.
+
+    std::string tempDir;
+
+    bool helpMode = false;
+    if( argc==2 && (strcmp(argv[1],"--help")==0 || strcmp(argv[1],"-h")==0))
+    {
+            helpMode = true;
+    }
+    set<string> tests;
+    set<string> suites;
+
+
+    if ( !helpMode )
+    {
+	    tempDir = makeTempDir();
     }
 
     TEST (testMagic, "core");
@@ -235,8 +265,43 @@ main (int argc, char *argv[])
 #endif    
 
 
-    std::cout << "removing temp dir " << tempDir << std::endl;
-    rmdir (tempDir.c_str());
+    if ( helpMode )
+    {
+        cout << "IlmImfTest runs a series of tests to confirm\n"
+		"correct behavior of the IlmImf OpenEXR library.\n"
+	        "If all is correct, IlmImfTest will complete without\n"
+		"crashing or leaking memory.\n";
+	cout << "\n";
+	cout << "If a test fails, an individual test can be re-run, avoiding\n"
+		"the wait for previous tests to complete. This allows easier debugging\n"
+                "of the failure.\n";
+	cout << "\n";
+	cout << "A 'suite' of tests can also be run, to allow a subset of\n"
+	     << "tests to run. This is useful as an initial confirmation\n"
+	     << "that a modification to the library has not introduced an error.\n"
+	     << "Suites can be run in parallel for speed. Every test is in one suite.\n";
+	cout << "\n";
+	cout << "usage:\n"
+	     << "IlmImfTest           : with no arguments, run all tests\n"
+	     << "IlmImfTest TEST      : run only specific test, then quit\n"
+             << "IlmImfTest SUITE     : run all the tests in the given SUITE\n";
+	cout << "\n";
+	cout << "available TESTs:\n";
+	for ( auto i = tests.begin() ; i!= tests.end() ; ++i)
+	{
+		cout << ' ' << *i << endl;
+	}
+	cout << "\n";
+	cout << "available SUITEs:\n";
+	for ( auto i = suites.begin() ; i!= suites.end() ; ++i )
+	{
+		cout << ' ' << *i << endl;
+	}
+    } 
+    else
+    {
+        cout << "removing temp dir " << tempDir << endl;
+        rmdir (tempDir.c_str());
 
 #ifdef OPENEXR_IMF_HAVE_LINUX_PROCFS
 
@@ -244,19 +309,19 @@ main (int argc, char *argv[])
         // Allow the user to check for file descriptor leaks
         //
 
-        std::cout << "open file descriptors:" << std::endl;
+        cout << "open file descriptors:" << endl;
 
-        std::stringstream ss;
+        stringstream ss;
         ss << "ls -lG /proc/" << getpid() << "/fd";
             
         if (system (ss.str().c_str()) == -1)
         {
-            std::cout << "failed to run ls\n";
+            cout << "failed to run ls\n";
         }
 
-        std::cout << std::endl;
+        cout << endl;
 
 #endif
-
+   }
     return 0;
 }


### PR DESCRIPTION
This extends each of the IlmImfFuzzTest tools to accept an EXR file to load.
E.g. `./IlmImfFuzzTest testFuzzScanLines /var/tmp/imf_test_scanline_file_fuzz_broken.exr`
This allows quicker debugging where a regular IlmImfFuzzTest run errors

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>