### PR TITLE
prevent invalid values in LineOrder enum

### DIFF
--- a/OpenEXR/IlmImf/ImfLineOrderAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfLineOrderAttribute.cpp
@@ -71,6 +71,19 @@ LineOrderAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, 
 {
     unsigned char tmp;
     Xdr::read <StreamIO> (is, tmp);
+
+    //
+    // prevent invalid values being written to LineOrder enum
+    // by forcing all unknown types to NUM_LINEORDERS which is also an invalid
+    // value but is a legal enum. Note that Header::sanityCheck will
+    // throw an exception when files with invalid lineOrders 
+    //
+    
+    if (tmp != INCREASING_Y &&
+        tmp != DECREASING_Y &&
+        tmp != RANDOM_Y)
+        tmp = NUM_LINEORDERS;
+
     _value = LineOrder (tmp);
 }
 


### PR DESCRIPTION
This avoids the 'undefined behavior' sanitizer warning when reading files with invalid LineOrder attribute values. The behavior is unchanged, since sanityCheck() throws an exception with invalid LineOrder values.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24333

Signed-off-by: Cary Phillips <cary@ilm.com>