### PR TITLE
change sanity check in stringvectorattribute to prevent overflow

### DIFF
--- a/OpenEXR/IlmImf/ImfStringVectorAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfStringVectorAttribute.cpp
@@ -84,7 +84,7 @@ StringVectorAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &i
 
        // check there is enough space remaining in attribute to
        // contain claimed string length
-       if( strSize < 0 || strSize+read > size)
+       if( strSize < 0 ||  strSize > size - read)
        {
            throw IEX_NAMESPACE::InputExc("Invalid size field reading stringvector attribute");
        }


### PR DESCRIPTION
Should fix overflow reported in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24178

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>