### PR TITLE
better flag/type verification in deep input files

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -851,7 +851,17 @@ void DeepScanLineInputFile::initialize(const Header& header)
         if (header.type() != DEEPSCANLINE)
             throw IEX_NAMESPACE::ArgExc("Can't build a DeepScanLineInputFile from "
             "a type-mismatched part.");
-        
+
+
+        if (_data->partNumber == -1)
+        {
+            if (isTiled (_data->version))
+                throw IEX_NAMESPACE::ArgExc ("Expected a deep scanline file but the file is tiled.");
+
+            if (!isNonImage (_data->version))
+                throw IEX_NAMESPACE::ArgExc ("Expected a deep scanline file but the file is not a deep image.");
+        }
+
         if(header.version()!=1)
         {
             THROW(IEX_NAMESPACE::ArgExc, "Version " << header.version() << " not supported for deepscanline images in this version of the library");

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -868,6 +868,7 @@ DeepTiledInputFile::DeepTiledInputFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream 
         }
         else
         {
+
             _data->_streamData = new InputStreamMutex();
             _data->_streamData->is = &is;
             _data->header.readFrom (*_data->_streamData->is, _data->version);
@@ -977,9 +978,18 @@ DeepTiledInputFile::multiPartInitialize(InputPartData* part)
 void
 DeepTiledInputFile::initialize ()
 {
+
+    if (_data->header.type() != DEEPTILE)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Expected a deep tiled file but the file is not deep tiled.");
+    }
+
     if (_data->partNumber == -1)
-        if (_data->header.type() != DEEPTILE)
-            throw IEX_NAMESPACE::ArgExc ("Expected a deep tiled file but the file is not deep tiled.");
+    {
+        if (!isNonImage (_data->version))
+            throw IEX_NAMESPACE::ArgExc ("Expected a deep tiled file but the file is not a deep image.");
+    }
+
    if(_data->header.version()!=1)
    {
        THROW(IEX_NAMESPACE::ArgExc, "Version " << _data->header.version() << " not supported for deeptiled images in this version of the library");


### PR DESCRIPTION
Improve validation checks when using DeepTiledInputFile and DeepScanlineInputFile. DeepTiledInputFile wasn't verifying `type` attribute correctly on multipart files. Also DeepTiledInputFile and DeepScanlineInputFile were only checking the `type` attribute, and not confirming the version flags were consistent. If there's an inconsistency between the `type` attribute and the version flags, the version flags should be assumed to be correct.

Addresses:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31539
This file has no deep ('nonImage') or tiled flags set, but has a type attribute set to 'deeptiled', which is inconsistent. MultipartInputFile was treating the file as a scanline image, but DeepTiled was treating this as a deep tiled image. This meant exrcheck's test for large tiles were being bypassed.


Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>