### PR TITLE
Build-time options for where to get Imath

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -246,6 +246,11 @@ endif()
 #######################################
 
 # Check to see if Imath is installed outside of the current build directory.
+set(IMATH_REPO "https://github.com/AcademySoftwareFoundation/Imath.git" CACHE STRING
+    "Repo for auto-build of Imath")
+set(IMATH_TAG "master" CACHE STRING
+    "Tag for auto-build of Imath (branch, tag, or SHA)")
+#TODO: ^^ Release should not clone from master, this is a place holder
 set(CMAKE_IGNORE_PATH "${CMAKE_CURRENT_BINARY_DIR}/_deps/imath-src/config;${CMAKE_CURRENT_BINARY_DIR}/_deps/imath-build/config")
 find_package(Imath QUIET)
 set(CMAKE_IGNORE_PATH)
@@ -254,12 +259,12 @@ if(NOT TARGET Imath::Imath AND NOT Imath_FOUND)
   if (${CMAKE_VERSION} VERSION_LESS "3.11.0")
     message(FATAL_ERROR "CMake 3.11 or newer is required for FetchContent, you must manually install Imath if you are using an earlier version of CMake")
   endif()
-  message(STATUS "Imath was not found, installing from github")
+  message(STATUS "Imath was not found, installing from ${IMATH_REPO} (${IMATH_TAG})")
   
   include(FetchContent)
   FetchContent_Declare(Imath
-    GIT_REPOSITORY https://github.com/AcademySoftwareFoundation/Imath.git
-    GIT_TAG origin/master #TODO: Release should not clone from master, this is a place holder
+    GIT_REPOSITORY ${IMATH_REPO}
+    GIT_TAG ${IMATH_TAG}
     GIT_SHALLOW ON
       )
     


### PR DESCRIPTION
It's super convenient that the openexr build will automatically download
and incorporate Imath. But what if you want to test a specific Imath
PR, experimental changes in your own repo, or simply want to sync to a
particular commit or branch that is different than what's hard coded?

This patch adds cmake options that let you set the repo and the tag
for the Imath auto-build. Of course, they default to the official
ASWF Imath repo and the master branch (which will be changed to a release
tag, when it exists).

Signed-off-by: Larry Gritz <lg@larrygritz.com>