### PR TITLE
Fix sign-compare warning

### DIFF
--- a/src/lib/OpenEXR/ImfHuf.cpp
+++ b/src/lib/OpenEXR/ImfHuf.cpp
@@ -1121,7 +1121,7 @@ hufUncompress (const char compressed[],
         FastHufDecoder fhd (ptr, nCompressed - (ptr - compressed), im, iM, iM);
 
         // must be nBytes remaining in buffer
-        if( ptr-compressed  + nBytes > nCompressed)
+        if( ptr-compressed  + nBytes > static_cast<uint64_t>(nCompressed))
         {
             notEnoughData();
             return;


### PR DESCRIPTION
I get the following compiler warning:

```
src/lib/OpenEXR/ImfHuf.cpp:1124:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if( ptr-compressed  + nBytes > nCompressed)
             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```

By introducing a cast the compiler warning disappears:

```diff
-if( ptr-compressed  + nBytes > nCompressed)
+if( ptr-compressed  + nBytes > static_cast<uint64_t>(nCompressed))
```