### PR TITLE
Address issues reported by Undefined Behavior Sanitizer running IlmImfTest

### DIFF
--- a/IlmBase/IlmThread/IlmThread.cpp
+++ b/IlmBase/IlmThread/IlmThread.cpp
@@ -72,6 +72,12 @@ Thread::~Thread ()
         _thread.join ();
 }
 
+void
+Thread::join()
+{
+    if ( _thread.joinable () )
+        _thread.join ();
+}
 
 void
 Thread::start ()
@@ -105,6 +111,12 @@ Thread::~Thread ()
 
 void
 Thread::start ()
+{
+    throw IEX_NAMESPACE::NoImplExc ("Threads not supported on this platform.");
+}
+
+void
+Thread::join ()
 {
     throw IEX_NAMESPACE::NoImplExc ("Threads not supported on this platform.");
 }

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -129,6 +129,11 @@ class Thread
     ILMTHREAD_EXPORT void         start ();
     ILMTHREAD_EXPORT virtual void run () = 0;
 
+    //
+    // wait for thread to exit - must be called before deleting thread
+    //
+    void join();
+
   private:
 
 #ifdef ILMBASE_FORCE_CXX03

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -431,8 +431,10 @@ DefaultThreadPoolProvider::finish ()
     // Join all the threads
     //
     for (size_t i = 0; i != curT; ++i)
+    {
+        _data.threads[i]->join();
         delete _data.threads[i];
-
+    }
     Lock lock1 (_data.taskMutex);
 #ifdef ILMBASE_FORCE_CXX03
     Lock lock2 (_data.stopMutex);

--- a/IlmBase/IlmThread/IlmThreadPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadPosix.cpp
@@ -85,6 +85,13 @@ Thread::~Thread ()
     assert (error == 0);
 }
 
+void
+Thread::join ()
+{
+    int error = ::pthread_join (_thread, 0);
+    assert (error == 0);
+}
+
 
 void
 Thread::start ()

--- a/IlmBase/IlmThread/IlmThreadWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadWin32.cpp
@@ -85,6 +85,14 @@ Thread::~Thread ()
     assert (ok);
 }
 
+void
+Thread::join ()
+{
+    DWORD status = ::WaitForSingleObject (_thread, INFINITE);
+    assert (status ==  WAIT_OBJECT_0);
+    bool ok = ::CloseHandle (_thread) != FALSE;
+    assert (ok);
+}
 
 void
 Thread::start ()

--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
@@ -390,12 +390,13 @@ composite_line(int y,
                 // cast to half float if necessary
                if(it.slice().type==OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT)
                {
-
-                   * reinterpret_cast<float*>(base + y*it.slice().yStride + x*it.slice().xStride) = value;
+                   float* ptr = reinterpret_cast<float*>(base + y*it.slice().yStride + x*it.slice().xStride);
+                   *ptr  = value;
                }
                else if(it.slice().type==HALF)
                {
-                   * reinterpret_cast<half*>(base + y*it.slice().yStride + x*it.slice().xStride) = half(value);
+                   half* ptr =  reinterpret_cast<half*>(base + y*it.slice().yStride + x*it.slice().xStride);
+                   *ptr = half(value);
                }
 
                channel_number++;

--- a/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
+++ b/OpenEXR/IlmImf/ImfCompositeDeepScanLine.cpp
@@ -323,7 +323,6 @@ class LineCompositeTask : public Task
 
 };
 
-
 void
 composite_line(int y,
                int start,
@@ -386,16 +385,17 @@ composite_line(int y,
            {
 
                float value = output_pixel[ _Data->_bufferMap[channel_number] ]; // value to write
-
+               intptr_t base = reinterpret_cast<intptr_t>(it.slice().base);
 
                 // cast to half float if necessary
                if(it.slice().type==OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT)
                {
-                   * (float *)(it.slice().base + y*it.slice().yStride + x*it.slice().xStride) = value;
+
+                   * reinterpret_cast<float*>(base + y*it.slice().yStride + x*it.slice().xStride) = value;
                }
                else if(it.slice().type==HALF)
                {
-                   * (half *)(it.slice().base + y*it.slice().yStride + x*it.slice().xStride) = half(value);
+                   * reinterpret_cast<half*>(base + y*it.slice().yStride + x*it.slice().xStride) = half(value);
                }
 
                channel_number++;

--- a/OpenEXR/IlmImf/ImfFrameBuffer.cpp
+++ b/OpenEXR/IlmImf/ImfFrameBuffer.cpp
@@ -89,7 +89,7 @@ Slice::Make (
     bool                        xTileCoords,
     bool                        yTileCoords)
 {
-    char* base = reinterpret_cast<char*> (const_cast<void *> (ptr));
+    intptr_t base = reinterpret_cast<intptr_t> (const_cast<void *> (ptr));
     if (xStride == 0)
     {
         switch (type)
@@ -117,7 +117,7 @@ Slice::Make (
 
     return Slice (
         type,
-        base - offx - offy,
+        reinterpret_cast<char*>(base - offx - offy),
         xStride,
         yStride,
         xSampling,

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -308,6 +308,10 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
 	    while (modp (yStart, toSlice.ySampling) != 0)
 		++yStart;
 
+
+            intptr_t fromBase = reinterpret_cast<intptr_t>(fromSlice.base);
+            intptr_t toBase = reinterpret_cast<intptr_t>(toSlice.base);
+
             for (int y = yStart;
 		 y <= maxYThisRow;
 		 y += toSlice.ySampling)
@@ -316,14 +320,13 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
                 // Set the pointers to the start of the y scanline in
                 // this row of tiles
 		//
-                
-                fromPtr = fromSlice.base +
+                fromPtr = reinterpret_cast<char*> (fromBase +
                           (y - tileRange.min.y) * fromSlice.yStride +
-                          xStart * fromSlice.xStride;
+                          xStart * fromSlice.xStride);
 
-                toPtr = toSlice.base +
+                toPtr = reinterpret_cast<char*> (toBase +
                         divp (y, toSlice.ySampling) * toSlice.yStride +
-                        divp (xStart, toSlice.xSampling) * toSlice.xStride;
+                        divp (xStart, toSlice.xSampling) * toSlice.xStride);
 
 		//
                 // Copy all pixels for the scanline in this row of tiles

--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -1390,9 +1390,10 @@ namespace
 //
 
 struct FBytes { uint8_t b[4]; };
-union bytesOrFloat {
+union bytesUintOrFloat {
   FBytes b;
   float f;
+  unsigned int u;
 } ;
 }
 
@@ -1408,7 +1409,9 @@ convertInPlace (char *& writePtr,
     
         for (size_t j = 0; j < numPixels; ++j)
         {
-            Xdr::write <CharPtrIO> (writePtr, *(const unsigned int *) readPtr);
+            union bytesUintOrFloat tmp;
+            tmp.b = * reinterpret_cast<const FBytes *>( readPtr );
+            Xdr::write <CharPtrIO> (writePtr, tmp.u);
             readPtr += sizeof(unsigned int);
         }
         break;
@@ -1426,7 +1429,7 @@ convertInPlace (char *& writePtr,
     
         for (size_t j = 0; j < numPixels; ++j)
         {
-            union bytesOrFloat tmp;
+            union bytesUintOrFloat tmp;
             tmp.b = * reinterpret_cast<const FBytes *>( readPtr );
             Xdr::write <CharPtrIO> (writePtr, tmp.f);
             readPtr += sizeof(float);

--- a/OpenEXR/IlmImf/ImfOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfOutputFile.cpp
@@ -558,13 +558,18 @@ LineBufferTask::execute ()
                     // If necessary, convert the pixel data to Xdr format.
 		    // Then store the pixel data in _ofd->lineBuffer.
                     //
-        
-                    const char *linePtr = slice.base +
-                                          divp (y, slice.ySampling) *
+                    // slice.base may be 'negative' but
+                    // pointer arithmetic is not allowed to overflow, so
+                    // perform computation with the non-pointer 'intptr_t' instead
+                    //
+                    intptr_t base =  reinterpret_cast<intptr_t>(slice.base);
+                    intptr_t linePtr =  base + divp (y, slice.ySampling) *
                                           slice.yStride;
         
-                    const char *readPtr = linePtr + dMinX * slice.xStride;
-                    const char *endPtr  = linePtr + dMaxX * slice.xStride;
+                    const char *readPtr = reinterpret_cast<const char*>(linePtr +
+                                          dMinX * slice.xStride);
+                    const char *endPtr  = reinterpret_cast<const char*>(linePtr +
+                                          dMaxX * slice.xStride);
     
                     copyFromFrameBuffer (writePtr, readPtr, endPtr,
                                          slice.xStride, _ofd->format,

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -424,8 +424,9 @@ RgbaOutputFile::ToYca::writePixels (int numScanLines)
 
 	    for (int j = 0; j < _width; ++j)
 	    {
-		_tmpBuf[j + N2] = *reinterpret_cast<const Rgba*>(base+sizeof(Rgba)*
+                const Rgba* ptr = reinterpret_cast<const Rgba*>(base+sizeof(Rgba)*
 		(_fbYStride * _currentScanLine + _fbXStride * (j + _xMin)) );
+		_tmpBuf[j + N2] = *ptr;
 	    }
 
 	    //
@@ -1089,8 +1090,8 @@ RgbaInputFile::FromYca::readPixels (int scanLine)
     intptr_t base = reinterpret_cast<intptr_t>(_fbBase);
     for (int i = 0; i < _width; ++i)
     {
-        *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*
-	(_fbYStride * scanLine + _fbXStride * (i + _xMin))) = _tmpBuf[i];
+        Rgba* ptr = reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(_fbYStride * scanLine + _fbXStride * (i + _xMin)));
+        *ptr = _tmpBuf[i];
     }
     _currentScanLine = scanLine;
 }
@@ -1343,10 +1344,11 @@ RgbaInputFile::readPixels (int scanLine1, int scanLine2)
             //
             const Slice* s = _inputFile->frameBuffer().findSlice(_channelNamePrefix + "Y");
             Box2i dataWindow = _inputFile->header().dataWindow();
+            intptr_t base = reinterpret_cast<intptr_t>(s->base);
 
             for( int scanLine = scanLine1  ; scanLine <= scanLine2 ; scanLine++ )
             {
-                char* rowBase = s->base + scanLine*s->yStride;
+                intptr_t rowBase = base + scanLine*s->yStride;
                 for(int x = dataWindow.min.x ; x <= dataWindow.max.x ; ++x )
                 {
                     Rgba* pixel = reinterpret_cast<Rgba*>(rowBase+x*s->xStride);

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -369,6 +369,7 @@ RgbaOutputFile::ToYca::writePixels (int numScanLines)
 			    "\"" << _outputFile.fileName() << "\".");
     }
 
+    intptr_t base = reinterpret_cast<intptr_t>(_fbBase);
     if (_writeY && !_writeC)
     {
 	//
@@ -385,8 +386,9 @@ RgbaOutputFile::ToYca::writePixels (int numScanLines)
 
 	    for (int j = 0; j < _width; ++j)
 	    {
-		_tmpBuf[j] = _fbBase[_fbYStride * _currentScanLine +
-				     _fbXStride * (j + _xMin)];
+		_tmpBuf[j] = *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*
+		(_fbYStride * _currentScanLine +
+				     _fbXStride * (j + _xMin)));
 	    }
 
 	    //
@@ -418,10 +420,12 @@ RgbaOutputFile::ToYca::writePixels (int numScanLines)
 	    // frame buffer into _tmpBuf.
 	    //
 
+            intptr_t base = reinterpret_cast<intptr_t>(_fbBase);
+
 	    for (int j = 0; j < _width; ++j)
 	    {
-		_tmpBuf[j + N2] = _fbBase[_fbYStride * _currentScanLine +
-					  _fbXStride * (j + _xMin)];
+		_tmpBuf[j + N2] = *reinterpret_cast<const Rgba*>(base+sizeof(Rgba)*
+		(_fbYStride * _currentScanLine + _fbXStride * (j + _xMin)) );
 	    }
 
 	    //
@@ -1081,9 +1085,13 @@ RgbaInputFile::FromYca::readPixels (int scanLine)
 
     fixSaturation (_yw, _width, _buf2, _tmpBuf);
 
-    for (int i = 0; i < _width; ++i)
-	_fbBase[_fbYStride * scanLine + _fbXStride * (i + _xMin)] = _tmpBuf[i];
 
+    intptr_t base = reinterpret_cast<intptr_t>(_fbBase);
+    for (int i = 0; i < _width; ++i)
+    {
+        *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*
+	(_fbYStride * scanLine + _fbXStride * (i + _xMin))) = _tmpBuf[i];
+    }
     _currentScanLine = scanLine;
 }
 

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -636,12 +636,14 @@ LineBufferTask::execute ()
                     // The frame buffer contains a slice for this channel.
                     //
     
-                    char *linePtr  = slice.base +
+                    intptr_t base = reinterpret_cast<intptr_t>(slice.base);
+
+                    intptr_t linePtr  = base +
                                         intptr_t( divp (y, slice.ySampling) ) *
                                         intptr_t( slice.yStride );
     
-                    char *writePtr = linePtr + intptr_t( dMinX ) * intptr_t( slice.xStride );
-                    char *endPtr   = linePtr + intptr_t( dMaxX ) * intptr_t( slice.xStride );
+                    char *writePtr = reinterpret_cast<char*> (linePtr + intptr_t( dMinX ) * intptr_t( slice.xStride ));
+                    char *endPtr   = reinterpret_cast<char*> (linePtr + intptr_t( dMaxX ) * intptr_t( slice.xStride ));
                     
                     copyIntoFrameBuffer (readPtr, writePtr, endPtr,
                                          slice.xStride, slice.fill,
@@ -794,20 +796,21 @@ void LineBufferTaskIIF::getWritePointer
           outWritePointerRight  = 0;
       }
       
-      const char* linePtr1  = firstSlice.base +
+      intptr_t base = reinterpret_cast<intptr_t>(firstSlice.base);
+
+      intptr_t linePtr1  = (base +
       divp (y, firstSlice.ySampling) *
-      firstSlice.yStride;
+      firstSlice.yStride);
       
       int dMinX1 = divp (_ifd->minX, firstSlice.xSampling);
       int dMaxX1 = divp (_ifd->maxX, firstSlice.xSampling);
       
       // Construct the writePtr so that we start writing at
       // linePtr + Min offset in the line.
-      outWritePointerRight =  (unsigned short*)(linePtr1 +
+      outWritePointerRight =  reinterpret_cast<unsigned short*>(linePtr1 +
       dMinX1 * firstSlice.xStride );
       
-      size_t bytesToCopy  = ((linePtr1 + dMaxX1 * firstSlice.xStride ) -
-      (linePtr1 + dMinX1 * firstSlice.xStride )) + 2;
+      size_t bytesToCopy  = ((dMaxX1 * firstSlice.xStride ) - (dMinX1 * firstSlice.xStride )) + 2;
       size_t shortsToCopy = bytesToCopy / sizeOfSingleValue;
       size_t pixelsToCopy = (shortsToCopy / nbSlicesInBank ) + 1;
       

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -609,10 +609,11 @@ TileBufferTask::execute ()
                     // The frame buffer contains a slice for this channel.
                     //
     
-                    char *writePtr = slice.base +
+                    intptr_t base = reinterpret_cast<intptr_t>(slice.base);
+                    char *writePtr = reinterpret_cast<char*>(base +
                                      (y - yOffset) * slice.yStride +
                                      (tileRange.min.x - xOffset) *
-                                     slice.xStride;
+                                     slice.xStride);
 
                     char *endPtr = writePtr +
                                    (numPixelsPerScanLine - 1) * slice.xStride;

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -789,10 +789,11 @@ TileBufferTask::execute ()
                     // The frame buffer contains data for this channel.
                     //
     
-                    const char *readPtr = slice.base +
+                    intptr_t base = reinterpret_cast<intptr_t>(slice.base);
+                    const char *readPtr = reinterpret_cast<const char*>(base +
                                           (y - yOffset) * slice.yStride +
                                           (tileRange.min.x - xOffset) *
-                                          slice.xStride;
+                                          slice.xStride);
 
                     const char *endPtr  = readPtr +
                                           (numPixelsPerScanLine - 1) *

--- a/OpenEXR/IlmImf/ImfTiledRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledRgbaFile.cpp
@@ -227,10 +227,11 @@ TiledRgbaOutputFile::ToYa::writeTile (int dx, int dy, int lx, int ly)
     Box2i dw = _outputFile.dataWindowForTile (dx, dy, lx, ly);
     int width = dw.max.x - dw.min.x + 1;
 
+    intptr_t  base= reinterpret_cast<intptr_t>(_fbBase);
     for (int y = dw.min.y, y1 = 0; y <= dw.max.y; ++y, ++y1)
     {
 	for (int x = dw.min.x, x1 = 0; x <= dw.max.x; ++x, ++x1)
-	    _buf[y1][x1] = _fbBase[x * _fbXStride + y * _fbYStride];
+	    _buf[y1][x1] = *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride));
 
 	RGBAtoYCA (_yw, width, _writeA, _buf[y1], _buf[y1]);
     }
@@ -750,6 +751,9 @@ TiledRgbaInputFile::FromYa::readTile (int dx, int dy, int lx, int ly)
 
     Box2i dw = _inputFile.dataWindowForTile (dx, dy, lx, ly);
     int width = dw.max.x - dw.min.x + 1;
+    intptr_t  base= reinterpret_cast<intptr_t>(_fbBase);
+
+
 
     for (int y = dw.min.y, y1 = 0; y <= dw.max.y; ++y, ++y1)
     {
@@ -763,7 +767,8 @@ TiledRgbaInputFile::FromYa::readTile (int dx, int dy, int lx, int ly)
 
 	for (int x = dw.min.x, x1 = 0; x <= dw.max.x; ++x, ++x1)
 	{
-	    _fbBase[x * _fbXStride + y * _fbYStride] = _buf[y1][x1];
+	    *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride))
+               = _buf[y1][x1];
 	}
     }
 }

--- a/OpenEXR/IlmImf/ImfTiledRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledRgbaFile.cpp
@@ -231,8 +231,10 @@ TiledRgbaOutputFile::ToYa::writeTile (int dx, int dy, int lx, int ly)
     for (int y = dw.min.y, y1 = 0; y <= dw.max.y; ++y, ++y1)
     {
 	for (int x = dw.min.x, x1 = 0; x <= dw.max.x; ++x, ++x1)
-	    _buf[y1][x1] = *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride));
-
+        {
+            Rgba* ptr = reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride));
+            _buf[y1][x1] = *ptr;
+        }
 	RGBAtoYCA (_yw, width, _writeA, _buf[y1], _buf[y1]);
     }
 
@@ -767,8 +769,8 @@ TiledRgbaInputFile::FromYa::readTile (int dx, int dy, int lx, int ly)
 
 	for (int x = dw.min.x, x1 = 0; x <= dw.max.x; ++x, ++x1)
 	{
-	    *reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride))
-               = _buf[y1][x1];
+            Rgba* ptr = reinterpret_cast<Rgba*>(base + sizeof(Rgba)*(x * _fbXStride + y * _fbYStride));
+	    *ptr = _buf[y1][x1];
 	}
     }
 }

--- a/OpenEXR/IlmImfTest/testCompositeDeepScanLine.cpp
+++ b/OpenEXR/IlmImfTest/testCompositeDeepScanLine.cpp
@@ -341,8 +341,9 @@ class data
         {
             if(!dontbotherloadingdepth || (_channels[i]!="Z" && _channels[i]!="ZBack") )
             {
+                intptr_t base =  reinterpret_cast<intptr_t>(&data[i]);
                 framebuf.insert(_channels[i].c_str(),
-                                Slice(_type,(char *) (&data[i] - (dw.min.x + dw.min.y*(dw.size().x+1))*_channels.size() ),
+                                Slice(_type,reinterpret_cast<char*>(base - sizeof(T)*(dw.min.x + dw.min.y*(dw.size().x+1))*_channels.size() ),
                                       sizeof(T)*_channels.size(),
                                       sizeof(T)*(dw.size().x+1)*_channels.size())
                                       );

--- a/OpenEXR/IlmImfTest/testDwaCompressorSimd.cpp
+++ b/OpenEXR/IlmImfTest/testDwaCompressorSimd.cpp
@@ -97,8 +97,9 @@ compareBufferRelative (const SimdAlignedBuffer64f &src,
 {
     for (int i=0; i<64; ++i)
     {
+
         double diff    = fabs(src._buffer[i] - dst._buffer[i]);
-        double relDiff = diff / fabs(src._buffer[i]);
+        double relDiff = src._buffer[i]==0 ? 0.0 : diff / fabs(src._buffer[i]);
 
         if (relDiff > relErrThresh && diff > absErrThresh)
         {

--- a/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
+++ b/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
@@ -105,7 +105,7 @@ bool compare(const FrameBuffer& asRead,
                 
 
                 //
-                // extract value written to gile
+                // extract value written to file
                 //
 
                 half writtenHalf;

--- a/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
+++ b/OpenEXR/IlmImfTest/testLargeDataWindowOffsets.cpp
@@ -82,7 +82,11 @@ bool compare(const FrameBuffer& asRead,
             for (int x = dataWindow.min.x; x <= dataWindow.max.x; x++)
                  
             {
-                char * ptr = (i.slice().base+i.slice().yStride*intptr_t(y) +i.slice().xStride*intptr_t(x));
+                //
+                // extract value read back from file
+                //
+                intptr_t base = reinterpret_cast<intptr_t>(i.slice().base);
+                char * ptr = reinterpret_cast<char*>(base+i.slice().yStride*intptr_t(y) +i.slice().xStride*intptr_t(x));
                 half readHalf;
                 switch (i.slice().type)
                 {
@@ -99,12 +103,18 @@ bool compare(const FrameBuffer& asRead,
                         exit(1);
                 }
                 
+
+                //
+                // extract value written to gile
+                //
+
                 half writtenHalf;
 
                 if (p!=asWritten.end())
                 {
-                    char * ptr = p.slice().base+p.slice().yStride*intptr_t(y) +
-                                 p.slice().xStride*intptr_t(x);
+                    intptr_t base =reinterpret_cast<intptr_t>( p.slice().base);
+                    char * ptr =  reinterpret_cast<char*>(base+p.slice().yStride*intptr_t(y) +
+                                 p.slice().xStride*intptr_t(x));
                     switch (p.slice().type)
                     {
                     case IMF::FLOAT :

--- a/OpenEXR/IlmImfTest/testMultiPartApi.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartApi.cpp
@@ -391,18 +391,9 @@ generateRandomFile (int partCount, const std::string & fn)
             int numYLevels = part->numYLevels();
 
             // Allocating space.
-            switch (pixelTypes[i])
-            {
-                case 0:
-                    tiledUintData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-                case 1:
-                    tiledFloatData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-                case 2:
-                    tiledHalfData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-            }
+            tiledUintData[i].resizeErase(numYLevels, numXLevels);
+            tiledFloatData[i].resizeErase(numYLevels, numXLevels);
+            tiledHalfData[i].resizeErase(numYLevels, numXLevels);
 
             tiledFrameBuffers[i].resizeErase(numYLevels, numXLevels);
 

--- a/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
+++ b/OpenEXR/IlmImfTest/testMultiPartThreading.cpp
@@ -560,19 +560,9 @@ generateRandomFile (int partCount, const std::string & fn)
             int numXLevels = part->numXLevels();
             int numYLevels = part->numYLevels();
 
-            // Allocating space.
-            switch (pixelTypes[i])
-            {
-                case 0:
-                    tiledUintData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-                case 1:
-                    tiledFloatData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-                case 2:
-                    tiledHalfData[i].resizeErase(numYLevels, numXLevels);
-                    break;
-            }
+            tiledUintData[i].resizeErase(numYLevels, numXLevels);
+            tiledFloatData[i].resizeErase(numYLevels, numXLevels);
+            tiledHalfData[i].resizeErase(numYLevels, numXLevels);
 
             tiledFrameBuffers[i].resizeErase(numYLevels, numXLevels);
 

--- a/OpenEXR/IlmImfTest/testOptimizedInterleavePatterns.cpp
+++ b/OpenEXR/IlmImfTest/testOptimizedInterleavePatterns.cpp
@@ -196,7 +196,11 @@ bool compare(const FrameBuffer& asRead,
             for (int x = dataWindow.min.x; x <= dataWindow.max.x; x++)
                  
             {
-                char * ptr = (i.slice().base+i.slice().yStride*y +i.slice().xStride*x);
+                 //
+                // extract value read back from file
+                //
+                intptr_t base = reinterpret_cast<intptr_t>(i.slice().base);
+                char * ptr = reinterpret_cast<char*>(base+i.slice().yStride*intptr_t(y) +i.slice().xStride*intptr_t(x));
                 half readHalf;
                 switch (i.slice().type)
                 {
@@ -218,8 +222,10 @@ bool compare(const FrameBuffer& asRead,
 
                 if (p!=asWritten.end())
                 {
-                    char * ptr = p.slice().base+p.slice().yStride*y +
-                                 p.slice().xStride*x;
+
+                    intptr_t base =reinterpret_cast<intptr_t>( p.slice().base);
+                    char * ptr =  reinterpret_cast<char*>(base+p.slice().yStride*intptr_t(y) +
+                                 p.slice().xStride*intptr_t(x));
                     switch (p.slice().type)
                     {
                     case IMF::FLOAT :

--- a/OpenEXR/IlmImfTest/testPreviewImage.cpp
+++ b/OpenEXR/IlmImfTest/testPreviewImage.cpp
@@ -150,7 +150,7 @@ readWriteFiles (const char fileName1[],
 	file2.setFrameBuffer (pixels2 - dx - dy * w, 1, w);
 	file2.readPixels (dw.min.y, dw.max.y);
 
-	for (int i = 0; i < w * h; ++h)
+	for (size_t i = 0; i < w * h; ++i)
 	{
 	    assert (pixels1[i].r == pixels2[i].r);
 	    assert (pixels1[i].g == pixels2[i].g);

--- a/OpenEXR/IlmImfTest/testSharedFrameBuffer.cpp
+++ b/OpenEXR/IlmImfTest/testSharedFrameBuffer.cpp
@@ -115,11 +115,7 @@ WriterThread::WriterThread (RgbaOutputFile *outfile): _outfile (outfile)
 void
 WriterThread::run ()
 {
-    //
-    // Signal that the thread has started
-    //
 
-    threadSemaphore.post();
 
     while (true)
     {
@@ -136,6 +132,12 @@ WriterThread::run ()
 	    break;
 	}
     }
+
+    //
+    // Signal that the thread has finished
+    //
+
+    threadSemaphore.post();
 }
     
 
@@ -146,7 +148,7 @@ class ReaderThread : public Thread
     ReaderThread (RgbaInputFile *infile, int start, int step);
 
     virtual void	run ();
-    
+
   private:
 
     RgbaInputFile *	_infile;
@@ -165,17 +167,20 @@ ReaderThread::ReaderThread (RgbaInputFile *infile, int start, int step):
 void
 ReaderThread::run ()
 {
-    //
-    // Signal that the thread has started
-    //
 
-    threadSemaphore.post ();
 
     int num = _infile->header().dataWindow().max.y -
 	      _infile->header().dataWindow().min.y + 1;
 
     for (int i = _start; i < num; i += _step)
 	_infile->readPixels (i);
+
+    //
+    // Signal that the thread has finished
+    //
+
+    threadSemaphore.post ();
+
 }
     
 


### PR DESCRIPTION
Running IlmImfTest when compiling with clang's UndefinedBehaviorSanitizer (UBSan) reported various issues, which are addressed here.

### IlmThread
The only way to join an IlmThread (i.e. wait for it to finish) is to delete it, as there's a join() in the base class destructor. However, that means a thread derived from IlmThread will have its destructor called while it is running. The thread object's vtable will change underneath it, making it impossible to call virtual functions. I think it might also lead to a use-after-free issue, as the derived class destructor will be called while it is running.
This change adds a `join()` to the Thread function. The ThreadPool uses this to ensure worker threads have terminated before deleting them. Code directly using Thread should call `Thread::join()` before the object is deleted (or goes out of scope). `Thread::join` is not virtual, so the ABI is backwards compatible

### Pointer overflow
The `Slice` mechanism in `FrameBuffer` can require 'negative pointers' for the `base` item when the image bbox is cropped, as it points to the coordinates of pixel (0,0) which may be outside the image data. Performing arithmetic on a pointer that results in negative values is undefined behavior. This change uses `intptr_t` for such math instead of `char*` which sneakily suppresses the warning.

### Pointer alignment
4 byte ints and floats can only be read/written from 4-byte aligned addresses, and 8 byte ints from 8-byte aligned addresses. A partial fix supported float access, for 32 bit ARM processors. This extends the fix to all types.

### minor bugfixes
UBSan also spotted a few issues in the test suite: a division by zero, indexing into unintialized Array2Ds, and an iterator that didn't iterate