### PR TITLE
Avoid integer overflow in calculateNumTiles()

### DIFF
--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -301,7 +301,11 @@ calculateNumTiles (int *numTiles,
 {
     for (int i = 0; i < numLevels; i++)
     {
-	numTiles[i] = (levelSize (min, max, i, rmode) + size - 1) / size;
+	int l = levelSize (min, max, i, rmode);
+        if (l >= std::numeric_limits<int>::max() - size + 1)
+            throw IEX_NAMESPACE::ArgExc ("Invalid size.");
+
+	numTiles[i] = (l + size - 1) / size;
     }
 }
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -301,11 +301,11 @@ calculateNumTiles (int *numTiles,
 {
     for (int i = 0; i < numLevels; i++)
     {
-	int l = levelSize (min, max, i, rmode);
-        if (l >= std::numeric_limits<int>::max() - size + 1)
+        int l = levelSize (min, max, i, rmode);
+        if (l > std::numeric_limits<int>::max() - size + 1)
             throw IEX_NAMESPACE::ArgExc ("Invalid size.");
 
-	numTiles[i] = (l + size - 1) / size;
+        numTiles[i] = (l + size - 1) / size;
     }
 }
 


### PR DESCRIPTION
Addresses https://oss-fuzz.com/testcase-detail/5157125555486720

Signed-off-by: Cary Phillips <cary@ilm.com>