### PR TITLE
expand testCompression to better test DWAA, DWAB and tiled images 

### DIFF
--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -112,6 +112,20 @@ isValidCompression (Compression c)
     }
 }
 
+bool isLossyCompression(Compression c)
+{
+    switch (c)
+    {
+      case B44_COMPRESSION:
+      case B44A_COMPRESSION:
+      case DWAA_COMPRESSION:
+      case DWAB_COMPRESSION:
+	return true;
+      default:
+	return false;
+    }
+}
+
 bool isValidDeepCompression(Compression c)
 {
   switch(c)

--- a/src/lib/OpenEXR/ImfCompressor.h
+++ b/src/lib/OpenEXR/ImfCompressor.h
@@ -223,6 +223,15 @@ IMF_EXPORT
 bool            isValidDeepCompression (Compression c);
 
 
+//---------------------------------------
+// Return true for compression types which
+// do not guarantee that HALF type values
+// are preserved precisely
+//---------------------------------------
+IMF_EXPORT
+bool isLossyCompression(Compression c);
+
+
 //-----------------------------------------------------------------
 // Construct a Compressor for compression type c:
 //


### PR DESCRIPTION
  + expand testCompression with a test which reads/writes tiled images
  + write channels named R,G,B, and A to testCompression, as some schemes use different strategies for color channels than for channels with other names. DWAA and DWAB compression were not using lossy compression for the half-float channel since it was called 'H'
  + add a very loose check for accuracy of DWAA and DWAB compression of RGBA channels (within 0.1 for values of magnitude less than 1, 10% difference above 1)
  + functionality to test whether a compression scheme was lossy or not seemed like a handy thing to have, so isLossyCompression() has been added to the API. This treats PXR24 as lossless, since it doesn't change half float values, even though it does quantize float values.

(updated motivated by #877 which introduces a change that otherwise had no test coverage)