### PR TITLE
exrcheck: check for tilesize in reduceMemory mode

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -950,6 +950,13 @@ runChecks(T& source,bool reduceMemory,bool reduceTime)
              }
 
          }
+         else
+         {
+             // file is not tiled, so can't contain large tiles
+             // setting largeTiles false here causes the Tile and DeepTile API
+             // tests to run on non-tiled files, which should cause exceptions to be thrown
+             largeTiles = false;
+         }
 
 
          threw = readMultiPart(multi , reduceMemory , reduceTime);


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30605

Extend #895 to bypass TiledInputFile and DeepTiledInputFile test on files which contain large tiles. The tests are also bypassed on files where the MultiPartInputFile constructor fails.

Excessively large tiles cause the constructor to allocate large amounts of memory to decode the file. The MultiPartInputFile API constructor does not allocate such memory up-front, so the calling code can check the header attributes to check that tile/scanline sizes are reasonable before calling InputPart or TiledInputPart to allocate memory and read the image. 

Header::setMaxImageSize and Header::setMaxTileSize can also be used to abort constructors early before memory is allocated.
