### PR TITLE
pkgconfig {OpenEXR,IlmBase}.pc was including OpenEXR directory

### DIFF
--- a/cmake/IlmBase.pc.in
+++ b/cmake/IlmBase.pc.in
@@ -14,4 +14,4 @@ Version: @ILMBASE_VERSION@
 Requires:
 Conflicts:
 Libs: -L${libdir} -lIex${libsuffix} -lIexMath${libsuffix} -lIlmThread${libsuffix} @PTHREAD_LIBS@
-Cflags: @PTHREAD_CFLAGS@ -I${includedir} -I${includedir}/OpenEXR
+Cflags: @PTHREAD_CFLAGS@ -I${includedir}

--- a/cmake/OpenEXR.pc.in
+++ b/cmake/OpenEXR.pc.in
@@ -7,7 +7,6 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-OpenEXR_includedir=@includedir@/OpenEXR
 libsuffix=@LIB_SUFFIX_DASH@
 
 Name: OpenEXR
@@ -15,6 +14,6 @@ Description: OpenEXR image library
 Version: @OPENEXR_VERSION@
 
 Libs: -L${libdir} -lOpenEXR${libsuffix}
-Cflags: -I${OpenEXR_includedir}
+Cflags: -I${includedir}
 Requires: IlmBase
 Libs.private: @zlib_link@


### PR DESCRIPTION
Hi,

Just little cleanings in pkgconfig files to not include the base OpenEXR directory in include directories.
The problem was fixed in OpenImageIO, you can read the pull requests comments if you want some arguments why it's good to do so. :)
https://github.com/OpenImageIO/oiio/pull/2869

```
# CURRENTLY

% PKG_CONFIG_PATH=before_pc/lib/pkgconfig/ pkg-config --cflags IlmBase
-I/usr/local/include -I/usr/local/include/OpenEXR

% PKG_CONFIG_PATH=before_pc/lib/pkgconfig/ pkg-config --cflags OpenEXR
-I/usr/local/include/OpenEXR -I/usr/local/include -I/usr/local/include/OpenEXR

% PKG_CONFIG_PATH=before_pc/lib/pkgconfig/ pkg-config --cflags Imath  
-I/usr/local/include -I/usr/local/include/Imath


# AFTER PATCH

% PKG_CONFIG_PATH=after_pc/lib/pkgconfig/ pkg-config --cflags IlmBase
-I/usr/local/include

% PKG_CONFIG_PATH=after_pc/lib/pkgconfig/ pkg-config --cflags OpenEXR
-I/usr/local/include

# Obviously its in another repository ...
% PKG_CONFIG_PATH=after_pc/lib/pkgconfig/ pkg-config --cflags Imath  
-I/usr/local/include -I/usr/local/include/Imath
```