### PR TITLE
Cherry-pick PRs from master branch which fix issues reported by fuzz tests

### DIFF
--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -494,7 +494,7 @@ B44Compressor::B44Compressor
     //
 
     _tmpBuffer = new unsigned short
-        [checkArraySize (uiMult (maxScanLineSize, numScanLines),
+        [checkArraySize (uiMult (maxScanLineSize / sizeof(unsigned short), numScanLines),
                          sizeof (unsigned short))];
 
     const ChannelList &channels = header().channels();

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -381,26 +381,26 @@ unpack14 (const unsigned char b[14], unsigned short s[16])
     s[ 0] = (b[0] << 8) | b[1];
 
     unsigned short shift = (b[ 2] >> 2);
-    unsigned short bias = (0x20 << shift);
+    unsigned short bias = (0x20u << shift);
 
-    s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3f) << shift) - bias;
-    s[ 8] = s[ 4] + ((((b[ 3] << 2) | (b[ 4] >> 6)) & 0x3f) << shift) - bias;
-    s[12] = s[ 8] +   ((b[ 4]                       & 0x3f) << shift) - bias;
+    s[ 4] = s[ 0] + ((((b[ 2] << 4) | (b[ 3] >> 4)) & 0x3fu) << shift) - bias;
+    s[ 8] = s[ 4] + ((((b[ 3] << 2) | (b[ 4] >> 6)) & 0x3fu) << shift) - bias;
+    s[12] = s[ 8] +   ((b[ 4]                       & 0x3fu) << shift) - bias;
     
-    s[ 1] = s[ 0] +   ((b[ 5] >> 2)                         << shift) - bias;
-    s[ 5] = s[ 4] + ((((b[ 5] << 4) | (b[ 6] >> 4)) & 0x3f) << shift) - bias;
-    s[ 9] = s[ 8] + ((((b[ 6] << 2) | (b[ 7] >> 6)) & 0x3f) << shift) - bias;
-    s[13] = s[12] +   ((b[ 7]                       & 0x3f) << shift) - bias;
+    s[ 1] = s[ 0] +   ((unsigned int) (b[ 5] >> 2)           << shift) - bias;
+    s[ 5] = s[ 4] + ((((b[ 5] << 4) | (b[ 6] >> 4)) & 0x3fu) << shift) - bias;
+    s[ 9] = s[ 8] + ((((b[ 6] << 2) | (b[ 7] >> 6)) & 0x3fu) << shift) - bias;
+    s[13] = s[12] +   ((b[ 7]                       & 0x3fu) << shift) - bias;
     
-    s[ 2] = s[ 1] +   ((b[ 8] >> 2)                         << shift) - bias;
-    s[ 6] = s[ 5] + ((((b[ 8] << 4) | (b[ 9] >> 4)) & 0x3f) << shift) - bias;
-    s[10] = s[ 9] + ((((b[ 9] << 2) | (b[10] >> 6)) & 0x3f) << shift) - bias;
-    s[14] = s[13] +   ((b[10]                       & 0x3f) << shift) - bias;
+    s[ 2] = s[ 1] +   ((unsigned int)(b[ 8] >> 2)            << shift) - bias;
+    s[ 6] = s[ 5] + ((((b[ 8] << 4) | (b[ 9] >> 4)) & 0x3fu) << shift) - bias;
+    s[10] = s[ 9] + ((((b[ 9] << 2) | (b[10] >> 6)) & 0x3fu) << shift) - bias;
+    s[14] = s[13] +   ((b[10]                       & 0x3fu) << shift) - bias;
     
-    s[ 3] = s[ 2] +   ((b[11] >> 2)                         << shift) - bias;
-    s[ 7] = s[ 6] + ((((b[11] << 4) | (b[12] >> 4)) & 0x3f) << shift) - bias;
-    s[11] = s[10] + ((((b[12] << 2) | (b[13] >> 6)) & 0x3f) << shift) - bias;
-    s[15] = s[14] +   ((b[13]                       & 0x3f) << shift) - bias;
+    s[ 3] = s[ 2] +   ((unsigned int)(b[11] >> 2)            << shift) - bias;
+    s[ 7] = s[ 6] + ((((b[11] << 4) | (b[12] >> 4)) & 0x3fu) << shift) - bias;
+    s[11] = s[10] + ((((b[12] << 2) | (b[13] >> 6)) & 0x3fu) << shift) - bias;
+    s[15] = s[14] +   ((b[13]                       & 0x3fu) << shift) - bias;
 
     for (int i = 0; i < 16; ++i)
     {

--- a/OpenEXR/IlmImf/ImfB44Compressor.cpp
+++ b/OpenEXR/IlmImf/ImfB44Compressor.cpp
@@ -951,7 +951,10 @@ B44Compressor::uncompress (const char *inPtr,
 		if (inSize < 3)
 		    notEnoughData();
 
-		if (((const unsigned char *)inPtr)[2] == 0xfc)
+                //
+                // If shift exponent is 63, call unpack14 (ignoring unused bits)
+                //
+		if (((const unsigned char *)inPtr)[2] >= (13<<2) )
 		{
 		    unpack3 ((const unsigned char *)inPtr, s);
 		    inPtr += 3;

--- a/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfDeepImageStateAttribute.cpp
@@ -58,6 +58,12 @@ template <>
 void
 DeepImageStateAttribute::writeValueTo
     (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, int version) const
+#if defined (__clang__)
+    // _value may be an invalid value, which the clang sanitizer reports
+    // as undefined behavior, even though the value is acceptable in this
+    // context.
+    __attribute__((no_sanitize ("undefined")))
+#endif
 {
     unsigned char tmp = _value;
     Xdr::write <StreamIO> (os, tmp);

--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -721,10 +721,12 @@ LineBufferTask::execute ()
 
                     int width = (_ifd->maxX - _ifd->minX + 1);
 
+                    ptrdiff_t base = reinterpret_cast<ptrdiff_t>(&_ifd->sampleCount[0][0]);
+                    base -= sizeof(unsigned int)*_ifd->minX;
+                    base -= sizeof(unsigned int)*static_cast<ptrdiff_t>(_ifd->minY) * static_cast<ptrdiff_t>(width);
+
                     copyIntoDeepFrameBuffer (readPtr, slice.base,
-                                             (char*) (&_ifd->sampleCount[0][0]
-                                                      - _ifd->minX
-                                                      - _ifd->minY * width),
+                                             reinterpret_cast<char*>(base),
                                              sizeof(unsigned int) * 1,
                                              sizeof(unsigned int) * width,
                                              y, _ifd->minX, _ifd->maxX,

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -990,8 +990,8 @@ DeepTiledInputFile::initialize ()
     for (size_t i = 0; i < _data->tileBuffers.size(); i++)
         _data->tileBuffers[i] = new TileBuffer ();
 
-    _data->maxSampleCountTableSize = _data->tileDesc.ySize *
-                                     _data->tileDesc.xSize *
+    _data->maxSampleCountTableSize = static_cast<size_t>(_data->tileDesc.ySize) *
+                                     static_cast<size_t>(_data->tileDesc.xSize) *
                                      sizeof(int);
 
     _data->sampleCountTableBuffer.resizeErase(_data->maxSampleCountTableSize);

--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -2535,7 +2535,7 @@ DwaCompressor::uncompress
 
     if (acCompressedSize > 0)
     {
-        if (totalAcUncompressedCount*sizeof(unsigned short) > _packedAcBufferSize)
+        if ( !_packedAcBuffer || totalAcUncompressedCount*sizeof(unsigned short) > _packedAcBufferSize)
         {
             throw IEX_NAMESPACE::InputExc("Error uncompressing DWA data"
                                 "(corrupt header).");

--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -2681,6 +2681,10 @@ DwaCompressor::uncompress
         int gChan = _cscSets[csc].idx[1];    
         int bChan = _cscSets[csc].idx[2];    
 
+        if (_channelData[rChan].compression != LOSSY_DCT || _channelData[gChan].compression != LOSSY_DCT || _channelData[bChan].compression != LOSSY_DCT)
+        {
+            throw IEX_NAMESPACE::BaseExc("Bad DWA compression type detected");
+        }
 
         LossyDctDecoderCsc decoder
             (rowPtrs[rChan],

--- a/OpenEXR/IlmImf/ImfEnvmapAttribute.cpp
+++ b/OpenEXR/IlmImf/ImfEnvmapAttribute.cpp
@@ -57,6 +57,12 @@ EnvmapAttribute::staticTypeName ()
 template <>
 void
 EnvmapAttribute::writeValueTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, int version) const
+#if defined (__clang__)
+    // _value may be an invalid value, which the clang sanitizer reports
+    // as undefined behavior, even though the value is acceptable in this
+    // context.
+    __attribute__((no_sanitize ("undefined")))
+#endif
 {
     unsigned char tmp = _value;
     Xdr::write <StreamIO> (os, tmp);

--- a/OpenEXR/IlmImf/ImfFastHuf.cpp
+++ b/OpenEXR/IlmImf/ImfFastHuf.cpp
@@ -205,7 +205,7 @@ FastHufDecoder::FastHufDecoder
         for (int l = _minCodeLength; l <= _maxCodeLength; ++l)
         {
             countTmp[l] = (double)codeCount[l] * 
-                          (double)(2 << (_maxCodeLength-l));
+                          (double)(2ll << (_maxCodeLength-l));
         }
     
         for (int l = _minCodeLength; l <= _maxCodeLength; ++l)
@@ -215,7 +215,7 @@ FastHufDecoder::FastHufDecoder
             for (int k =l + 1; k <= _maxCodeLength; ++k)
                 tmp += countTmp[k];
             
-            tmp /= (double)(2 << (_maxCodeLength - l));
+            tmp /= (double)(2ll << (_maxCodeLength - l));
 
             base[l] = (Int64)ceil (tmp);
         }

--- a/OpenEXR/IlmImf/ImfFastHuf.cpp
+++ b/OpenEXR/IlmImf/ImfFastHuf.cpp
@@ -538,18 +538,24 @@ FastHufDecoder::refill
 
         buffer |= bufferBack >> (64 - numBits);
     }
-    
-    bufferBack         = bufferBack << numBits;
-    bufferBackNumBits -= numBits;
 
-    // 
-    // We can have cases where the previous shift of bufferBack is << 64 - 
-    // in which case no shift occurs. The bit count math still works though,
-    // so if we don't have any bits left, zero out bufferBack.
+
+    //
+    // We can have cases where the previous shift of bufferBack is << 64 -
+    // this is an undefined operation but tends to create just zeroes.
+    // so if we won't have any bits left, zero out bufferBack insetad of computing the shift
     //
 
-    if (bufferBackNumBits == 0)
+    if (bufferBackNumBits <= numBits)
+    {
         bufferBack = 0;
+    }else
+    {
+        bufferBack = bufferBack << numBits;
+    }
+    bufferBackNumBits -= numBits;
+
+
 }
 
 //

--- a/OpenEXR/IlmImf/ImfFastHuf.cpp
+++ b/OpenEXR/IlmImf/ImfFastHuf.cpp
@@ -127,7 +127,7 @@ FastHufDecoder::FastHufDecoder
 
     for (Int64 symbol = static_cast<Int64>(minSymbol); symbol <= static_cast<Int64>(maxSymbol); symbol++)
     {
-        if (currByte - table > numBytes)
+        if (currByte - table >= numBytes)
         {
             throw IEX_NAMESPACE::InputExc ("Error decoding Huffman table "
                                            "(Truncated table data).");
@@ -144,7 +144,7 @@ FastHufDecoder::FastHufDecoder
 
         if (codeLen == (Int64) LONG_ZEROCODE_RUN)
         {
-            if (currByte - table > numBytes)
+            if (currByte - table >= numBytes)
             {
                 throw IEX_NAMESPACE::InputExc ("Error decoding Huffman table "
                                                "(Truncated table data).");

--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -1093,7 +1093,9 @@ hufUncompress (const char compressed[],
 
     const char *ptr = compressed + 20;
 
-    if ( ptr + (nBits+7 )/8 > compressed+nCompressed)
+    uint64_t nBytes = (static_cast<uint64_t>(nBits)+7) / 8 ;
+
+    if ( ptr + nBytes > compressed+nCompressed)
     {
         notEnoughData();
         return;

--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -910,6 +910,11 @@ hufDecode
 		//
 
 		lc -= pl.len;
+
+		if ( lc < 0 )
+		{
+			invalidCode(); // code length too long
+		}
 		getCode (pl.lit, rlc, c, lc, in, out, outb, oe);
 	    }
 	    else
@@ -967,6 +972,10 @@ hufDecode
 	if (pl.len)
 	{
 	    lc -= pl.len;
+            if ( lc < 0 )
+            {
+   	        invalidCode(); // code length too long
+            }
 	    getCode (pl.lit, rlc, c, lc, in, out, outb, oe);
 	}
 	else

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -278,9 +278,14 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
             //
             // We don't have any valid buffered info, so we need to read in
             // from the file.
+            // if no channels are being read that are present in file, cachedBuffer will be empty
             //
 
-            ifd->tFile->readTiles (0, ifd->tFile->numXTiles (0) - 1, j, j);
+            if (ifd->cachedBuffer->begin() != ifd->cachedBuffer->end())
+            {
+                ifd->tFile->readTiles (0, ifd->tFile->numXTiles (0) - 1, j, j);
+            }
+
             ifd->cachedTileY = j;
         }
 
@@ -313,7 +318,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
             if( c!=ifd->cachedBuffer->end())
             {
                 //
-                // copy channel from source slice to output slice
+                // output channel was read from source image: copy to output slice
                 //
                 Slice fromSlice = c.slice();	// slice to write to
 
@@ -357,7 +362,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
             {
 
                 //
-                // fill output slice
+                // channel wasn't present in source file: fill output slice
                 //
                 for (int y = yStart;
                     y <= maxYThisRow;
@@ -841,6 +846,7 @@ InputFile::setFrameBuffer (const FrameBuffer &frameBuffer)
 	    }
 
 	    _data->tFile->setFrameBuffer (*_data->cachedBuffer);
+
         }
 
 	_data->tFileBuffer = frameBuffer;

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -281,7 +281,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
             // if no channels are being read that are present in file, cachedBuffer will be empty
             //
 
-            if (ifd->cachedBuffer->begin() != ifd->cachedBuffer->end())
+            if (ifd->cachedBuffer && ifd->cachedBuffer->begin() != ifd->cachedBuffer->end())
             {
                 ifd->tFile->readTiles (0, ifd->tFile->numXTiles (0) - 1, j, j);
             }

--- a/OpenEXR/IlmImf/ImfInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfInputFile.cpp
@@ -456,6 +456,14 @@ InputFile::InputFile (const char fileName[], int numThreads):
             _data->_streamData->is = is;
             _data->header.readFrom (*_data->_streamData->is, _data->version);
             
+            if(isNonImage(_data->version))
+            {
+                if(!_data->header.hasType())
+                {
+                      throw(IEX_NAMESPACE::InputExc("Non-image files must have a 'type' attribute"));
+                }
+            }
+
             // fix type attribute in single part regular image types
             // (may be wrong if an old version of OpenEXR converts
             // a tiled image to scanline or vice versa)
@@ -524,6 +532,14 @@ InputFile::InputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int numThread
             _data->_streamData->is = &is;
             _data->header.readFrom (*_data->_streamData->is, _data->version);
             
+            if(isNonImage(_data->version))
+            {
+                if(!_data->header.hasType())
+                {
+                      throw(IEX_NAMESPACE::InputExc("Non-image files must have a 'type' attribute"));
+                }
+            }
+
             // fix type attribute in single part regular image types
             // (may be wrong if an old version of OpenEXR converts
             // a tiled image to scanline or vice versa)

--- a/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfMultiPartInputFile.cpp
@@ -340,6 +340,11 @@ MultiPartInputFile::initialize()
     // Perform usual check on headers.
     //
 
+    if ( _data->_headers.size() == 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Files must contain at least one header");
+    }
+
     for (size_t i = 0; i < _data->_headers.size(); i++)
     {
         //

--- a/OpenEXR/IlmImf/ImfPizCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfPizCompressor.cpp
@@ -594,7 +594,7 @@ Xdr::read <CharPtrIO> (inPtr, (char *) &bitmap[0] + minNonZero,
     int length;
     Xdr::read <CharPtrIO> (inPtr, length);
 
-    if (length > inSize)
+    if (inPtr + length > inputEnd || length<0 )
     {
 	throw InputExc ("Error in header for PIZ-compressed data "
 			"(invalid array length).");

--- a/OpenEXR/IlmImf/ImfRgbaFile.cpp
+++ b/OpenEXR/IlmImf/ImfRgbaFile.cpp
@@ -1180,7 +1180,7 @@ RgbaInputFile::RgbaInputFile (const char name[], int numThreads):
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1192,7 +1192,7 @@ RgbaInputFile::RgbaInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int n
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1207,7 +1207,7 @@ RgbaInputFile::RgbaInputFile (const char name[],
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1222,7 +1222,7 @@ RgbaInputFile::RgbaInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 {
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 }
 
@@ -1249,27 +1249,42 @@ RgbaInputFile::setFrameBuffer (Rgba *base, size_t xStride, size_t yStride)
 
 	FrameBuffer fb;
 
-	fb.insert (_channelNamePrefix + "R",
-		   Slice (HALF,
-			  (char *) &base[0].r,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
+        if( channels() & WRITE_Y )
+        {
+            fb.insert (_channelNamePrefix + "Y",
+                    Slice (HALF,
+                            (char *) &base[0].r,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+        }
+        else
+        {
 
-	fb.insert (_channelNamePrefix + "G",
-		   Slice (HALF,
-			  (char *) &base[0].g,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
 
-	fb.insert (_channelNamePrefix + "B",
-		   Slice (HALF,
-			  (char *) &base[0].b,
-			  xs, ys,
-			  1, 1,		// xSampling, ySampling
-			  0.0));	// fillValue
+            fb.insert (_channelNamePrefix + "R",
+                    Slice (HALF,
+                            (char *) &base[0].r,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
 
+
+
+            fb.insert (_channelNamePrefix + "G",
+                    Slice (HALF,
+                            (char *) &base[0].g,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+
+            fb.insert (_channelNamePrefix + "B",
+                    Slice (HALF,
+                            (char *) &base[0].b,
+                            xs, ys,
+                            1, 1,		// xSampling, ySampling
+                            0.0));	// fillValue
+        }
 	fb.insert (_channelNamePrefix + "A",
 		   Slice (HALF,
 			  (char *) &base[0].a,
@@ -1292,7 +1307,7 @@ RgbaInputFile::setLayerName (const string &layerName)
 
     RgbaChannels rgbaChannels = channels();
 
-    if (rgbaChannels & (WRITE_Y | WRITE_C))
+    if (rgbaChannels & WRITE_C)
 	_fromYca = new FromYca (*_inputFile, rgbaChannels);
 
     FrameBuffer fb;
@@ -1311,6 +1326,28 @@ RgbaInputFile::readPixels (int scanLine1, int scanLine2)
     else
     {
 	_inputFile->readPixels (scanLine1, scanLine2);
+
+        if (channels() & WRITE_Y)
+        {
+            //
+            // Luma channel has been written into red channel
+            // Duplicate into green and blue channel to create gray image
+            //
+            const Slice* s = _inputFile->frameBuffer().findSlice(_channelNamePrefix + "Y");
+            Box2i dataWindow = _inputFile->header().dataWindow();
+
+            for( int scanLine = scanLine1  ; scanLine <= scanLine2 ; scanLine++ )
+            {
+                char* rowBase = s->base + scanLine*s->yStride;
+                for(int x = dataWindow.min.x ; x <= dataWindow.max.x ; ++x )
+                {
+                    Rgba* pixel = reinterpret_cast<Rgba*>(rowBase+x*s->xStride);
+                    pixel->g = pixel->r;
+                    pixel->b = pixel->r;
+                }
+
+            }
+        }
     }
 }
 

--- a/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfScanLineInputFile.cpp
@@ -1145,6 +1145,10 @@ void ScanLineInputFile::initialize(const Header& header)
             for (size_t i = 0; i < _data->lineBuffers.size(); i++)
             {
                 _data->lineBuffers[i]->buffer = (char *) EXRAllocAligned(_data->lineBufferSize*sizeof(char),16);
+                if (!_data->lineBuffers[i]->buffer)
+                {
+                    throw IEX_NAMESPACE::LogicExc("Failed to allocate memory for scanline buffers");
+                }
             }
         }
         _data->nextLineBufferMinY = _data->minY - 1;

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -958,7 +958,10 @@ TiledInputFile::initialize ()
     {
         if (!isTiled (_data->version))
             throw IEX_NAMESPACE::ArgExc ("Expected a tiled file but the file is not tiled.");
-        
+
+        if (isNonImage (_data->version))
+            throw IEX_NAMESPACE::ArgExc ("File is not a regular tiled image.");
+
     }
     else
     {

--- a/OpenEXR/IlmImf/ImfTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledInputFile.cpp
@@ -1000,6 +1000,16 @@ TiledInputFile::initialize ()
     _data->tileBufferSize = _data->maxBytesPerTileLine * _data->tileDesc.ySize;
 
     //
+    // OpenEXR has a limit of INT_MAX compressed bytes per tile
+    // disallow uncompressed tile sizes above INT_MAX too to guarantee file is written
+    //
+    if( _data->tileBufferSize > INT_MAX )
+    {
+        throw IEX_NAMESPACE::ArgExc ("Tile size too large for OpenEXR format");
+    }
+
+
+    //
     // Create all the TileBuffers and allocate their internal buffers
     //
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -301,10 +301,8 @@ calculateNumTiles (int *numTiles,
 {
     for (int i = 0; i < numLevels; i++)
     {
-        int l = levelSize (min, max, i, rmode);
-        if (l > std::numeric_limits<int>::max() - size + 1)
-            throw IEX_NAMESPACE::ArgExc ("Invalid size.");
-
+        // use 64 bits to avoid int overflow if size is large.
+        Int64 l = levelSize (min, max, i, rmode);
         numTiles[i] = (l + size - 1) / size;
     }
 }

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -97,13 +97,14 @@ dataWindowForTile (const TileDescription &tileDesc,
     V2i tileMin = V2i (minX + dx * tileDesc.xSize,
 		       minY + dy * tileDesc.ySize);
 
-    V2i tileMax = tileMin + V2i (tileDesc.xSize - 1, tileDesc.ySize - 1);
+    int64_t tileMaxX = int64_t(tileMin[0]) + tileDesc.xSize - 1;
+    int64_t tileMaxY = int64_t(tileMin[1]) + tileDesc.ySize - 1;
 
     V2i levelMax = dataWindowForLevel
 		       (tileDesc, minX, maxX, minY, maxY, lx, ly).max;
 
-    tileMax = V2i (std::min (tileMax[0], levelMax[0]),
-		   std::min (tileMax[1], levelMax[1]));
+    V2i tileMax = V2i (std::min (tileMaxX, int64_t(levelMax[0])),
+		   std::min (tileMaxY, int64_t(levelMax[1])));
 
     return Box2i (tileMin, tileMax);
 }

--- a/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
+++ b/OpenEXR/IlmImf/ImfTiledOutputFile.cpp
@@ -1035,6 +1035,17 @@ TiledOutputFile::initialize (const Header &header)
 
     _data->tileBufferSize = _data->maxBytesPerTileLine * _data->tileDesc.ySize;
      
+        //
+    // OpenEXR has a limit of INT_MAX compressed bytes per tile
+    // disallow uncompressed tile sizes above INT_MAX too to guarantee file is written
+    //
+    if( _data->tileBufferSize > INT_MAX )
+    {
+        throw IEX_NAMESPACE::ArgExc ("Tile size too large for OpenEXR format");
+    }
+
+
+
     //
     // Create all the TileBuffers and allocate their internal buffers
     //

--- a/OpenEXR/IlmImfTest/testHuf.cpp
+++ b/OpenEXR/IlmImfTest/testHuf.cpp
@@ -245,70 +245,86 @@ testHuf (const std::string&)
 
 	IMATH_NAMESPACE::Rand48 rand48 (0);
 
-	const int N = 1000000;
-	Array <unsigned short> raw (N);
+        //
+        // FastHufDecoder is used for more than 128 bits, so first test with fewer than 128 bits,
+        // then test FastHufDecoder
+        //
+        for (int pass = 0 ; pass < 2 ; ++pass)
+        {
 
-	fill1 (raw, N, 1, rand48);	  // test various symbol distributions
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 10, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 100, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill1 (raw, N, 1000, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            int N = pass==0 ? 12 : 1000000;
+            Array <unsigned short> raw (N);
 
-	fill2 (raw, N, 1, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 10, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 100, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill2 (raw, N, 1000, rand48);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill1 (raw, N, 1, rand48);	  // test various symbol distributions
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 10, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 100, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill1 (raw, N, 1000, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill3 (raw, N, 0);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, 1);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, USHRT_MAX - 1);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
-	fill3 (raw, N, USHRT_MAX);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill2 (raw, N, 1, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 10, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 100, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill2 (raw, N, 1000, rand48);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill4 (raw, USHRT_MAX + 1);
-        compressVerify(raw, USHRT_MAX + 1, HUF_COMPRESS_DEK_HASH_FOR_FILL4_USHRT_MAX_PLUS_ONE);
-	compressUncompress (raw, USHRT_MAX + 1);
-	compressUncompressSubset (raw, USHRT_MAX + 1);
-	fill4 (raw, N);
-        compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL4_N);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+            fill3 (raw, N, 0);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, 1);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, USHRT_MAX - 1);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+            fill3 (raw, N, USHRT_MAX);
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
 
-	fill4 (raw, 0);
-	compressUncompress (raw, 0);	// test small input data sets
-	fill4 (raw, 1);
-	compressUncompress (raw, 1);
-	fill4 (raw, 2);
-	compressUncompress (raw, 2);
-	fill4 (raw, 3);
-	compressUncompress (raw, 3);
+            if (pass==1)
+            {
+                fill4 (raw, USHRT_MAX + 1);
+                compressVerify(raw, USHRT_MAX + 1, HUF_COMPRESS_DEK_HASH_FOR_FILL4_USHRT_MAX_PLUS_ONE);
 
-	fill5 (raw, N);			// test run-length coding of code table
-        compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL5_N);
-	compressUncompress (raw, N);
-	compressUncompressSubset (raw, N);
+                compressUncompress (raw, USHRT_MAX + 1);
+                compressUncompressSubset (raw, USHRT_MAX + 1);
+                fill4 (raw, N);
+                compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL4_N);
+            }
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+
+            fill4 (raw, 0);
+            compressUncompress (raw, 0);	// test small input data sets
+            fill4 (raw, 1);
+            compressUncompress (raw, 1);
+            fill4 (raw, 2);
+            compressUncompress (raw, 2);
+            fill4 (raw, 3);
+            compressUncompress (raw, 3);
+
+            fill5 (raw, N);			// test run-length coding of code table
+            if (pass==1)
+            {
+                compressVerify(raw, N, HUF_COMPRESS_DEK_HASH_FOR_FILL5_N);
+            }
+            compressUncompress (raw, N);
+            compressUncompressSubset (raw, N);
+
+        }
 
 	cout << "ok\n" << endl;
     }

--- a/OpenEXR/IlmImfTest/testScanLineApi.cpp
+++ b/OpenEXR/IlmImfTest/testScanLineApi.cpp
@@ -93,7 +93,9 @@ writeRead (const Array2D<unsigned int> &pi1,
            int yOffset,
            Compression comp,
            LevelMode mode,
-	   LevelRoundingMode rmode)
+	   LevelRoundingMode rmode,
+           bool fillChannel
+          )
 {
     //
     // Write the pixel data in pi1, ph1 and ph2 to a tiled
@@ -263,6 +265,16 @@ writeRead (const Array2D<unsigned int> &pi1,
         Array2D<half>         ph2 (h, w);
         Array2D<float>        pf2 (h, w);
 
+        Array2D<unsigned int> fi2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<half>         fh2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<float>        ff2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+
+
+        const unsigned int fillInt = 12;
+        const half fillHalf = 4.5;
+        const float fillFloat = M_PI;
+
+
         FrameBuffer fb;
 
         fb.insert ("I",                             // name
@@ -285,6 +297,30 @@ writeRead (const Array2D<unsigned int> &pi1,
                           sizeof (pf2[0][0]),       // xStride
                           sizeof (pf2[0][0]) * w)   // yStride
                   );
+
+        if(fillChannel)
+        {
+            fb.insert ("FI",                             // name
+                   Slice (IMF::UINT,                // type
+                          (char *) &fi2[-dwy][-dwx],// base
+                          sizeof (fi2[0][0]),       // xStride
+                          sizeof (fi2[0][0]) * w,1,1,fillInt)  // yStride
+                  );
+
+            fb.insert ("FH",                             // name
+                    Slice (IMF::HALF,                // type
+                            (char *) &fh2[-dwy][-dwx],// base
+                            sizeof (fh2[0][0]),       // xStride
+                            sizeof (fh2[0][0]) * w,1,1,fillHalf)   // yStride
+                    );
+
+            fb.insert ("FF",                             // name
+                    Slice (IMF::FLOAT,               // type
+                            (char *) &ff2[-dwy][-dwx],// base
+                            sizeof (ff2[0][0]),       // xStride
+                            sizeof (ff2[0][0]) * w,1,1,fillFloat)   // yStride
+                    );
+        }
 
         in.setFrameBuffer (fb);
         for (int y = dw.min.y; y <= dw.max.y; ++y)
@@ -323,6 +359,13 @@ writeRead (const Array2D<unsigned int> &pi1,
                 assert (pi1[y][x] == pi2[y][x]);
                 assert (ph1[y][x] == ph2[y][x]);
                 assert (pf1[y][x] == pf2[y][x]);
+
+                if (fillChannel)
+                {
+                    assert(fi2[y][x] == fillInt);
+                    assert(fh2[y][x] == fillHalf);
+                    assert(ff2[y][x] == fillFloat);
+                }
             }
         }    
     }
@@ -341,6 +384,10 @@ writeRead (const Array2D<unsigned int> &pi1,
         Array2D<unsigned int> pi2 (h, w);
         Array2D<half>         ph2 (h, w);
         Array2D<float>        pf2 (h, w);
+
+        Array2D<unsigned int> fi2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<half>         fh2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<float>        ff2 (fillChannel ? h : 1 , fillChannel ? w : 1);
 
         FrameBuffer fb;
 
@@ -364,6 +411,34 @@ writeRead (const Array2D<unsigned int> &pi1,
                           sizeof (pf2[0][0]),       // xStride
                           sizeof (pf2[0][0]) * w)   // yStride
                   );
+        const unsigned int fillInt = 21;
+        const half fillHalf = 42;
+        const float fillFloat = 2.8;
+
+        if (fillChannel)
+        {
+            fb.insert ("FI",                             // name
+                   Slice (IMF::UINT,                // type
+                          (char *) &fi2[-dwy][-dwx],// base
+                          sizeof (fi2[0][0]),       // xStride
+                          sizeof (fi2[0][0]) * w,1,1,fillInt)   // yStride
+                  );
+
+            fb.insert ("FH",                             // name
+                    Slice (IMF::HALF,                // type
+                            (char *) &fh2[-dwy][-dwx],// base
+                            sizeof (fh2[0][0]),       // xStride
+                            sizeof (fh2[0][0]) * w,1,1,fillHalf)   // yStride
+                    );
+
+            fb.insert ("FF",                             // name
+                    Slice (IMF::FLOAT,               // type
+                            (char *) &ff2[-dwy][-dwx],// base
+                            sizeof (ff2[0][0]),       // xStride
+                            sizeof (ff2[0][0]) * w,1,1,fillFloat)   // yStride
+                    );
+
+        }
 
         in.setFrameBuffer (fb);
         for (int y = dw.max.y; y >= dw.min.y; --y)
@@ -402,6 +477,12 @@ writeRead (const Array2D<unsigned int> &pi1,
                 assert (pi1[y][x] == pi2[y][x]);
                 assert (ph1[y][x] == ph2[y][x]);
                 assert (pf1[y][x] == pf2[y][x]);
+                if (fillChannel)
+                {
+                    assert(fi2[y][x] == fillInt);
+                    assert(fh2[y][x] == fillHalf);
+                    assert(ff2[y][x] == fillFloat);
+                }
             }
         }
     }
@@ -421,6 +502,17 @@ writeRead (const Array2D<unsigned int> &pi1,
         Array2D<unsigned int> pi2 (h, w);
         Array2D<half>         ph2 (h, w);
         Array2D<float>        pf2 (h, w);
+
+
+        Array2D<unsigned int> fi2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<half>         fh2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+        Array2D<float>        ff2 (fillChannel ? h : 1 , fillChannel ? w : 1);
+
+
+        const unsigned int fillInt = 81;
+        const half fillHalf = 0.5;
+        const float fillFloat = 7.8;
+
 
         for (int y = dw.min.y; y <= dw.max.y; ++y)
 	{
@@ -446,6 +538,31 @@ writeRead (const Array2D<unsigned int> &pi1,
 			      sizeof (pf2[0][0]),		// xStride
 			      0)				// yStride
 		      );
+
+            if (fillChannel)
+            {
+                fb.insert ("FI",					// name
+                        Slice (IMF::UINT,			// type
+                                (char *) &fi2[y - dwy][-dwx],	// base
+                                sizeof (fi2[0][0]),		// xStride
+                                0,1,1,fillInt)				// yStride
+                        );
+
+                fb.insert ("FH",					// name
+                        Slice (IMF::HALF,			// type
+                                (char *) &fh2[y - dwy][-dwx],	// base
+                                sizeof (fh2[0][0]),		// xStride
+                                0,1,1,fillHalf)				// yStride
+                        );
+
+                fb.insert ("FF",                     	        // name
+                        Slice (IMF::FLOAT,			// type
+                                (char *) &ff2[y - dwy][-dwx],	// base
+                                sizeof (ff2[0][0]),		// xStride
+                                0,1,1,fillFloat)				// yStride
+                        );
+
+            }
 
 	    in.setFrameBuffer (fb);
             in.readPixels (y);
@@ -484,7 +601,14 @@ writeRead (const Array2D<unsigned int> &pi1,
                 assert (pi1[y][x] == pi2[y][x]);
                 assert (ph1[y][x] == ph2[y][x]);
                 assert (pf1[y][x] == pf2[y][x]);
+                if (fillChannel)
+                {
+                    assert (fi2[y][x] == fillInt);
+                    assert (fh2[y][x] == fillHalf);
+                    assert (ff2[y][x] == fillFloat);
+                }
             }
+
         }    
     }
 
@@ -509,11 +633,13 @@ writeRead (const std::string &tempDir,
     std::string filename = tempDir + "imf_test_scanline_api.exr";
 
     writeRead (pi, ph, pf, filename.c_str(), lorder, W, H,
-               xSize, ySize, dx, dy, comp, ONE_LEVEL, rmode);
+               xSize, ySize, dx, dy, comp, ONE_LEVEL, rmode , false);
     writeRead (pi, ph, pf, filename.c_str(), lorder, W, H,
-               xSize, ySize, dx, dy, comp, MIPMAP_LEVELS, rmode);
+               xSize, ySize, dx, dy, comp, MIPMAP_LEVELS, rmode , false );
     writeRead (pi, ph, pf, filename.c_str(), lorder, W, H,
-               xSize, ySize, dx, dy, comp, RIPMAP_LEVELS, rmode);
+               xSize, ySize, dx, dy, comp, RIPMAP_LEVELS, rmode , false);
+    writeRead (pi, ph, pf, filename.c_str(), lorder, W, H,
+               xSize, ySize, dx, dy, comp, ONE_LEVEL, rmode , true);
 }
 
 } // namespace

--- a/OpenEXR/IlmImfTest/testYca.cpp
+++ b/OpenEXR/IlmImfTest/testYca.cpp
@@ -195,6 +195,7 @@ writeReadYca (const char fileName[],
 	    else
 	    {
 		assert (p1.g == p2.g);
+		assert (p1.b == p2.b);
 	    }
 
 	    if (channels & WRITE_A)

--- a/OpenEXR/exrmaketiled/main.cpp
+++ b/OpenEXR/exrmaketiled/main.cpp
@@ -393,31 +393,32 @@ main(int argc, char **argv)
 
     int exitStatus = 0;
 
-    //
-    // check input
-    //
-    {
-        MultiPartInputFile input (inFile);
-        int parts = input.parts();
-
-        if (partnum < 0 || partnum >= parts){
-            cerr << "ERROR: you asked for part " << partnum << " in " << inFile;
-            cerr << ", which only has " << parts << " parts\n";
-            exit(1);
-        }
-
-        Header h = input.header (partnum);
-        if (h.type() == DEEPTILE || h.type() == DEEPSCANLINE)
-        {
-            cerr << "Cannot make tile for deep data" << endl;
-            exit(1);
-        }
-
-    }
-
-
     try
     {
+        //
+        // check input
+        //
+        {
+            MultiPartInputFile input (inFile);
+            int parts = input.parts();
+
+            if (partnum < 0 || partnum >= parts){
+                cerr << "ERROR: you asked for part " << partnum << " in " << inFile;
+                cerr << ", which only has " << parts << " parts\n";
+                exit(1);
+            }
+
+            Header h = input.header (partnum);
+            if (h.type() == DEEPTILE || h.type() == DEEPSCANLINE)
+            {
+                cerr << "Cannot make tile for deep data" << endl;
+                exit(1);
+            }
+
+        }
+
+
+
         makeTiled (inFile, outFile, partnum,
                    mode, roundingMode, compression,
                    tileSizeX, tileSizeY,


### PR DESCRIPTION

#817: double-check unpackedBuffer created in DWA uncompress (OSS-fuzz 24854)
#818 compute Huf codelengths using 64 bit to prevent shift overrflow (OSS-fuzz 24831)
#820: suppress sanitizer warnings when writing invalid enums (OSS-fuzz 24969)
#825: Avoid overflow in calculateNumTiles when size=MAX_INT (OSS-fuzz 25297)
#826: restrict maximum tile size to INT_MAX byte limit (OSS-fuzz 25297)
#832: ignore unused bits in B44 mode detection (OSS-fuzz 24787)
#827: lighter weight reading of Luma-only images via RgbaInputFile (OSS-fuzz 25326)
#829: fix buffer overflow check in PIZ decompression (OSS-fuzz 25399, OSS-fuzz 25415)
#830: refactor channel filling in InputFile API with tiled source (OSS-fuzz 25370 , OSS-fuzz 25501)
#831: Use Int64 in dataWindowForTile to prevent integer overflow (OSS-fuzz 25505)
#836: prevent overflow in hufUncompress if nBits is large (OSS-fuzz 25562)
#840: add sanity check for reading multipart files with no parts (OSS-fuzz 25740 , OSS-fuzz 25743)
#841: more elegant exception handling in exrmaketiled (ZhiWei Sun from Topsec Alpha Lab)
#843: reduce B44 _tmpBufferSize (was allocating two bytes per byte) (OSS-fuzz 25913)
#844: check EXRAllocAligned succeeded to allocate ScanlineInputFile lineBuffers (ZhiWei Sun from Topsec Alpha Lab)
#845: test channels are DCT compressed before DWA decompression (ZhiWei Sun from Topsec Alpha Lab)
#849: check for valid Huf code lengths (OSS-fuzz 26229)
#860: check 1 part files with 'nonimage' bit have type attribute (OSS-fuzz 26658)
#861: Fix overflow computing deeptile sample table size (OSS-fuzz 26956)
#863: re-order shift/compare in FastHuf to prevent undefined shift overflow (OSS-fuzz 27409)

Also partial fixes from #842 which do not change the ABI:  (OSS-fuzz 25892 , OSS-fuzz 25894)
