### PR TITLE
Add missing <limits> includes

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -156,6 +156,7 @@
 #include <cctype>
 #include <cassert>
 #include <algorithm>
+#include <limits>
 
 #include <cstddef>
 

--- a/src/lib/OpenEXR/ImfTiledMisc.cpp
+++ b/src/lib/OpenEXR/ImfTiledMisc.cpp
@@ -45,6 +45,7 @@
 #include <ImfChannelList.h>
 #include <ImfTileDescription.h>
 #include <algorithm>
+#include <limits>
 
 #include "ImfNamespace.h"
 

--- a/src/test/OpenEXRTest/testLargeDataWindowOffsets.cpp
+++ b/src/test/OpenEXRTest/testLargeDataWindowOffsets.cpp
@@ -40,6 +40,7 @@
 #include "ImfStandardAttributes.h"
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <assert.h>
 #include <IlmThread.h>
 #include <ImathBox.h>

--- a/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
+++ b/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
@@ -44,6 +44,7 @@
 #include "ImfStandardAttributes.h"
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <assert.h>
 #include <IlmThread.h>
 #include <ImathBox.h>


### PR DESCRIPTION
These files use std::numeric_limits without including the <limits>
headers.