### PR TITLE
Add explicit #include <limits> for numeric_limits

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -156,6 +156,7 @@
 #include <cctype>
 #include <cassert>
 #include <algorithm>
+#include <limits>
 
 #include <cstddef>
 

--- a/OpenEXR/IlmImf/ImfTiledMisc.cpp
+++ b/OpenEXR/IlmImf/ImfTiledMisc.cpp
@@ -45,6 +45,7 @@
 #include <ImfChannelList.h>
 #include <ImfTileDescription.h>
 #include <algorithm>
+#include <limits>
 
 #include "ImfNamespace.h"
 


### PR DESCRIPTION
GCC 11.0 seems to miss the include and fails on std::numeric_limits.

Signed-off-by: Cary Phillips <cary@ilm.com>