### PR TITLE
sanity check ScanlineInput bytesPerLine instead of lineOffset size

### DIFF
--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -1135,14 +1135,14 @@ void ScanLineInputFile::initialize(const Header& header)
                               _data->linesInBuffer) / _data->linesInBuffer;
 
         //
-        // avoid allocating excessive memory due to large lineOffsets table size.
+        // avoid allocating excessive memory due to large lineOffsets and bytesPerLine table sizes.
         // If the chunktablesize claims to be large,
-        // check the file is big enough to contain the table before allocating memory
+        // check the file is big enough to contain the lineOffsets table before allocating memory
         // in the bytesPerLineTable and the lineOffsets table.
         // Attempt to read the last entry in the table. Either the seekg() or the read()
         // call will throw an exception if the file is too small to contain the table
         //
-        if (lineOffsetSize > gLargeChunkTableSize)
+        if (lineOffsetSize * _data->linesInBuffer > gLargeChunkTableSize)
         {
             Int64 pos = _streamData->is->tellg();
             _streamData->is->seekg(pos + (lineOffsetSize-1)*sizeof(Int64));


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27409
Updates the filesize check added by #824 to files with a large number of scanlines, rather than a large number of chunks, giving more protection against very small specially crafted files causing large memory allocations.

#824 prevented large memory allocations for scanline offset tables in files which were too small to contain large tables. ScanLineInput files have a 'scanline offset table' (one per chunk) as well as 'bytesPerLine' and 'offsetInLineBuffer' tables (each one per scanline). DWAB files contain 256 scanlines per chunk, so can have a huge bytesPerLine table with only a moderate scanline offset table.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>