### PR TITLE
suppress sanitizer warnings when writing invalid enums

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
@@ -58,6 +58,12 @@ template <>
 void
 DeepImageStateAttribute::writeValueTo
     (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, int version) const
+#if defined (__clang__)
+    // _value may be an invalid value, which the clang sanitizer reports
+    // as undefined behavior, even though the value is acceptable in this
+    // context.
+    __attribute__((no_sanitize ("undefined")))
+#endif
 {
     unsigned char tmp = _value;
     Xdr::write <StreamIO> (os, tmp);

--- a/OpenEXR/IlmImf/ImfEnvmapAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfEnvmapAttribute.cpp
@@ -57,6 +57,12 @@ EnvmapAttribute::staticTypeName ()
 template <>
 void
 EnvmapAttribute::writeValueTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, int version) const
+#if defined (__clang__)
+    // _value may be an invalid value, which the clang sanitizer reports
+    // as undefined behavior, even though the value is acceptable in this
+    // context.
+    __attribute__((no_sanitize ("undefined")))
+#endif
 {
     unsigned char tmp = _value;
     Xdr::write <StreamIO> (os, tmp);


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24969

It is permitted to read DeepImageState and EnvMap attributes that are out-of-range of enums. This allows for new states to be added in the future (see PR #794 and #806). This PR also allows those values to be written so a file with a new, unknown, enum value can be read in and written back out.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>