### PR TITLE
IexMathFpu.cpp: Fix build on non-glibc (e.g. musl libc).

### DIFF
--- a/IlmBase/IexMath/IexMathFpu.cpp
+++ b/IlmBase/IexMath/IexMathFpu.cpp
@@ -281,10 +281,18 @@ restoreControlRegs (const ucontext_t & ucon, bool clearExceptions)
 inline void
 restoreControlRegs (const ucontext_t & ucon, bool clearExceptions)
 {
+#if defined(__GLIBC__) || defined(__i386__)
     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
+#else
+    setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
+#endif
     
     _fpstate * kfp = reinterpret_cast<_fpstate *> (ucon.uc_mcontext.fpregs);
+#if defined(__GLIBC__) || defined(__i386__)
     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
+#else
+    setMxcsr (kfp->mxcsr, clearExceptions);
+#endif
 }
 
 #endif


### PR DESCRIPTION
Originally from:
https://github.com/void-linux/void-packages/blob/80bbc168faa25448bd3399f4df331b836e74b85c/srcpkgs/ilmbase/patches/musl-_fpstate.patch

Fixes error:

    IlmBase/IexMath/IexMathFpu.cpp: In function ‘void Iex_2_4::FpuControl::restoreControlRegs(const ucontext_t&, bool)’:
    IlmBase/IexMath/IexMathFpu.cpp:284:38: error: ‘struct _fpstate’ has no member named ‘cw’; did you mean ‘cwd’?
      284 |     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
          |                                      ^~
          |                                      cwd
    IlmBase/IexMath/IexMathFpu.cpp:287:20: error: ‘struct Iex_2_4::FpuControl::_fpstate_64’ has no member named ‘magic’
      287 |     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
          |                    ^~~~~
