### PR TITLE
fix extra byte in DWA compressed data

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -2301,7 +2301,7 @@ DwaCompressor::compress
 
     outPtr = _outBuffer;
 
-    return static_cast<int>(outDataPtr - _outBuffer + 1);
+    return static_cast<int>(outDataPtr - _outBuffer);
 }
 
 


### PR DESCRIPTION
The size of DWA compressed data is declared to be one byte larger than it needs to be, causing an extra byte to be written at the end of each block. Since the memory is not zero-allocated, this byte is undefined, causing file differences. This should solve the same issue as #750 but without the overhead of zero-allocation, as well as save a few bytes.

This change does not break backwards compatibility, but does mean the file size on disk will differ depending which library version wrote the file. As @alexeyvo points out in #750, the file content used to differ anyway. A safer fix could have been to zero the last extraneous byte and continue writing it, but that would be wasteful.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>