### PR TITLE
remove extraneous vector allocation in getScanlineChunkOffsetTableSize

### DIFF
--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -1886,9 +1886,6 @@ getScanlineChunkOffsetTableSize(const Header& header)
 {
     const Box2i &dataWindow = header.dataWindow();
 
-    vector<size_t> bytesPerLine;
-    bytesPerLineTable (header, bytesPerLine);
-
     int linesInBuffer = numLinesInBuffer ( header.compression() );
 
     int lineOffsetSize = (dataWindow.max.y - dataWindow.min.y +


### PR DESCRIPTION
The changes in a6408c903 made the call to bytesPerLineTable redundant. For files with a very large number of scanlines, this call temporarily allocates a large amount of unnecessary memory

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>