### PR TITLE
enforce limit on area of deep tiles to prevent excessive memory use

### DIFF
--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -1015,7 +1015,7 @@ DeepTiledInputFile::initialize ()
 
    if(_data->maxSampleCountTableSize > std::numeric_limits<unsigned int>::max())
    {
-           THROW(IEX_NAMESPACE::ArgExc, "Version " << _data->header.version() << " not supported for deeptiled images in this version of the library");
+       THROW(IEX_NAMESPACE::ArgExc, "Deep tile size exceeds maximum permitted area");
    }
 
 

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -1001,6 +1001,24 @@ DeepTiledInputFile::initialize ()
     _data->tileDesc = _data->header.tileDescription();
     _data->lineOrder = _data->header.lineOrder();
 
+
+   _data->maxSampleCountTableSize = static_cast<size_t>(_data->tileDesc.ySize) *
+                                    static_cast<size_t>(_data->tileDesc.xSize) *
+                                    sizeof(int);
+
+
+    //
+    // impose limit of 2^32 bytes of storage for maxSampleCountTableSize
+    // (disallow files with very large tile areas that would otherwise cause excessive memory allocation)
+    //
+
+
+   if(_data->maxSampleCountTableSize > std::numeric_limits<unsigned int>::max())
+   {
+           THROW(IEX_NAMESPACE::ArgExc, "Version " << _data->header.version() << " not supported for deeptiled images in this version of the library");
+   }
+
+
     //
     // Save the dataWindow information
     //
@@ -1034,9 +1052,6 @@ DeepTiledInputFile::initialize ()
     for (size_t i = 0; i < _data->tileBuffers.size(); i++)
         _data->tileBuffers[i] = new TileBuffer ();
 
-    _data->maxSampleCountTableSize = static_cast<size_t>(_data->tileDesc.ySize) *
-                                     static_cast<size_t>(_data->tileDesc.xSize) *
-                                     sizeof(int);
 
     _data->sampleCountTableBuffer.resizeErase(_data->maxSampleCountTableSize);
 

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1011,7 +1011,7 @@ runChecks(T& source,bool reduceMemory,bool reduceTime)
                  firstPartWide = true;
              }
 
-             if( tileDescription.ySize * tileDescription.xSize <= gMaxTileSize)
+             if( tileSize <= gMaxTileSize)
              {
                  largeTiles = false;
              }


### PR DESCRIPTION
This change enforces a hard limit on deep tile sizes, so that xSize*ySize must be less than 2^30, approx 1gigapixel per tile.
This would require more than 2GB of memory to allocate the 'sample count' table. This is not possible on 32 bit architectures, and causes excessive memory allocation on 64 bit architectures.

It is assumed that 'real' files will have much smaller deep tiles (1024x1024 pixels is already quite large), so files that contain tileDescription attributes indicating very large tiles are either corrupt or malicious.

This change is to Deep tiles only. A similar limit is already imposed on regular Tiled images, since the format cannot store compressed tiles with more than 2^31 bytes.

Address:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31390
(additionally, a bug in Imf::CheckFile meant that the large tiles were not being detected)

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>