### PR TITLE
re-order shift/compare in FastHuf to prevent undefined shift overflow

### DIFF
--- a/OpenEXR/IlmImf/ImfFastHuf.cpp
+++ b/OpenEXR/IlmImf/ImfFastHuf.cpp
@@ -538,18 +538,24 @@ FastHufDecoder::refill
 
         buffer |= bufferBack >> (64 - numBits);
     }
-    
-    bufferBack         = bufferBack << numBits;
-    bufferBackNumBits -= numBits;
 
-    // 
-    // We can have cases where the previous shift of bufferBack is << 64 - 
-    // in which case no shift occurs. The bit count math still works though,
-    // so if we don't have any bits left, zero out bufferBack.
+
+    //
+    // We can have cases where the previous shift of bufferBack is << 64 -
+    // this is an undefined operation but tends to create just zeroes.
+    // so if we won't have any bits left, zero out bufferBack insetad of computing the shift
     //
 
-    if (bufferBackNumBits == 0)
+    if (bufferBackNumBits <= numBits)
+    {
         bufferBack = 0;
+    }else
+    {
+        bufferBack = bufferBack << numBits;
+    }
+    bufferBackNumBits -= numBits;
+
+
 }
 
 //


### PR DESCRIPTION
[UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) warns at `bufferBack = bufferBack << numBits` when numBits is too large, as that is an undefined operation. In practice this is safe because `bufferBack` was guaranteed to be set to zero in a subsequent check. 
This change reorders operations to prevent the shift being computed in this case, which prevents the warning.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>