### PR TITLE
Problem with ILMBASE_FORCE_CXX03 for c++11 GCC

### DIFF
--- a/IlmBase/IlmThread/IlmThread.cpp
+++ b/IlmBase/IlmThread/IlmThread.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -43,11 +43,11 @@
 
 #include "IlmBaseConfig.h"
 #include "IlmThread.h"
-#include "Iex.h"
+#include "../Iex/Iex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
 //-----------------------------------------------------------------------------
 // C++11 and newer implementation
 //-----------------------------------------------------------------------------
@@ -86,7 +86,8 @@ Thread::start ()
 }
 
 #else
-#   if !defined (_WIN32) && !defined (_WIN64) && ! defined(HAVE_PTHREAD)
+#   if !defined (_WIN32) && !defined (_WIN64)
+#   if !HAVE_PTHREAD
 //-----------------------------------------------------------------------------
 // OPENEXR_FORCE_CXX03 with no windows / pthread support
 //-----------------------------------------------------------------------------
@@ -120,7 +121,8 @@ Thread::join ()
 {
     throw IEX_NAMESPACE::NoImplExc ("Threads not supported on this platform.");
 }
-#   endif
+#   endif // PTHREAD
+#   endif // _WIN32
 #endif
 
 

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -108,7 +108,11 @@
 #   endif
 #   endif
 #else
-#   include "jpegxl/mingw.thread.h"
+#   if defined(__MINGW32__) || defined(__MINGW64__)
+#      include "mingw.thread.h"
+#   else
+#      include <thread>
+#   endif
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/IlmBase/IlmThread/IlmThread.h
+++ b/IlmBase/IlmThread/IlmThread.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -94,19 +94,21 @@
 #include "IlmThreadExport.h"
 #include "IlmThreadNamespace.h"
 
-#ifdef ILMBASE_FORCE_CXX03
-#   if (defined (_WIN32) || defined (_WIN64)) && !defined(HAVE_PTHREAD)
+#if ILMBASE_FORCE_CXX03
+#   if defined (_WIN32) || defined (_WIN64)
+#   if !HAVE_PTHREAD
 #       ifdef NOMINMAX
 #          undef NOMINMAX
 #       endif
 #       define NOMINMAX
 #       include <windows.h>
 #       include <process.h>
-#   elif HAVE_PTHREAD
+#   else
 #      include <pthread.h>
 #   endif
+#   endif
 #else
-#   include <thread>
+#   include "jpegxl/mingw.thread.h"
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -136,11 +138,13 @@ class Thread
 
   private:
 
-#ifdef ILMBASE_FORCE_CXX03
-#   if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_PTHREAD)
+#if ILMBASE_FORCE_CXX03
+#   if defined (_WIN32) || defined (_WIN64)
+#   if !HAVE_PTHREAD
 	HANDLE _thread;
-#   elif HAVE_PTHREAD
+#   else
 	pthread_t _thread;
+#   endif
 #   endif
     void operator = (const Thread& t);	// not implemented
     Thread (const Thread& t);		// not implemented

--- a/IlmBase/IlmThread/IlmThreadForward.h
+++ b/IlmBase/IlmThread/IlmThreadForward.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -37,14 +37,14 @@
 
 #include "IlmThreadNamespace.h"
 
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
 namespace std { class mutex; }
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
 
 class Thread;
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
 class Mutex;
 #else
 using Mutex = std::mutex;

--- a/IlmBase/IlmThread/IlmThreadMutex.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutex.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -41,9 +41,10 @@
 
 #include "IlmBaseConfig.h"
 
-#ifdef ILMBASE_FORCE_CXX03
-#   if !defined (_WIN32) && !defined (_WIN64) && !defined (HAVE_PTHREAD)
-#      include "IlmThreadMutex.h"
+#if ILMBASE_FORCE_CXX03
+#    if defined _WIN32 || defined _WIN64
+#    if !HAVE_PTHREAD
+#        include "IlmThreadMutex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -56,5 +57,6 @@ void Mutex::unlock () const {}
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#   endif
+#endif // HAVE_PTHREAD
+#endif // _WIN32
 #endif

--- a/IlmBase/IlmThread/IlmThreadMutex.h
+++ b/IlmBase/IlmThread/IlmThreadMutex.h
@@ -82,7 +82,11 @@
 #      include <pthread.h>
 #   endif
 #else
-#   include "jpegxl/mingw.mutex.h"
+#   if defined(__MINGW32__) || defined(__MINGW64__)
+#      include "mingw.mutex.h"
+#   else
+#      include <mutex>
+#   endif
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/IlmBase/IlmThread/IlmThreadMutex.h
+++ b/IlmBase/IlmThread/IlmThreadMutex.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -51,7 +51,7 @@
 //	share a Lock object among multiple threads.
 //
 //	Typical usage:
-//    
+//
 //	    Mutex mtx;	// Create a Mutex object that is visible
 //	    		//to multiple threads
 //
@@ -70,7 +70,7 @@
 #include "IlmBaseConfig.h"
 #include "IlmThreadNamespace.h"
 
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
 #   if defined (_WIN32) || defined (_WIN64)
 #      ifdef NOMINMAX
 #         undef NOMINMAX
@@ -78,11 +78,11 @@
 #      define NOMINMAX
 #      include <windows.h>
 #   endif
-#   ifdef HAVE_PTHREAD
+#   if HAVE_PTHREAD
 #      include <pthread.h>
 #   endif
 #else
-#   include <mutex>
+#   include "jpegxl/mingw.mutex.h"
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -100,8 +100,8 @@ ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
 // or
 // using Lock = std::unique_lock<std::mutex>;
 //
-// (or eliminate the type completely and have people use the std library) 
-#ifdef ILMBASE_FORCE_CXX03
+// (or eliminate the type completely and have people use the std library)
+#if ILMBASE_FORCE_CXX03
 
 class Lock;
 
@@ -117,15 +117,17 @@ class ILMTHREAD_EXPORT Mutex
     void	lock () const;
     void	unlock () const;
 
-    #if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_PTHREAD)
+#   if defined (_WIN32) || defined (_WIN64)
+#   if !HAVE_PTHREAD
 	mutable CRITICAL_SECTION _mutex;
-    #elif defined (HAVE_PTHREAD)
+#   else
 	mutable pthread_mutex_t _mutex;
-    #endif
+#   endif
+#   endif
 
     void operator = (const Mutex& M);	// not implemented
     Mutex (const Mutex& M);		// not implemented
-    
+
     friend class Lock;
 };
 #else
@@ -145,7 +147,7 @@ class ILMTHREAD_EXPORT Lock
             _locked = true;
         }
     }
-    
+
     ~Lock ()
     {
         if (_locked)
@@ -161,13 +163,13 @@ class ILMTHREAD_EXPORT Lock
         _mutex.lock();
         _locked = true;
     }
-    
+
     void release ()
     {
         _mutex.unlock();
         _locked = false;
     }
-    
+
     bool locked ()
     {
         return _locked;

--- a/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
@@ -43,7 +43,7 @@
 #include "IlmThreadMutex.h"
 
 #if ILMBASE_FORCE_CXX03
-#   ifdef HAVE_PTHREAD
+#   if HAVE_PTHREAD
 #      include "Iex.h"
 #      include <assert.h>
 

--- a/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexPosix.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -42,7 +42,7 @@
 #include "IlmBaseConfig.h"
 #include "IlmThreadMutex.h"
 
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
 #   ifdef HAVE_PTHREAD
 #      include "Iex.h"
 #      include <assert.h>

--- a/IlmBase/IlmThread/IlmThreadMutexWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadMutexWin32.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -41,9 +41,9 @@
 #include "IlmBaseConfig.h"
 #include "IlmThreadMutex.h"
 
-#ifdef ILMBASE_FORCE_CXX03
-#    if ((defined _WIN32 || defined _WIN64) && !defined(__MINGW64_VERSION_MAJOR))
-#        include "Iex.h"
+#if ILMBASE_FORCE_CXX03
+#    if (defined _WIN32 || defined _WIN64) && !defined(__MINGW64_VERSION_MAJOR)
+#        include "../Iex/Iex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -489,7 +489,7 @@ TaskGroup::Data::~Data ()
 
     isEmpty.wait ();
 
-#ifdef ENABLE_SEM_DTOR_WORKAROUND
+#if ENABLE_SEM_DTOR_WORKAROUND
     // Update: this was fixed in v. 2.2.21, so this ifdef checks for that
     //
     // Alas, given the current bug in glibc we need a secondary

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -47,7 +47,11 @@
 #if !ILMBASE_FORCE_CXX03
 # include <memory>
 # include <atomic>
-# include "jpegxl/mingw.thread.h"
+# if defined(__MINGW32__) || defined(__MINGW64__)
+#  include "mingw.thread.h"
+# else
+#  include <thread>
+# endif
 #else
 #if !defined (_WIN32) && !defined (_WIN64)
 # include <unistd.h>

--- a/IlmBase/IlmThread/IlmThreadPool.cpp
+++ b/IlmBase/IlmThread/IlmThreadPool.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -42,16 +42,16 @@
 #include "IlmThreadMutex.h"
 #include "IlmThreadSemaphore.h"
 #include "IlmThreadPool.h"
-#include "Iex.h"
+#include "../Iex/Iex.h"
 #include <vector>
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
 # include <memory>
 # include <atomic>
-# include <thread>
+# include "jpegxl/mingw.thread.h"
 #else
-# ifndef _WIN32
-#  include <unistd.h>
-# endif
+#if !defined (_WIN32) && !defined (_WIN64)
+# include <unistd.h>
+#endif
 #endif
 
 using namespace std;
@@ -59,23 +59,23 @@ using namespace std;
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 #if defined(__GNU_LIBRARY__) && ( __GLIBC__ < 2 || ( __GLIBC__ == 2 && __GLIBC_MINOR__ < 21 ) )
-# define ENABLE_SEM_DTOR_WORKAROUND
+# define ENABLE_SEM_DTOR_WORKAROUND 1
 #endif
 
 struct TaskGroup::Data
 {
      Data ();
     ~Data ();
-    
+
     void    addTask () ;
     void    removeTask ();
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
     std::atomic<int> numPending;
 #else
     int              numPending;     // number of pending tasks to still execute
 #endif
     Semaphore        isEmpty;        // used to signal that the taskgroup is empty
-#if defined(ENABLE_SEM_DTOR_WORKAROUND) || defined(ILMBASE_FORCE_CXX03)
+#if ENABLE_SEM_DTOR_WORKAROUND || ILMBASE_FORCE_CXX03
     // this mutex is also used to lock numPending in the legacy c++ mode...
     Mutex            dtorMutex;      // used to work around the glibc bug:
                                      // http://sources.redhat.com/bugzilla/show_bug.cgi?id=12674
@@ -124,7 +124,7 @@ struct ThreadPool::Data
             }
             return *this;
         }
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
         SafeProvider( SafeProvider &&o )
             : _data( o._data ), _ptr( o._ptr )
         {
@@ -157,7 +157,7 @@ struct ThreadPool::Data
     inline void bumpProviderUse ();
     inline void setProvider (ThreadPoolProvider *p);
 
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Semaphore provSem;
     Mutex provMutex;
     int provUsers;
@@ -184,8 +184,8 @@ struct DefaultWorkData
     Semaphore threadSemaphore;      // signaled when a thread starts executing
     mutable Mutex threadMutex;      // mutual exclusion for threads list
     vector<DefaultWorkerThread*> threads;  // the list of all threads
-    
-#ifdef ILMBASE_FORCE_CXX03
+
+#if ILMBASE_FORCE_CXX03
     bool stopping;                  // flag indicating whether to stop threads
     mutable Mutex stopMutex;        // mutual exclusion for stopping flag
 #else
@@ -195,7 +195,7 @@ struct DefaultWorkData
 
     inline bool stopped () const
     {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
         Lock lock (stopMutex);
         return stopping;
 #else
@@ -205,7 +205,7 @@ struct DefaultWorkData
 
     inline void stop ()
     {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
         Lock lock (stopMutex);
 #endif
         stopping = true;
@@ -222,7 +222,7 @@ class DefaultWorkerThread: public Thread
     DefaultWorkerThread (DefaultWorkData* data);
 
     virtual void    run ();
-    
+
   private:
 
     DefaultWorkData *  _data;
@@ -255,7 +255,7 @@ DefaultWorkerThread::run ()
 
         {
             Lock taskLock (_data->taskMutex);
-    
+
             //
             // If there is a task pending, pop off the next task in the FIFO
             //
@@ -352,7 +352,7 @@ DefaultThreadPoolProvider::setNumThreads (int count)
         while (_data.threads.size() < desired)
             _data.threads.push_back (new DefaultWorkerThread (&_data));
     }
-#ifndef ILMBASE_FORCE_CXX03
+#if !ILMBASE_FORCE_CXX03
     _data.hasThreads = !(_data.threads.empty());
 #endif
 }
@@ -363,7 +363,7 @@ DefaultThreadPoolProvider::addTask (Task *task)
     //
     // Lock the threads, needed to access numThreads
     //
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     bool doPush;
     {
         Lock lock (_data.threadMutex);
@@ -387,7 +387,7 @@ DefaultThreadPoolProvider::addTask (Task *task)
             //
             _data.tasks.push_back (task);
         }
-        
+
         //
         // Signal that we have a new task to process
         //
@@ -436,7 +436,7 @@ DefaultThreadPoolProvider::finish ()
         delete _data.threads[i];
     }
     Lock lock1 (_data.taskMutex);
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock lock2 (_data.stopMutex);
 #endif
     _data.threads.clear();
@@ -460,7 +460,7 @@ class NullThreadPoolProvider : public ThreadPoolProvider
         delete t;
     }
     virtual void finish () {}
-}; 
+};
 
 } //namespace
 
@@ -504,14 +504,14 @@ TaskGroup::Data::~Data ()
 
 
 void
-TaskGroup::Data::addTask () 
+TaskGroup::Data::addTask ()
 {
     //
     // in c++11, we use an atomic to protect numPending to avoid the
     // extra lock but for c++98, to add the ability for custom thread
     // pool we add the lock here
     //
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock lock (dtorMutex);
 #endif
     if (numPending++ == 0)
@@ -536,11 +536,11 @@ TaskGroup::Data::removeTask ()
 
     // Further update:
     //
-    // we could remove this if it is a new enough glibc, however 
+    // we could remove this if it is a new enough glibc, however
     // we've changed the API to enable a custom override of a
     // thread pool. In order to provide safe access to the numPending,
     // we need the lock anyway, except for c++11 or newer
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock lock (dtorMutex);
 
     if (--numPending == 0)
@@ -548,14 +548,14 @@ TaskGroup::Data::removeTask ()
 #else
     if (--numPending == 0)
     {
-#ifdef ENABLE_SEM_DTOR_WORKAROUND
+#if ENABLE_SEM_DTOR_WORKAROUND
         Lock lock (dtorMutex);
 #endif
         isEmpty.post ();
     }
 #endif
 }
-    
+
 
 //
 // struct ThreadPool::Data
@@ -563,7 +563,7 @@ TaskGroup::Data::removeTask ()
 
 ThreadPool::Data::Data ():
     provUsers (0), provider (NULL)
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     , oldprovider (NULL)
 #else
 #endif
@@ -574,7 +574,7 @@ ThreadPool::Data::Data ():
 
 ThreadPool::Data::~Data()
 {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     provider->finish();
     delete provider;
 #else
@@ -587,7 +587,7 @@ ThreadPool::Data::~Data()
 inline ThreadPool::Data::SafeProvider
 ThreadPool::Data::getProvider ()
 {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock provLock( provMutex );
     ++provUsers;
     return SafeProvider( this, provider );
@@ -601,7 +601,7 @@ ThreadPool::Data::getProvider ()
 inline void
 ThreadPool::Data::coalesceProviderUse ()
 {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock provLock( provMutex );
     --provUsers;
     if ( provUsers == 0 )
@@ -614,7 +614,7 @@ ThreadPool::Data::coalesceProviderUse ()
     // ov is the previous value, so one means that now it might be 0
     if ( ov == 1 )
     {
-        
+
     }
 #endif
 }
@@ -623,7 +623,7 @@ ThreadPool::Data::coalesceProviderUse ()
 inline void
 ThreadPool::Data::bumpProviderUse ()
 {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock lock (provMutex);
     ++provUsers;
 #else
@@ -635,7 +635,7 @@ ThreadPool::Data::bumpProviderUse ()
 inline void
 ThreadPool::Data::setProvider (ThreadPoolProvider *p)
 {
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
     Lock provLock( provMutex );
 
     if ( oldprovider )
@@ -672,7 +672,7 @@ ThreadPool::Data::setProvider (ThreadPoolProvider *p)
     //
     // (well, and normally, people don't do this mid stream anyway, so
     // this will be 0 99.999% of the time, but just to be safe)
-    // 
+    //
     while ( provUsers.load( std::memory_order_relaxed ) > 0 )
         std::this_thread::yield();
 
@@ -835,7 +835,7 @@ ThreadPool::setThreadProvider (ThreadPoolProvider *provider)
 
 
 void
-ThreadPool::addTask (Task* task) 
+ThreadPool::addTask (Task* task)
 {
     _data->getProvider ()->addTask (task);
 }
@@ -847,7 +847,7 @@ ThreadPool::globalThreadPool ()
     //
     // The global thread pool
     //
-    
+
     static ThreadPool gThreadPool (0);
 
     return gThreadPool;
@@ -863,17 +863,17 @@ ThreadPool::addGlobalTask (Task* task)
 unsigned
 ThreadPool::estimateThreadCountForFileIO ()
 {
-#ifdef ILMBASE_FORCE_CXX03
-#    if defined (_WIN32) || defined (_WIN64)
+#if ILMBASE_FORCE_CXX03
+#   if defined (_WIN32) || defined (_WIN64)
     SYSTEM_INFO sysinfo;
     GetSystemInfo (&sysinfo);
     return static_cast<unsigned> (sysinfo.dwNumberOfProcessors);
-#    elif defined(_SC_NPROCESSORS_ONLN)
+#   elif defined(_SC_NPROCESSORS_ONLN)
     int count = sysconf (_SC_NPROCESSORS_ONLN);
     return static_cast<unsigned>( count < 0 ? 0 : count );
-#    else
+#   else
     return 0;
-#    endif
+#   endif
 #else
     return std::thread::hardware_concurrency ();
 #endif

--- a/IlmBase/IlmThread/IlmThreadPosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadPosix.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -42,7 +42,7 @@
 #include "IlmBaseConfig.h"
 
 #ifdef HAVE_PTHREAD
-#ifdef ILMBASE_FORCE_CXX03
+#if ILMBASE_FORCE_CXX03
 
 #include "IlmThread.h"
 #include "Iex.h"

--- a/IlmBase/IlmThread/IlmThreadSemaphore.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -41,7 +41,8 @@
 
 #include "IlmBaseConfig.h"
 
-#if !defined (_WIN32) && !(_WIN64) && !(HAVE_PTHREAD)
+#if !defined (_WIN32) && !defined (_WIN64)
+#if !HAVE_PTHREAD
 #include "IlmThreadSemaphore.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
@@ -57,4 +58,5 @@ int Semaphore::value () const {return 0;}
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#endif
+#endif // PTHREAD
+#endif // _WIN32

--- a/IlmBase/IlmThread/IlmThreadSemaphore.h
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.h
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -46,7 +46,7 @@
 #include "IlmThreadExport.h"
 #include "IlmThreadNamespace.h"
 
-#if defined _WIN32 || defined _WIN64
+#if defined(_WIN32) || defined(_WIN64)
 #   ifdef NOMINMAX
 #      undef NOMINMAX
 #   endif
@@ -54,18 +54,18 @@
 #   include <windows.h>
 #endif
 
-#ifdef HAVE_POSIX_SEMAPHORES
+#if HAVE_POSIX_SEMAPHORES
 #   include <semaphore.h>
 #elif defined(__APPLE__)
 #   include <dispatch/dispatch.h>
 #else
-#   ifdef ILMBASE_FORCE_CXX03
-#      ifdef HAVE_PTHREAD
+#   if ILMBASE_FORCE_CXX03
+#      if HAVE_PTHREAD
 #         include <pthread.h>
 #      endif
 #   else
-#      include <mutex>
-#      include <condition_variable>
+#      include "jpegxl/mingw.mutex.h"
+#      include "jpegxl/mingw.condition_variable.h"
 #   endif
 #endif
 
@@ -86,15 +86,18 @@ class ILMTHREAD_EXPORT Semaphore
 
   private:
 
-#if (defined (_WIN32) || defined (_WIN64)) && !defined (HAVE_POSIX_SEMAPHORES)
+#if defined (_WIN32) || defined (_WIN64)
+#if !HAVE_POSIX_SEMAPHORES
 
 	mutable HANDLE _semaphore;
 
-#elif defined(HAVE_POSIX_SEMAPHORES)
+#else
 
 	mutable sem_t _semaphore;
 
+#endif
 #elif defined(__APPLE__)
+
 	mutable dispatch_semaphore_t _semaphore;
 
 #else
@@ -121,7 +124,7 @@ class ILMTHREAD_EXPORT Semaphore
 	};
 
 	mutable sema_t _semaphore;
-  
+
 #endif
 
     void operator = (const Semaphore& s);	// not implemented

--- a/IlmBase/IlmThread/IlmThreadSemaphore.h
+++ b/IlmBase/IlmThread/IlmThreadSemaphore.h
@@ -64,8 +64,13 @@
 #         include <pthread.h>
 #      endif
 #   else
-#      include "jpegxl/mingw.mutex.h"
-#      include "jpegxl/mingw.condition_variable.h"
+#      if defined(__MINGW32__) || defined(__MINGW64__)
+#         include "mingw.mutex.h"
+#         include "mingw.condition_variable.h"
+#      else
+#         include <mutex>
+#         include <condition_variable>
+#      endif
 #   endif
 #endif
 

--- a/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -44,7 +44,7 @@
 #if defined (HAVE_PTHREAD) && defined(HAVE_POSIX_SEMAPHORES)
 
 #include "IlmThreadSemaphore.h"
-#include "Iex.h"
+#include "../Iex/Iex.h"
 #include <assert.h>
 #include <errno.h>
 

--- a/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphorePosix.cpp
@@ -41,7 +41,7 @@
 
 #include "IlmBaseConfig.h"
 
-#if defined (HAVE_PTHREAD) && defined(HAVE_POSIX_SEMAPHORES)
+#if HAVE_PTHREAD && HAVE_POSIX_SEMAPHORES
 
 #include "IlmThreadSemaphore.h"
 #include "../Iex/Iex.h"

--- a/IlmBase/IlmThread/IlmThreadSemaphoreWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadSemaphoreWin32.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -39,10 +39,11 @@
 //-----------------------------------------------------------------------------
 
 #include "IlmBaseConfig.h"
-#if (defined(_WIN32) || defined(_WIN64)) && !defined(HAVE_POSIX_SEMAPHORES)
+#if defined(_WIN32) || defined(_WIN64)
+#if !HAVE_POSIX_SEMAPHORES
 
 #include "IlmThreadSemaphore.h"
-#include "Iex.h"
+#include "../Iex/Iex.h"
 #include <string>
 #include <assert.h>
 #include <iostream>
@@ -61,7 +62,7 @@ errorString ()
     std::string message;
 
     //
-    // Call FormatMessage() to allow for message 
+    // Call FormatMessage() to allow for message
     // text to be acquired from the system.
     //
 
@@ -149,4 +150,5 @@ Semaphore::value() const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#endif // HAVE_POSIX_SEMAPHORES
 #endif // _WIN32

--- a/IlmBase/IlmThread/IlmThreadWin32.cpp
+++ b/IlmBase/IlmThread/IlmThreadWin32.cpp
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2005-2012, Industrial Light & Magic, a division of Lucas
 // Digital Ltd. LLC
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -16,8 +16,8 @@
 // distribution.
 // *       Neither the name of Industrial Light & Magic nor the names of
 // its contributors may be used to endorse or promote products derived
-// from this software without specific prior written permission. 
-// 
+// from this software without specific prior written permission.
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -42,10 +42,11 @@
 #include "IlmBaseConfig.h"
 #include "IlmThread.h"
 
-#ifdef ILMBASE_FORCE_CXX03
-#if (defined (_WIN32) || defined (_WIN64)) && !defined(HAVE_PTHREAD)
+#if ILMBASE_FORCE_CXX03
+#if defined (_WIN32) || defined (_WIN64)
+#if !HAVE_PTHREAD
 
-#include "Iex.h"
+#include "../Iex/Iex.h"
 #include <iostream>
 #include <assert.h>
 
@@ -107,5 +108,6 @@ Thread::start ()
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#endif // PTHREAD
 #endif // _WIN32
 #endif

--- a/IlmBase/config/IlmBaseConfig.h.in
+++ b/IlmBase/config/IlmBaseConfig.h.in
@@ -9,7 +9,7 @@
 #pragma once
 
 //
-// Define and set to 1 if the target system has c++11/14 support
+// Define and set to 1 if the target system has c++03 support
 // and you want IlmBase to NOT use it's features
 //
 


### PR DESCRIPTION
I had to disable ILMBASE_FORCE_CXX03 while merging the JPEGXL codec. Then thread can run under Windows. I have used the same library mingw.thread.h which is located in JPEGXL.
```
Define and set to 1 if the target system has c++11/14 support and you want IlmBase to NOT use it's features
```