### PR TITLE
check EXRAllocAligned succeeded to allocate ScanlineInputFile lineBuffers

### DIFF
--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1176,6 +1176,10 @@ void ScanLineInputFile::initialize(const Header& header)
             for (size_t i = 0; i < _data->lineBuffers.size(); i++)
             {
                 _data->lineBuffers[i]->buffer = (char *) EXRAllocAligned(_data->lineBufferSize*sizeof(char),16);
+                if (!_data->lineBuffers[i]->buffer)
+                {
+                    throw IEX_NAMESPACE::LogicExc("Failed to allocate memory for scanline buffers");
+                }
             }
         }
         _data->nextLineBufferMinY = _data->minY - 1;


### PR DESCRIPTION
When memory is limited, EXRAllocAligned may fail by returning nullptr. This return value wasn't checked.
ImfDwaCompressorSimd.h might also need to test that return value.
(I wasn't sure what the appropriate exception to throw here was, that would still allow a useful explanatory string?)

Thanks to ZhiWei Sun(@5n1p3r0010) from Topsec Alpha Lab for reporting

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>