### PR TITLE
fix undefined behavior: clamp shift in B44 Decompress

### DIFF
--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -951,7 +951,10 @@ B44Compressor::uncompress (const char *inPtr,
 		if (inSize < 3)
 		    notEnoughData();
 
-		if (((const unsigned char *)inPtr)[2] == 0xfc)
+                //
+                // If shift exponent is 63, call unpack14 (ignoring unused bits)
+                //
+		if (((const unsigned char *)inPtr)[2] >= (13<<2) )
 		{
 		    unpack3 ((const unsigned char *)inPtr, s);
 		    inPtr += 3;

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -383,33 +383,32 @@ unpack14 (const unsigned char b[14], unsigned short s[16])
 
 
     //
-    //TODO unverified fix for undefined behavior
-    // (0x20 << shift) will overflow 32 bit int if 'shift' is greater than 26
-    // this should only occur in corrupt files. Clamping 'shift' to 26
-    // prevents undefined behavior in this circumstance (but cast to unsigned short
-    // will still overflow)
+    // shifting unsigned ints by more than 31 bits is undefined behavior
+    // clamp shift to 31 to enforce consistent handling
     //
-    unsigned short shift = std::min( 26 , b[ 2] >> 2);
-    unsigned short bias = (0x20 << shift);
+    //
 
-    s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3f) << shift) - bias;
-    s[ 8] = s[ 4] + ((((b[ 3] << 2) | (b[ 4] >> 6)) & 0x3f) << shift) - bias;
-    s[12] = s[ 8] +   ((b[ 4]                       & 0x3f) << shift) - bias;
+    unsigned short shift = std::min( 31 , b[ 2] >> 2);
+    unsigned short bias = (0x20u << shift);
+
+    s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3fu) << shift) - bias;
+    s[ 8] = s[ 4] + ((((b[ 3] << 2) | (b[ 4] >> 6)) & 0x3fu) << shift) - bias;
+    s[12] = s[ 8] +   ((b[ 4]                       & 0x3fu) << shift) - bias;
     
-    s[ 1] = s[ 0] +   ((b[ 5] >> 2)                         << shift) - bias;
-    s[ 5] = s[ 4] + ((((b[ 5] << 4) | (b[ 6] >> 4)) & 0x3f) << shift) - bias;
-    s[ 9] = s[ 8] + ((((b[ 6] << 2) | (b[ 7] >> 6)) & 0x3f) << shift) - bias;
-    s[13] = s[12] +   ((b[ 7]                       & 0x3f) << shift) - bias;
+    s[ 1] = s[ 0] +   ((unsigned int) (b[ 5] >> 2)           << shift) - bias;
+    s[ 5] = s[ 4] + ((((b[ 5] << 4) | (b[ 6] >> 4)) & 0x3fu) << shift) - bias;
+    s[ 9] = s[ 8] + ((((b[ 6] << 2) | (b[ 7] >> 6)) & 0x3fu) << shift) - bias;
+    s[13] = s[12] +   ((b[ 7]                       & 0x3fu) << shift) - bias;
     
-    s[ 2] = s[ 1] +   ((b[ 8] >> 2)                         << shift) - bias;
-    s[ 6] = s[ 5] + ((((b[ 8] << 4) | (b[ 9] >> 4)) & 0x3f) << shift) - bias;
-    s[10] = s[ 9] + ((((b[ 9] << 2) | (b[10] >> 6)) & 0x3f) << shift) - bias;
-    s[14] = s[13] +   ((b[10]                       & 0x3f) << shift) - bias;
+    s[ 2] = s[ 1] +   ((unsigned int)(b[ 8] >> 2)            << shift) - bias;
+    s[ 6] = s[ 5] + ((((b[ 8] << 4) | (b[ 9] >> 4)) & 0x3fu) << shift) - bias;
+    s[10] = s[ 9] + ((((b[ 9] << 2) | (b[10] >> 6)) & 0x3fu) << shift) - bias;
+    s[14] = s[13] +   ((b[10]                       & 0x3fu) << shift) - bias;
     
-    s[ 3] = s[ 2] +   ((b[11] >> 2)                         << shift) - bias;
-    s[ 7] = s[ 6] + ((((b[11] << 4) | (b[12] >> 4)) & 0x3f) << shift) - bias;
-    s[11] = s[10] + ((((b[12] << 2) | (b[13] >> 6)) & 0x3f) << shift) - bias;
-    s[15] = s[14] +   ((b[13]                       & 0x3f) << shift) - bias;
+    s[ 3] = s[ 2] +   ((unsigned int)(b[11] >> 2)            << shift) - bias;
+    s[ 7] = s[ 6] + ((((b[11] << 4) | (b[12] >> 4)) & 0x3fu) << shift) - bias;
+    s[11] = s[10] + ((((b[12] << 2) | (b[13] >> 6)) & 0x3fu) << shift) - bias;
+    s[15] = s[14] +   ((b[13]                       & 0x3fu) << shift) - bias;
 
     for (int i = 0; i < 16; ++i)
     {

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -380,7 +380,16 @@ unpack14 (const unsigned char b[14], unsigned short s[16])
 
     s[ 0] = (b[0] << 8) | b[1];
 
-    unsigned short shift = (b[ 2] >> 2);
+
+
+    //
+    //TODO unverified fix for undefined behavior
+    // (0x20 << shift) will overflow 32 bit int if 'shift' is greater than 26
+    // this should only occur in corrupt files. Clamping 'shift' to 26
+    // prevents undefined behavior in this circumstance (but cast to unsigned short
+    // will still overflow)
+    //
+    unsigned short shift = std::min( 26 , b[ 2] >> 2);
     unsigned short bias = (0x20 << shift);
 
     s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3f) << shift) - bias;

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -380,15 +380,7 @@ unpack14 (const unsigned char b[14], unsigned short s[16])
 
     s[ 0] = (b[0] << 8) | b[1];
 
-
-
-    //
-    // shifting unsigned ints by more than 31 bits is undefined behavior
-    // clamp shift to 31 to enforce consistent handling
-    //
-    //
-
-    unsigned short shift = std::min( 31 , b[ 2] >> 2);
+    unsigned short shift = (b[ 2] >> 2);
     unsigned short bias = (0x20u << shift);
 
     s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3fu) << shift) - bias;


### PR DESCRIPTION
Fix undefined behavior with overflow as described in #821 
This fix at least suppresses the error in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24787

A better fix may be possible, and it would be good to confirm the overflow only arises with specially crafted input files, and can never occur with images written via the OpenEXR library.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>