### PR TITLE
reduce size limit for scanline files; prevent large chunkoffset allocations

### DIFF
--- a/OpenEXR/IlmImf/ImfCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfCompressor.cpp
@@ -176,6 +176,37 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header &hdr)
 }
 
 
+// for a given compression type, return the number of scanlines
+// compressed into a single chunk
+// TODO add to API and move to ImfCompressor.cpp
+int
+numLinesInBuffer(Compression comp)
+{
+    switch(comp)
+    {
+        case NO_COMPRESSION :
+        case RLE_COMPRESSION:
+        case ZIPS_COMPRESSION:
+            return 1;
+        case ZIP_COMPRESSION:
+            return 16;
+        case PIZ_COMPRESSION:
+            return 32;
+        case PXR24_COMPRESSION:
+            return 16;
+        case B44_COMPRESSION:
+        case B44A_COMPRESSION:
+        case DWAA_COMPRESSION:
+            return 32;
+        case DWAB_COMPRESSION:
+            return 256;
+
+        default:
+	        throw IEX_NAMESPACE::ArgExc ("Unknown compression type");
+    }
+}
+
+
 Compressor *
 newTileCompressor (Compression c,
 		   size_t tileLineSize,

--- a/OpenEXR/IlmImf/ImfCompressor.h
+++ b/OpenEXR/IlmImf/ImfCompressor.h
@@ -268,6 +268,14 @@ Compressor *    newTileCompressor (Compression c,
 				   const Header &hdr);
 
 
+//-----------------------------------------------------------------
+// Return the maximum number of scanlines in each chunk
+// of a scanline image using the given compression scheme
+//-----------------------------------------------------------------
+
+IMF_EXPORT
+int              numLinesInBuffer(Compression comp);
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 #endif

--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -1848,38 +1848,7 @@ usesLongNames (const Header &header)
     return false;
 }
 
-namespace
-{
-// for a given compression type, return the number of scanlines
-// compressed into a single chunk
-// TODO add to API and move to ImfCompressor.cpp
-int
-numLinesInBuffer(Compression comp)
-{
-    switch(comp)
-    {
-        case NO_COMPRESSION :
-        case RLE_COMPRESSION:
-        case ZIPS_COMPRESSION:
-            return 1;
-        case ZIP_COMPRESSION:
-            return 16;
-        case PIZ_COMPRESSION:
-            return 32;
-        case PXR24_COMPRESSION:
-            return 16;
-        case B44_COMPRESSION:
-        case B44A_COMPRESSION:
-        case DWAA_COMPRESSION:
-            return 32;
-        case DWAB_COMPRESSION:
-            return 256;
 
-        default:
-	        throw IEX_NAMESPACE::ArgExc ("Unknown compression type");
-    }
-}
-}
 
 int
 getScanlineChunkOffsetTableSize(const Header& header)

--- a/OpenEXR/IlmImf/ImfMisc.h
+++ b/OpenEXR/IlmImf/ImfMisc.h
@@ -476,12 +476,6 @@ IMF_EXPORT
 int getChunkOffsetTableSize(const Header& header,bool deprecated_attribute=false);
 
 
-//
-// return the number of scanlines in each chunk of a scanlineimage for the given scheme
-//
-IMF_EXPORT int
-numLinesInBuffer(Compression comp);
-
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 

--- a/OpenEXR/IlmImf/ImfMisc.h
+++ b/OpenEXR/IlmImf/ImfMisc.h
@@ -475,6 +475,13 @@ bool usesLongNames (const Header &header);
 IMF_EXPORT
 int getChunkOffsetTableSize(const Header& header,bool deprecated_attribute=false);
 
+
+//
+// return the number of scanlines in each chunk of a scanlineimage for the given scheme
+//
+IMF_EXPORT int
+numLinesInBuffer(Compression comp);
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -762,7 +762,7 @@ MultiPartInputFile::Data::readChunkOffsetTables(bool reconstructChunkOffsetTable
         if(chunkOffsetTableSize > gLargeChunkTableSize)
         {
             Int64 pos = is->tellg();
-            is->seekg(pos + (gLargeChunkTableSize-1)*sizeof(Int64));
+            is->seekg(pos + (chunkOffsetTableSize-1)*sizeof(Int64));
             Int64 temp;
             OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*is, temp);
             is->seekg(pos);

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -757,9 +757,11 @@ MultiPartInputFile::Data::readChunkOffsetTables(bool reconstructChunkOffsetTable
         //
         // avoid allocating excessive memory.
         // If the chunktablesize claims to be large,
-        // check the file is big enough to contain the file before allocating memory
+        // check the file is big enough to contain the table before allocating memory.
+        // Attempt to read the last entry in the table. Either the seekg() or the read()
+        // call will throw an exception if the file is too small to contain the table
         //
-        if(chunkOffsetTableSize > gLargeChunkTableSize)
+        if (chunkOffsetTableSize > gLargeChunkTableSize)
         {
             Int64 pos = is->tellg();
             is->seekg(pos + (chunkOffsetTableSize-1)*sizeof(Int64));

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1129,8 +1129,10 @@ void ScanLineInputFile::initialize(const Header& header)
         //
         // avoid allocating excessive memory due to large lineOffsets table size.
         // If the chunktablesize claims to be large,
-        // check the file is big enough to contain the file before allocating memory
-        // in the bytesPerLineTable and the lineOffsets table
+        // check the file is big enough to contain the table before allocating memory
+        // in the bytesPerLineTable and the lineOffsets table.
+        // Attempt to read the last entry in the table. Either the seekg() or the read()
+        // call will throw an exception if the file is too small to contain the table
         //
         if (lineOffsetSize > gLargeChunkTableSize)
         {

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1161,17 +1161,17 @@ void ScanLineInputFile::initialize(const Header& header)
 
 
         //
-        // avoid allocating excessive memory due to large lineOffsets table size
-        // if the chunktablesize claims to be large,
+        // avoid allocating excessive memory due to large lineOffsets table size.
+        // If the chunktablesize claims to be large,
         // check the file is big enough to contain the file before allocating memory
         //
-        if(chunkOffsetTableSize > gLargeChunkTableSize)
+        if(lineOffsetSize > gLargeChunkTableSize)
         {
-            Int64 pos = is->tellg();
-            is->seekg(pos + (gLargeChunkTableSize-1)*sizeof(Int64));
+            Int64 pos = _streamData->is->tellg();
+            _streamData->is->seekg(pos + (lineOffsetSize-1)*sizeof(Int64));
             Int64 temp;
-            OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*is, temp);
-            is->seekg(pos);
+            OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
+            _streamData->is->seekg(pos);
 
         }
 


### PR DESCRIPTION
**This change introduces a new function into the API**
Specially crafted OpenEXR files can cause large amounts of memory to be allocated by the library when reading code, even if the file is very small. This PR proposes two ways to mitigate this:

- regular (non-deep) scanline files are now limited to less than 2GB of uncompressed data per chunk of scanlines, Previously the maximum size was 2GB of compressed data per scanline chunk, and 2GB uncompressed data per scanline
- if the computed chunkoffsettable size in scanline or multipart images is very large, a seek followed by temporary read of the last element in the chunk table is attempted before allocating memory. This may cause slightly slower initialization of OpenEXR files containing huge images. This helps to prevent very small OpenEXR files being used to cause a target machine to allocate large amounts of memory, which may form part of a (very obscure) denial of service attack. With this change, memory is only allocated if the file really does contain enough data to store the declared size of chunk table, which means large memory allocations for the table would require an even larger file to be transferred to the target machine

It is not known if any legitimate EXRs exist that have more than 2GB of uncompressed data per scanline chunk. If so, they will rely on effective compression to prevent the compressed data size exceeding 2GB. Such files will have many channels (in which case using multiple parts would be more appropriate) or very wide scanlines (in which case tiled images would be more appropriate). Uncompressed files, and zip-single compressed files, are not affected by this change.

This PR moves `int numLinesInBuffer(Compression comp)` into ImfCompressor.h and makes it part of the API. It previously was in an anonymous namespace.

Addresses the following oss-fuzz issues:

- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24573
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24857
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25002

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>