### PR TITLE
add buffer size validation to FastHuf decode

### DIFF
--- a/src/lib/OpenEXR/ImfHuf.cpp
+++ b/src/lib/OpenEXR/ImfHuf.cpp
@@ -1119,6 +1119,14 @@ hufUncompress (const char compressed[],
     if (FastHufDecoder::enabled() && nBits > 128)
     {
         FastHufDecoder fhd (ptr, nCompressed - (ptr - compressed), im, iM, iM);
+
+        // must be nBytes remaining in buffer
+        if( ptr-compressed  + nBytes > nCompressed)
+        {
+            notEnoughData();
+            return;
+        }
+
         fhd.decode ((unsigned char*)ptr, nBits, raw, nRaw);
     }
     else


### PR DESCRIPTION
address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29106 by adding extra sanity check to buffer size

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>