### PR TITLE
Validate tileoffset table size

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -261,7 +261,7 @@ struct DeepTiledInputFile::Data: public Mutex
                                                     // sample count table
     int             combinedSampleSize;             // total size of all channels combined to check sampletable size
     static const int gLargeChunkTableSize = 1024*1024;
-    DeepTiledInputFile validateStreamSize();        // throw an exception if the file is significantly
+    void validateStreamSize();        // throw an exception if the file is significantly
                                                     // smaller than the data/tile geometry would require
     InputStreamMutex *  _streamData;
     bool                _deleteStream; // should we delete the stream

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -253,6 +253,11 @@ struct TiledInputFile::Data: public Mutex
     Data (Data&& other) = delete;
     Data& operator = (Data&& other) = delete;
 
+    static const int gLargeChunkTableSize = 1024*1024;
+    void validateStreamSize();                       // throw an exception if the file is significantly
+                                                     // smaller than the data/tile geometry would require
+
+
     inline TileBuffer * getTileBuffer (int number);
 					    // hash function from tile indices
 					    // into our vector of tile buffers
@@ -298,6 +303,39 @@ TiledInputFile::Data::getTileBuffer (int number)
     return tileBuffers[number % tileBuffers.size()];
 }
 
+
+
+//
+// avoid allocating excessive memory due to large lineOffsets table size.
+// If the chunktablesize claims to be large,
+// check the file is big enough to contain the table before allocating memory
+// in the bytesPerLineTable and the lineOffsets table.
+// Attempt to read the last entry in the table. Either the seekg() or the read()
+// call will throw an exception if the file is too small to contain the table
+//
+
+// assumes the input stream pointer is at (or before) the beginning of the chunk table
+
+
+void
+TiledInputFile::Data::validateStreamSize()
+{
+    int chunkCount = getTiledChunkOffsetTableSize(header);
+    if ( chunkCount > gLargeChunkTableSize)
+    {
+
+        if (chunkCount > gLargeChunkTableSize)
+        {
+            Int64 pos = _streamData->is->tellg();
+            _streamData->is->seekg(pos + (chunkCount-1)*sizeof(Int64));
+            Int64 temp;
+            OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
+            _streamData->is->seekg(pos);
+
+        }
+    }
+
+}
 
 namespace {
 
@@ -732,6 +770,7 @@ TiledInputFile::TiledInputFile (const char fileName[], int numThreads):
             _data->_streamData = new InputStreamMutex();
             _data->_streamData->is = is;
             _data->header.readFrom (*_data->_streamData->is, _data->version);
+
             initialize();
             //read tile offsets - we are not multipart or deep
             _data->tileOffsets.readFrom (*(_data->_streamData->is), _data->fileIsComplete,false,false);
@@ -971,6 +1010,15 @@ TiledInputFile::initialize ()
     
     _data->header.sanityCheck (true);
 
+    //
+    // before allocating memory for tile offsets, confirm file is large enough
+    // to contain tile offset table
+    // (for multipart files, the chunk offset table has already been read)
+    //
+    if (!isMultiPart(_data->version))
+    {
+        _data->validateStreamSize();
+    }
     _data->tileDesc = _data->header.tileDescription();
     _data->lineOrder = _data->header.lineOrder();
 


### PR DESCRIPTION
Applies similar logic to #824's ScanLine handling to prevent excessive memory allocation when reading truncated Tiled and DeepTiled files.
If the dataWindow and tileDescription indicate there are over a million tiles in level 0 of the file, will scan forward to check the file is at least large enough to contain enough tiles for that level. This prevents small specially crafted OpenEXR files causing large memory allocations in the library.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25648
