### PR TITLE
ImfCompressor: use STATIC_HUFFMAN for tiled DWAB files (fix #344)

### DIFF
--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -241,10 +241,14 @@ newTileCompressor (Compression c,
 	return new B44Compressor (hdr, tileLineSize, numTileLines, true);
 
       case DWAA_COMPRESSION:
-      case DWAB_COMPRESSION:
 
 	return new DwaCompressor (hdr, tileLineSize, numTileLines, 
                                DwaCompressor::DEFLATE);
+
+      case DWAB_COMPRESSION:
+
+	return new DwaCompressor (hdr, tileLineSize, numTileLines, 
+                               DwaCompressor::STATIC_HUFFMAN);
 
       default:
 


### PR DESCRIPTION
Choosing DWAA for tiled files behaves exactly as before. DWAB now uses the
STATIC_HUFFMAN compressor, which can be way faster than DEFLATE, especially
for tiles of size 64x64 and larger.