### PR TITLE
add sanity check for reading multipart files with no parts

### DIFF
--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -340,6 +340,11 @@ MultiPartInputFile::initialize()
     // Perform usual check on headers.
     //
 
+    if ( _data->_headers.size() == 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Files must contain at least one header");
+    }
+
     for (size_t i = 0; i < _data->_headers.size(); i++)
     {
         //


### PR DESCRIPTION
Add test to protect against reading files with no parts/headers.

There is a check to prevent files with no parts being written, and the Technical Introduction declares that files must have at least one part.

Addresses https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25740 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25743

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>