### PR TITLE
Zero allocated memory to guarantee always identical output in DWAA compression

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -1937,7 +1937,7 @@ DwaCompressor::compress
         _outBufferSize = outBufferSize;
         if (_outBuffer != 0)
             delete[] _outBuffer;       
-        _outBuffer = new char[outBufferSize];
+        _outBuffer = new char[outBufferSize]();
     }
 
     char *outDataPtr = &_outBuffer[NUM_SIZES_SINGLE * sizeof(OPENEXR_IMF_NAMESPACE::Int64) +


### PR DESCRIPTION
DWAA compression sometimes could generate binary-different files because some bytes are not initialized with any value. Here you can see output comparison of debug and release builds of same application:
![image](https://user-images.githubusercontent.com/2393951/83903489-e644e900-a766-11ea-888a-fedf62fe7681.png)
some bytes in debug build filled with CD and 0 in release. Depending on os\compiler\etc this byte could contain any value, it could be different even between multiple runs of same application.
This behavior may be not expected by some applications, so consider merging this fix or provide different fix.