### PR TITLE
Use Int64 in dataWindowForTile to prevent integer overflow

### DIFF
--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -97,13 +97,14 @@ dataWindowForTile (const TileDescription &tileDesc,
     V2i tileMin = V2i (minX + dx * tileDesc.xSize,
 		       minY + dy * tileDesc.ySize);
 
-    V2i tileMax = tileMin + V2i (tileDesc.xSize - 1, tileDesc.ySize - 1);
+    Int64 tileMaxX = Int64(tileMin[0]) + tileDesc.xSize - 1;
+    Int64 tileMaxY = Int64(tileMin[1]) + tileDesc.ySize - 1;
 
     V2i levelMax = dataWindowForLevel
 		       (tileDesc, minX, maxX, minY, maxY, lx, ly).max;
 
-    tileMax = V2i (std::min (tileMax[0], levelMax[0]),
-		   std::min (tileMax[1], levelMax[1]));
+    V2i tileMax = V2i (std::min (tileMaxX, Int64(levelMax[0])),
+		   std::min (tileMaxY, Int64(levelMax[1])));
 
     return Box2i (tileMin, tileMax);
 }

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -97,14 +97,14 @@ dataWindowForTile (const TileDescription &tileDesc,
     V2i tileMin = V2i (minX + dx * tileDesc.xSize,
 		       minY + dy * tileDesc.ySize);
 
-    Int64 tileMaxX = Int64(tileMin[0]) + tileDesc.xSize - 1;
-    Int64 tileMaxY = Int64(tileMin[1]) + tileDesc.ySize - 1;
+    int64_t tileMaxX = int64_t(tileMin[0]) + tileDesc.xSize - 1;
+    int64_t tileMaxY = int64_t(tileMin[1]) + tileDesc.ySize - 1;
 
     V2i levelMax = dataWindowForLevel
 		       (tileDesc, minX, maxX, minY, maxY, lx, ly).max;
 
-    V2i tileMax = V2i (std::min (tileMaxX, Int64(levelMax[0])),
-		   std::min (tileMaxY, Int64(levelMax[1])));
+    V2i tileMax = V2i (std::min (tileMaxX, int64_t(levelMax[0])),
+		   std::min (tileMaxY, int64_t(levelMax[1])));
 
     return Box2i (tileMin, tileMax);
 }


### PR DESCRIPTION
Intermediate calculation in Imf::dataWindowForTile overflowed if dataWindow.min + tileSize was larger than INT_MAX, potentially causing insufficient memory allocation. Throw some more bits at the problem.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25505

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>