### PR TITLE
Avoid overflow in calculateNumTiles when size=MAX_INT

### DIFF
--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -302,10 +302,11 @@ calculateNumTiles (int *numTiles,
     for (int i = 0; i < numLevels; i++)
     {
         int l = levelSize (min, max, i, rmode);
-        if (l > std::numeric_limits<int>::max() - size + 1)
+        
+        if (l > (std::numeric_limits<int>::max() - size) + 1)
             throw IEX_NAMESPACE::ArgExc ("Invalid size.");
 
-        numTiles[i] = (l + size - 1) / size;
+        numTiles[i] = (l + (size - 1)) / size;
     }
 }
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -301,12 +301,9 @@ calculateNumTiles (int *numTiles,
 {
     for (int i = 0; i < numLevels; i++)
     {
-        int l = levelSize (min, max, i, rmode);
-        
-        if (l > (std::numeric_limits<int>::max() - size) + 1)
-            throw IEX_NAMESPACE::ArgExc ("Invalid size.");
-
-        numTiles[i] = (l + (size - 1)) / size;
+        // use 64 bits to avoid int overflow if size is large.
+        Int64 l = levelSize (min, max, i, rmode);
+        numTiles[i] = (l + size - 1) / size;
     }
 }
 


### PR DESCRIPTION
Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25297

Signed-off-by: Cary Phillips <cary@ilm.com>