### PR TITLE
cast signed chars to unsigned longs before left shift in Xdr::read of signed long

### DIFF
--- a/OpenEXR/IlmImf/ImfXdr.h
+++ b/OpenEXR/IlmImf/ImfXdr.h
@@ -707,10 +707,10 @@ read (T &in, signed long &v)
 
     #if LONG_MAX == 2147483647
 
-        v =  (static_cast <unsigned char> (b[0])        & 0x000000ff) |
-            ((static_cast <unsigned char> (b[1]) << 8)  & 0x0000ff00) |
-            ((static_cast <unsigned char> (b[2]) << 16) & 0x00ff0000) |
-             (static_cast <unsigned char> (b[3]) << 24);
+        v =  (static_cast <unsigned long> (b[0])        & 0x000000ff) |
+            ((static_cast <unsigned long> (b[1]) << 8)  & 0x0000ff00) |
+            ((static_cast <unsigned long> (b[2]) << 16) & 0x00ff0000) |
+             (static_cast <unsigned long> (b[3]) << 24);
 
 	if (( b[4] ||  b[5] ||  b[6] ||  b[7]) &&
 	    (~b[4] || ~b[5] || ~b[6] || ~b[7]))
@@ -721,14 +721,14 @@ read (T &in, signed long &v)
 
     #elif LONG_MAX == 9223372036854775807L
 
-	v =  ((long) b[0]        & 0x00000000000000ff) |
-	    (((long) b[1] << 8)  & 0x000000000000ff00) |
-	    (((long) b[2] << 16) & 0x0000000000ff0000) |
-	    (((long) b[3] << 24) & 0x00000000ff000000) |
-	    (((long) b[4] << 32) & 0x000000ff00000000) |
-	    (((long) b[5] << 40) & 0x0000ff0000000000) |
-	    (((long) b[6] << 48) & 0x00ff000000000000) |
-	     ((long) b[7] << 56);
+	v =  (static_cast <unsigned long> (b[0])        & 0x00000000000000ff) |
+	    ((static_cast <unsigned long> (b[1]) << 8)  & 0x000000000000ff00) |
+	    ((static_cast <unsigned long> (b[2]) << 16) & 0x0000000000ff0000) |
+	    ((static_cast <unsigned long> (b[3]) << 24) & 0x00000000ff000000) |
+	    ((static_cast <unsigned long> (b[4]) << 32) & 0x000000ff00000000) |
+	    ((static_cast <unsigned long> (b[5]) << 40) & 0x0000ff0000000000) |
+	    ((static_cast <unsigned long> (b[6]) << 48) & 0x00ff000000000000) |
+             (static_cast <unsigned long> (b[7]) << 56);
 
     #else
 


### PR DESCRIPTION
Should prevent UBSAN undefined behavior with left shift of negative signed chars.

Signed-off-by: Cary Phillips <cary@ilm.com>