### PR TITLE
prevent overflow in hufUncompress if nBits is large

### DIFF
--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -1093,7 +1093,9 @@ hufUncompress (const char compressed[],
 
     const char *ptr = compressed + 20;
 
-    if ( ptr + (nBits+7 )/8 > compressed+nCompressed)
+    uint64_t nBytes = (static_cast<uint64_t>(nBits)+7) / 8 ;
+
+    if ( ptr + nBytes > compressed+nCompressed)
     {
         notEnoughData();
         return;


### PR DESCRIPTION
Address overflow in https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25562

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>