### PR TITLE
lighter weight reading of Luma-only images via RgbaInputFile

### DIFF
--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -1180,7 +1180,7 @@ RgbaInputFile::RgbaInputFile (const char name[], int numThreads):
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1192,7 +1192,7 @@ RgbaInputFile::RgbaInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int n
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1207,7 +1207,7 @@ RgbaInputFile::RgbaInputFile (const char name[],
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1222,7 +1222,7 @@ RgbaInputFile::RgbaInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1249,27 +1249,42 @@ RgbaInputFile::setFrameBuffer (Rgba *base, size_t xStride, size_t yStride)
 
 	FrameBuffer fb;
 
-	fb.insert (_channelNamePrefix + "R",
-		   Slice (HALF,
-			  (char *) &base[0].r,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
+        if( channels() & WRITE_Y )
+        {
+            fb.insert (_channelNamePrefix + "Y",
+                    Slice (HALF,
+                            (char *) &base[0].r,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+        }
+        else
+        {
 
-	fb.insert (_channelNamePrefix + "G",
-		   Slice (HALF,
-			  (char *) &base[0].g,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
 
-	fb.insert (_channelNamePrefix + "B",
-		   Slice (HALF,
-			  (char *) &base[0].b,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
+            fb.insert (_channelNamePrefix + "R",
+                    Slice (HALF,
+                            (char *) &base[0].r,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
 
+
+
+            fb.insert (_channelNamePrefix + "G",
+                    Slice (HALF,
+                            (char *) &base[0].g,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+
+            fb.insert (_channelNamePrefix + "B",
+                    Slice (HALF,
+                            (char *) &base[0].b,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+        }
 	fb.insert (_channelNamePrefix + "A",
 		   Slice (HALF,
 			  (char *) &base[0].a,
@@ -1292,7 +1307,7 @@ RgbaInputFile::setLayerName (const string &layerName)
 
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 
     FrameBuffer fb;
@@ -1311,6 +1326,28 @@ RgbaInputFile::readPixels (int scanLine1, int scanLine2)
     else
     {
 	_inputFile->readPixels (scanLine1, scanLine2);
+
+        if (channels() & WRITE_Y)
+        {
+            //
+            // Luma channel has been written into red channel
+            // Duplicate into green and blue channel to create gray image
+            //
+            const Slice* s = _inputFile->frameBuffer().findSlice(_channelNamePrefix + "Y");
+            Box2i dataWindow = _inputFile->header().dataWindow();
+
+            for( int scanLine = scanLine1  ; scanLine <= scanLine2 ; scanLine++ )
+            {
+                char* rowBase = s->base + scanLine*s->yStride;
+                for(int x = dataWindow.min.x ; x <= dataWindow.max.x ; ++x )
+                {
+                    Rgba* pixel = reinterpret_cast<Rgba*>(rowBase+x*s->xStride);
+                    pixel->g = pixel->r;
+                    pixel->b = pixel->r;
+                }
+
+            }
+        }
     }
 }
 

--- a/OpenEXR/IlmImfTest/testYca.cpp
+++ b/OpenEXR/IlmImfTest/testYca.cpp
@@ -195,6 +195,7 @@ writeReadYca (const char fileName[],
 	    else
 	    {
 		assert (p1.g == p2.g);
+		assert (p1.b == p2.b);
 	    }
 
 	    if (channels & WRITE_A)


### PR DESCRIPTION
When using the RgbaInputFile interface to read files, images which contain only a 'Y' (luma) channel are read using the Yca interface, which also does chroma conversion/filtering. This has extra memory and processing overhead. This change special-cases files that do not have any chroma channels (BY or RY channels)

Relates to issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25326

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>