### PR TITLE
add exrcheck utility and hooks for fuzz testing

### DIFF
--- a/OpenEXR/CMakeLists.txt
+++ b/OpenEXR/CMakeLists.txt
@@ -80,6 +80,7 @@ if(OPENEXR_BUILD_UTILS)
   add_subdirectory( exrenvmap )
   add_subdirectory( exrmultiview )
   add_subdirectory( exrmultipart )
+  add_subdirectory( exrcheck )
 endif()
 
 option(INSTALL_OPENEXR_DOCS "Install OpenEXR documentation" ON)

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.h
@@ -65,6 +65,11 @@ class DeepScanLineInputFile : public GenericInputFile
                            int numThreads = globalThreadCount());
 
     IMF_EXPORT
+    DeepScanLineInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
+                           int numThreads = globalThreadCount());
+
+
+    IMF_EXPORT
     DeepScanLineInputFile (const Header &header, OPENEXR_IMF_INTERNAL_NAMESPACE::IStream *is,
                            int version, /*version field from file*/
                            int numThreads = globalThreadCount());

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -281,7 +281,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
             // if no channels are being read that are present in file, cachedBuffer will be empty
             //
 
-            if (ifd->cachedBuffer->begin() != ifd->cachedBuffer->end())
+            if (ifd->cachedBuffer && ifd->cachedBuffer->begin() != ifd->cachedBuffer->end())
             {
                 ifd->tFile->readTiles (0, ifd->tFile->numXTiles (0) - 1, j, j);
             }

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -194,6 +194,18 @@ MultiPartInputFile::getInputPart(int partNumber)
         else return (T*) _data->_inputFiles[partNumber];
 }
 
+void
+MultiPartInputFile::flushPartCache()
+{
+    Lock lock(*_data);
+    while ( _data->_inputFiles.begin() != _data->_inputFiles.end())
+    {
+       delete _data->_inputFiles.begin()->second;
+       _data->_inputFiles.erase(_data->_inputFiles.begin());
+    }
+
+}
+
 
 template InputFile* MultiPartInputFile::getInputPart<InputFile>(int);
 template TiledInputFile* MultiPartInputFile::getInputPart<TiledInputFile>(int);

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.h
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.h
@@ -91,6 +91,18 @@ class MultiPartInputFile : public GenericInputFile
     bool partComplete(int part) const;
 
 
+    // ----------------------------------------
+    // Flush internal part cache
+    // Invalidates all 'Part' types previously
+    // constructed from this file
+    // Intended for test purposes, but can be
+    // used to temporarily reduce memory overhead,
+    // or to switch between types (e.g. TiledInputPart
+    // or DeepScanLineInputPart to InputPart)
+    // ----------------------------------------
+
+    IMF_EXPORT
+    void flushPartCache();
     struct Data;
 
 

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -959,7 +959,10 @@ TiledInputFile::initialize ()
     {
         if (!isTiled (_data->version))
             throw IEX_NAMESPACE::ArgExc ("Expected a tiled file but the file is not tiled.");
-        
+
+        if (isNonImage (_data->version))
+            throw IEX_NAMESPACE::ArgExc ("File is not a regular tiled image.");
+
     }
     else
     {

--- a/OpenEXR/IlmImfFuzzTest/oss-fuzz/openexr_exrcheck_fuzzer.cc
+++ b/OpenEXR/IlmImfFuzzTest/oss-fuzz/openexr_exrcheck_fuzzer.cc
@@ -1,0 +1,20 @@
+
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+//
+// this file is found by the oss-fuzz project to generate a fuzzer. It is not part of
+// OpenEXR's internal IlmImfFuzzTest suite
+//
+
+#include <ImfNamespace.h>
+#include <ImfCheckFile.h>
+#include <stdint.h>
+
+using OPENEXR_IMF_NAMESPACE::checkOpenEXRFile;
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  checkOpenEXRFile( (const char*) data , size , true , true );
+  return 0;
+}
+

--- a/OpenEXR/IlmImfUtil/CMakeLists.txt
+++ b/OpenEXR/IlmImfUtil/CMakeLists.txt
@@ -19,6 +19,7 @@ openexr_define_library(IlmImfUtil
     ImfFlatImageIO.cpp
     ImfDeepImageIO.cpp
     ImfImageDataWindow.cpp
+    ImfCheckFile.cpp
   HEADERS
     ImfImageChannel.h
     ImfFlatImageChannel.h
@@ -36,6 +37,7 @@ openexr_define_library(IlmImfUtil
     ImfImageDataWindow.h
     ImfImageChannelRenaming.h
     ImfUtilExport.h
+    ImfCheckFile.h
   DEPENDENCIES
     OpenEXR::IlmImf
 )

--- a/OpenEXR/IlmImfUtil/ImfCheckFile.cpp
+++ b/OpenEXR/IlmImfUtil/ImfCheckFile.cpp
@@ -1,0 +1,951 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+#include "ImfCheckFile.h"
+#include "Iex.h"
+#include "ImfRgbaFile.h"
+#include "ImfArray.h"
+#include "ImfChannelList.h"
+#include "ImfFrameBuffer.h"
+#include "ImfPartType.h"
+#include "ImfInputPart.h"
+#include "ImfDeepScanLineInputPart.h"
+#include "ImfTiledInputPart.h"
+#include "ImfDeepTiledInputPart.h"
+#include "ImfStdIO.h"
+#include "ImfMultiPartInputFile.h"
+
+#include <vector>
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
+
+
+namespace {
+
+using std::vector;
+using std::max;
+using Imath::Box2i;
+
+
+int
+getStep( const Box2i &dw , bool reduceTime)
+{
+
+    // limit to approximately 2,000,000 pixels in fast mode
+    if (reduceTime)
+    {
+        size_t pixelCount = (dw.max.y - dw.min.y + 1);
+        pixelCount *= (dw.max.x - dw.min.x + 1);
+        return  max( 1 , static_cast<int>(pixelCount / 2000000) );
+    }
+    else
+    {
+        return 1;
+    }
+
+}
+
+//
+// read image or part using the Rgba interface
+//
+template<class T> bool
+readRgba(T& in, bool reduceMemory , bool reduceTime)
+{
+
+    bool threw = false;
+
+    try
+    {
+        const Box2i &dw = in.dataWindow();
+
+        int w = dw.max.x - dw.min.x + 1;
+        int dx = dw.min.x;
+
+        if (reduceMemory && w > (1 << 10))
+        {
+            return false;
+        }
+
+        Array<Rgba> pixels (w);
+        in.setFrameBuffer (&pixels[-dx], 1, 0);
+
+
+
+        int step = getStep( dw , reduceTime );
+
+        //
+        // try reading scanlines. Continue reading scanlines
+        // even if an exception is encountered
+        //
+        for (int y = dw.min.y; y <= dw.max.y; y+=step )
+        {
+            try
+            {
+               in.readPixels (y);
+            }
+            catch(...)
+            {
+                threw = true;
+            }
+        }
+    }
+    catch(...)
+    {
+        threw = true;
+    }
+
+    return threw;
+}
+
+
+template<class T> bool
+readScanline(T& in, bool reduceMemory , bool reduceTime)
+{
+
+    bool threw = false;
+
+    try
+    {
+        const Box2i &dw = in.header().dataWindow();
+
+        int w = dw.max.x - dw.min.x + 1;
+        int dx = dw.min.x;
+
+        if (reduceMemory && w > (1 << 10))
+        {
+            return false;
+        }
+
+        FrameBuffer i;
+
+
+        // read all channels present (later channels will overwrite earlier ones)
+        vector<half> halfChannels(w);
+        vector<float> floatChannels(w);
+        vector<unsigned int> uintChannels(w);
+
+        int channelIndex = 0;
+        const ChannelList& channelList = in.header().channels();
+        for (ChannelList::ConstIterator c = channelList.begin() ; c != channelList.end() ; ++c )
+        {
+            switch (channelIndex % 3)
+            {
+                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dx] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                break;
+                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dx] , sizeof(float) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dx] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                break;
+            }
+            channelIndex ++;
+        }
+
+        in.setFrameBuffer(i);
+
+        int step = getStep( dw , reduceTime );
+
+
+
+        //
+        // try reading scanlines. Continue reading scanlines
+        // even if an exception is encountered
+        //
+        for (int y = dw.min.y; y <= dw.max.y; y+=step )
+        {
+            try
+            {
+               in.readPixels (y);
+            }
+            catch(...)
+            {
+                threw = true;
+            }
+        }
+    }
+    catch(...)
+    {
+        threw = true;
+    }
+
+    return threw;
+}
+
+
+template<class T>
+bool
+readTileRgba( T& in,bool reduceMemory, bool reduceTime)
+{
+    try{
+        const Box2i &dw = in.dataWindow();
+
+        int w = dw.max.x - dw.min.x + 1;
+        int h = dw.max.y - dw.min.y + 1;
+
+        if ( (reduceMemory || reduceTime ) && h*w > 1000*1000)
+        {
+            return false;
+        }
+
+        int dwx = dw.min.x;
+        int dwy = dw.min.y;
+
+
+
+        Array2D<Rgba> pixels (h, w);
+        in.setFrameBuffer (&pixels[-dwy][-dwx], 1, w);
+        in.readTiles (0, in.numXTiles() - 1, 0, in.numYTiles() - 1);
+    }
+    catch(...)
+    {
+       return true;
+    }
+
+    return false;
+}
+
+
+// read image as ripmapped image
+template<class T>
+bool
+readTile(T& in, bool reduceMemory , bool reduceTime)
+{
+    bool threw = false;
+    try
+    {
+        const Box2i& dw = in.header().dataWindow();
+
+        int w = dw.max.x - dw.min.x + 1;
+        int h = dw.max.y - dw.min.y + 1;
+        int dwx = dw.min.x;
+        int dwy = dw.min.y;
+        int numXLevels = in.numXLevels();
+        int numYLevels = in.numYLevels();
+
+        const TileDescription& td = in.header().tileDescription();
+
+
+        if (reduceMemory && w > (1 << 10))
+        {
+                return false;
+        }
+
+        FrameBuffer i;
+        // read all channels present (later channels will overwrite earlier ones)
+        vector<half> halfChannels(w);
+        vector<float> floatChannels(w);
+        vector<unsigned int> uintChannels(w);
+
+        int channelIndex = 0;
+        const ChannelList& channelList = in.header().channels();
+        for (ChannelList::ConstIterator c = channelList.begin() ; c != channelList.end() ; ++c )
+        {
+            switch (channelIndex % 3)
+            {
+                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dwx] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                break;
+                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dwx] , sizeof(float) , 0 ,  c.channel().xSampling , c.channel().ySampling));
+                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dwx] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling));
+                break;
+            }
+            channelIndex ++;
+        }
+
+        in.setFrameBuffer (i);
+
+
+        //
+        // limit to 2,000 tiles
+        //
+        size_t step = 1;
+
+        if (reduceTime && in.numXTiles(0) * in.numYTiles(0) > 2000)
+        {
+            step = max(1, (in.numXTiles(0) * in.numYTiles(0)) / 2000 );
+        }
+
+
+
+        size_t tileIndex =0;
+        bool isRipMap = td.mode == RIPMAP_LEVELS;
+
+        //
+        // read all tiles from all levels.
+        //
+        for (int ylevel = 0; ylevel < numYLevels; ++ylevel )
+        {
+            for (int xlevel = 0; xlevel < numXLevels; ++xlevel )
+            {
+                for(int y  = 0 ; y < in.numYTiles(ylevel) ; ++y )
+                {
+                    for(int x = 0 ; x < in.numXTiles(xlevel) ; ++x )
+                    {
+                        if(tileIndex % step == 0)
+                        {
+                            try
+                            {
+                                in.readTile ( x, y, xlevel , ylevel);
+                            }
+                            catch(...)
+                            {
+                                //
+                                // for one level and mipmapped images,
+                                // xlevel must match ylevel,
+                                // otherwise an exception is thrown
+                                // ignore that exception
+                                //
+                                if (isRipMap || xlevel==ylevel)
+                                {
+                                    threw = true;
+                                }
+                            }
+                        }
+                        tileIndex++;
+                    }
+                }
+            }
+        }
+    }
+    catch(...)
+    {
+        threw = true;
+    }
+
+    return threw;
+}
+
+template<class T>
+bool readDeepScanLine(T& in,bool reduceMemory, bool reduceTime)
+{
+
+    bool threw = false;
+    try
+    {
+        const Header& fileHeader = in.header();
+        const Box2i &dw = fileHeader.dataWindow();
+
+
+        int w = dw.max.x - dw.min.x + 1;
+        int dwx = dw.min.x;
+        int dwy = dw.min.y;
+
+        if ( reduceMemory && w > (1 << 8) )
+        {
+            return false;
+        }
+
+
+
+        int channelCount=0;
+        for(ChannelList::ConstIterator i=fileHeader.channels().begin();i!=fileHeader.channels().end();++i,++channelCount);
+
+        Array<unsigned int> localSampleCount;
+        localSampleCount.resizeErase(w );
+        Array<Array< void* > > data(channelCount);
+
+
+        for (int i = 0; i < channelCount; i++)
+        {
+            data[i].resizeErase( w );
+        }
+
+        DeepFrameBuffer frameBuffer;
+
+        frameBuffer.insertSampleCountSlice (Slice (UINT,(char *) (&localSampleCount[-dwx]), sizeof (unsigned int) ,0) );
+
+        int channel =0;
+        for(ChannelList::ConstIterator i=fileHeader.channels().begin();
+            i!=fileHeader.channels().end();++i , ++channel)
+        {
+            PixelType type = FLOAT;
+
+            int sampleSize = sizeof (float);
+
+            int pointerSize = sizeof (char *);
+
+            frameBuffer.insert (i.name(), DeepSlice (type,(char *) (&data[channel][-dwx]),pointerSize , 0, sampleSize));
+        }
+
+
+
+        in.setFrameBuffer(frameBuffer);
+
+        int step = 1;
+        // only read 200 scanlines in fast mode
+        if (reduceTime)
+        {
+           step = max( 1 , (dw.max.y - dw.min.y + 1) / 200 );
+        }
+
+        vector<float> pixelBuffer;
+
+        for (int y = dw.min.y ; y <= dw.max.y ; y+=step )
+        {
+            in.readPixelSampleCounts( y );
+
+
+            //
+            // count how many samples are required to store this scanline
+            //
+            size_t bufferSize = 0;
+            for (int j = 0; j < w ; j++)
+            {
+                for (int k = 0; k < channelCount; k++)
+                {
+                    //
+                    // don't read samples which require a lot of memory in reduceMemory mode
+                    //
+                    if (!reduceMemory || localSampleCount[j] <= 1000)
+                    {
+                        bufferSize += localSampleCount[j];
+                    }
+                }
+            }
+
+            //
+            // limit total number of samples read in reduceMemory mode
+            //
+            if (!reduceMemory || bufferSize < 1<<12)
+            {
+                //
+                // allocate sample buffer and set per-pixel pointers into buffer
+                //
+                pixelBuffer.resize(bufferSize);
+
+                size_t bufferIndex = 0;
+                for (int j = 0; j < w ; j++)
+                {
+                    for (int k = 0; k < channelCount; k++)
+                    {
+
+                        if (reduceMemory && localSampleCount[j] > 1000)
+                        {
+                            data[k][j] = nullptr;
+                        }
+                        else
+                        {
+                            data[k][j] = &pixelBuffer[bufferIndex];
+                            bufferIndex += localSampleCount[j];
+                        }
+                    }
+                }
+
+                try
+                {
+                    in.readPixels(y);
+                }
+                catch(...)
+                {
+                    threw = true;
+                }
+            }
+
+        }
+    }
+    catch(...)
+    {
+        threw = true;
+    }
+    return threw;
+
+}
+
+//
+// read a deep tiled image, tile by tile, using the 'tile relative' mode
+//
+template<class T> bool
+readDeepTile(T& in,bool reduceMemory , bool reduceTime)
+{
+    bool threw = false;
+    try
+    {
+        const Header& fileHeader = in.header();
+
+        Array2D<unsigned int> localSampleCount;
+
+        Box2i dataWindow = fileHeader.dataWindow();
+
+        int height = dataWindow.size().y+1;
+        int width = dataWindow.size().x+1;
+
+        const TileDescription& td = in.header().tileDescription();
+        int tileWidth = td.xSize;
+        int tileHeight = td.ySize;
+        int numYLevels = in.numYLevels();
+        int numXLevels = in.numXLevels();
+
+
+        localSampleCount.resizeErase(height, width);
+
+        int channelCount=0;
+        for(ChannelList::ConstIterator i=fileHeader.channels().begin();i!=fileHeader.channels().end();++i, channelCount++);
+
+        Array<Array2D< float* > > data(channelCount);
+
+        for (int i = 0; i < channelCount; i++)
+        {
+            data[i].resizeErase(height, width);
+        }
+
+        DeepFrameBuffer frameBuffer;
+
+        int memOffset = dataWindow.min.x + dataWindow.min.y * width;
+        frameBuffer.insertSampleCountSlice (Slice (UINT,
+                                                   (char *) (&localSampleCount[0][0] - memOffset),
+                                                   sizeof (unsigned int) * 1,
+                                                   sizeof (unsigned int) * width,
+                                                   0.0, // fill
+                                                   1 , 1, // x/ysampling
+                                                   true,  // relative x
+                                                   true  // relative y
+                                                  )
+                                                   );
+
+        int channel = 0;
+         for (ChannelList::ConstIterator i=fileHeader.channels().begin();i!=fileHeader.channels().end();++i, ++channel)
+         {
+             int sampleSize  = sizeof (float);
+
+             int pointerSize = sizeof (char *);
+
+             frameBuffer.insert (i.name(),
+                                 DeepSlice (FLOAT,
+                                            (char *) (&data[channel][0][0] - memOffset),
+                                            pointerSize * 1,
+                                            pointerSize * width,
+                                            sampleSize,
+                                            0.0,
+                                            1 , 1,
+                                            true,
+                                            true
+                                           ) );
+         }
+
+         in.setFrameBuffer(frameBuffer);
+         size_t step = 1;
+
+         if (reduceTime && in.numXTiles(0) * in.numYTiles(0) > 2000)
+         {
+            step = max(1, (in.numXTiles(0) * in.numYTiles(0)) / 2000 );
+         }
+
+         int tileIndex = 0;
+         bool isRipMap = td.mode == RIPMAP_LEVELS;
+
+
+         vector<float> pixelBuffer;
+
+
+         for (int ly = 0; ly < numYLevels; ly++)
+         {
+             for (int lx = 0; lx < numXLevels; lx++)
+             {
+
+
+                //
+                // read all tiles from all levels.
+                //
+                for (int ylevel = 0; ylevel < numYLevels; ++ylevel )
+                {
+                    for (int xlevel = 0; xlevel < numXLevels; ++xlevel )
+                    {
+                        for(int y  = 0 ; y < in.numYTiles(ylevel) ; ++y )
+                        {
+                            for(int x = 0 ; x < in.numXTiles(xlevel) ; ++x )
+                            {
+                                if(tileIndex % step == 0)
+                                {
+                                    try
+                                    {
+
+                                        in.readPixelSampleCounts( x , y , x , y, lx, ly);
+
+
+                                        size_t bufferSize = 0;
+
+                                        for (int ty = 0 ; ty < tileHeight ; ++ty )
+                                        {
+                                            for (int tx = 0 ; tx < tileWidth ; ++tx )
+                                            {
+                                                if (!reduceMemory || localSampleCount[ty][tx] <  100)
+                                                {
+                                                    bufferSize += channelCount * localSampleCount[ty][tx];
+                                                }
+                                            }
+                                        }
+
+                                        // limit total samples allocated for this tile
+                                        if (!reduceMemory || bufferSize < 1<<12)
+                                        {
+
+                                            pixelBuffer.resize( bufferSize );
+                                            size_t bufferIndex = 0;
+
+                                            for (int ty = 0 ; ty < tileHeight ; ++ty )
+                                            {
+                                                for (int tx = 0 ; tx < tileWidth ; ++tx )
+                                                {
+                                                    if (!reduceMemory || localSampleCount[ty][tx] <  100)
+                                                    {
+                                                        for (int k = 0 ; k < channelCount ; ++k )
+                                                        {
+                                                           data[k][ty][tx] = &pixelBuffer[bufferIndex];
+                                                           bufferIndex += localSampleCount[ty][tx];
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        for (int k = 0 ; k < channelCount ; ++k )
+                                                        {
+                                                            data[k][ty][tx] = nullptr;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+
+                                            in.readTile ( x, y, xlevel , ylevel);
+                                        }
+                                    }
+
+                                    catch(...)
+                                    {
+                                        //
+                                        // for one level and mipmapped images,
+                                        // xlevel must match ylevel,
+                                        // otherwise an exception is thrown
+                                        // ignore that exception
+                                        //
+                                        if (isRipMap || xlevel==ylevel)
+                                        {
+                                            threw = true;
+                                        }
+
+                                    }
+                                }
+                                tileIndex++;
+                            }
+                        }
+                    }
+                }
+             }
+         }
+    }catch(...)
+    {
+        threw = true;
+    }
+    return threw;
+}
+
+
+bool
+readMultiPart(MultiPartInputFile& in,bool reduceMemory,bool reduceTime)
+{
+    bool threw = false;
+    for(int part = 0 ; part < in.parts() ; ++ part)
+    {
+
+       {
+            bool gotThrow = false;
+            try
+            {
+                InputPart pt( in , part );
+                gotThrow = readScanline( pt , reduceMemory , reduceTime);
+            }
+            catch(...)
+            {
+                gotThrow = true;
+            }
+            // only 'DeepTiled' parts are expected to throw
+            // all others are an error
+            if( gotThrow && in.header(part).type() != DEEPTILE )
+            {
+                threw = true;
+            }
+       }
+
+       {
+            bool gotThrow = false;
+
+            try
+            {
+                in.flushPartCache();
+                TiledInputPart pt (in,part);
+                gotThrow = readTile( pt , reduceMemory , reduceTime);
+            }
+            catch(...)
+            {
+                gotThrow = true;
+            }
+
+            if( gotThrow && in.header(part).type() == TILEDIMAGE)
+            {
+                threw = true;
+            }
+       }
+
+       {
+            bool gotThrow = false;
+
+            try
+            {
+                in.flushPartCache();
+                DeepScanLineInputPart pt (in,part);
+                gotThrow = readDeepScanLine( pt , reduceMemory , reduceTime);
+            }
+            catch(...)
+            {
+                gotThrow = true;
+            }
+
+            if( gotThrow && in.header(part).type() == DEEPSCANLINE)
+            {
+                threw = true;
+            }
+       }
+
+       {
+            bool gotThrow = false;
+
+            try
+            {
+                in.flushPartCache();
+                DeepTiledInputPart pt (in,part);
+                gotThrow = readDeepTile( pt , reduceMemory , reduceTime);
+            }
+            catch(...)
+            {
+                gotThrow = true;
+            }
+
+            if( gotThrow && in.header(part).type() == DEEPTILE)
+            {
+                threw = true;
+            }
+       }
+    }
+
+    return threw;
+}
+
+
+//------------------------------------------------
+// class PtrIStream -- allow reading an EXR file from
+// a pointer
+//
+//------------------------------------------------
+
+class PtrIStream: public IStream
+{
+  public:
+
+    PtrIStream (const char* data, size_t nBytes) : IStream("none") , base(data) , current(data) , end(data+nBytes) {}
+
+    virtual bool        isMemoryMapped () const { return false;}
+
+
+    IMF_EXPORT
+    virtual char *	readMemoryMapped (int n)
+    {
+
+        if (n + current > end)
+	{
+		THROW (IEX_NAMESPACE::InputExc, "Early end of file: requesting " << end - (n+current) << " extra bytes after file\n");
+	}
+	const char* value = current;
+        current += n;
+
+        return const_cast<char*>(value);
+    }
+
+    virtual bool	read (char c[/*n*/], int n)
+    {
+        if( n < 0 )
+        {
+             	THROW (IEX_NAMESPACE::InputExc,n << " bytes requested from stream");
+        }
+
+        if (n + current > end)
+	{
+		THROW (IEX_NAMESPACE::InputExc, "Early end of file: requesting " << end - (n+current) << " extra bytes after file\n");
+	}
+	memcpy( c , current , n);
+        current += n;
+
+        return (current != end);
+
+    }
+
+    virtual Int64	tellg ()
+    {
+        return (current - base);
+    }
+    virtual void	seekg (Int64 pos)
+    {
+        if( pos < 0 )
+        {
+          THROW (IEX_NAMESPACE::InputExc, "internal error: seek to " << pos << " requested");
+        }
+
+        current = base + pos;
+
+        if( current < base || current > end)
+        {
+            THROW (IEX_NAMESPACE::InputExc, "Out of range seek requested\n");
+        }
+
+    }
+
+  private:
+
+    const char*        base;
+    const char*        current;
+    const char*        end;
+};
+
+
+
+void resetInput(const char*fileName)
+{
+    // do nothing: filename doesn't need to be 'reset' between calls
+}
+
+void resetInput(PtrIStream& stream)
+{
+    // return stream to beginning to prepare reading with a different API
+    stream.seekg(0);
+}
+
+
+template<class T> bool
+runChecks(T& source,bool reduceMemory,bool reduceTime)
+{
+    //
+    // multipart test: also grab the type of the first part to
+    // check which other tests are expected to fail
+    //
+
+    string firstPartType;
+    bool threw = false;
+    {
+      try
+      {
+         MultiPartInputFile multi(source);
+         firstPartType = multi.header(0).type();
+         threw = readMultiPart(multi , reduceMemory , reduceTime);
+      }
+      catch(...)
+      {
+         threw = true;
+      }
+
+    }
+    {
+        bool gotThrow = false;
+        resetInput(source);
+        try
+        {
+          RgbaInputFile rgba(source);
+          gotThrow = readRgba( rgba, reduceMemory , reduceTime );
+        }
+        catch(...)
+        {
+            gotThrow = true;
+        }
+        if (gotThrow && firstPartType != DEEPTILE)
+        {
+            threw = true;
+        }
+    }
+    {
+        bool gotThrow = false;
+        resetInput(source);
+        try
+        {
+          InputFile rgba(source);
+          gotThrow = readScanline( rgba, reduceMemory , reduceTime );
+        }
+        catch(...)
+        {
+            gotThrow = true;
+        }
+        if (gotThrow && firstPartType != DEEPTILE)
+        {
+            threw = true;
+        }
+    }
+    {
+        bool gotThrow = false;
+        resetInput(source);
+        try
+        {
+          TiledInputFile rgba(source);
+          gotThrow = readTile( rgba, reduceMemory , reduceTime );
+        }
+        catch(...)
+        {
+            gotThrow = true;
+        }
+        if (gotThrow && firstPartType == TILEDIMAGE)
+        {
+            threw = true;
+        }
+    }
+
+    {
+        bool gotThrow = false;
+        resetInput(source);
+        try
+        {
+          DeepScanLineInputFile rgba(source);
+          gotThrow = readDeepScanLine( rgba, reduceMemory , reduceTime );
+        }
+        catch(...)
+        {
+            gotThrow = true;
+        }
+        if (gotThrow && firstPartType == DEEPSCANLINE)
+        {
+            threw = true;
+        }
+    }
+    {
+        bool gotThrow = false;
+        resetInput(source);
+        try
+        {
+          DeepTiledInputFile rgba(source);
+          gotThrow = readDeepTile( rgba, reduceMemory , reduceTime );
+        }
+        catch(...)
+        {
+            gotThrow = true;
+        }
+        if (gotThrow && firstPartType == DEEPTILE)
+        {
+            threw = true;
+        }
+    }
+
+    return threw;
+}
+
+
+}
+
+
+bool
+checkOpenEXRFile(const char* fileName, bool reduceMemory,bool reduceTime)
+{
+   return runChecks( fileName , reduceMemory , reduceTime );
+}
+
+
+bool
+checkOpenEXRFile(const char* data, size_t numBytes, bool reduceMemory , bool reduceTime )
+{
+  PtrIStream stream(data,numBytes);
+  return runChecks( stream , reduceMemory , reduceTime );
+}
+
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/OpenEXR/IlmImfUtil/ImfCheckFile.h
+++ b/OpenEXR/IlmImfUtil/ImfCheckFile.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+
+#ifndef INCLUDED_IMF_CHECKFILE_H
+#define INCLUDED_IMF_CHECKFILE_H
+
+#include "ImfNamespace.h"
+#include "ImfExport.h"
+#include <cstddef>
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
+
+//
+// attempt to read the given file as an OpenEXR, using
+// various OpenEXR read paths.
+// This can be used to validate correctness of the library, when running the library
+// with a sanitizer or memory checker, as well as checking that a file is a correct OpenEXR
+//
+// returns true if the file read correctly using expected API calls, or false
+// if an exception was thrown that indicates the file is invalid
+//
+// if reduceMemory and/or reduceTime are true, will avoid tests or inputs that are known to
+// take large amounts of memory and/or time respectively. This may hide errors within the
+// file or library
+//
+//
+
+IMF_EXPORT bool
+checkOpenEXRFile(const char* fileName,
+                 bool reduceMemory  = false,
+                 bool reduceTime = false
+                );
+
+
+//
+// overloaded version of checkOpenEXRFile that takes a pointer to in-memory data
+//
+
+IMF_EXPORT bool
+checkOpenEXRFile(const char* data,
+                 size_t numBytes,
+                 bool reduceMemory = false,
+                 bool reduceTime = false
+                );
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#endif
+

--- a/OpenEXR/exrcheck/CMakeLists.txt
+++ b/OpenEXR/exrcheck/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+add_executable(exrcheck main.cpp)
+target_link_libraries(exrcheck OpenEXR::IlmImf OpenEXR::IlmImfUtil)
+set_target_properties(exrcheck PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+# install(TARGETS exrcheck DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(WIN32 AND (BUILD_SHARED_LIBS OR OPENEXR_BUILD_BOTH_STATIC_SHARED))
+  target_compile_definitions(exrcheck PRIVATE OPENEXR_DLL)
+endif()

--- a/OpenEXR/exrcheck/main.cpp
+++ b/OpenEXR/exrcheck/main.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenEXR Project.
+
+#include <ImfCheckFile.h>
+
+
+#include <iostream>
+#include <fstream>
+#include <string.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace OPENEXR_IMF_NAMESPACE;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::ifstream;
+using std::vector;
+using std::streampos;
+
+void
+usageMessage (const char argv0[])
+{
+    cerr << "usage: " << argv0 << " [options] imagefile [imagefile ...]\n";
+    cerr << "options: \n";
+    cerr << "  -m : avoid excessive memory allocation (some files will not be fully checked)\n";
+    cerr << "  -t : avoid spending excessive time (some files will not be fully checked)\n";
+    cerr << "  -s : use stream API instead of file API\n";
+
+}
+
+
+bool
+exrCheck(const char* filename, bool reduceMemory, bool reduceTime, bool useStream)
+{
+  if (useStream)
+  {
+      //
+      // open file as stream, check size
+      //
+      ifstream instream(filename,ifstream::binary);
+      instream.seekg(0,instream.end);
+      streampos length = instream.tellg();
+      instream.seekg(0,instream.beg);
+
+      //
+      // read into memory
+      //
+      vector<char> data(length);
+      instream.read( data.data() , length);
+      if (instream.bad())
+      {
+          cerr << "internal error: failed to read file " << filename << endl;
+
+      }
+      return checkOpenEXRFile( data.data() , length , reduceMemory , reduceTime);
+  }
+  else
+  {
+      return checkOpenEXRFile( filename , reduceMemory , reduceTime);
+  }
+
+}
+
+int
+main(int argc, char **argv)
+{
+    if (argc < 2)
+    {
+        usageMessage (argv[0]);
+        return 1;
+    }
+
+    bool reduceMemory = false;
+    bool reduceTime = false;
+    bool badFileFound = false;
+    bool useStream = false;
+    for (int i = 1; i < argc; ++i)
+    {
+        if (!strcmp (argv[i], "-h"))
+        {
+            usageMessage (argv[0]);
+            return 1;
+        }
+        else if (!strcmp (argv[i], "-m"))
+        {
+            reduceMemory = true;
+        }
+        else if (!strcmp (argv[i], "-t"))
+        {
+            reduceTime = true;
+        }
+        else if (!strcmp (argv[i],"-s"))
+        {
+            useStream = true;
+        }
+        else
+        {
+
+            if (access (argv[i], R_OK) != 0)
+            {
+               cerr << "No such file: " << argv[i] << endl;
+               exit (-1);
+            }
+
+            cout << " file " << argv[i] << ' ';
+            cout.flush();
+
+            bool hasError = exrCheck(argv[i],reduceMemory,reduceTime,useStream);
+            if (hasError)
+            {
+                cout << "bad\n";
+                badFileFound = true;
+            }
+            else
+            {
+                cout << "OK\n";
+            }
+        }
+    }
+
+    return badFileFound;
+
+}


### PR DESCRIPTION
This adds an `exrcheck` binary (not installed by default) that can be used to check for bad files, as well as looking for issues in the OpenEXR library. This wraps a new API call in IlmImfUtil: checkOpenEXRFile()

A hook to call this function with the [oss-fuzz](https://github.com/google/oss-fuzz) project has also been added in IlmImfFuzzTest. This file is to be compiled by that project

OpenEXR's internal fuzz tests could also be adapted to use checkOpenEXRFile instead of their own function. This would allow for more exhaustive testing.

A few other additions to the API:

- For this to work efficiently, missing functionality is added to open (single part) DeepScanLineInputFiles via a stream interface. This was the only API missing that functionality
- MultiPartInputFile::flushPartCache method is required to switch between part readers (Tiled files can be read either as TiledInputPart or InputPart. flushPartCache must be called to change the reader type within the same object)

Other bugfixes to address issues found while testing against the 'Damaged' file list that were required to properly test `exrcheck`:

- DeepScanLineInputFile had a 32 bit integer overflow accessing the sample count table with very large values of dataWindow.min.x
- InputFile could crash when reading tiled files as scanlines in 'readPixels' if 'setFrameBuffer' was called with an empty frame buffer
- Single part non-image files would not be detected in the TiledInputFile. Attempting to read anything which isn't a tiled regular image with this call now throws an exception. This should also address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25892 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25894