### PR TITLE
Fix missing header for Visual Studio

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -16,7 +16,7 @@
 #include "ImfMultiPartInputFile.h"
 
 #include <vector>
-
+#include <algorithm>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 


### PR DESCRIPTION
Error message in Visual Studio:
```
src\lib\OpenEXRUtil\ImfCheckFile.cpp(26): error C2039: "max": is not a member of "std"
```

See https://en.cppreference.com/w/cpp/algorithm/max, `std::max` is defined in header `algorithm`.