### PR TITLE
restrict maximum tile size to INT_MAX byte limit

### DIFF
--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -1000,6 +1000,16 @@ TiledInputFile::initialize ()
     _data->tileBufferSize = _data->maxBytesPerTileLine * _data->tileDesc.ySize;
 
     //
+    // OpenEXR has a limit of INT_MAX compressed bytes per tile
+    // disallow uncompressed tile sizes above INT_MAX too to guarantee file is written
+    //
+    if( _data->tileBufferSize > INT_MAX )
+    {
+        throw IEX_NAMESPACE::ArgExc ("Tile size too large for OpenEXR format");
+    }
+
+
+    //
     // Create all the TileBuffers and allocate their internal buffers
     //
 

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -1035,6 +1035,17 @@ TiledOutputFile::initialize (const Header &header)
 
     _data->tileBufferSize = _data->maxBytesPerTileLine * _data->tileDesc.ySize;
      
+        //
+    // OpenEXR has a limit of INT_MAX compressed bytes per tile
+    // disallow uncompressed tile sizes above INT_MAX too to guarantee file is written
+    //
+    if( _data->tileBufferSize > INT_MAX )
+    {
+        throw IEX_NAMESPACE::ArgExc ("Tile size too large for OpenEXR format");
+    }
+
+
+
     //
     // Create all the TileBuffers and allocate their internal buffers
     //


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25315

Similar to #824, but for tiled images. The maximum size of a compressed tile is 2^31 bytes. These changes throw exceptions when writing or reading files with tile sizes and channel counts that would result in uncompressed tile sizes greater than 2^31 bytes. This protects against excessive memory allocation when opening tiled images with specially crafted headers.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>