### PR TITLE
use 64 bit computation in chunk offset table reconstruction

### DIFF
--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -626,7 +626,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
                     
                     //add 40 byte header to packed sizes (tile coordinates, packed sizes, unpacked size)
-                    size_of_chunk=packed_offset+packed_sample + 40l;
+                    size_of_chunk=packed_offset+packed_sample + 40ll;
                 }
                 else
                 {
@@ -634,7 +634,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     // regular image has 20 bytes of header, 4 byte chunksize;
                     int chunksize;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, chunksize);
-                    size_of_chunk=static_cast<Int64>(chunksize) + 20l;
+                    size_of_chunk=static_cast<Int64>(chunksize) + 20ll;
                 }
             }
             else
@@ -665,13 +665,13 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
                     
                     
-                    size_of_chunk=packed_offset+packed_sample + 28l;
+                    size_of_chunk=packed_offset+packed_sample + 28ll;
                 }
                 else
                 {
                     int chunksize;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, chunksize);   
-                    size_of_chunk=static_cast<Int64>(chunksize) + 8l;
+                    size_of_chunk=static_cast<Int64>(chunksize) + 8ll;
                 }
                 
             }

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -626,7 +626,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
                     
                     //add 40 byte header to packed sizes (tile coordinates, packed sizes, unpacked size)
-                    size_of_chunk=packed_offset+packed_sample+40;
+                    size_of_chunk=packed_offset+packed_sample + 40l;
                 }
                 else
                 {
@@ -634,7 +634,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     // regular image has 20 bytes of header, 4 byte chunksize;
                     int chunksize;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, chunksize);
-                    size_of_chunk=chunksize+20;
+                    size_of_chunk=static_cast<Int64>(chunksize) + 20l;
                 }
             }
             else
@@ -665,13 +665,13 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
                     
                     
-                    size_of_chunk=packed_offset+packed_sample+28;
+                    size_of_chunk=packed_offset+packed_sample + 28l;
                 }
                 else
                 {
                     int chunksize;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, chunksize);   
-                    size_of_chunk=chunksize+8;
+                    size_of_chunk=static_cast<Int64>(chunksize) + 8l;
                 }
                 
             }


### PR DESCRIPTION
address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24188
ensure 64 bit types are used in all cases when reconstructing offsets 
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>