### PR TITLE
Replace UINT_MAX with explicit cast

### DIFF
--- a/src/lib/OpenEXR/ImfConvert.cpp
+++ b/src/lib/OpenEXR/ImfConvert.cpp
@@ -108,8 +108,9 @@ floatToUint (float f)
     if (isNegative (f) || isNan (f))
 	return 0;
 
-    if (isInfinity (f) || f > static_cast <float> (std::numeric_limits <unsigned int>::max()))
-	return static_cast <float> (std::numeric_limits <unsigned int>::max());
+    constexpr float ui_max = static_cast <float> (std::numeric_limits <unsigned int>::max());
+    if (isInfinity (f) || f > ui_max)
+	return ui_max;
 
     return static_cast <unsigned int> (f);
 }

--- a/src/lib/OpenEXR/ImfConvert.cpp
+++ b/src/lib/OpenEXR/ImfConvert.cpp
@@ -46,7 +46,6 @@
 #include "halfLimits.h"
 #include <limits>
 
-
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 namespace {
@@ -108,9 +107,9 @@ floatToUint (float f)
     if (isNegative (f) || isNan (f))
 	return 0;
 
-    constexpr float ui_max = static_cast <float> (std::numeric_limits <unsigned int>::max());
-    if (isInfinity (f) || f > ui_max)
-	return ui_max;
+    if (isInfinity (f) ||
+        f > static_cast <float> (std::numeric_limits <unsigned int>::max()))
+	return std::numeric_limits<unsigned int>::max();
 
     return static_cast <unsigned int> (f);
 }

--- a/src/lib/OpenEXR/ImfConvert.cpp
+++ b/src/lib/OpenEXR/ImfConvert.cpp
@@ -43,7 +43,8 @@
 #include "ImfConvert.h"
 #include "ImfNamespace.h"
 
-#include <limits.h>
+#include "halfLimits.h"
+#include <limits>
 
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
@@ -95,9 +96,9 @@ halfToUint (half h)
 	return 0;
 
     if (h.isInfinity())
-	return UINT_MAX;
+	return std::numeric_limits <unsigned int>::max();
 
-    return (unsigned int) h;
+    return static_cast <unsigned int> (h);
 }
 
 
@@ -107,17 +108,17 @@ floatToUint (float f)
     if (isNegative (f) || isNan (f))
 	return 0;
 
-    if (isInfinity (f) || f > UINT_MAX)
-	return UINT_MAX;
+    if (isInfinity (f) || f > static_cast <float> (std::numeric_limits <unsigned int>::max()))
+	return static_cast <float> (std::numeric_limits <unsigned int>::max());
 
-    return (unsigned int) f;
+    return static_cast <unsigned int> (f);
 }
 
 
 half	
 uintToHalf (unsigned int ui)
 {
-    if (ui >  HALF_MAX)
+    if (ui >  std::numeric_limits<half>::max())
 	return half::posInf();
 
     return half ((float) ui);
@@ -129,10 +130,10 @@ floatToHalf (float f)
 {
     if (isFinite (f))
     {
-	if (f >  HALF_MAX)
+	if (f >  std::numeric_limits<half>::max())
 	    return half::posInf();
 
-	if (f < -HALF_MAX)
+	if (f < -std::numeric_limits<half>::max())
 	    return half::negInf();
     }
 

--- a/src/lib/OpenEXR/ImfConvert.cpp
+++ b/src/lib/OpenEXR/ImfConvert.cpp
@@ -133,7 +133,7 @@ floatToHalf (float f)
 	if (f >  std::numeric_limits<half>::max())
 	    return half::posInf();
 
-	if (f < -std::numeric_limits<half>::max())
+	if (f < std::numeric_limits<half>::lowest())
 	    return half::negInf();
     }
 


### PR DESCRIPTION
Avoid a compiler warning about implicit cast from integer to float, and use numeric_limits<> instead of explicit macro symbols.

Signed-off-by: Cary Phillips cary@ilm.com