### PR TITLE
sanity check preview attribute sizes

### DIFF
--- a/OpenEXR/IlmImf/ImfPreviewImageAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfPreviewImageAttribute.cpp
@@ -83,6 +83,17 @@ PreviewImageAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &i
     Xdr::read <StreamIO> (is, width);
     Xdr::read <StreamIO> (is, height);
 
+    if (width < 0 || height < 0)
+    {
+        throw IEX_NAMESPACE::InputExc("Invalid dimensions in Preview Image Attribute");
+    }
+
+    // total attribute size should be four bytes per pixel + 8 bytes for width and height dimensions
+    if (static_cast<Int64>(width) * static_cast<Int64>(height) * 4l + 8l != static_cast<Int64>(size) )
+    {
+        throw IEX_NAMESPACE::InputExc("Mismatch between Preview Image Attribute size and dimensions");
+    }
+
     PreviewImage p (width, height);
 
     int numPixels = p.width() * p.height();


### PR DESCRIPTION
Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23990
Maximum attribute size 2^31 bytes but PreviewImageAttribute could be tricked into allocating more memory than that to load a preview.
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>