### PR TITLE
suppress clang undefined behavior sanitizer in ImfAttribute<T>::copyValuesFrom()

### DIFF
--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -323,6 +323,9 @@ template <class T>
 void		
 TypedAttribute<T>::copyValueFrom (const Attribute &other)
 #if defined (__clang__)
+// if T is an enum, _value may be an invalid value, which the clang
+// sanitizer reports as undefined behavior, even though the value is
+// acceptable in this context.
     __attribute__((no_sanitize ("undefined")))
 #endif    
 {

--- a/OpenEXR/IlmImf/ImfAttribute.h
+++ b/OpenEXR/IlmImf/ImfAttribute.h
@@ -322,8 +322,11 @@ TypedAttribute<T>::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 template <class T>
 void		
 TypedAttribute<T>::copyValueFrom (const Attribute &other)
+#if defined (__clang__)
+    __attribute__((no_sanitize ("undefined")))
+#endif    
 {
-    _value = cast(other)._value;
+    _value = cast(other).value();
 }
 
 


### PR DESCRIPTION
Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23996

If an input file contains an invalid value for DeepImageState, clang will generate an Invalid-enum-value warning. The proper behavior is to carry the invalid value, so it will be preserved on file write. This could potentially happen with "legal" files if the DeepImageState enum were ever extended in the future, in which case old versions of the library should read the new files.

Suppressing the warning in this one case is preferable to disabling all undefined behavior by the sanitizer, because other instances of undefined behavior may be legitimate bugs.

Signed-off-by: Cary Phillips <cary@ilm.com>