### PR TITLE
free up memory if DWA unRle throws

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -830,7 +830,15 @@ DwaCompressor::LossyDctDecoderBase::execute ()
                 // UnRLE the AC. This will modify currAcComp
                 //
 
-                lastNonZero = unRleAc (currAcComp, acCompEnd, halfZigBlock[comp]._buffer);
+                try
+                {
+                   lastNonZero = unRleAc (currAcComp, acCompEnd, halfZigBlock[comp]._buffer);
+                }
+                catch(...)
+                {
+                    delete [] rowBlockHandle;
+                    throw;
+                }
 
                 //
                 // Convert from XDR to NATIVE


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=30969
#919 added an exception throw if the DWA AC buffer size was wrong. That change introduced a memory leak in LossyDctDecoderBase::execute, since `rowBlockHandle` was never deleted

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>