### PR TITLE
Removed glew fix from CI

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -172,11 +172,6 @@ jobs:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
     steps:
-      # TODO: Remove this workaround following resolution of:
-      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
-      - name: Setup container
-        run: sudo rm -rf /usr/local/lib64/cmake/glew
-        if: matrix.vfx-cy == 2020
       - name: Checkout
         uses: actions/checkout@v2
       - name: Create build directories


### PR DESCRIPTION
A very simple PR, mostly to check that my corporate CLA is working fine.

This just removes a CI fix that was only necessary for packages that need glew on the VFX-2020 image, the fix is still needed for glew dependencies but I don't think OpenEXR requires glew?