### PR TITLE
suppress clang undefined behavior sanitizer in Channel constructor

### DIFF
--- a/OpenEXR/IlmImf/ImfChannelList.cpp
+++ b/OpenEXR/IlmImf/ImfChannelList.cpp
@@ -52,11 +52,17 @@ using std::set;
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 
-Channel::Channel (PixelType t, int xs, int ys, bool pl):
-    type (t),
-    xSampling (xs),
-    ySampling (ys),
-    pLinear (pl)
+Channel::Channel (PixelType t, int xs, int ys, bool pl)
+#if defined (__clang__)
+// t may be an invalid enum value, which the clang sanitizer reports
+// as undefined behavior, even though the value is acceptable in this
+// context.
+    __attribute__((no_sanitize ("undefined")))
+#endif    
+    : type (t),
+      xSampling (xs),
+      ySampling (ys),
+      pLinear (pl)
 {
     // empty
 }


### PR DESCRIPTION
Similar to #779...

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24021

If an input file contains a channel with an invalid PixelType, clang will generate an Invalid-enum-value warning. The proper behavior is to carry the invalid value, so it will be preserved on file write. This could potentially happen with "legal" files if the PixelType enum were ever extended in the future, in which case old versions of the library should read the new files.

Suppressing the warning in this one case is preferable to disabling all undefined behavior by the sanitizer, because other instances of undefined behavior may be legitimate bugs.

Signed-off-by: Cary Phillips <cary@ilm.com>