### PR TITLE
prevent invalid Compression enum values being read from file

### DIFF
--- a/OpenEXR/IlmImf/ImfCompressionAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfCompressionAttribute.cpp
@@ -71,6 +71,28 @@ CompressionAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is
 {
     unsigned char tmp;
     Xdr::read <StreamIO> (is, tmp);
+
+    //
+    // prevent invalid values being written to Compressin enum
+    // by forcing all unknown types to NUM_COMPRESSION_METHODS which is also an invalid
+    // pixel type, but can be used as a PixelType enum value
+    // (Header::sanityCheck will throw an exception when files with invalid Compression types are read)
+    //
+
+    if (tmp!= NO_COMPRESSION &&
+      tmp != RLE_COMPRESSION &&
+      tmp != ZIPS_COMPRESSION &&
+      tmp != ZIP_COMPRESSION &&
+      tmp != PIZ_COMPRESSION &&
+      tmp != PXR24_COMPRESSION &&
+      tmp != B44_COMPRESSION &&
+      tmp != B44A_COMPRESSION &&
+      tmp != DWAA_COMPRESSION &&
+      tmp != DWAB_COMPRESSION)
+    {
+        tmp = NUM_COMPRESSION_METHODS;
+    }
+
     _value = Compression (tmp);
 }
 


### PR DESCRIPTION
Apply same logic as #785 and #795 to Compression attribute
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>