### PR TITLE
Fix stack corruption in Matrix tests

### DIFF
--- a/IlmBase/ImathTest/testMatrix.cpp
+++ b/IlmBase/ImathTest/testMatrix.cpp
@@ -78,7 +78,7 @@ testMatrix ()
 
     IMATH_INTERNAL_NAMESPACE::M22f m1;
     m1[0][0] = 99.0f;
-    m1[1][2] = 101.0f;
+    m1[1][1] = 101.0f;
 
 	IMATH_INTERNAL_NAMESPACE::M22f test(m1);
 	assert(test == m1);
@@ -96,7 +96,7 @@ testMatrix ()
 
 	IMATH_INTERNAL_NAMESPACE::M22d m2;
 	m2[0][0] = 99.0f;
-	m2[1][2] = 101.0f;
+	m2[1][1] = 101.0f;
 
 	IMATH_INTERNAL_NAMESPACE::M22d test(m2);
 	assert(test == m2);


### PR DESCRIPTION
Hi,

I was running the tests on Windows 10 with Visual Studio 2019 and getting this exception from ImathTest/testMatrix.cpp:

Run-Time Check Failure #2 - Stack around the variable 'm1' was corrupted.

It looks like this is coming from the M22 tests, there are two assignments that are out of bounds. I made a small fix and the test run now completes succesfully with no exceptions. Strangely I also tried running the test on CentOS 7 and did not get any exceptions, and even running it through Valgrind didn't turn up any errors, so I'm not quite sure what's going on there...
