### PR TITLE
E2K: added initial support of MCST Elbrus 2000 CPU architecture

### DIFF
--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -316,15 +316,15 @@ FastHufDecoder::~FastHufDecoder()
 bool
 FastHufDecoder::enabled()
 {
-    #if defined(__INTEL_COMPILER) || defined(__GNUC__)  
+    #if defined(__INTEL_COMPILER) || defined(__GNUC__)
 
         //
         // Enabled for ICC, GCC:
         //       __i386__   -> x86
         //       __x86_64__ -> 64-bit x86
-        //
+        //       __e2k__    -> e2k (MCST Elbrus 2000)
 
-        #if defined (__i386__) || defined(__x86_64__)
+        #if defined (__i386__) || defined(__x86_64__) || defined(__e2k__)
             return true;
         #else
             return false;

--- a/src/lib/OpenEXR/ImfSimd.h
+++ b/src/lib/OpenEXR/ImfSimd.h
@@ -53,6 +53,27 @@
     #define IMF_HAVE_SSE4_1 1
 #endif
 
+// Compiler flags on e2k (MCST Elbrus 2000) architecture
+#if defined(__SSE3__) && defined(__e2k__)
+    #define IMF_HAVE_SSE3 1
+#endif
+
+#if defined(__SSSE3__) && defined(__e2k__)
+    #define IMF_HAVE_SSSE3 1
+#endif
+
+#if defined(__SSE4_2__) && defined(__e2k__)
+    #define IMF_HAVE_SSE4_2 1
+#endif
+
+#if defined(__AVX__) && defined(__e2k__)
+    #define IMF_HAVE_AVX 1
+#endif
+
+#if defined(__F16C__) && defined(__e2k__)
+    #define IMF_HAVE_F16C 1
+#endif
+
 extern "C"
 {
 #ifdef IMF_HAVE_SSE2


### PR DESCRIPTION
e2k (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.
Architecture has half native / half software support of most Intel/AMD SIMD (e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4)

- https://en.wikipedia.org/wiki/Elbrus_2000