### PR TITLE
exrcheck: fix handling xSampling when computating slice base

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -165,11 +165,11 @@ readScanline(T& in, bool reduceMemory , bool reduceTime)
         {
             switch (channelIndex % 3)
             {
-                case 0 : i.insert(c.name(),Slice(HALF, (char*) (halfData - sizeof(half)*dx/c.channel().xSampling)  , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 0 : i.insert(c.name(),Slice(HALF, (char*) (halfData - sizeof(half)*(dx/c.channel().xSampling))  , sizeof(half) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
-                case 1 : i.insert(c.name(),Slice(FLOAT, (char*) (floatData - sizeof(float)*dx/c.channel().xSampling)  , sizeof(float) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 1 : i.insert(c.name(),Slice(FLOAT, (char*) (floatData - sizeof(float)*(dx/c.channel().xSampling))  , sizeof(float) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
-                case 2 : i.insert(c.name(),Slice(UINT, (char*) (uintData - sizeof(unsigned int)*dx/c.channel().xSampling)  , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling ));
+                case 2 : i.insert(c.name(),Slice(UINT, (char*) (uintData - sizeof(unsigned int)*(dx/c.channel().xSampling))  , sizeof(unsigned int) , 0 , c.channel().xSampling , c.channel().ySampling ));
                 break;
             }
             channelIndex ++;


### PR DESCRIPTION
Fix regression from #930: missing parentheses caused the Slice 'base' to be computed incorrectly whenever dataWindow.min.x is not a multiple of xSampling.

Addresses
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31291
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31293


Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>