### PR TITLE
prevent int overflow in DWA buffersize calculation

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -2931,7 +2931,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // of channels we have. 
     //
 
-    int maxOutBufferSize  = 0;
+    size_t maxOutBufferSize  = 0;
     int numLossyDctChans  = 0;
     int unknownBufferSize = 0;
     int rleBufferSize     = 0;
@@ -2958,8 +2958,8 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
             //
 
             maxOutBufferSize += std::max(
-                            (int)(2 * maxLossyDctAcSize + 65536),
-                            (int)compressBound (maxLossyDctAcSize) );
+                            2lu * maxLossyDctAcSize + 65536lu,
+                            compressBound (maxLossyDctAcSize) );
             numLossyDctChans++;
             break;
 
@@ -2998,13 +2998,13 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // which could take slightly more space
     //
 
-    maxOutBufferSize += (int)compressBound ((uLongf)rleBufferSize);
+    maxOutBufferSize += compressBound ((uLongf)rleBufferSize);
     
     //
     // And the same goes for the UNKNOWN data
     //
 
-    maxOutBufferSize += (int)compressBound ((uLongf)unknownBufferSize);
+    maxOutBufferSize += compressBound ((uLongf)unknownBufferSize);
 
     //
     // Allocate a zip/deflate compressor big enought to hold the DC data


### PR DESCRIPTION
Fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29423
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>