### PR TITLE
Add a conditional to prevent analysis on forks

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -19,6 +19,7 @@ jobs:
 
   linux_sonarcloud:
     name: 'SonarCloud Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    if: github.repository == ‘AcademySoftwareFoundation/openexr’
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
@@ -85,6 +86,7 @@ jobs:
   # ------------------------------------------------------------------------------
   linux_valgrind:
     name: 'Valgrind Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    if: github.repository == ‘AcademySoftwareFoundation/openexr’
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
@@ -151,6 +153,7 @@ jobs:
   # ------------------------------------------------------------------------------
   linux_fuzz:
     name: 'Fuzz Test Linux CentOS 7 VFX CY2020 <GCC 6.3.1>'
+    if: github.repository == ‘AcademySoftwareFoundation/openexr’
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Forked repos do not have permission to write to sonarcloud anyway,
disable analysis on forks in general, leaving them to run on the main
upstream repo

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>