### PR TITLE
A clean version of #673: Allow the use of Pthreads with WIN32/64

### DIFF
--- a/IlmBase/IlmThread/IlmThread.cpp
+++ b/IlmBase/IlmThread/IlmThread.cpp
@@ -80,7 +80,7 @@ Thread::start ()
 }
 
 #else
-#   if !defined (_WIN32) &&!(_WIN64) && !(HAVE_PTHREAD)
+#   if !defined (_WIN32) && !defined (_WIN64) && ! defined(HAVE_PTHREAD)
 //-----------------------------------------------------------------------------
 // OPENEXR_FORCE_CXX03 with no windows / pthread support
 //-----------------------------------------------------------------------------

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -95,7 +95,7 @@
 #include "IlmThreadNamespace.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if defined _WIN32 || defined _WIN64
+#   if (defined (_WIN32) || defined (_WIN64)) && !defined(HAVE_PTHREAD)
 #       ifdef NOMINMAX
 #          undef NOMINMAX
 #       endif
@@ -132,7 +132,7 @@ class Thread
   private:
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if defined _WIN32 || defined _WIN64
+#   if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_PTHREAD)
 	HANDLE _thread;
 #   elif HAVE_PTHREAD
 	pthread_t _thread;

--- a/IlmBase/IlmThread/IlmThreadMutex.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutex.cpp
@@ -42,7 +42,7 @@
 #include "IlmBaseConfig.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD)
+#   if !defined (_WIN32) && !defined (_WIN64) && !defined (HAVE_PTHREAD)
 #      include "IlmThreadMutex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER

--- a/IlmBase/IlmThread/IlmThreadMutex.h
+++ b/IlmBase/IlmThread/IlmThreadMutex.h
@@ -71,13 +71,13 @@
 #include "IlmThreadNamespace.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if defined _WIN32 || defined _WIN64
+#   if defined (_WIN32) || defined (_WIN64)
 #      ifdef NOMINMAX
 #         undef NOMINMAX
 #      endif
 #      define NOMINMAX
 #      include <windows.h>
-#   elif HAVE_PTHREAD
+#   elif defined (HAVE_PTHREAD)
 #      include <pthread.h>
 #   endif
 #else
@@ -116,9 +116,9 @@ class ILMTHREAD_EXPORT Mutex
     void	lock () const;
     void	unlock () const;
 
-    #if defined _WIN32 || defined _WIN64
+    #if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_PTHREADS)
 	mutable CRITICAL_SECTION _mutex;
-    #elif HAVE_PTHREAD
+    #elif defined (HAVE_PTHREAD)
 	mutable pthread_mutex_t _mutex;
     #endif
 

--- a/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
@@ -40,11 +40,10 @@
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
+#include "IlmThreadMutex.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if HAVE_PTHREAD
-
-#      include "IlmThreadMutex.h"
+#   ifdef HAVE_PTHREAD
 #      include "Iex.h"
 #      include <assert.h>
 

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -509,7 +509,7 @@ TaskGroup::Data::addTask ()
     // extra lock but for c++98, to add the ability for custom thread
     // pool we add the lock here
     //
-#if ILMBASE_FORCE_CXX03
+#ifdef ILMBASE_FORCE_CXX03
     Lock lock (dtorMutex);
 #endif
     if (numPending++ == 0)
@@ -862,7 +862,7 @@ unsigned
 ThreadPool::estimateThreadCountForFileIO ()
 {
 #ifdef ILMBASE_FORCE_CXX03
-#    if defined(_WIN32)
+#    if defined (_WIN32) || defined (_WIN64)
     SYSTEM_INFO sysinfo;
     GetSystemInfo (&sysinfo);
     return static_cast<unsigned> (sysinfo.dwNumberOfProcessors);

--- a/IlmBase/IlmThread/IlmThreadPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadPosix.cpp
@@ -41,7 +41,7 @@
 
 #include "IlmBaseConfig.h"
 
-#if HAVE_PTHREAD
+#ifdef HAVE_PTHREAD
 #ifdef ILMBASE_FORCE_CXX03
 
 #include "IlmThread.h"

--- a/IlmBase/IlmThread/IlmThreadSemaphore.h
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.h
@@ -58,7 +58,7 @@
 #   include <dispatch/dispatch.h>
 #else
 #   ifdef ILMBASE_FORCE_CXX03
-#      if HAVE_PTHREAD
+#      ifdef HAVE_PTHREAD
 #         include <pthread.h>
 #      endif
 #   else
@@ -84,7 +84,7 @@ class ILMTHREAD_EXPORT Semaphore
 
   private:
 
-#if defined _WIN32 || defined _WIN64
+#if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_POSIX_SEMAPHORES)
 
 	mutable HANDLE _semaphore;
 

--- a/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
@@ -41,7 +41,7 @@
 
 #include "IlmBaseConfig.h"
 
-#if HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
+#if defined (HAVE_PTHREAD) && defined(HAVE_POSIX_SEMAPHORES)
 
 #include "IlmThreadSemaphore.h"
 #include "Iex.h"

--- a/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphorePosixCompat.cpp
@@ -40,16 +40,17 @@
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
-
-#if (!HAVE_POSIX_SEMAPHORES) && !defined (_WIN32) && ! defined (_WIN64) && ! defined (__APPLE__)
-
 #include "IlmThreadSemaphore.h"
+
+#if !defined (HAVE_POSIX_SEMAPHORES) && !defined (APPLE)
+#if (!defined (_WIN32) && !defined (_WIN64)) || defined (__MINGW64_VERSION_MAJOR)
+
 #include "Iex.h"
 #include <assert.h>
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-#if ILMBASE_FORCE_CXX03 && HAVE_PTHREAD
+#if defined (ILMBASE_FORCE_CXX03) && defined(HAVE_PTHREAD)
 Semaphore::Semaphore (unsigned int value)
 {
     if (int error = ::pthread_mutex_init (&_semaphore.mutex, 0))
@@ -224,3 +225,5 @@ Semaphore::value () const
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
 #endif
+#endif
+

--- a/IlmBase/IlmThread/IlmThreadWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadWin32.cpp
@@ -40,11 +40,11 @@
 
 
 #include "IlmBaseConfig.h"
+#include "IlmThread.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#ifdef _WIN32
+#if (defined (_WIN32) || defined (_WIN64)) && !defined(HAVE_POSIX_SEMAPHORES)
 
-#include "IlmThread.h"
 #include "Iex.h"
 #include <iostream>
 #include <assert.h>


### PR DESCRIPTION
Clean up use of #if defined and #ifdef 

Signed-off-by: Cary Phillips <cary@ilm.com>