### PR TITLE
Fix python module install on macOS

### DIFF
--- a/PyIlmBase/CMakeLists.txt
+++ b/PyIlmBase/CMakeLists.txt
@@ -95,6 +95,16 @@ function(PYILMBASE_EXTRACT_REL_SITEARCH varname pyver pyexe pysitearch)
   endwhile()
   math(EXPR _elen "${_elen}+1")
   string(SUBSTRING ${_basedir} ${_elen} -1 _reldir)
+  if(APPLE)
+    # on macOS, set install path to user's python package directory
+    # so that elevated privileges are not necessary
+    execute_process(
+      COMMAND "${pyexe}" -c "if True:
+        import sysconfig
+        print(sysconfig.get_path('platlib', 'posix_user'))"
+      OUTPUT_VARIABLE _reldir
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
   set(${varname} ${_reldir} CACHE STRING "Destination sub-folder (relative) for the python ${pyver} modules")
   message(STATUS "  -> Will install to: ${_reldir}")
 endfunction()


### PR DESCRIPTION
Signed-off-by: Mark Sisson <5761292+marksisson@users.noreply.github.com>

Before this change, installing resulted in permission error:

CMake Error at PyIlmBase/PyIex/cmake_install.cmake:114 (file):
  file cannot create directory: /usr/local/ibrary/Python/2.7/site-packages.
  Maybe need administrative privileges.
Call Stack (most recent call first):
  PyIlmBase/cmake_install.cmake:38 (include)
  cmake_install.cmake:39 (include)
