### PR TITLE
additional verification of DWA data sizes

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -2606,6 +2606,14 @@ DwaCompressor::uncompress
             throw IEX_NAMESPACE::BaseExc("DC data corrupt.");
         }
     }
+    else
+    {
+        // if the compressed size is 0, then the uncompressed size must also be zero
+        if (totalDcUncompressedCount!=0)
+        {
+             throw IEX_NAMESPACE::BaseExc("DC data corrupt.");
+        }
+    }
 
     //
     // Uncompress the RLE data into _rleBuffer, then unRLE the results


### PR DESCRIPTION
Fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30291

When DWA data requires DC data, then the compressed DC block size must be non-zero.
Otherwise, potentially large amounts uninitialized memory are processed, which is slow and unpredictable.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>