### PR TITLE
handle reallocation of idmanifest attributes

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifestAttribute.cpp
+++ b/src/lib/OpenEXR/ImfIDManifestAttribute.cpp
@@ -33,11 +33,30 @@ template <>
 void
 IDManifestAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, int size, int version)
 {
-    int read = 0;
 
-    Xdr::read<StreamIO>(is,_value._uncompressedDataSize);
-    _value._data = (unsigned char*) malloc(size-4);
+    if (size<4)
+    {
+          throw IEX_NAMESPACE::InputExc("Invalid size field reading idmanifest attribute");
+    }
     _value._compressedDataSize = size-4;
+
+    if (_value._data)
+    {
+        // if attribute is reallocated , free up previous memory
+        free( static_cast<void*>(_value._data) );
+        _value._data = nullptr;
+    }
+
+
+    //
+    // first four bytes: data size once data is uncompressed
+    //
+    Xdr::read<StreamIO>(is,_value._uncompressedDataSize);
+
+    //
+    // allocate memory for compressed storage and read data
+    //
+    _value._data = static_cast<unsigned char*>( malloc(size-4) );
     char* input = (char*) _value._data;
     Xdr::read<StreamIO>(is,input,_value._compressedDataSize);
 }


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31015
If a file contains multiple definitions of an idmanifest attribute with the same name, the memory allocated reading the first attribute was leaking.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>