### PR TITLE
Implementation of Matrix22

### DIFF
--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -4192,6 +4192,29 @@ operator << (std::ostream &s, const Matrix44<T> &m)
 
 template <class S, class T>
 inline const Vec2<S> &
+operator *= (Vec2<S> &v, const Matrix22<T> &m)
+{
+    S x = S(v.x * m[0][0] + v.y * m[1][0]);
+    S y = S(v.x * m[0][1] + v.y * m[1][1]);
+
+    v.x = x;
+    v.y = y;
+
+    return v;
+}
+
+template <class S, class T>
+inline Vec2<S>
+operator * (const Vec2<S> &v, const Matrix22<T> &m)
+{
+    S x = S(v.x * m[0][0] + v.y * m[1][0]);
+    S y = S(v.x * m[0][1] + v.y * m[1][1]);
+
+    return Vec2<S> (x, y);
+}
+
+template <class S, class T>
+inline const Vec2<S> &
 operator *= (Vec2<S> &v, const Matrix33<T> &m)
 {
     S x = S(v.x * m[0][0] + v.y * m[1][0] + m[2][0]);

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -66,6 +66,276 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 enum Uninitialized {UNINITIALIZED};
 
 
+template <class T> class Matrix22
+{
+  public:
+
+    //-------------------
+    // Access to elements
+    //-------------------
+
+    T           x[2][2];
+
+    T *         operator [] (int i);
+    const T *   operator [] (int i) const;
+
+
+    //-------------
+    // Constructors
+    //-------------
+
+    Matrix22 (Uninitialized) {}
+
+    Matrix22 ();
+                                // 1 0
+                                // 0 1
+
+    Matrix22 (T a);
+                                // a a
+                                // a a
+
+    Matrix22 (const T a[2][2]);
+                                // a[0][0] a[0][1]
+                                // a[1][0] a[1][1]
+
+    Matrix22 (T a, T b, T c, T d);
+
+                                // a b
+                                // c d
+
+
+    //--------------------------------
+    // Copy constructor and assignment
+    //--------------------------------
+
+    Matrix22 (const Matrix22 &v);
+    template <class S> explicit Matrix22 (const Matrix22<S> &v);
+
+    const Matrix22 &    operator = (const Matrix22 &v);
+    const Matrix22 &    operator = (T a);
+
+
+    //------------
+    // Destructor
+    //------------
+
+    ~Matrix22 () = default;
+	
+    //----------------------
+    // Compatibility with Sb
+    //----------------------
+    
+    T *                 getValue ();
+    const T *           getValue () const;
+
+    template <class S>
+    void                getValue (Matrix22<S> &v) const;
+    template <class S>
+    Matrix22 &          setValue (const Matrix22<S> &v);
+
+    template <class S>
+    Matrix22 &          setTheMatrix (const Matrix22<S> &v);
+
+
+    //---------
+    // Identity
+    //---------
+
+    void                makeIdentity();
+
+
+    //---------
+    // Equality
+    //---------
+
+    bool                operator == (const Matrix22 &v) const;
+    bool                operator != (const Matrix22 &v) const;
+
+    //-----------------------------------------------------------------------
+    // Compare two matrices and test if they are "approximately equal":
+    //
+    // equalWithAbsError (m, e)
+    //
+    //      Returns true if the coefficients of this and m are the same with
+    //      an absolute error of no more than e, i.e., for all i, j
+    //
+    //      abs (this[i][j] - m[i][j]) <= e
+    //
+    // equalWithRelError (m, e)
+    //
+    //      Returns true if the coefficients of this and m are the same with
+    //      a relative error of no more than e, i.e., for all i, j
+    //
+    //      abs (this[i] - v[i][j]) <= e * abs (this[i][j])
+    //-----------------------------------------------------------------------
+
+    bool                equalWithAbsError (const Matrix22<T> &v, T e) const;
+    bool                equalWithRelError (const Matrix22<T> &v, T e) const;
+
+
+    //------------------------
+    // Component-wise addition
+    //------------------------
+
+    const Matrix22 &    operator += (const Matrix22 &v);
+    const Matrix22 &    operator += (T a);
+    Matrix22            operator + (const Matrix22 &v) const;
+
+
+    //---------------------------
+    // Component-wise subtraction
+    //---------------------------
+
+    const Matrix22 &    operator -= (const Matrix22 &v);
+    const Matrix22 &    operator -= (T a);
+    Matrix22            operator - (const Matrix22 &v) const;
+
+
+    //------------------------------------
+    // Component-wise multiplication by -1
+    //------------------------------------
+
+    Matrix22            operator - () const;
+    const Matrix22 &    negate ();
+
+
+    //------------------------------
+    // Component-wise multiplication
+    //------------------------------
+
+    const Matrix22 &    operator *= (T a);
+    Matrix22            operator * (T a) const;
+
+
+    //-----------------------------------
+    // Matrix-times-matrix multiplication
+    //-----------------------------------
+
+    const Matrix22 &    operator *= (const Matrix22 &v);
+    Matrix22            operator * (const Matrix22 &v) const;
+
+
+    //-----------------------------------------------------------------
+    // Vector-times-matrix multiplication; see also the "operator *"
+    // functions defined below.
+    //
+    // m.multDirMatrix(src,dst) multiplies src by the matrix m.
+    //-----------------------------------------------------------------
+
+    template <class S>
+    void                multDirMatrix(const Vec2<S> &src, Vec2<S> &dst) const;
+
+
+    //------------------------
+    // Component-wise division
+    //------------------------
+
+    const Matrix22 &    operator /= (T a);
+    Matrix22            operator / (T a) const;
+
+
+    //------------------
+    // Transposed matrix
+    //------------------
+
+    const Matrix22 &    transpose ();
+    Matrix22            transposed () const;
+
+
+    //------------------------------------------------------------
+    // Inverse matrix: If singExc is false, inverting a singular
+    // matrix produces an identity matrix.  If singExc is true,
+    // inverting a singular matrix throws a SingMatrixExc.
+    //
+    // inverse() and invert() invert matrices using determinants.
+    //
+    //------------------------------------------------------------
+
+    const Matrix22 &    invert (bool singExc = false);
+
+    Matrix22<T>         inverse (bool singExc = false) const;
+
+    //------------
+    // Determinant
+    //------------
+
+    T                   determinant() const;
+
+    //-----------------------------------------
+    // Set matrix to rotation by r (in radians)
+    //-----------------------------------------
+
+    template <class S>
+    const Matrix22 &    setRotation (S r);
+
+
+    //-----------------------------
+    // Rotate the given matrix by r
+    //-----------------------------
+
+    template <class S>
+    const Matrix22 &    rotate (S r);
+
+
+    //--------------------------------------------
+    // Set matrix to scale by given uniform factor
+    //--------------------------------------------
+
+    const Matrix22 &    setScale (T s);
+
+
+    //------------------------------------
+    // Set matrix to scale by given vector
+    //------------------------------------
+
+    template <class S>
+    const Matrix22 &    setScale (const Vec2<S> &s);
+
+
+    //----------------------
+    // Scale the matrix by s
+    //----------------------
+
+    template <class S>
+    const Matrix22 &    scale (const Vec2<S> &s);
+
+
+    //--------------------------------------------------------
+    // Number of the row and column dimensions, since
+    // Matrix22 is a square matrix.
+    //--------------------------------------------------------
+
+    static unsigned int	dimensions() {return 2;}
+
+
+    //-------------------------------------------------
+    // Limitations of type T (see also class limits<T>)
+    //-------------------------------------------------
+
+    static T            baseTypeMin()           {return limits<T>::min();}
+    static T            baseTypeMax()           {return limits<T>::max();}
+    static T            baseTypeSmallest()      {return limits<T>::smallest();}
+    static T            baseTypeEpsilon()       {return limits<T>::epsilon();}
+
+    typedef T		BaseType;
+    typedef Vec2<T>	BaseVecType;
+    
+  private:
+
+    template <typename R, typename S>
+    struct isSameType
+    {
+        enum {value = 0};
+    };
+
+    template <typename R>
+    struct isSameType<R, R>
+    {
+        enum {value = 1};
+    };
+};
+
+
 template <class T> class Matrix33
 {
   public:
@@ -833,6 +1103,9 @@ template <class T> class Matrix44
 //--------------
 
 template <class T>
+std::ostream &  operator << (std::ostream & s, const Matrix22<T> &m); 
+
+template <class T>
 std::ostream &  operator << (std::ostream & s, const Matrix33<T> &m); 
 
 template <class T>
@@ -842,6 +1115,13 @@ std::ostream &  operator << (std::ostream & s, const Matrix44<T> &m);
 //---------------------------------------------
 // Vector-times-matrix multiplication operators
 //---------------------------------------------
+
+
+template <class S, class T>
+const Vec2<S> &            operator *= (Vec2<S> &v, const Matrix22<T> &m);
+
+template <class S, class T>
+Vec2<S>                    operator * (const Vec2<S> &v, const Matrix22<T> &m);
 
 template <class S, class T>
 const Vec2<S> &            operator *= (Vec2<S> &v, const Matrix33<T> &m);
@@ -871,10 +1151,561 @@ Vec4<S>                    operator * (const Vec4<S> &v, const Matrix44<T> &m);
 // Typedefs for convenience
 //-------------------------
 
+typedef Matrix22 <float>  M22f;
+typedef Matrix22 <double> M22d;
 typedef Matrix33 <float>  M33f;
 typedef Matrix33 <double> M33d;
 typedef Matrix44 <float>  M44f;
 typedef Matrix44 <double> M44d;
+
+
+//---------------------------
+// Implementation of Matrix22
+//---------------------------
+
+template <class T>
+inline T *
+Matrix22<T>::operator [] (int i)
+{
+    return x[i];
+}
+
+template <class T>
+inline const T *
+Matrix22<T>::operator [] (int i) const
+{
+    return x[i];
+}
+
+template <class T>
+inline
+Matrix22<T>::Matrix22 ()
+{
+    memset (x, 0, sizeof (x));
+    x[0][0] = 1;
+    x[1][1] = 1;
+}
+
+template <class T>
+inline
+Matrix22<T>::Matrix22 (T a)
+{
+    x[0][0] = a;
+    x[0][1] = a;
+    x[1][0] = a;
+    x[1][1] = a;
+}
+
+template <class T>
+inline
+Matrix22<T>::Matrix22 (const T a[2][2]) 
+{
+    memcpy (x, a, sizeof (x));
+}
+
+template <class T>
+inline
+Matrix22<T>::Matrix22 (T a, T b, T c, T d)
+{
+    x[0][0] = a;
+    x[0][1] = b;
+    x[1][0] = c;
+    x[1][1] = d;
+}
+
+template <class T>
+inline
+Matrix22<T>::Matrix22 (const Matrix22 &v)
+{
+    memcpy (x, v.x, sizeof (x));
+}
+
+template <class T>
+template <class S>
+inline
+Matrix22<T>::Matrix22 (const Matrix22<S> &v)
+{
+    x[0][0] = T (v.x[0][0]);
+    x[0][1] = T (v.x[0][1]);
+    x[1][0] = T (v.x[1][0]);
+    x[1][1] = T (v.x[1][1]);
+}
+
+template <class T>
+inline const Matrix22<T> &
+Matrix22<T>::operator = (const Matrix22 &v)
+{
+    memcpy (x, v.x, sizeof (x));
+    return *this;
+}
+
+template <class T>
+inline const Matrix22<T> &
+Matrix22<T>::operator = (T a)
+{
+    x[0][0] = a;
+    x[0][1] = a;
+    x[1][0] = a;
+    x[1][1] = a;
+    return *this;
+}
+
+template <class T>
+inline T *
+Matrix22<T>::getValue ()
+{
+    return (T *) &x[0][0];
+}
+
+template <class T>
+inline const T *
+Matrix22<T>::getValue () const
+{
+    return (const T *) &x[0][0];
+}
+
+template <class T>
+template <class S>
+inline void
+Matrix22<T>::getValue (Matrix22<S> &v) const
+{
+    if (isSameType<S,T>::value)
+    {
+        memcpy (v.x, x, sizeof (x));
+    }
+    else
+    {
+        v.x[0][0] = x[0][0];
+        v.x[0][1] = x[0][1];
+        v.x[1][0] = x[1][0];
+        v.x[1][1] = x[1][1];
+    }
+}
+
+template <class T>
+template <class S>
+inline Matrix22<T> &
+Matrix22<T>::setValue (const Matrix22<S> &v)
+{
+    if (isSameType<S,T>::value)
+    {
+        memcpy (x, v.x, sizeof (x));
+    }
+    else
+    {
+        x[0][0] = v.x[0][0];
+        x[0][1] = v.x[0][1];
+        x[1][0] = v.x[1][0];
+        x[1][1] = v.x[1][1];
+    }
+
+    return *this;
+}
+
+template <class T>
+template <class S>
+inline Matrix22<T> &
+Matrix22<T>::setTheMatrix (const Matrix22<S> &v)
+{
+    if (isSameType<S,T>::value)
+    {
+        memcpy (x, v.x, sizeof (x));
+    }
+    else
+    {
+        x[0][0] = v.x[0][0];
+        x[0][1] = v.x[0][1];
+        x[1][0] = v.x[1][0];
+        x[1][1] = v.x[1][1];
+    }
+
+    return *this;
+}
+
+template <class T>
+inline void
+Matrix22<T>::makeIdentity()
+{
+    memset (x, 0, sizeof (x));
+    x[0][0] = 1;
+    x[1][1] = 1;
+}
+
+template <class T>
+bool
+Matrix22<T>::operator == (const Matrix22 &v) const
+{
+    return x[0][0] == v.x[0][0] &&
+           x[0][1] == v.x[0][1] &&
+           x[1][0] == v.x[1][0] &&
+           x[1][1] == v.x[1][1];
+}
+
+template <class T>
+bool
+Matrix22<T>::operator != (const Matrix22 &v) const
+{
+    return x[0][0] != v.x[0][0] ||
+           x[0][1] != v.x[0][1] ||
+           x[1][0] != v.x[1][0] ||
+           x[1][1] != v.x[1][1];
+}
+
+template <class T>
+bool
+Matrix22<T>::equalWithAbsError (const Matrix22<T> &m, T e) const
+{
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            if (!IMATH_INTERNAL_NAMESPACE::equalWithAbsError ((*this)[i][j], m[i][j], e))
+                return false;
+
+    return true;
+}
+
+template <class T>
+bool
+Matrix22<T>::equalWithRelError (const Matrix22<T> &m, T e) const
+{
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            if (!IMATH_INTERNAL_NAMESPACE::equalWithRelError ((*this)[i][j], m[i][j], e))
+                return false;
+
+    return true;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator += (const Matrix22<T> &v)
+{
+    x[0][0] += v.x[0][0];
+    x[0][1] += v.x[0][1];
+    x[1][0] += v.x[1][0];
+    x[1][1] += v.x[1][1];
+
+    return *this;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator += (T a)
+{
+    x[0][0] += a;
+    x[0][1] += a;
+    x[1][0] += a;
+    x[1][1] += a;
+  
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator + (const Matrix22<T> &v) const
+{
+    return Matrix22 (x[0][0] + v.x[0][0],
+                     x[0][1] + v.x[0][1],
+                     x[1][0] + v.x[1][0],
+                     x[1][1] + v.x[1][1]);
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator -= (const Matrix22<T> &v)
+{
+    x[0][0] -= v.x[0][0];
+    x[0][1] -= v.x[0][1];
+    x[1][0] -= v.x[1][0];
+    x[1][1] -= v.x[1][1];
+  
+    return *this;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator -= (T a)
+{
+    x[0][0] -= a;
+    x[0][1] -= a;
+    x[1][0] -= a;
+    x[1][1] -= a;
+  
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator - (const Matrix22<T> &v) const
+{
+    return Matrix22 (x[0][0] - v.x[0][0],
+                     x[0][1] - v.x[0][1],
+                     x[1][0] - v.x[1][0],
+                     x[1][1] - v.x[1][1]);
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator - () const
+{
+    return Matrix22 (-x[0][0],
+                     -x[0][1],
+                     -x[1][0],
+                     -x[1][1]);
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::negate ()
+{
+    x[0][0] = -x[0][0];
+    x[0][1] = -x[0][1];
+    x[1][0] = -x[1][0];
+    x[1][1] = -x[1][1];
+
+    return *this;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator *= (T a)
+{
+    x[0][0] *= a;
+    x[0][1] *= a;
+    x[1][0] *= a;
+    x[1][1] *= a;
+  
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator * (T a) const
+{
+    return Matrix22 (x[0][0] * a,
+                     x[0][1] * a,
+                     x[1][0] * a,
+                     x[1][1] * a);
+}
+
+template <class T>
+inline Matrix22<T>
+operator * (T a, const Matrix22<T> &v)
+{
+    return v * a;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator *= (const Matrix22<T> &v)
+{
+    Matrix22 tmp (T (0));
+
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            for (int k = 0; k < 2; k++)
+                tmp.x[i][j] += x[i][k] * v.x[k][j];
+
+    *this = tmp;
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator * (const Matrix22<T> &v) const
+{
+    Matrix22 tmp (T (0));
+
+    for (int i = 0; i < 2; i++)
+        for (int j = 0; j < 2; j++)
+            for (int k = 0; k < 2; k++)
+                tmp.x[i][j] += x[i][k] * v.x[k][j];
+
+    return tmp;
+}
+
+template <class T>
+template <class S>
+void
+Matrix22<T>::multDirMatrix(const Vec2<S> &src, Vec2<S> &dst) const
+{
+    S a, b;
+
+    a = src[0] * x[0][0] + src[1] * x[1][0];
+    b = src[0] * x[0][1] + src[1] * x[1][1];
+
+    dst.x = a;
+    dst.y = b;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::operator /= (T a)
+{
+    x[0][0] /= a;
+    x[0][1] /= a;
+    x[1][0] /= a;
+    x[1][1] /= a;
+  
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::operator / (T a) const
+{
+    return Matrix22 (x[0][0] / a,
+                     x[0][1] / a,
+                     x[1][0] / a,
+                     x[1][1] / a);
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::transpose ()
+{
+    Matrix22 tmp (x[0][0],
+                  x[1][0],
+                  x[0][1],
+                  x[1][1]);
+    *this = tmp;
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::transposed () const
+{
+    return Matrix22 (x[0][0],
+                     x[1][0],
+                     x[0][1],
+                     x[1][1]);
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::invert (bool singExc)
+{
+    *this = inverse (singExc);
+    return *this;
+}
+
+template <class T>
+Matrix22<T>
+Matrix22<T>::inverse (bool singExc) const
+{
+    Matrix22 s ( x[1][1],  -x[0][1],
+                -x[1][0],   x[0][0]);
+
+    T r = x[0][0] * x[1][1] - x[1][0] * x[0][1];
+
+    if (IMATH_INTERNAL_NAMESPACE::abs (r) >= 1)
+    {
+        for (int i = 0; i < 2; ++i)
+        {
+            for (int j = 0; j < 2; ++j)
+            {
+                s[i][j] /= r;
+            }
+        }
+    }
+    else
+    {
+        T mr = IMATH_INTERNAL_NAMESPACE::abs (r) / limits<T>::smallest();
+
+        for (int i = 0; i < 2; ++i)
+        {
+            for (int j = 0; j < 2; ++j)
+            {
+                if (mr > IMATH_INTERNAL_NAMESPACE::abs (s[i][j]))
+                {
+                    s[i][j] /= r;
+                }
+                else
+                {
+                    if (singExc)
+                        throw SingMatrixExc ("Cannot invert "
+                                                "singular matrix.");
+                    return Matrix22();
+                }
+            }
+        }
+    }
+    return s;
+}
+
+template <class T>
+inline T
+Matrix22<T>::determinant () const
+{
+    return x[0][0] * x[1][1] - x[1][0] * x[0][1];
+}
+
+template <class T>
+template <class S>
+const Matrix22<T> &
+Matrix22<T>::setRotation (S r)
+{
+    S cos_r, sin_r;
+
+    cos_r = Math<T>::cos (r);
+    sin_r = Math<T>::sin (r);
+
+    x[0][0] =  cos_r;
+    x[0][1] =  sin_r;
+
+    x[1][0] =  -sin_r;
+    x[1][1] =  cos_r;
+
+    return *this;
+}
+
+template <class T>
+template <class S>
+const Matrix22<T> &
+Matrix22<T>::rotate (S r)
+{
+    *this *= Matrix22<T>().setRotation (r);
+    return *this;
+}
+
+template <class T>
+const Matrix22<T> &
+Matrix22<T>::setScale (T s)
+{
+    x[0][0] = s;
+    x[0][1] = static_cast<T>(0);
+    x[1][0] = static_cast<T>(0);
+    x[1][1] = s;
+
+    return *this;
+}
+
+template <class T>
+template <class S>
+const Matrix22<T> &
+Matrix22<T>::setScale (const Vec2<S> &s)
+{
+    x[0][0] = s[0];
+    x[0][1] = static_cast<T>(0);
+    x[1][0] = static_cast<T>(0);
+    x[1][1] = s[1];
+
+    return *this;
+}
+
+template <class T>
+template <class S>
+const Matrix22<T> &
+Matrix22<T>::scale (const Vec2<S> &s)
+{
+    x[0][0] *= s[0];
+    x[0][1] *= s[0];
+
+    x[1][0] *= s[1];
+    x[1][1] *= s[1];
+
+    return *this;
+}
 
 
 //---------------------------

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -4078,6 +4078,35 @@ Matrix44<T>::shear (const Shear6<S> &h)
 
 template <class T>
 std::ostream &
+operator << (std::ostream &s, const Matrix22<T> &m)
+{
+    std::ios_base::fmtflags oldFlags = s.flags();
+    int width;
+
+    if (s.flags() & std::ios_base::fixed)
+    {
+        s.setf (std::ios_base::showpoint);
+        width = static_cast<int>(s.precision()) + 5;
+    }
+    else
+    {
+        s.setf (std::ios_base::scientific);
+        s.setf (std::ios_base::showpoint);
+        width = static_cast<int>(s.precision()) + 8;
+    }
+
+    s << "(" << std::setw (width) << m[0][0] <<
+         " " << std::setw (width) << m[0][1] << "\n" <<
+
+         " " << std::setw (width) << m[1][0] <<
+         " " << std::setw (width) << m[1][1] << ")\n";
+
+    s.flags (oldFlags);
+    return s;
+}
+
+template <class T>
+std::ostream &
 operator << (std::ostream &s, const Matrix33<T> &m)
 {
     std::ios_base::fmtflags oldFlags = s.flags();

--- a/IlmBase/Imath/ImathMatrix.h
+++ b/IlmBase/Imath/ImathMatrix.h
@@ -1181,8 +1181,9 @@ template <class T>
 inline
 Matrix22<T>::Matrix22 ()
 {
-    memset (x, 0, sizeof (x));
     x[0][0] = 1;
+    x[0][1] = 0;
+    x[1][0] = 0;
     x[1][1] = 1;
 }
 
@@ -1326,8 +1327,9 @@ template <class T>
 inline void
 Matrix22<T>::makeIdentity()
 {
-    memset (x, 0, sizeof (x));
     x[0][0] = 1;
+    x[0][1] = 0;
+    x[1][0] = 0;
     x[1][1] = 1;
 }
 

--- a/IlmBase/Imath/ImathMatrixAlgo.cpp
+++ b/IlmBase/Imath/ImathMatrixAlgo.cpp
@@ -54,6 +54,12 @@
 
 IMATH_INTERNAL_NAMESPACE_SOURCE_ENTER
 
+EXPORT_CONST M22f identity22f ( 1, 0,
+				0, 1);
+
+EXPORT_CONST M22d identity22d ( 1, 0,
+				0, 1);
+
 EXPORT_CONST M33f identity33f ( 1, 0, 0,
 				0, 1, 0,
 				0, 0, 1);

--- a/IlmBase/Imath/ImathMatrixAlgo.h
+++ b/IlmBase/Imath/ImathMatrixAlgo.h
@@ -64,8 +64,10 @@ IMATH_INTERNAL_NAMESPACE_HEADER_ENTER
 // Identity matrices
 //------------------
 
+IMATH_EXPORT_CONST M22f identity22f;
 IMATH_EXPORT_CONST M33f identity33f;
 IMATH_EXPORT_CONST M44f identity44f;
+IMATH_EXPORT_CONST M22d identity22d;
 IMATH_EXPORT_CONST M33d identity33d;
 IMATH_EXPORT_CONST M44d identity44d;
 
@@ -323,6 +325,10 @@ template <class T>  bool        extractAndRemoveScalingAndShear
 					     Vec2<T>     &scl,
 					     T           &shr,
 					     bool exc = true);
+
+template <class T>  void	extractEuler
+                                            (const Matrix22<T> &mat,
+					     T       &rot);
 
 template <class T>  void	extractEuler
                                             (const Matrix33<T> &mat,
@@ -1231,6 +1237,26 @@ extractAndRemoveScalingAndShear (Matrix33<T> &mat,
     return true;
 }
 
+template <class T>
+void
+extractEuler (const Matrix22<T> &mat, T &rot)
+{
+    //
+    // Normalize the local x and y axes to remove scaling.
+    //
+
+    Vec2<T> i (mat[0][0], mat[0][1]);
+    Vec2<T> j (mat[1][0], mat[1][1]);
+
+    i.normalize();
+    j.normalize();
+
+    //
+    // Extract the angle, rot.
+    // 
+
+    rot = - Math<T>::atan2 (j[0], i[0]);
+}
 
 template <class T>
 void

--- a/IlmBase/ImathTest/testMatrix.cpp
+++ b/IlmBase/ImathTest/testMatrix.cpp
@@ -73,6 +73,54 @@ testMatrix ()
     union {double d; Int64 i;} nand;
     nand.i = 0x7ff0000000000001ULL; //  NAN
 
+    {	
+	cout << "Imath::M22f constructors and equality operators" << endl;
+
+    IMATH_INTERNAL_NAMESPACE::M22f m1;
+    m1[0][0] = 99.0f;
+    m1[1][2] = 101.0f;
+
+	IMATH_INTERNAL_NAMESPACE::M22f test(m1);
+	assert(test == m1);
+
+	IMATH_INTERNAL_NAMESPACE::M22f test2;
+	assert(test != test2);
+
+	IMATH_INTERNAL_NAMESPACE::M22f test3;
+	test3.makeIdentity();
+	assert(test2 == test3);
+    }
+
+    {
+	cout << "M22d constructors and equality operators" << endl;
+
+	IMATH_INTERNAL_NAMESPACE::M22d m2;
+	m2[0][0] = 99.0f;
+	m2[1][2] = 101.0f;
+
+	IMATH_INTERNAL_NAMESPACE::M22d test(m2);
+	assert(test == m2);
+
+	IMATH_INTERNAL_NAMESPACE::M22d test2;
+	assert(test != test2);
+
+	IMATH_INTERNAL_NAMESPACE::M22d test3;
+	test3.makeIdentity();
+	assert(test2 == test3);
+
+        IMATH_INTERNAL_NAMESPACE::M22f test4 (1.0f, 2.0f, 3.0f,
+                           4.0f);
+
+        IMATH_INTERNAL_NAMESPACE::M22d test5 = IMATH_INTERNAL_NAMESPACE::M22d (test4);
+
+        assert (test5[0][0] == 1.0);
+        assert (test5[0][1] == 2.0);
+
+
+        assert (test5[1][0] == 3.0);
+        assert (test5[1][1] == 4.0);
+    }
+    
     {
 	cout << "Imath::M33f shear functions" << endl;
 
@@ -276,6 +324,40 @@ testMatrix ()
     }
 
     // Determinants (by building a random singular value decomposition)
+    
+    {
+        cout << "2x2 determinant" << endl;
+
+        IMATH_INTERNAL_NAMESPACE::Rand32 random;
+
+        IMATH_INTERNAL_NAMESPACE::M22f u;
+        IMATH_INTERNAL_NAMESPACE::M22f v;
+        IMATH_INTERNAL_NAMESPACE::M22f s;
+
+        u.setRotation( random.nextf() );
+        v.setRotation( random.nextf() );
+        s[0][0] = random.nextf();
+        s[1][1] = random.nextf();
+
+        IMATH_INTERNAL_NAMESPACE::M22f c = u * s * v.transpose();
+        assert (fabsf(c.determinant() - s[0][0]*s[1][1]) <= u.baseTypeEpsilon());
+    }
+    {
+        IMATH_INTERNAL_NAMESPACE::Rand32 random;
+
+        IMATH_INTERNAL_NAMESPACE::M22d u;
+        IMATH_INTERNAL_NAMESPACE::M22d v;
+        IMATH_INTERNAL_NAMESPACE::M22d s;
+
+        u.setRotation( (double)random.nextf() );
+        v.setRotation( (double)random.nextf() );
+        s[0][0] = (double)random.nextf();
+        s[1][1] = (double)random.nextf();
+
+        IMATH_INTERNAL_NAMESPACE::M22d c = u * s * v.transpose();
+        assert (fabs(c.determinant() - s[0][0]*s[1][1]) <= u.baseTypeEpsilon());
+    }
+
     {
         cout << "3x3 determinant" << endl;
 

--- a/PyIlmBase/PyImath/CMakeLists.txt
+++ b/PyIlmBase/PyImath/CMakeLists.txt
@@ -17,6 +17,7 @@ pyilmbase_define_module(imath
     PyImathFixedArray.cpp
     PyImathFrustum.cpp
     PyImathLine.cpp
+    PyImathMatrix22.cpp
     PyImathMatrix33.cpp
     PyImathMatrix44.cpp
     PyImathPlane.cpp

--- a/PyIlmBase/PyImath/PyImathMatrix.h
+++ b/PyIlmBase/PyImath/PyImathMatrix.h
@@ -43,10 +43,14 @@
 
 namespace PyImath {
 
+template <class T> boost::python::class_<IMATH_NAMESPACE::Matrix22<T> > register_Matrix22();
 template <class T> boost::python::class_<IMATH_NAMESPACE::Matrix33<T> > register_Matrix33();
 template <class T> boost::python::class_<IMATH_NAMESPACE::Matrix44<T> > register_Matrix44();
 template <class T> boost::python::class_<FixedArray<IMATH_NAMESPACE::Matrix44<T> > > register_M44Array();
 template <class T> boost::python::class_<FixedArray<IMATH_NAMESPACE::Matrix33<T> > > register_M33Array();
+template <class T> boost::python::class_<FixedArray<IMATH_NAMESPACE::Matrix22<T> > > register_M22Array();
+typedef FixedArray<IMATH_NAMESPACE::Matrix22<float> >  M22fArray;
+typedef FixedArray<IMATH_NAMESPACE::Matrix22<double> >  M22dArray;
 typedef FixedArray<IMATH_NAMESPACE::Matrix33<float> >  M33fArray;
 typedef FixedArray<IMATH_NAMESPACE::Matrix33<double> >  M33dArray;
 typedef FixedArray<IMATH_NAMESPACE::Matrix44<float> >  M44fArray;
@@ -60,6 +64,13 @@ typedef FixedArray<IMATH_NAMESPACE::Matrix44<double> >  M44dArray;
 // respectively.  The class Boost generates from the Imath class does not
 // have these properties, so we define a companion class here.
 // The template argument, T, is the element type (e.g.,float, double).
+
+template <class T>
+class M22 {
+  public:
+    static PyObject *	wrap (const IMATH_NAMESPACE::Matrix22<T> &m);
+    static int		convert (PyObject *p, IMATH_NAMESPACE::Matrix22<T> *m);
+};
 
 template <class T>
 class M33 {
@@ -77,6 +88,15 @@ class M44 {
 
 template <class T>
 PyObject *
+M22<T>::wrap (const IMATH_NAMESPACE::Matrix22<T> &m)
+{
+    typename boost::python::return_by_value::apply < IMATH_NAMESPACE::Matrix22<T> >::type converter;
+    PyObject *p = converter (m);
+    return p;
+}
+
+template <class T>
+PyObject *
 M33<T>::wrap (const IMATH_NAMESPACE::Matrix33<T> &m)
 {
     typename boost::python::return_by_value::apply < IMATH_NAMESPACE::Matrix33<T> >::type converter;
@@ -91,6 +111,29 @@ M44<T>::wrap (const IMATH_NAMESPACE::Matrix44<T> &m)
     typename boost::python::return_by_value::apply < IMATH_NAMESPACE::Matrix44<T> >::type converter;
     PyObject *p = converter (m);
     return p;
+}
+
+template <class T>
+int
+M22<T>::convert (PyObject *p, IMATH_NAMESPACE::Matrix22<T> *m)
+{
+    boost::python::extract <IMATH_NAMESPACE::M22f> extractorMf (p);
+    if (extractorMf.check())
+    {
+        IMATH_NAMESPACE::M22f e = extractorMf();
+        m->setValue (e);
+        return 1;
+    }
+
+    boost::python::extract <IMATH_NAMESPACE::M22d> extractorMd (p);
+    if (extractorMd.check())
+    {
+        IMATH_NAMESPACE::M22d e = extractorMd();
+        m->setValue (e);
+        return 1;
+    }
+
+    return 0;
 }
 
 template <class T>
@@ -174,6 +217,8 @@ jacobiEigensolve(const Matrix& m)
     return boost::python::make_tuple (Q, S);
 }
 
+typedef M22<float>	M22f;
+typedef M22<double>	M22d;
 
 typedef M33<float>	M33f;
 typedef M33<double>	M33d;

--- a/PyIlmBase/PyImath/PyImathMatrix22.cpp
+++ b/PyIlmBase/PyImath/PyImathMatrix22.cpp
@@ -1,0 +1,734 @@
+///////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 1998-2011, Industrial Light & Magic, a division of Lucas
+// Digital Ltd. LLC
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// *       Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// *       Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// *       Neither the name of Industrial Light & Magic nor the names of
+// its contributors may be used to endorse or promote products derived
+// from this software without specific prior written permission. 
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////
+
+#define BOOST_PYTHON_MAX_ARITY 17
+
+#include "PyImathMatrix.h"
+#include "PyImathExport.h"
+#include "PyImathDecorators.h"
+#include <Python.h>
+#include <boost/python.hpp>
+#include <boost/python/make_constructor.hpp>
+#include <boost/format.hpp>
+#include <boost/python/tuple.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/raw_function.hpp>
+#include "PyImath.h"
+#include "PyImathVec.h"
+#include "PyImathMathExc.h"
+#include <ImathVec.h>
+#include <ImathMatrixAlgo.h>
+#include <Iex.h>
+
+namespace PyImath {
+
+template<> const char *PyImath::M22fArray::name() { return "M22fArray"; }
+template<> const char *PyImath::M22dArray::name() { return "M22dArray"; }
+
+using namespace boost::python;
+using namespace IMATH_NAMESPACE;
+
+template <class T, int len>
+struct MatrixRow {
+    explicit MatrixRow(T *data) : _data(data) {}
+    T & operator [] (int i) { return _data[i]; }
+    T *_data;
+
+    static const char *name;
+    static void register_class()
+    {
+        typedef PyImath::StaticFixedArray<MatrixRow,T,len> MatrixRow_helper;
+        class_<MatrixRow> matrixRow_class(name,no_init);
+        matrixRow_class
+            .def("__len__", MatrixRow_helper::len)
+            .def("__getitem__", MatrixRow_helper::getitem,return_value_policy<copy_non_const_reference>())
+            .def("__setitem__", MatrixRow_helper::setitem)
+            ;
+    }
+};
+
+template <> const char *MatrixRow<float,2>::name = "M22fRow";
+template <> const char *MatrixRow<double,2>::name = "M22dRow";
+
+
+template <class Container, class Data, int len>
+struct IndexAccessMatrixRow {
+    typedef MatrixRow<Data,len> result_type;
+    static MatrixRow<Data,len> apply(Container &c, int i) { return MatrixRow<Data,len>(c[i]); }
+};
+
+template <class T> struct Matrix22Name { static const char *value; };
+template<> const char *Matrix22Name<float>::value  = "M22f";
+template<> const char *Matrix22Name<double>::value = "M22d";
+
+template <class T>
+static std::string Matrix22_str(const Matrix22<T> &v)
+{
+    std::stringstream stream;
+    stream << Matrix22Name<T>::value << "(";
+    for (int row = 0; row < 2; row++)
+    {
+        stream << "(";
+	for (int col = 0; col < 2; col++)
+	{
+	    stream << v[row][col];
+            stream << (col != 1 ? ", " : "");
+	}
+        stream << ")" << (row != 1 ? ", " : "");
+    }
+    stream << ")";
+    return stream.str();
+}
+
+// Non-specialized repr is same as str
+template <class T>
+static std::string Matrix22_repr(const Matrix22<T> &v)
+{
+    return Matrix22_str(v);
+}
+
+// Specialization for float to full precision
+template <>
+std::string Matrix22_repr(const Matrix22<float> &v)
+{
+    return (boost::format("%s((%.9g, %.9g), (%.9g, %.9g))")
+                        % Matrix22Name<float>::value
+                        % v[0][0] % v[0][1]
+                        % v[1][0] % v[1][1]).str();
+}
+
+// Specialization for double to full precision
+template <>
+std::string Matrix22_repr(const Matrix22<double> &v)
+{
+    return (boost::format("%s((%.17g, %.17g), (%.17g, %.17g))")
+                        % Matrix22Name<double>::value
+                        % v[0][0] % v[0][1]
+                        % v[1][0] % v[1][1]).str();
+}
+
+template <class T>
+static const Matrix22<T> &
+invert22 (Matrix22<T> &m, bool singExc = true)
+{
+    MATH_EXC_ON;
+    return m.invert(singExc);
+}
+
+template <class T>
+static Matrix22<T>
+inverse22 (Matrix22<T> &m, bool singExc = true)
+{
+    MATH_EXC_ON;
+    return m.inverse(singExc);
+}
+
+template <class T, class U>
+static const Matrix22<T> &
+iadd22(Matrix22<T> &m, const Matrix22<U> &m2)
+{
+    MATH_EXC_ON;
+    Matrix22<T> m3;
+    m3.setValue (m2);
+    return m += m3;
+}
+
+template <class T>
+static const Matrix22<T> &
+iadd22T(Matrix22<T> &mat, T a)
+{
+    MATH_EXC_ON;
+    return mat += a;
+}
+
+template <class T>
+static Matrix22<T>
+add22(Matrix22<T> &m, const Matrix22<T> &m2)
+{
+    MATH_EXC_ON;
+    return m + m2;
+}
+
+template <class T, class U>
+static const Matrix22<T> &
+isub22(Matrix22<T> &m, const Matrix22<U> &m2)
+{
+    MATH_EXC_ON;
+    Matrix22<T> m3;
+    m3.setValue (m2);
+    return m -= m3;
+}
+
+template <class T>
+static const Matrix22<T> &
+isub22T(Matrix22<T> &mat, T a)
+{
+    MATH_EXC_ON;
+    return mat -= a;
+}
+
+template <class T>
+static Matrix22<T>
+sub22(Matrix22<T> &m, const Matrix22<T> &m2)
+{
+    MATH_EXC_ON;
+    return m - m2;
+}
+
+template <class T>
+static const Matrix22<T> &
+negate22 (Matrix22<T> &m)
+{
+    MATH_EXC_ON;
+    return m.negate();
+}
+
+template <class T>
+static Matrix22<T>
+neg22 (Matrix22<T> &m)
+{
+    MATH_EXC_ON;
+    return -m;
+}
+
+template <class T>
+static const Matrix22<T> &
+imul22T(Matrix22<T> &m, const T &t)
+{
+    MATH_EXC_ON;
+    return m *= t;
+}
+
+template <class T>
+static Matrix22<T>
+mul22T(Matrix22<T> &m, const T &t)
+{
+    MATH_EXC_ON;
+    return m * t;
+}
+
+template <class T>
+static Matrix22<T>
+rmul22T(Matrix22<T> &m, const T &t)
+{
+    MATH_EXC_ON;
+    return t * m;
+}
+
+template <class T>
+static const Matrix22<T> &
+idiv22T(Matrix22<T> &m, const T &t)
+{
+    MATH_EXC_ON;
+    return m /= t;
+}
+
+template <class T>
+static Matrix22<T>
+div22T(Matrix22<T> &m, const T &t)
+{
+    MATH_EXC_ON;
+    return m / t;
+}
+
+template <class T>
+void
+outerProduct22(Matrix22<T> &mat, const Vec2<T> &a, const Vec2<T> &b)
+{
+    MATH_EXC_ON;
+    mat = IMATH_NAMESPACE::outerProduct(a,b);
+}
+
+template <class TV,class TM>
+static void
+multDirMatrix22(Matrix22<TM> &mat, const Vec2<TV> &src, Vec2<TV> &dst)
+{
+    MATH_EXC_ON;
+    mat.multDirMatrix(src, dst);    
+}
+
+template <class TV,class TM>
+static Vec2<TV>
+multDirMatrix22_return_value(Matrix22<TM> &mat, const Vec2<TV> &src)
+{
+    MATH_EXC_ON;
+    Vec2<TV> dst;
+    mat.multDirMatrix(src, dst);    
+    return dst;
+}
+
+template <class TV,class TM>
+static FixedArray<Vec2<TV> >
+multDirMatrix22_array(Matrix22<TM> &mat, const FixedArray<Vec2<TV> >&src)
+{
+    MATH_EXC_ON;
+    size_t len = src.len();
+    FixedArray<Vec2<TV> > dst(len);
+    for (size_t i=0; i<len; ++i) mat.multDirMatrix(src[i], dst[i]);    
+    return dst;
+}
+
+template <class T>
+static const Matrix22<T> &
+rotate22(Matrix22<T> &mat, const T &r)
+{
+    MATH_EXC_ON;
+    return mat.rotate(r);    
+}
+
+template <class T>
+static void
+extractEuler(Matrix22<T> &mat, Vec2<T> &dstObj)
+{
+    MATH_EXC_ON;
+    T dst;
+    IMATH_NAMESPACE::extractEuler(mat, dst);
+    dstObj.setValue(dst, T (0));
+}
+
+template <class T>
+static const Matrix22<T> &
+scaleSc22(Matrix22<T> &mat, const T &s)
+{
+    MATH_EXC_ON;
+    Vec2<T> sVec(s, s);
+    return mat.scale(sVec);
+}
+
+template <class T>
+static const Matrix22<T> &
+scaleV22(Matrix22<T> &mat, const Vec2<T> &s)
+{
+    MATH_EXC_ON;
+    return mat.scale(s);
+}
+
+template <class T>
+static const Matrix22<T> &
+scale22Tuple(Matrix22<T> &mat, const tuple &t)
+{
+    MATH_EXC_ON;
+    if(t.attr("__len__")() == 2)
+    {
+        Vec2<T> s;
+        s.x = extract<T>(t[0]);
+        s.y = extract<T>(t[1]);
+        
+        return mat.scale(s);
+    }
+    else
+        THROW(IEX_NAMESPACE::LogicExc, "m.scale needs tuple of length 2");
+}
+
+template <class T>
+static const Matrix22<T> &
+setRotation22(Matrix22<T> &mat, const T &r)
+{
+    MATH_EXC_ON;
+    return mat.setRotation(r);    
+}
+
+template <class T>
+static const Matrix22<T> &
+setScaleSc22(Matrix22<T> &mat, const T &s)
+{
+    MATH_EXC_ON;
+    Vec2<T> sVec(s, s);
+    return mat.setScale(sVec);
+}
+
+template <class T>
+static const Matrix22<T> &
+setScaleV22(Matrix22<T> &mat, const Vec2<T> &s)
+{
+    MATH_EXC_ON;
+    return mat.setScale(s);
+}
+
+template <class T>
+static const Matrix22<T> &
+setScale22Tuple(Matrix22<T> &mat, const tuple &t)
+{
+    MATH_EXC_ON;
+    if(t.attr("__len__")() == 2)
+    {
+        Vec2<T> s;
+        s.x = extract<T>(t[0]);
+        s.y = extract<T>(t[1]);
+        
+        return mat.setScale(s);
+    }
+    else
+        THROW(IEX_NAMESPACE::LogicExc, "m.setScale needs tuple of length 2");
+}
+
+template <class T>
+static void
+setValue22(Matrix22<T> &mat, const Matrix22<T> &value)
+{
+    MATH_EXC_ON;
+    mat.setValue(value);
+}
+
+template <class T>
+static Matrix22<T>
+subtractTL22(Matrix22<T> &mat, T a)
+{
+    MATH_EXC_ON;
+    Matrix22<T> m(mat.x);
+    for(int i = 0; i < 2; ++i)
+        for(int j = 0; j < 2; ++j)
+            m.x[i][j] -= a;
+    
+    return m;
+}
+
+template <class T>
+static Matrix22<T>
+subtractTR22(Matrix22<T> &mat, T a)
+{
+    MATH_EXC_ON;
+    Matrix22<T> m(mat.x);
+    for(int i = 0; i < 2; ++i)
+        for(int j = 0; j < 2; ++j)
+            m.x[i][j] = a - m.x[i][j];
+    
+    return m;
+}
+
+
+template <class T>
+static Matrix22<T>
+add22T(Matrix22<T> &mat, T a)
+{
+    MATH_EXC_ON;
+    Matrix22<T> m(mat.x);
+    for(int i = 0; i < 2; ++i)
+        for(int j = 0; j < 2; ++j)
+            m.x[i][j] += a;
+    
+    return m;
+}
+
+template <class S, class T>
+static Matrix22<T>
+mul22(Matrix22<T> &mat1, Matrix22<S> &mat2)
+{
+    MATH_EXC_ON;
+    Matrix22<T> mat2T;
+    mat2T.setValue (mat2);
+    return mat1 * mat2T;
+}
+
+template <class S, class T>
+static Matrix22<T>
+rmul22(Matrix22<T> &mat2, Matrix22<S> &mat1)
+{
+    MATH_EXC_ON;
+    Matrix22<T> mat1T;
+    mat1T.setValue (mat1);
+    return mat1T * mat2;
+}
+
+template <class S, class T>
+static const Matrix22<T> &
+imul22(Matrix22<T> &mat1, Matrix22<S> &mat2)
+{
+    MATH_EXC_ON;
+    Matrix22<T> mat2T;
+    mat2T.setValue (mat2);
+    return mat1 *= mat2T;
+}
+
+template <class T>
+static bool
+lessThan22(Matrix22<T> &mat1, const Matrix22<T> &mat2)
+{
+    for(int i = 0; i < 2; ++i){
+        for(int j = 0; j < 2; ++j){
+            if(mat1[i][j] > mat2[i][j]){
+                return false;
+            }
+        }
+    }
+    
+    return (mat1 != mat2);            
+}
+
+template <class T>
+static bool
+lessThanEqual22(Matrix22<T> &mat1, const Matrix22<T> &mat2)
+{
+    for(int i = 0; i < 2; ++i){
+        for(int j = 0; j < 2; ++j){
+            if(mat1[i][j] > mat2[i][j]){
+                return false;
+            }
+        }
+    }
+    
+    return true;            
+}
+
+template <class T>
+static bool
+greaterThan22(Matrix22<T> &mat1, const Matrix22<T> &mat2)
+{
+    for(int i = 0; i < 2; ++i){
+        for(int j = 0; j < 2; ++j){
+            if(mat1[i][j] < mat2[i][j]){
+                std::cout << mat1[i][j] << " " << mat2[i][j] << std::endl;
+                return false;
+            }
+        }
+    }
+    
+    return (mat1 != mat2);            
+}
+
+template <class T>
+static bool
+greaterThanEqual22(Matrix22<T> &mat1, const Matrix22<T> &mat2)
+{
+    for(int i = 0; i < 2; ++i){
+        for(int j = 0; j < 2; ++j){
+            if(mat1[i][j] < mat2[i][j]){
+                return false;
+            }
+        }
+    }
+    
+    return true;            
+}
+
+BOOST_PYTHON_FUNCTION_OVERLOADS(invert22_overloads, invert22, 1, 2);
+BOOST_PYTHON_FUNCTION_OVERLOADS(inverse22_overloads, inverse22, 1, 2);
+BOOST_PYTHON_FUNCTION_OVERLOADS(outerProduct22_overloads, outerProduct22, 3, 3);
+
+template <class T>
+static Matrix22<T> * Matrix2_tuple_constructor(const tuple &t0, const tuple &t1)
+{
+  if(t0.attr("__len__")() == 2 && t1.attr("__len__")() == 2)
+  {
+      return new Matrix22<T>(extract<T>(t0[0]),  extract<T>(t0[1]),
+                             extract<T>(t1[0]),  extract<T>(t1[1]));
+  }
+  else
+      THROW(IEX_NAMESPACE::LogicExc, "Matrix22 takes 2 tuples of length 2");
+}
+
+template <class T, class S>
+static Matrix22<T> *Matrix2_matrix_constructor(const Matrix22<S> &mat)
+{
+    Matrix22<T> *m = new Matrix22<T>;
+    
+    for(int i = 0; i < 2; ++i)
+        for(int j = 0; j < 2; ++j)
+            m->x[i][j] = T (mat.x[i][j]);
+    
+    return m;
+}
+
+template <class T>
+class_<Matrix22<T> >
+register_Matrix22()
+{
+    typedef PyImath::StaticFixedArray<Matrix22<T>,T,2,IndexAccessMatrixRow<Matrix22<T>,T,2> > Matrix22_helper;
+
+    MatrixRow<T,2>::register_class();
+    class_<Matrix22<T> > matrix22_class(Matrix22Name<T>::value, Matrix22Name<T>::value,init<Matrix22<T> >("copy construction"));
+    matrix22_class
+        .def(init<>("initialize to identity"))
+        .def(init<T>("initialize all entries to a single value"))
+        .def(init<T,T,T,T>("make from components"))
+        .def("__init__", make_constructor(Matrix2_tuple_constructor<T>))
+        .def("__init__", make_constructor(Matrix2_matrix_constructor<T,float>))
+        .def("__init__", make_constructor(Matrix2_matrix_constructor<T,double>))
+        
+	//.def_readwrite("x00", &Matrix22<T>::x[0][0])
+	//.def_readwrite("x01", &Matrix22<T>::x[0][1])
+	//.def_readwrite("x02", &Matrix22<T>::x[0][2])
+	//.def_readwrite("x10", &Matrix22<T>::x[1][0])
+	//.def_readwrite("x11", &Matrix22<T>::x[1][1])
+	//.def_readwrite("x12", &Matrix22<T>::x[1][2])
+	//.def_readwrite("x20", &Matrix22<T>::x[2][0])
+	//.def_readwrite("x21", &Matrix22<T>::x[2][1])
+	//.def_readwrite("x22", &Matrix22<T>::x[2][2])
+        .def("baseTypeEpsilon", &Matrix22<T>::baseTypeEpsilon,"baseTypeEpsilon() epsilon value of the base type of the vector")
+        .staticmethod("baseTypeEpsilon")
+        .def("baseTypeMax", &Matrix22<T>::baseTypeMax,"baseTypeMax() max value of the base type of the vector")
+        .staticmethod("baseTypeMax")
+        .def("baseTypeMin", &Matrix22<T>::baseTypeMin,"baseTypeMin() min value of the base type of the vector")
+        .staticmethod("baseTypeMin")
+        .def("baseTypeSmallest", &Matrix22<T>::baseTypeSmallest,"baseTypeSmallest() smallest value of the base type of the vector")
+        .staticmethod("baseTypeSmallest")
+        .def("equalWithAbsError", &Matrix22<T>::equalWithAbsError,"m1.equalWithAbsError(m2,e) true if the elements "
+             "of v1 and v2 are the same with an absolute error of no more than e, "
+             "i.e., abs(m1[i] - m2[i]) <= e")
+        .def("equalWithRelError", &Matrix22<T>::equalWithRelError,"m1.equalWithAbsError(m2,e) true if the elements "
+             "of m1 and m2 are the same with an absolute error of no more than e, "
+             "i.e., abs(m1[i] - m2[i]) <= e * abs(m1[i])")
+        // need a different version for matrix data access
+        .def("__len__", Matrix22_helper::len)
+        .def("__getitem__", Matrix22_helper::getitem)
+	//.def("__setitem__", Matrix22_helper::setitem)
+        .def("makeIdentity",&Matrix22<T>::makeIdentity,"makeIdentity() make this matrix the identity matrix")
+        .def("transpose",&Matrix22<T>::transpose,return_internal_reference<>(),"transpose() transpose this matrix")
+        .def("transposed",&Matrix22<T>::transposed,"transposed() return a transposed copy of this matrix")
+        .def("invert",&invert22<T>,invert22_overloads("invert() invert this matrix")[return_internal_reference<>()])
+        .def("inverse",&inverse22<T>,inverse22_overloads("inverse() return an inverted copy of this matrix"))
+        .def("determinant",&Matrix22<T>::determinant,"determinant() return the determinant of this matrix")
+        .def(self == self) // NOSONAR - suppress SonarCloud bug report.
+        .def(self != self) // NOSONAR - suppress SonarCloud bug report.
+        .def("__iadd__", &iadd22<T, float>,return_internal_reference<>())
+        .def("__iadd__", &iadd22<T, double>,return_internal_reference<>())
+        .def("__iadd__", &iadd22T<T>,return_internal_reference<>())
+        .def("__add__", &add22<T>)
+        .def("__isub__", &isub22<T, float>,return_internal_reference<>())
+        .def("__isub__", &isub22<T, double>,return_internal_reference<>())
+        .def("__isub__", &isub22T<T>,return_internal_reference<>())
+        .def("__sub__", &sub22<T>)
+        .def("negate",&negate22<T>,return_internal_reference<>(),"negate() negate all entries in this matrix")
+        .def("__neg__", &neg22<T>)
+        .def("__imul__", &imul22T<T>,return_internal_reference<>())
+        .def("__mul__", &mul22T<T>)
+        .def("__rmul__", &rmul22T<T>)
+        .def("__idiv__", &idiv22T<T>,return_internal_reference<>())
+        .def("__itruediv__", &idiv22T<T>,return_internal_reference<>())
+        .def("__div__", &div22T<T>)
+        .def("__truediv__", &div22T<T>)
+        .def("__add__", &add22T<T>)
+        .def("__radd__", &add22T<T>)
+        .def("__sub__", &subtractTL22<T>)
+        .def("__rsub__", &subtractTR22<T>)
+        .def("__mul__", &mul22<float, T>)
+        .def("__mul__", &mul22<double, T>)
+        .def("__rmul__", &rmul22<float, T>)
+        .def("__rmul__", &rmul22<double, T>)
+        .def("__imul__", &imul22<float, T>,return_internal_reference<>())
+        .def("__imul__", &imul22<double, T>,return_internal_reference<>())
+        .def("__lt__", &lessThan22<T>)
+        .def("__le__", &lessThanEqual22<T>)
+        .def("__gt__", &greaterThan22<T>)
+        .def("__ge__", &greaterThanEqual22<T>)
+	//.def(self_ns::str(self))
+        .def("__str__",&Matrix22_str<T>)
+        .def("__repr__",&Matrix22_repr<T>)
+
+         .def("extractEuler", &extractEuler<T>, 				
+              "M.extractEuler(r) -- extracts the "
+			  "rotation component of M into r. "
+              "Assumes that M contains no shear or "
+              "non-uniform scaling; results are "
+              "meaningless if it does.")
+              
+         .def("multDirMatrix", &multDirMatrix22<double,T>, "mult matrix")
+         .def("multDirMatrix", &multDirMatrix22_return_value<double,T>, "mult matrix")
+         .def("multDirMatrix", &multDirMatrix22_array<double,T>, "mult matrix")
+         .def("multDirMatrix", &multDirMatrix22<float,T>, "mult matrix")
+         .def("multDirMatrix", &multDirMatrix22_return_value<float,T>, "mult matrix")
+         .def("multDirMatrix", &multDirMatrix22_array<float,T>, "mult matrix")
+
+         .def("rotate", &rotate22<T>, return_internal_reference<>(),"rotate matrix")
+
+         .def("scale", &scaleSc22<T>, return_internal_reference<>(),"scale matrix")
+         .def("scale", &scaleV22<T>, return_internal_reference<>(),"scale matrix")
+         .def("scale", &scale22Tuple<T>, return_internal_reference<>(),"scale matrix")
+
+         .def("setRotation", &setRotation22<T>, return_internal_reference<>(),"setRotation()")
+         .def("setScale", &setScaleSc22<T>, return_internal_reference<>(),"setScale()")
+         .def("setScale", &setScaleV22<T>, return_internal_reference<>(),"setScale()")
+         .def("setScale", &setScale22Tuple<T>, return_internal_reference<>(),"setScale()")
+
+         .def("setValue", &setValue22<T>, "setValue()")
+         ;
+
+    decoratecopy(matrix22_class);
+
+    return matrix22_class;
+/*
+    const Matrix22 &	operator = (const Matrix22 &v);
+    const Matrix22 &	operator = (T a);
+    T *			getValue ();
+    const T *		getValue () const;
+    template <class S> void getValue (Matrix22<S> &v) const;
+    template <class S> Matrix22 & setValue (const Matrix22<S> &v);
+    template <class S> Matrix22 & setTheMatrix (const Matrix22<S> &v);
+    template <class S> void multVecMatrix(const Vec2<S> &src, Vec2<S> &dst) const;
+    template <class S> void multDirMatrix(const Vec2<S> &src, Vec2<S> &dst) const;
+    template <class S> const Matrix22 &	setRotation (S r);
+    template <class S> const Matrix22 &	rotate (S r);
+    const Matrix22 &	setScale (T s);
+    template <class S> const Matrix22 &	setScale (const Vec2<S> &s);
+    template <class S> const Matrix22 &	scale (const Vec2<S> &s);
+    template <class S> const Matrix22 &	setTranslation (const Vec2<S> &t);
+    Vec2<T>		translation () const;
+    template <class S> const Matrix22 &	translate (const Vec2<S> &t);
+    template <class S> const Matrix22 &	setShear (const S &h);
+    template <class S> const Matrix22 &	setShear (const Vec2<S> &h);
+    template <class S> const Matrix22 &	shear (const S &xy);
+    template <class S> const Matrix22 &	shear (const Vec2<S> &h);
+*/
+}
+
+template <class T>
+static void
+setM22ArrayItem(FixedArray<IMATH_NAMESPACE::Matrix22<T> > &ma,
+                Py_ssize_t index,
+                const IMATH_NAMESPACE::Matrix22<T> &m)
+{
+    ma[ma.canonical_index(index)] = m;
+}
+
+template <class T>
+class_<FixedArray<IMATH_NAMESPACE::Matrix22<T> > >
+register_M22Array()
+{
+    class_<FixedArray<IMATH_NAMESPACE::Matrix22<T> > > matrixArray_class = FixedArray<IMATH_NAMESPACE::Matrix22<T> >::register_("Fixed length array of IMATH_NAMESPACE::Matrix22");
+    matrixArray_class
+         .def("__setitem__", &setM22ArrayItem<T>)
+        ;
+    return matrixArray_class;
+}
+
+template PYIMATH_EXPORT class_<IMATH_NAMESPACE::Matrix22<float> > register_Matrix22<float>();
+template PYIMATH_EXPORT class_<IMATH_NAMESPACE::Matrix22<double> > register_Matrix22<double>();
+
+template PYIMATH_EXPORT class_<FixedArray<IMATH_NAMESPACE::Matrix22<float> > > register_M22Array<float>();
+template PYIMATH_EXPORT class_<FixedArray<IMATH_NAMESPACE::Matrix22<double> > > register_M22Array<double>();
+
+
+template<> PYIMATH_EXPORT IMATH_NAMESPACE::Matrix22<float> FixedArrayDefaultValue<IMATH_NAMESPACE::Matrix22<float> >::value() { return IMATH_NAMESPACE::Matrix22<float>(); }
+template<> PYIMATH_EXPORT IMATH_NAMESPACE::Matrix22<double> FixedArrayDefaultValue<IMATH_NAMESPACE::Matrix22<double> >::value() { return IMATH_NAMESPACE::Matrix22<double>(); }
+}

--- a/PyIlmBase/PyImath/PyImathVec2Impl.h
+++ b/PyIlmBase/PyImath/PyImathVec2Impl.h
@@ -407,6 +407,14 @@ Vec2_imulT(IMATH_NAMESPACE::Vec2<T> &v, T t)
 
 template <class T, class U>
 static Vec2<T>
+Vec2_mulM22 (Vec2<T> &v, const Matrix22<U> &m)
+{
+    MATH_EXC_ON;
+    return v * m;
+}
+
+template <class T, class U>
+static Vec2<T>
 Vec2_mulM33 (Vec2<T> &v, const Matrix33<U> &m)
 {
     MATH_EXC_ON;
@@ -569,6 +577,14 @@ Vec2_mulTuple(const Vec2<T> &v, BoostPyType t)
         THROW(IEX_NAMESPACE::LogicExc, "tuple must have length of 1 or 2");
     
     return w;
+}
+
+template <class T, class U>
+static const Vec2<T> &
+Vec2_imulM22 (Vec2<T> &v, const Matrix22<U> &m)
+{
+    MATH_EXC_ON;
+    return v *= m;
 }
 
 template <class T, class U>
@@ -1003,8 +1019,12 @@ register_Vec2()
         .def("__imul__", &Vec2_imulV<T, double>,return_internal_reference<>())
         .def("__imul__", &Vec2_imulT<T>,return_internal_reference<>())
         .def(self * self)
+        .def("__mul__", &Vec2_mulM22<T, float>)
+        .def("__mul__", &Vec2_mulM22<T, double>)
         .def("__mul__", &Vec2_mulM33<T, float>)
         .def("__mul__", &Vec2_mulM33<T, double>)
+        .def("__imul__", &Vec2_imulM22<T, float>, return_internal_reference<>())
+        .def("__imul__", &Vec2_imulM22<T, double>, return_internal_reference<>())
         .def("__imul__", &Vec2_imulM33<T, float>, return_internal_reference<>())
         .def("__imul__", &Vec2_imulM33<T, double>, return_internal_reference<>())
         .def(self / self) // NOSONAR - suppress SonarCloud bug report.

--- a/PyIlmBase/PyImath/imathmodule.cpp
+++ b/PyIlmBase/PyImath/imathmodule.cpp
@@ -310,15 +310,17 @@ BOOST_PYTHON_MODULE(imath)
     class_<FixedArray<IMATH_NAMESPACE::Box3d> > b3d_class = register_BoxArray<IMATH_NAMESPACE::V3d>();
 
     //
-    // Matrix33/44
+    // Matrix22/33/44
     //
+    register_Matrix22<float>();
+    register_Matrix22<double>();
     register_Matrix33<float>();
     register_Matrix33<double>();
     register_Matrix44<float>();
     register_Matrix44<double>();
 
     //
-    // M33/44Array
+    // M22/M33/44Array
     //
     class_<FixedArray<IMATH_NAMESPACE::M44d> > m44d_class = register_M44Array<double>();
     class_<FixedArray<IMATH_NAMESPACE::M44f> > m44f_class = register_M44Array<float>();
@@ -329,6 +331,11 @@ BOOST_PYTHON_MODULE(imath)
     class_<FixedArray<IMATH_NAMESPACE::M33f> > m33f_class = register_M33Array<float>();
     add_explicit_construction_from_type< IMATH_NAMESPACE::Matrix33<double> >(m33d_class);
     add_explicit_construction_from_type< IMATH_NAMESPACE::Matrix33<float> > (m33f_class);
+
+    class_<FixedArray<IMATH_NAMESPACE::M22d> > m22d_class = register_M22Array<double>();
+    class_<FixedArray<IMATH_NAMESPACE::M22f> > m22f_class = register_M22Array<float>();
+    add_explicit_construction_from_type< IMATH_NAMESPACE::Matrix22<double> >(m22d_class);
+    add_explicit_construction_from_type< IMATH_NAMESPACE::Matrix22<float> > (m22f_class);
 
     //
     // String Array

--- a/PyIlmBase/PyImathTest/pyImathTest.in
+++ b/PyIlmBase/PyImathTest/pyImathTest.in
@@ -1,12 +1,14 @@
 #!/usr/bin/env python2
 
-from imath import *
-from math import sqrt, pi, sin, cos
 import math
-import string, traceback, sys
-import iex
 import random
+import string
+import sys
+import traceback
+from math import cos, pi, sin, sqrt
 
+import iex
+from imath import *
 
 
 testList = []
@@ -4783,6 +4785,340 @@ def testShearConversions ():
 testList.append (('testShearConversions',testShearConversions))
 
 
+# -------------------------------------------------------------------------
+# Tests for M22x
+
+def testM22x (Mat, Vec):
+    
+    # Constructors (and element access).
+
+    m = Mat()
+    assert m[0][0] == 1 and m[0][1] == 0 and \
+           m[1][0] == 0 and m[1][1] == 1
+
+    m = Mat(1)
+    assert m[0][0] == 1 and m[0][1] == 1 and \
+           m[1][0] == 1 and m[1][1] == 1
+
+    m = Mat((0, 1), (2, 3))
+    assert m[0][0] == 0 and m[0][1] == 1 and \
+           m[1][0] == 2 and m[1][1] == 3
+
+
+    m = Mat(0, 1, 2, 3)
+    assert m[0][0] == 0 and m[0][1] == 1 and \
+           m[1][0] == 2 and m[1][1] == 3
+
+    # Repr.
+
+    m = Mat(0/9., 1/9., 2/9., 3/9.)
+    assert m == eval(repr(m))
+
+    # Sequence length.
+
+    m = Mat()
+    assert len(m) == 2
+
+    # Element setting.
+
+    m = Mat()
+    m[0][0] = 10
+    m[1][1] = 11
+    assert m[0][0] == 10 and m[1][1] == 11
+
+    try:
+        m[-4][0] = 0           # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    try:
+        v[3][0] = 0           # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    try:
+        m[0][-4] = 0           # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    try:
+        v[0][3] = 0           # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    try:
+        v[1] = (1,2,3)           # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    # Assignment.
+
+    m1 = Mat(1)
+    
+    m2 = m1
+    assert m2[0][0] == 1 and m2[0][1] == 1 and \
+           m2[1][0] == 1 and m2[1][1] == 1
+
+    m1[0][0] = 2
+    assert m2[0][0] == 2 and m2[0][1] == 1 and \
+           m2[1][0] == 1 and m2[1][1] == 1
+
+    # Identity.
+
+    m = Mat(2)
+
+    m.makeIdentity()
+    assert m[0][0] == 1 and m[0][1] == 0 and \
+           m[1][0] == 0 and m[1][1] == 1
+           
+    # Comparison operators.
+
+    m1 = Mat()
+    m1[1][1] = 2
+    m2 = Mat()
+    m2[1][1] = 2
+    m3 = Mat()
+    m3[1][1] = 3
+
+    assert m1 == m2
+    assert m1 != m3
+    assert not (m1 < m2)
+    assert m1 < m3
+    assert m1 <= m2
+    assert m1 <= m3
+    assert not (m3 <= m1)
+    assert not (m2 > m1)
+    assert m3 > m1
+    assert m2 >= m1
+    assert m3 >= m1
+    assert not (m1 >= m3)
+
+    # Epsilon equality.
+
+    e = 0.005
+    m1 = Mat(1)
+    m2 = Mat(1 + e)
+
+    assert m1.equalWithAbsError(m2, e)
+    assert m2.equalWithAbsError(m1, e)
+
+    e = 0.003
+    m1 = Mat(10)
+    m2 = Mat(10 + 10 * e)
+
+    assert m1.equalWithRelError(m2, e)
+    assert m2.equalWithRelError(m1, e)
+
+    # Addition.
+
+    m1 = Mat(1)
+    m2 = Mat(2)
+
+    assert m1 + m2 == Mat(3)
+    assert m2 + m1 == m1 + m2
+    assert m1 + 1 == Mat(2)
+    assert 1 + m1 == m1 + 1
+
+    # Subtraction and negation.
+
+    m1 = Mat(2)
+    m2 = Mat(3)
+
+    assert m2 - m1 == Mat(1)
+    assert m1 - 1 == Mat(1)
+    assert 1 - m1 == - (m1 - 1)
+    assert m1.negate() == Mat(-2)
+
+    # Multiplication.
+
+    m1 = Mat(1)
+    # (Scales by (3, 4).)
+    m2 = Mat()
+    m2[0][0] = 3
+    m2[1][1] = 4
+    v = Vec(1, 2)
+
+    assert m1 * 2 == Mat(2)
+    assert m1 * 2 == 2 * m1
+    assert m1 * m2 == Mat((3,4),(3,4))
+    assert v * m2 == Vec(3, 8)
+    try:
+        m1 * v                   # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    m2f = M22f()
+    m2f[0][0] = 1
+    m2f[1][1] = 2
+    v = Vec(1, 2)
+    v *= m2f
+    assert v == Vec(1, 4)
+
+    m2d = M22d()
+    m2d[0][0] = 1
+    m2d[1][1] = 2
+    v = Vec(1, 2)
+    v *= m2d
+    assert v == Vec(1, 4)
+
+    # (Rotates by 45 degrees.)
+    m3 = Mat()
+    m3[0][0] = 0
+    m3[0][1] = 1
+    m3[1][0] = -1
+    m3[1][1] = 0    
+    m4 = m3 * Mat()
+    v1 = Vec(1, 0)
+    v2 = Vec()
+
+    m4.multDirMatrix(v1,v2)
+    assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
+    v2 = m4.multDirMatrix(v1)
+    assert v2.equalWithAbsError((0, 1), v2.baseTypeEpsilon())
+    v1a = V2fArray(1)
+    v1a[:] = V2f(v1)
+    v2a = m4.multDirMatrix(v1a)
+    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
+    v1a = V2dArray(1)
+    v1a[:] = V2d(v1)
+    v2a = m4.multDirMatrix(v1a)
+    assert v2a[0].equalWithAbsError((0, 1), v2a[0].baseTypeEpsilon())
+    
+    # Division.
+
+    m = Mat(4)
+
+    assert m / 2 == Mat(2)
+    try:
+        4 / m                   # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0           # We shouldn't get here.
+
+    # Transpose.
+
+    m = Mat(1, 2, 3, 4)
+
+    assert m.transpose() == Mat(1, 3, 2, 4)
+    m.transposed()
+    assert m == Mat(1, 3, 2, 4)
+    
+    # Invert.
+
+    m1 = Mat()
+    m1[0][0] = 1
+    m1[1][1] = 2
+    
+    m1I = m1.inverse()
+    assert m1 * m1I == Mat()
+
+    m2 = Mat(m1)
+    m2.invert()
+    assert m1 * m2 == Mat()
+
+    # Rotation (in radians).
+
+    v1 = Vec(1, 0)
+
+    m = Mat()
+    m.setRotation(-pi / 2)
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((0, -1), v2.baseTypeEpsilon())
+
+    m.rotate(-pi / 2)
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((-1, 0), v2.baseTypeEpsilon())
+
+    # Scaling.
+
+    v1 = Vec(1, 2)
+
+    m = Mat()
+    m.setScale(2)
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((2, 4), v2.baseTypeEpsilon())
+
+    m.scale(3)
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((6, 12), v2.baseTypeEpsilon())
+
+    m = Mat()
+    m.setScale((1, 2))
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((1, 4), v2.baseTypeEpsilon())
+
+    m.scale((2, 3))
+
+    v2 = v1 * m
+    assert v2.equalWithAbsError((2, 12), v2.baseTypeEpsilon())
+
+    # It is not essential for correctness that the following exceptions
+    # occur.  Instead, these tests merely document the way the Python
+    # wrappings currently work.
+    try:
+        m.setScale(1, 2)        # This should raise an exception.
+    except:
+        pass
+    else:
+        assert 0                   # We shouldn't get here.
+
+    m = Mat()
+    a = pi/4
+    # (Rotation by -a around Z axis.)
+    m[0][0] = cos(a)
+    m[0][1] = -sin(a)
+    m[1][0] = sin(a)
+    m[1][1] = cos(a)
+    v = Vec()
+
+    m.extractEuler(v)
+    assert v.equalWithAbsError((-a, 0), v.baseTypeEpsilon())
+
+    # Determinants (by building a random singular value decomposition)
+
+    u = Mat()
+    v = Mat()
+    s = Mat()
+
+    u.setRotation( random.random() )
+    v.setRotation( random.random() )
+    s[0][0] = random.random()
+    s[1][1] = random.random()
+
+    c = u * s * v.transpose()
+    assert abs(c.determinant() - s[0][0]*s[1][1]) <= u.baseTypeEpsilon()
+
+
+    print ("ok")
+    return
+
+def testM22 ():
+
+    print ("M22f")
+    testM22x (M22f, V2f)
+    print ("M22d")
+    testM22x (M22d, V2d)
+
+testList.append (('testM22',testM22))
+
 
 # -------------------------------------------------------------------------
 # Tests for M33x
@@ -6166,6 +6502,54 @@ testList.append (('testM44',testM44))
 # -------------------------------------------------------------------------
 # Tests for Mat --> Mat conversions
 
+def testM22xConversions (Mat):
+
+    # Assignment
+    
+    m1 = Mat(0,1, 2,3)
+
+    m2 = M22f (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 1
+
+    m2 = M22d (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 1
+
+    # The += operator
+
+    m2 = Mat(0,1, 2,3)
+    m2 += M22f (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 2
+    
+    m2 = Mat(0,1, 2,3)
+    m2 += M22d (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 2
+    
+    # The -= operator
+
+    m2 = Mat(0,1, 2,3)
+    m2 -= M22f (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 0
+    
+    m2 = Mat(0,1, 2,3)
+    m2 -= M22d (m1)
+    assert m2[0][0] == 0 and m2[0][1] == 0
+
+    # The *= operator
+
+    m2 = Mat(0,1, 2,3)
+    m2 *= M22f (m1)
+    assert m2[0][0] == 0*0 + 1*2
+    assert m2[0][1] == 0*1 + 1*3
+        
+    m2 = Mat(0,1, 2,3)
+    m2 *= M22d (m1)
+    assert m2[0][0] == 0*0 + 1*2
+    assert m2[0][1] == 0*1 + 1*3
+        
+    print ("ok")
+    return
+
+
 def testM33xConversions (Mat):
 
     # Assignment
@@ -6262,8 +6646,7 @@ def testM44xConversions (Mat):
     return
 
 
-def testM33xM44xConversion (MatA, MatB):
-
+def testInvalidConversion (MatA, MatB):
     try:
         m = MatA();
         m1 = MatB (m);           # This should raise an exception.
@@ -6273,7 +6656,24 @@ def testM33xM44xConversion (MatA, MatB):
         assert 0           # We shouldn't get here.
 
 
+def testM33xM44xConversion (MatA, MatB):
+    testInvalidConversion (MatA, MatB)
+
+
+def testM22xM33xConversion (MatA, MatB):
+    testInvalidConversion (MatA, MatB)
+
+
+def testM22xM44xConversion (MatA, MatB):
+    testInvalidConversion (MatA, MatB)
+
+
 def testMatConversions ():
+
+    print ("M22f")
+    testM22xConversions (M22f)
+    print ("M22d")
+    testM22xConversions (M22d)
 
     print ("M33f")
     testM33xConversions (M33f)
@@ -6287,6 +6687,13 @@ def testMatConversions ():
 
     print ("invalid conversions")
     # Deliberatly not exhaustive, just representative.
+
+    testM22xM33xConversion (M22f, M33d)
+    testM22xM33xConversion (M33f, M22d)
+
+    testM22xM44xConversion (M22f, M44d)
+    testM22xM44xConversion (M44f, M22d)
+
     testM33xM44xConversion (M33f, M44d)
     testM33xM44xConversion (M44f, M33d)
 
@@ -8366,6 +8773,11 @@ def testMatrixArray ():
     testMxArray (M33fArray, M33f)
     print ("M33dArray")
     testMxArray (M33dArray, M33d)
+    print ("M22fArray")
+    testMxArray (M22fArray, M22f)
+    print ("M22dArray")
+    testMxArray (M22dArray, M22d)
+
 
 testList.append(("testMatrixArray",testMatrixArray))
 


### PR DESCRIPTION
I have written all possible functionality for the case of a 2x2 Matrix. Prior it was only 3x3 and 4x4. Functions that are not transferable to this case were omitted. These are limits of the Matrix22 format and include: Shear, Minors, Gaus-Jordan Inversion, and Translation.  

Signed-off-by Owen Thompson (oxt3479)