### PR TITLE
Redefined WIN32 for MINGW

### DIFF
--- a/IlmBase/IlmThread/IlmThreadMutex.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutex.cpp
@@ -42,7 +42,7 @@
 #include "IlmBaseConfig.h"
 
 #ifdef ILMBASE_FORCE_CXX03
-#   if !defined (_WIN32) && !defined (_WIN64) && !defined (HAVE_PTHREAD)
+#   if (defined (__MINGW32__) || !defined (_WIN32)) && (defined (__MINGW64__) || !defined (_WIN64)) && !defined (HAVE_PTHREAD)
 #      include "IlmThreadMutex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER


### PR DESCRIPTION
```
c:/msys1100/bin/../lib/gcc/x86_64-w64-mingw32/11.0.0/../../../../x86_64-w64-mingw32/bin/ld.exe: IlmThread\IlmThreadPool.o:IlmThreadPool.cpp:(.text+0x53): undefined reference to `IlmThread::Mutex::lock() const'
c:/msys1100/bin/../lib/gcc/x86_64-w64-mingw32/11.0.0/../../../../x86_64-w64-mingw32/bin/ld.exe: IlmThread\IlmThreadPool.o:IlmThreadPool.cpp:(.text+0x69): undefined reference to `IlmThread::Mutex::unlock() const'
```