### PR TITLE
exrcheck: rework 'reduceMemory' and 'reduceTime' modes

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.h
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.h
@@ -14,17 +14,18 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
 
 //
-// attempt to read the given file as an OpenEXR, using
-// various OpenEXR read paths.
+// attempt to read the given file as an OpenEXR, using various OpenEXR read paths.
 // This can be used to validate correctness of the library, when running the library
 // with a sanitizer or memory checker, as well as checking that a file is a correct OpenEXR
 //
-// returns true if the file read correctly using expected API calls, or false
+// returns true if the file reads correctly using expected API calls, or false
 // if an exception was thrown that indicates the file is invalid
 //
-// if reduceMemory and/or reduceTime are true, will avoid tests or inputs that are known to
-// take large amounts of memory and/or time respectively. This may hide errors within the
-// file or library
+// if reduceMemory is true, will avoid tests or inputs that are known to
+// take large amounts of memory. This may hide errors within the file or library.
+//
+// if reduceTime is true and an error is found within the file, then future tests are reduced for speed.
+// This may hide errors within the library.
 //
 //
 


### PR DESCRIPTION
Better handling of reduceMemory and/or reduceTime flags in `checkOpenEXRFile` method or `exrcheck` utility:

  * in reduceTime mode, each test now returns immediately when it encounters an exception, rather than skipping scanlines/tiles. Files which are large on disk may now take longer to read, but are more thoroughly tested. Small files will fail faster.
  * reduceMemory mode now estimates the amount of memory required to read an entire scanline of tiles when using the scanline API for tiled images (tiled images with large tile heights require large memory allocations in the intermediate buffer) 
  * magic numbers used for time/memory limits are now constants

Adresses:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29393
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=29682

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>