### PR TITLE
more elegant exception handling in exrmaketiled

### DIFF
--- a/OpenEXR/exrmaketiled/main.cpp
+++ b/OpenEXR/exrmaketiled/main.cpp
@@ -393,31 +393,32 @@ main(int argc, char **argv)
 
     int exitStatus = 0;
 
-    //
-    // check input
-    //
-    {
-        MultiPartInputFile input (inFile);
-        int parts = input.parts();
-
-        if (partnum < 0 || partnum >= parts){
-            cerr << "ERROR: you asked for part " << partnum << " in " << inFile;
-            cerr << ", which only has " << parts << " parts\n";
-            exit(1);
-        }
-
-        Header h = input.header (partnum);
-        if (h.type() == DEEPTILE || h.type() == DEEPSCANLINE)
-        {
-            cerr << "Cannot make tile for deep data" << endl;
-            exit(1);
-        }
-
-    }
-
-
     try
     {
+        //
+        // check input
+        //
+        {
+            MultiPartInputFile input (inFile);
+            int parts = input.parts();
+
+            if (partnum < 0 || partnum >= parts){
+                cerr << "ERROR: you asked for part " << partnum << " in " << inFile;
+                cerr << ", which only has " << parts << " parts\n";
+                exit(1);
+            }
+
+            Header h = input.header (partnum);
+            if (h.type() == DEEPTILE || h.type() == DEEPSCANLINE)
+            {
+                cerr << "Cannot make tile for deep data" << endl;
+                exit(1);
+            }
+
+        }
+
+
+
         makeTiled (inFile, outFile, partnum,
                    mode, roundingMode, compression,
                    tileSizeX, tileSizeY,


### PR DESCRIPTION
Broken or missing input files to exrmaketiled produced scary looking error messages and an abort due to scoping of try/catch
(thanks to ZhiWei Sun(@5n1p3r0010) from Topsec Alpha Lab for report)

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>