### PR TITLE
test channels are DCT compressed before DWA decompression

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -2681,6 +2681,10 @@ DwaCompressor::uncompress
         int gChan = _cscSets[csc].idx[1];    
         int bChan = _cscSets[csc].idx[2];    
 
+        if (_channelData[rChan].compression != LOSSY_DCT || _channelData[gChan].compression != LOSSY_DCT || _channelData[bChan].compression != LOSSY_DCT)
+        {
+            throw IEX_NAMESPACE::BaseExc("Bad DWA compression type detected");
+        }
 
         LossyDctDecoderCsc decoder
             (rowPtrs[rChan],


### PR DESCRIPTION
Corrupt DWA compressed files may have inconsistent compression types in the rules table, so LossyDCT decompression is run on channels which are not tagged as DCT compressed, causing a buffer overrun storing the decompressed data. This check confirms channels are DCT compressed.

Reported by ZhiWei Sun(@5n1p3r0010) from Topsec Alpha Lab

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>