### PR TITLE
suppress clang undefined behavior sanitizer in DeepImageStateAttribute::copyValuesFrom()

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
@@ -74,5 +74,18 @@ DeepImageStateAttribute::readValueFrom
     _value = DeepImageState (tmp);
 }
 
+template <>
+void
+DeepImageStateAttribute::copyValueFrom (const OPENEXR_IMF_INTERNAL_NAMESPACE::Attribute &other)
+#if defined (__clang__)
+    // _value may be an invalid value, which the clang sanitizer reports
+    // as undefined behavior, even though the value is acceptable in this
+    // context.
+    __attribute__((no_sanitize ("undefined")))
+#endif 
+{
+    _value = cast(other).value();
+
+}
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT 

--- a/OpenEXR/IlmImf/ImfDeepImageStateAttribute.h
+++ b/OpenEXR/IlmImf/ImfDeepImageStateAttribute.h
@@ -62,6 +62,8 @@ template <> IMF_EXPORT
 void DeepImageStateAttribute::readValueFrom
     (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &, int, int);
 
+template <> IMF_EXPORT
+void DeepImageStateAttribute::copyValueFrom (const OPENEXR_IMF_INTERNAL_NAMESPACE::Attribute &other);
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 


### PR DESCRIPTION
A better solution to handling of undefined DeepImageState enums than #779, this restricts the suppression specifically to the handling of this particular attribute. For this attribute, it is permissible for the value to be an invalid enum value.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23996

Signed-off-by: Cary Phillips <cary@ilm.com>