### PR TITLE
update tileoffset sanitycheck to handle ripmaps 

### DIFF
--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -321,9 +321,6 @@ void
 TiledInputFile::Data::validateStreamSize()
 {
     const TileDescription& td = header.tileDescription();
-
-    Int64 tileWidth = td.xSize;
-    Int64 tileHeight = td.ySize;
     Int64 chunkCount;
 
     if (td.mode==RIPMAP_LEVELS)
@@ -338,7 +335,8 @@ TiledInputFile::Data::validateStreamSize()
         // but 'chunkCount' can be less than the real offset table size for a meaningful sanity check
         //
         const Box2i &dataWindow = header.dataWindow();
-
+        Int64 tileWidth = td.xSize;
+        Int64 tileHeight = td.ySize;
 
         Int64 tilesX = (static_cast<Int64>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
         Int64 tilesY = (static_cast<Int64>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -320,9 +320,8 @@ TiledInputFile::Data::getTileBuffer (int number)
 void
 TiledInputFile::Data::validateStreamSize()
 {
-    const Box2i &dataWindow = header.dataWindow();
-
     const TileDescription& td = header.tileDescription();
+
     Int64 tileWidth = td.xSize;
     Int64 tileHeight = td.ySize;
     Int64 chunkCount;
@@ -338,12 +337,16 @@ TiledInputFile::Data::validateStreamSize()
         // MIPMAP_LEVELS images will have roughly 1/3 more tiles than this
         // but 'chunkCount' can be less than the real offset table size for a meaningful sanity check
         //
+        const Box2i &dataWindow = header.dataWindow();
+
+
         Int64 tilesX = (static_cast<Int64>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
         Int64 tilesY = (static_cast<Int64>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;
 
         chunkCount = tilesX*tilesY;
     }
-    if ( chunkCount > gLargeChunkTableSize)
+
+    if (chunkCount > gLargeChunkTableSize)
     {
 
         if (chunkCount > gLargeChunkTableSize)

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -347,15 +347,11 @@ TiledInputFile::Data::validateStreamSize()
     if (chunkCount > gLargeChunkTableSize)
     {
 
-        if (chunkCount > gLargeChunkTableSize)
-        {
-            Int64 pos = _streamData->is->tellg();
-            _streamData->is->seekg(pos + (chunkCount-1)*sizeof(Int64));
-            Int64 temp;
-            OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
-            _streamData->is->seekg(pos);
-
-        }
+       Int64 pos = _streamData->is->tellg();
+       _streamData->is->seekg(pos + (chunkCount-1)*sizeof(Int64));
+       Int64 temp;
+       OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
+       _streamData->is->seekg(pos);
     }
 
 }


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30121

#839 added a check to confirm files which claim to contain a large number of tiles were sufficiently large to contain the required tile offset table, but only computed the size of the first level for speed. This is correct for single level files, and an adequate lower bound for MIP maps, but insufficient for RIP maps, which can contain many times more tiles than in the first level.

This change uses the slower getTiledChunkOffsetTableSize method for RIP maps to compute the exact size of the tile offset table.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>