### PR TITLE
Add #include <limits> to fix Windows compile error

### DIFF
--- a/src/test/OpenEXRTest/testCompression.cpp
+++ b/src/test/OpenEXRTest/testCompression.cpp
@@ -51,6 +51,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <limits>
+#include <algorithm>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;

--- a/src/test/OpenEXRTest/testCompression.cpp
+++ b/src/test/OpenEXRTest/testCompression.cpp
@@ -50,6 +50,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <limits>
 
 namespace IMF = OPENEXR_IMF_NAMESPACE;
 using namespace IMF;


### PR DESCRIPTION
Signed-off-by: Cary Phillips <cary@ilm.com>