### PR TITLE
Fixes for recent Imath deprecations

### DIFF
--- a/src/bin/exrmakepreview/makePreview.cpp
+++ b/src/bin/exrmakepreview/makePreview.cpp
@@ -85,7 +85,7 @@ gamma (half h, float m)
     if (x > 1)
 	x = 1 + knee (x - 1, 0.184874f);
 
-    return (unsigned char) (IMATH_NAMESPACE::clamp (Math<float>::pow (x, 0.4545f) * 84.66f, 
+    return (unsigned char) (IMATH_NAMESPACE::clamp (std::pow (x, 0.4545f) * 84.66f, 
 				   0.f,
 				   255.f));
 }
@@ -122,7 +122,7 @@ generatePreview (const char inFileName[],
 
     double fx = (previewWidth  > 1)? (double (w - 1) / (previewWidth  - 1)): 1;
     double fy = (previewHeight > 1)? (double (h - 1) / (previewHeight - 1)): 1;
-    float m  = Math<float>::pow (2.f, IMATH_NAMESPACE::clamp (exposure + 2.47393f, -20.f, 20.f));
+    float m  = std::pow (2.f, IMATH_NAMESPACE::clamp (exposure + 2.47393f, -20.f, 20.f));
 
     for (int y = 0; y < previewHeight; ++y)
     {

--- a/src/examples/generalInterfaceExamples.cpp
+++ b/src/examples/generalInterfaceExamples.cpp
@@ -52,6 +52,7 @@
 #include "drawImage.h"
 
 #include <iostream>
+#include <limits>
 
 #include "namespaceAlias.h"
 using namespace IMF;
@@ -210,7 +211,7 @@ readGZ1 (const char fileName[],
 			       sizeof (zPixels[0][0]) * 1,	 // xStride
 			       sizeof (zPixels[0][0]) * width,	// yStride
 			       1, 1,				// x/y sampling
-			       FLT_MAX));			// fillValue
+			       std::numeric_limits<float>::max()));		// fillValue
 
     file.setFrameBuffer (frameBuffer);
     file.readPixels (dw.min.y, dw.max.y);

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #ifdef _WIN32
+# define NOMINMAX
 # define VC_EXTRALEAN
 # include <string.h>
 # include <windows.h>


### PR DESCRIPTION
FLT_MAX was erroring for being undefined, because of some removals of
includes deep in Imath that we inadvertently depended on instead of
including `<limits.h>` here in OpenEXR. But that should be replaced by
`std::numeric_limits<float>::max()` anyway, in modern C++ style.

Also, fix some warnings due to `Imath::Math<>` having been marked as
deprecated and now `std::` for certain math functions is preferred.

Signed-off-by: Larry Gritz <lg@larrygritz.com>