### PR TITLE
Handle xsampling and bad seekg() calls in exrcheck

### DIFF
--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -960,7 +960,7 @@ DeepTiledInputFile::compatibilityInitialize(OPENEXR_IMF_INTERNAL_NAMESPACE::IStr
 void
 DeepTiledInputFile::multiPartInitialize(InputPartData* part)
 {
-    if (isTiled(part->header.type()) == false)
+    if (_data->header.type() != DEEPTILE)
         THROW (IEX_NAMESPACE::ArgExc, "Can't build a DeepTiledInputFile from a part of type " << part->header.type());
 
     _data->_streamData = part->mutex;

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -960,7 +960,7 @@ DeepTiledInputFile::compatibilityInitialize(OPENEXR_IMF_INTERNAL_NAMESPACE::IStr
 void
 DeepTiledInputFile::multiPartInitialize(InputPartData* part)
 {
-    if (_data->header.type() != DEEPTILE)
+    if (part->header.type() != DEEPTILE)
         THROW (IEX_NAMESPACE::ArgExc, "Can't build a DeepTiledInputFile from a part of type " << part->header.type());
 
     _data->_streamData = part->mutex;

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -782,17 +782,20 @@ class PtrIStream: public IStream
     }
     virtual void	seekg (Int64 pos)
     {
+
         if( pos < 0 )
         {
           THROW (IEX_NAMESPACE::InputExc, "internal error: seek to " << pos << " requested");
         }
 
-        current = base + pos;
+        const char* newcurrent = base + pos;
 
-        if( current < base || current > end)
+        if( newcurrent < base || newcurrent > end)
         {
             THROW (IEX_NAMESPACE::InputExc, "Out of range seek requested\n");
         }
+
+        current = newcurrent;
 
     }
 

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -131,10 +131,11 @@ readScanline(T& in, bool reduceMemory , bool reduceTime)
         {
             switch (channelIndex % 3)
             {
-                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dx] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dx/c.channel().xSampling ] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
-                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dx] , sizeof(float) , 0 , c.channel().xSampling , c.channel().ySampling ));
-                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dx] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dx/c.channel().xSampling ] , sizeof(float) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                break;
+                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dx/c.channel().xSampling ] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
             }
             channelIndex ++;
@@ -241,10 +242,10 @@ readTile(T& in, bool reduceMemory , bool reduceTime)
         {
             switch (channelIndex % 3)
             {
-                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dwx] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 0 : i.insert(c.name(),Slice(HALF, (char*)&halfChannels[-dwx / c.channel().xSampling ] , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
-                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dwx] , sizeof(float) , 0 ,  c.channel().xSampling , c.channel().ySampling));
-                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dwx] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling));
+                case 1 : i.insert(c.name(),Slice(FLOAT, (char*)&floatChannels[-dwx / c.channel().xSampling ] , sizeof(float) , 0 ,  c.channel().xSampling , c.channel().ySampling));
+                case 2 : i.insert(c.name(),Slice(UINT, (char*)&uintChannels[-dwx / c.channel().xSampling ] , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling));
                 break;
             }
             channelIndex ++;


### PR DESCRIPTION
Fix bugs in exrcheck:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28051
Framebuffer didn't handle images with nonzero dataWindow.min.x!=0 and xSampling!=1

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28155
In exrcheck's stream object, calling seekg() with a bad value would still seek to a bad position, even though it threw an exception, so a future read would segfault

Also fix check that DeepTiledInputPart is being constructed only on a deeptiled part. 