### PR TITLE
check for valid DeepImageState in DeepImageStateAttribute::readValueFrom()

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
@@ -71,6 +71,13 @@ DeepImageStateAttribute::readValueFrom
 {
     unsigned char tmp;
     Xdr::read <StreamIO> (is, tmp);
+    if (tmp >= DIS_NUMSTATES)
+    {
+        std::stringstream s;
+        s << "Invalid DeepImageState " << static_cast<int> (tmp);
+        throw IEX_NAMESPACE::InputExc(s);
+    }
+            
     _value = DeepImageState (tmp);
 }
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23996

Signed-off-by: Cary Phillips <cary@ilm.com>