### PR TITLE
reduce B44 _tmpBufferSize (was allocating two bytes per byte)

### DIFF
--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -494,7 +494,7 @@ B44Compressor::B44Compressor
     //
 
     _tmpBuffer = new unsigned short
-        [checkArraySize (uiMult (maxScanLineSize, numScanLines),
+        [checkArraySize (uiMult (maxScanLineSize / sizeof(unsigned short), numScanLines),
                          sizeof (unsigned short))];
 
     const ChannelList &channels = header().channels();


### PR DESCRIPTION
B44 was allocating a _tmpBuffer of `maxScanLineSize`*`numScanlines` `unsigned short` values. `maxScanLineSize` is the number of bytes of uncompressed data on each scanline, not the number of pixel samples. _tmpBuffer was therefore assigning one 16 bit short for every byte of uncompressed data, so making the buffer twice the size it needs to be

partially addresses out-of-memory issue https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25913

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>