### PR TITLE
check for valid Huf code lengths

### DIFF
--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -967,6 +967,10 @@ hufDecode
 	if (pl.len)
 	{
 	    lc -= pl.len;
+            if ( lc < 0 )
+            {
+   	        invalidCode(); // code length too long
+            }
 	    getCode (pl.lit, rlc, c, lc, in, out, outb, oe);
 	}
 	else

--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -910,6 +910,11 @@ hufDecode
 		//
 
 		lc -= pl.len;
+
+		if ( lc < 0 )
+		{
+			invalidCode(); // code length too long
+		}
 		getCode (pl.lit, rlc, c, lc, in, out, outb, oe);
 	    }
 	    else

--- a/OpenEXR/IlmImfTest/testHuf.cpp
+++ b/OpenEXR/IlmImfTest/testHuf.cpp
@@ -245,70 +245,86 @@ testHuf (const std::string&)
 
 	IMATH_NAMESPACE::Rand48 rand48 (0);
 
-	const int N = 1000000;
-	Array <unsigned short> raw (N);
+        //
+        // FastHufDecoder is used for more than 128 bits, so first test with fewer than 128 bits,
+        // then test FastHufDecoder
+        //
+        for (int pass = 0 ; pass < 2 ; ++pass)
+        {
 
-	fill1 (raw, N, 1, rand48);	  // test various symbol distributions
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 10, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 100, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 1000, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            int N = pass==0 ? 12 : 1000000;
+            Array <unsigned short> raw (N);
 
-	fill2 (raw, N, 1, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 10, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 100, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 1000, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill1 (raw, N, 1, rand48);	  // test various symbol distributions
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 10, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 100, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 1000, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill3 (raw, N, 0);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, 1);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, USHRT_MAX - 1);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, USHRT_MAX);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill2 (raw, N, 1, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 10, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 100, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 1000, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill4 (raw, USHRT_MAX + 1);
-        compressVerify(raw, USHRT_MAX + 1, HUF_COMPRESS_DEK_HASH_FOR_FILL4_USHRT_MAX_PLUS_ONE);
-	compressUncompress (raw, USHRT_MAX + 1);
-	compressUncompressSubset (raw, USHRT_MAX + 1);
-	fill4 (raw, N);
-        compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL4_N);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill3 (raw, N, 0);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, 1);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, USHRT_MAX - 1);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, USHRT_MAX);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill4 (raw, 0);
-	compressUncompress (raw, 0);	// test small input data sets
-	fill4 (raw, 1);
-	compressUncompress (raw, 1);
-	fill4 (raw, 2);
-	compressUncompress (raw, 2);
-	fill4 (raw, 3);
-	compressUncompress (raw, 3);
+            if (pass==1)
+            {
+                fill4 (raw, USHRT_MAX + 1);
+                compressVerify(raw, USHRT_MAX + 1, HUF_COMPRESS_DEK_HASH_FOR_FILL4_USHRT_MAX_PLUS_ONE);
 
-	fill5 (raw, N);			// test run-length coding of code table
-        compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL5_N);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+                compressUncompress (raw, USHRT_MAX + 1);
+                compressUncompressSubset (raw, USHRT_MAX + 1);
+                fill4 (raw, N);
+                compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL4_N);
+            }
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+
+            fill4 (raw, 0);
+            compressUncompress (raw, 0);	// test small input data sets
+            fill4 (raw, 1);
+            compressUncompress (raw, 1);
+            fill4 (raw, 2);
+            compressUncompress (raw, 2);
+            fill4 (raw, 3);
+            compressUncompress (raw, 3);
+
+            fill5 (raw, N);			// test run-length coding of code table
+            if (pass==1)
+            {
+                compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL5_N);
+            }
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+
+        }
 
 	cout << "ok\n" << endl;
     }


### PR DESCRIPTION
Address negative shift reported by https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26229.
As I understand it, a corrupt EXR file has a declared length of a short Huffman code (`pl.len`) that exceeds the number of bits remaining to represent it (`lc`). This causes the `lc` to go negative, causing a negative left shift, which has undefined behavior.

This is the 'non-fast' path taken when there are less than 128 bits of data. testHuf has been updated to test with small as well as large data sizes to ensure both decoders are covered.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>