### PR TITLE
Disable all Windows builds temporarily.

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -320,115 +320,116 @@ jobs:
   #       a corresponding boost python38 module. As a result PyIlmbase tests are not 
   #       built or run.
   # TODO: Determine why tests hang in Debug job.
+  # TODO: Fix boost script to install from sourceforge.
 
-  windows:
-    name: 'Windows 2019 
-      <MSVC 16.4 
-       config=${{ matrix.build-type }}, 
-       shared=${{ matrix.build-shared }}, 
-       cxx=${{ matrix.cxx-standard }}, 
-       python=${{ matrix.python-version }}, 
-       docs=${{ matrix.build-docs }}>'
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        build: [1, 3, 4]
-        include:
-          # C++11, Python 3.7
-          - build: 1
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'ON'
-            cxx-standard: 11
-            python-version: 3.7.7
-            boost-version: 1.70.0
-            zlib-version: 1.2.11
-            zlib-lib: zlib.lib
-            exclude-tests: ''
-          # Debug -
-          # - build: 2
-            # build-type: Debug
+  # windows:
+    # name: 'Windows 2019 
+      # <MSVC 16.4 
+       # config=${{ matrix.build-type }}, 
+       # shared=${{ matrix.build-shared }}, 
+       # cxx=${{ matrix.cxx-standard }}, 
+       # python=${{ matrix.python-version }}, 
+       # docs=${{ matrix.build-docs }}>'
+    # runs-on: windows-2019
+    # strategy:
+      # matrix:
+        # build: [1, 3, 4]
+        # include:
+          # # C++11, Python 3.7
+          # - build: 1
+            # build-type: Release
             # build-shared: 'ON'
-            # build-docs: 'OFF'
+            # build-docs: 'ON'
             # cxx-standard: 11
             # python-version: 3.7.7
             # boost-version: 1.70.0
             # zlib-version: 1.2.11
             # zlib-lib: zlib.lib
             # exclude-tests: ''
-          # C++14
-          - build: 3
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            cxx-standard: 14
-            python-version: 3.7.7
-            boost-version: 1.70.0
-            zlib-version: 1.2.11
-            zlib-lib: zlib.lib
-            exclude-tests: ''
-          # Static
-          - build: 4
-            build-type: Release
-            build-shared: 'OFF'
-            build-docs: 'OFF'
-            cxx-standard: 11
-            python-version: 3.7.7
-            boost-version: 1.70.0
-            zlib-version: 1.2.11
-            zlib-lib: zlibstatic.lib
-            exclude-tests: ''
+          # # Debug -
+          # # - build: 2
+            # # build-type: Debug
+            # # build-shared: 'ON'
+            # # build-docs: 'OFF'
+            # # cxx-standard: 11
+            # # python-version: 3.7.7
+            # # boost-version: 1.70.0
+            # # zlib-version: 1.2.11
+            # # zlib-lib: zlib.lib
+            # # exclude-tests: ''
+          # # C++14
+          # - build: 3
+            # build-type: Release
+            # build-shared: 'ON'
+            # build-docs: 'OFF'
+            # cxx-standard: 14
+            # python-version: 3.7.7
+            # boost-version: 1.70.0
+            # zlib-version: 1.2.11
+            # zlib-lib: zlib.lib
+            # exclude-tests: ''
+          # # Static
+          # - build: 4
+            # build-type: Release
+            # build-shared: 'OFF'
+            # build-docs: 'OFF'
+            # cxx-standard: 11
+            # python-version: 3.7.7
+            # boost-version: 1.70.0
+            # zlib-version: 1.2.11
+            # zlib-lib: zlibstatic.lib
+            # exclude-tests: ''
  
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Create build directories
-        run: |
-          mkdir _install
-          mkdir _build
-        shell: bash
-      - name: Install Dependences
-        run: |
-          share/ci/scripts/windows/install_python.ps1 ${{ matrix.python-version }} $HOME 
-          share/ci/scripts/windows/install_boost.ps1 ${{ matrix.boost-version }} $HOME 3.8
-          share/ci/scripts/windows/install_zlib.ps1 ${{ matrix.zlib-version }} $HOME 
-        shell: powershell
-      - name: Configure
-        run: |
-          cmake ../. \
-                -DCMAKE_INSTALL_PREFIX=../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
-                -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
-                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
-                -DBOOST_ROOT:FILEPATH=$BOOST_ROOT \
-                -DZLIB_ROOT:FILEPATH="$ZLIB_ROOT" \
-                -DZLIB_LIBRARY:FILEPATH="$ZLIB_ROOT/lib/${{ matrix.zlib-lib }}" \
-                -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
-                -DOPENEXR_BUILD_UTILS='ON' \
-                -DOPENEXR_RUN_FUZZ_TESTS='OFF' 
-               # -DPython_EXECUTABLE:FILEPATH="$PYTHON_ROOT" \
-               # -DPython_INCLUDE_DIR:FILEPATH="$PYTHON_ROOT/include" \       
-               # -DPython_LIBRARY:"$PYTHON_ROOT\libs" \
-        shell: bash
-        working-directory: _build
-      - name: Build
-        run: |
-          cmake --build . \
-                --target install \
-                --config ${{ matrix.build-type }}
-        shell: bash
-        working-directory: _build
-      - name: Test
-        run: |
-          ctest -T Test ${{ matrix.exclude-tests }} \
-                -C ${{ matrix.build-type }} \
-                --timeout 7200 \
-                --output-on-failure \
-                -VV
-        shell: bash
-        working-directory: _build
+    # steps:
+      # - name: Setup Python
+        # uses: actions/setup-python@v1
+        # with:
+          # python-version: ${{ matrix.python-version }}
+      # - name: Checkout
+        # uses: actions/checkout@v2
+      # - name: Create build directories
+        # run: |
+          # mkdir _install
+          # mkdir _build
+        # shell: bash
+      # - name: Install Dependences
+        # run: |
+          # share/ci/scripts/windows/install_python.ps1 ${{ matrix.python-version }} $HOME 
+          # share/ci/scripts/windows/install_boost.ps1 ${{ matrix.boost-version }} $HOME 3.8
+          # share/ci/scripts/windows/install_zlib.ps1 ${{ matrix.zlib-version }} $HOME 
+        # shell: powershell
+      # - name: Configure
+        # run: |
+          # cmake ../. \
+                # -DCMAKE_INSTALL_PREFIX=../_install \
+                # -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                # -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                # -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
+                # -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
+                # -DBOOST_ROOT:FILEPATH=$BOOST_ROOT \
+                # -DZLIB_ROOT:FILEPATH="$ZLIB_ROOT" \
+                # -DZLIB_LIBRARY:FILEPATH="$ZLIB_ROOT/lib/${{ matrix.zlib-lib }}" \
+                # -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                # -DOPENEXR_BUILD_UTILS='ON' \
+                # -DOPENEXR_RUN_FUZZ_TESTS='OFF' 
+               # # -DPython_EXECUTABLE:FILEPATH="$PYTHON_ROOT" \
+               # # -DPython_INCLUDE_DIR:FILEPATH="$PYTHON_ROOT/include" \       
+               # # -DPython_LIBRARY:"$PYTHON_ROOT\libs" \
+        # shell: bash
+        # working-directory: _build
+      # - name: Build
+        # run: |
+          # cmake --build . \
+                # --target install \
+                # --config ${{ matrix.build-type }}
+        # shell: bash
+        # working-directory: _build
+      # - name: Test
+        # run: |
+          # ctest -T Test ${{ matrix.exclude-tests }} \
+                # -C ${{ matrix.build-type }} \
+                # --timeout 7200 \
+                # --output-on-failure \
+                # -VV
+        # shell: bash
+        # working-directory: _build

--- a/share/ci/scripts/windows/install_boost.ps1
+++ b/share/ci/scripts/windows/install_boost.ps1
@@ -1,3 +1,6 @@
+#
+# TODO: fix this script to work with sourceforge archive!
+#
 $homeDir = (pwd)
 
 $boostVersion = $Args[0]
@@ -13,7 +16,7 @@ $boostMajor = $boostArray[0]
 $boostMinor = $boostArray[1]
 $boostPatch = $boostArray[2];
 $boostVersionU = "boost_${boostMajor}_${boostMinor}_${boostPatch}"
-$boostArchive = "http://dl.bintray.com/boostorg/release/${boostVersion}/source/${boostVersionU}.zip"
+$boostArchive = "https://sourceforge.net/projects/boost/files/boost-binaries/1.70.0/boost_1_70_0-msvc-14.1-64.exe"
 $boostBuildPath = "${boostRoot}\boost-${boostVersion}\${boostVersionU}"
 
 $pythonMajor = ($pythonVersion -split '\.')[0]


### PR DESCRIPTION
Signed-off-by: Christina Tempelaar-Lietz <xlietz@gmail.com>

Disable until the Windows boost script is fixed to not download and build from source.