### PR TITLE
Replace Int64/SInt64 with uint64_t/int64_t

### DIFF
--- a/src/examples/lowLevelIoExamples.cpp
+++ b/src/examples/lowLevelIoExamples.cpp
@@ -68,8 +68,8 @@ class C_IStream: public IStream
 	IStream (fileName), _file (file) {}
 
     virtual bool	read (char c[/*n*/], int n);
-    virtual Int64	tellg ();
-    virtual void	seekg (Int64 pos);
+    virtual uint64_t	tellg ();
+    virtual void	seekg (uint64_t pos);
     virtual void	clear ();
 
   private:
@@ -86,8 +86,8 @@ class C_OStream: public OStream
 	OStream (fileName), _file (file) {}
 
     virtual void	write (const char c[/*n*/], int n);
-    virtual Int64	tellp ();
-    virtual void	seekp (Int64 pos);
+    virtual uint64_t	tellp ();
+    virtual void	seekp (uint64_t pos);
 
   private:
 
@@ -116,7 +116,7 @@ C_IStream::read (char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 C_IStream::tellg ()
 {
     return ftell (_file);
@@ -124,7 +124,7 @@ C_IStream::tellg ()
 
 
 void
-C_IStream::seekg (Int64 pos)
+C_IStream::seekg (uint64_t pos)
 {
     clearerr (_file);
     fseek (_file, pos, SEEK_SET);
@@ -148,7 +148,7 @@ C_OStream::write (const char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 C_OStream::tellp ()
 {
     return ftell (_file);
@@ -156,7 +156,7 @@ C_OStream::tellp ()
 
 
 void
-C_OStream::seekp (Int64 pos)
+C_OStream::seekp (uint64_t pos)
 {
     clearerr (_file);
     fseek (_file, pos, SEEK_SET);

--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -146,8 +146,8 @@ struct LineBuffer
 {
     const char *        uncompressedData;
     char *              buffer;
-    uint64_t               packedDataSize;
-    uint64_t               unpackedDataSize;
+    uint64_t            packedDataSize;
+    uint64_t            unpackedDataSize;
 
     int                 minY;
     int                 maxY;
@@ -206,7 +206,7 @@ struct DeepScanLineInputFile::Data
     int                         maxX;               // data window's max x coord
     int                         minY;               // data window's min y coord
     int                         maxY;               // data window's max x coord
-    vector<uint64_t>               lineOffsets;        // stores offsets in file for
+    vector<uint64_t>            lineOffsets;        // stores offsets in file for
                                                     // each line
     bool                        fileIsComplete;     // True if no scanlines are missing
                                                     // in the file

--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
@@ -222,7 +222,7 @@ class DeepScanLineInputFile : public GenericInputFile
     IMF_EXPORT
     void                rawPixelData (int firstScanLine,
                                       char * pixelData,
-                                      Int64 &pixelDataSize);
+                                      uint64_t &pixelDataSize);
 
                                       
     //-------------------------------------------------

--- a/src/lib/OpenEXR/ImfDeepScanLineInputPart.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputPart.cpp
@@ -103,7 +103,7 @@ DeepScanLineInputPart::readPixels (int scanLine)
 void
 DeepScanLineInputPart::rawPixelData (int firstScanLine,
                                      char *pixelData,
-                                     Int64 &pixelDataSize)
+                                     uint64_t &pixelDataSize)
 {
     file->rawPixelData(firstScanLine, pixelData, pixelDataSize);
 }

--- a/src/lib/OpenEXR/ImfDeepScanLineInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputPart.h
@@ -150,7 +150,7 @@ class DeepScanLineInputPart
     IMF_EXPORT
     void                rawPixelData (int firstScanLine,
                                       char * pixelData,
-                                      Int64 &pixelDataSize);
+                                      uint64_t &pixelDataSize);
                              
                                       
     //-----------------------------------------------------------

--- a/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
@@ -133,11 +133,11 @@ struct LineBuffer
     Array< Array<char> >  buffer;
     Array<char>           consecutiveBuffer;
     const char *          dataPtr;
-    uint64_t                 uncompressedDataSize;
-    uint64_t                 dataSize;
+    uint64_t              uncompressedDataSize;
+    uint64_t              dataSize;
     Array<char>           sampleCountTableBuffer;
     const char *          sampleCountTablePtr;
-    uint64_t                 sampleCountTableSize;
+    uint64_t              sampleCountTableSize;
     Compressor*           sampleCountTableCompressor;
     int                   minY;                 // the min y scanline stored
     int                   maxY;                 // the max y scanline stored
@@ -192,7 +192,7 @@ struct DeepScanLineOutputFile::Data
     Header                      header;                // the image header
     int                         version;               // file format version
     bool                        multipart;             // from a multipart file
-    uint64_t                       previewPosition;       // file position for preview
+    uint64_t                    previewPosition;       // file position for preview
     DeepFrameBuffer             frameBuffer;           // framebuffer to write into
     int                         currentScanLine;       // next scanline to be written
     int                         missingScanLines;      // number of lines to write
@@ -201,13 +201,13 @@ struct DeepScanLineOutputFile::Data
     int                         maxX;                  // data window's max x coord
     int                         minY;                  // data window's min y coord
     int                         maxY;                  // data window's max x coord
-    vector<uint64_t>               lineOffsets;           // stores offsets in file for
+    vector<uint64_t>            lineOffsets;           // stores offsets in file for
                                                        // each scanline
     vector<size_t>              bytesPerLine;          // combined size of a line over
                                                        // all channels
     Compressor::Format          format;                // compressor's data format
     vector<OutSliceInfo*>       slices;                // info about channels in file
-    uint64_t                       lineOffsetsPosition;   // file position for line
+    uint64_t                    lineOffsetsPosition;   // file position for line
                                                        // offset table
 
     vector<LineBuffer*>         lineBuffers;           // each holds one line buffer
@@ -223,7 +223,7 @@ struct DeepScanLineOutputFile::Data
     Array<unsigned int>         lineSampleCount;       // the number of samples
                                                        // in each line
 
-    uint64_t                       maxSampleCountTableSize;
+    uint64_t                    maxSampleCountTableSize;
                                                        // the max size in bytes for a pixel
                                                        // sample count table
     OutputStreamMutex*  _streamData;

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -142,8 +142,8 @@ struct TileBuffer
     Array2D<unsigned int>       sampleCount;
     const char *                uncompressedData;
     char *                      buffer;
-    Int64                         dataSize;
-    Int64                         uncompressedDataSize;
+    uint64_t                         dataSize;
+    uint64_t                         uncompressedDataSize;
     Compressor *                compressor;
     Compressor::Format          format;
     int                         dx;
@@ -258,7 +258,7 @@ struct DeepTiledInputFile::Data
 
     Compressor*     sampleCountTableComp;           // the decompressor for sample count table
 
-    Int64           maxSampleCountTableSize;        // the max size in bytes for a pixel
+    uint64_t           maxSampleCountTableSize;        // the max size in bytes for a pixel
                                                     // sample count table
     int             combinedSampleSize;             // total size of all channels combined to check sampletable size
     static const int gLargeChunkTableSize = 1024*1024;
@@ -343,23 +343,23 @@ void
 DeepTiledInputFile::Data::validateStreamSize()
 {
     const Box2i &dataWindow = header.dataWindow();
-    Int64 tileWidth = header.tileDescription().xSize;
-    Int64 tileHeight = header.tileDescription().ySize;
+    uint64_t tileWidth = header.tileDescription().xSize;
+    uint64_t tileHeight = header.tileDescription().ySize;
 
-    Int64 tilesX = (static_cast<Int64>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
+    uint64_t tilesX = (static_cast<uint64_t>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
 
-    Int64 tilesY = (static_cast<Int64>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;
+    uint64_t tilesY = (static_cast<uint64_t>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;
 
 
-    Int64 chunkCount = tilesX*tilesY;
+    uint64_t chunkCount = tilesX*tilesY;
     if ( chunkCount > gLargeChunkTableSize)
     {
 
         if (chunkCount > gLargeChunkTableSize)
         {
-            Int64 pos = _streamData->is->tellg();
-            _streamData->is->seekg(pos + (chunkCount-1)*sizeof(Int64));
-            Int64 temp;
+            uint64_t pos = _streamData->is->tellg();
+            _streamData->is->seekg(pos + (chunkCount-1)*sizeof(uint64_t));
+            uint64_t temp;
             OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
             _streamData->is->seekg(pos);
 
@@ -377,8 +377,8 @@ readTileData (InputStreamMutex *streamData,
               int dx, int dy,
               int lx, int ly,
               char *&buffer,
-              Int64 &dataSize,
-              Int64 &unpackedDataSize)
+              uint64_t &dataSize,
+              uint64_t &unpackedDataSize)
 {
     //
     // Read a single tile block from the file and into the array pointed
@@ -392,7 +392,7 @@ readTileData (InputStreamMutex *streamData,
     // seek to that position if necessary
     //
 
-    Int64 tileOffset = ifd->tileOffsets (dx, dy, lx, ly);
+    uint64_t tileOffset = ifd->tileOffsets (dx, dy, lx, ly);
 
     if (tileOffset == 0)
     {
@@ -445,7 +445,7 @@ readTileData (InputStreamMutex *streamData,
     Xdr::read <StreamIO> (*streamData->is, levelX);
     Xdr::read <StreamIO> (*streamData->is, levelY);
 
-    Int64 tableSize;
+    uint64_t tableSize;
     Xdr::read <StreamIO> (*streamData->is, tableSize);
 
     Xdr::read <StreamIO> (*streamData->is, dataSize);
@@ -493,7 +493,7 @@ readTileData (InputStreamMutex *streamData,
     //
 
     streamData->currentPosition = tileOffset + 4 * Xdr::size<int>() +
-                                  3 * Xdr::size<Int64>()            +
+                                  3 * Xdr::size<uint64_t>()            +
                                   tableSize                         +
                                   dataSize;
 }
@@ -615,7 +615,7 @@ TileBufferTask::execute ()
         // Uncompress the data, if necessary
         //
 
-        if (_tileBuffer->compressor && _tileBuffer->dataSize < static_cast<Int64>(sizeOfTile))
+        if (_tileBuffer->compressor && _tileBuffer->dataSize < static_cast<uint64_t>(sizeOfTile))
         {
             _tileBuffer->format = _tileBuffer->compressor->format();
 
@@ -638,7 +638,7 @@ TileBufferTask::execute ()
 	// sanity check data size: the uncompressed data should be exactly 
 	// 'sizeOfTile' (if it's less, the file is corrupt and there'll be a buffer overrun)
 	//
-        if (_tileBuffer->dataSize != static_cast<Int64>(sizeOfTile))
+        if (_tileBuffer->dataSize != static_cast<uint64_t>(sizeOfTile))
 	{
 		THROW (IEX_NAMESPACE::InputExc, "size mismatch when reading deep tile: expected " << sizeOfTile << "bytes of uncompressed data but got " << _tileBuffer->dataSize);
 	}
@@ -1433,13 +1433,13 @@ void
 DeepTiledInputFile::rawTileData (int &dx, int &dy,
                              int &lx, int &ly,
                              char * pixelData,
-                             Int64 &pixelDataSize) const
+                             uint64_t &pixelDataSize) const
 {
      if (!isValidTile (dx, dy, lx, ly))
                throw IEX_NAMESPACE::ArgExc ("Tried to read a tile outside "
                                    "the image file's data window.");
     
-     Int64 tileOffset = _data->tileOffsets (dx, dy, lx, ly);
+     uint64_t tileOffset = _data->tileOffsets (dx, dy, lx, ly);
                                    
      if(tileOffset == 0)
      {
@@ -1478,8 +1478,8 @@ DeepTiledInputFile::rawTileData (int &dx, int &dy,
      Xdr::read <StreamIO> (*_data->_streamData->is, levelX);
      Xdr::read <StreamIO> (*_data->_streamData->is, levelY);
      
-     Int64 sampleCountTableSize;
-     Int64 packedDataSize;
+     uint64_t sampleCountTableSize;
+     uint64_t packedDataSize;
      Xdr::read <StreamIO> (*_data->_streamData->is, sampleCountTableSize);
      
      Xdr::read <StreamIO> (*_data->_streamData->is, packedDataSize);
@@ -1501,7 +1501,7 @@ DeepTiledInputFile::rawTileData (int &dx, int &dy,
      
      // total requirement for reading all the data
      
-     Int64 totalSizeRequired=40+sampleCountTableSize+packedDataSize;
+     uint64_t totalSizeRequired=40+sampleCountTableSize+packedDataSize;
      
      bool big_enough = totalSizeRequired<=pixelDataSize;
      
@@ -1525,11 +1525,11 @@ DeepTiledInputFile::rawTileData (int &dx, int &dy,
      *(int *) (pixelData+4) = dy;
      *(int *) (pixelData+8) = levelX;
      *(int *) (pixelData+12) = levelY;
-     *(Int64 *) (pixelData+16) =sampleCountTableSize;
-     *(Int64 *) (pixelData+24) = packedDataSize;
+     *(uint64_t *) (pixelData+16) =sampleCountTableSize;
+     *(uint64_t *) (pixelData+24) = packedDataSize;
      
      // didn't read the unpackedsize - do that now
-     Xdr::read<StreamIO> (*_data->_streamData->is, *(Int64 *) (pixelData+32));
+     Xdr::read<StreamIO> (*_data->_streamData->is, *(uint64_t *) (pixelData+32));
      
      // read the actual data
      _data->_streamData->is->read(pixelData+40, sampleCountTableSize+packedDataSize);
@@ -1752,7 +1752,7 @@ DeepTiledInputFile::readPixelSampleCounts (int dx1, int dx2,
                                            int dy1, int dy2,
                                            int lx,  int ly)
 {
-    Int64 savedFilePos = 0;
+    uint64_t savedFilePos = 0;
 
     try
     {
@@ -1843,7 +1843,7 @@ DeepTiledInputFile::readPixelSampleCounts (int dx1, int dx2,
                 if (lyInFile != ly)
                     throw IEX_NAMESPACE::InputExc ("Unexpected tile y level number coordinate.");
 
-                Int64 tableSize, dataSize, unpackedDataSize;
+                uint64_t tableSize, dataSize, unpackedDataSize;
                 Xdr::read <StreamIO> (*_data->_streamData->is, tableSize);
                 Xdr::read <StreamIO> (*_data->_streamData->is, dataSize);
                 Xdr::read <StreamIO> (*_data->_streamData->is, unpackedDataSize);
@@ -1865,7 +1865,7 @@ DeepTiledInputFile::readPixelSampleCounts (int dx1, int dx2,
                 // @TODO refactor the compressor code to ensure full 64-bit support.
                 //
 
-                Int64 compressorMaxDataSize = static_cast<Int64>(std::numeric_limits<int>::max());
+                uint64_t compressorMaxDataSize = static_cast<uint64_t>(std::numeric_limits<int>::max());
                 if (dataSize         > compressorMaxDataSize ||
                     unpackedDataSize > compressorMaxDataSize ||
                     tableSize        > compressorMaxDataSize)

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -142,8 +142,8 @@ struct TileBuffer
     Array2D<unsigned int>       sampleCount;
     const char *                uncompressedData;
     char *                      buffer;
-    uint64_t                         dataSize;
-    uint64_t                         uncompressedDataSize;
+    uint64_t                    dataSize;
+    uint64_t                    uncompressedDataSize;
     Compressor *                compressor;
     Compressor::Format          format;
     int                         dx;
@@ -258,7 +258,7 @@ struct DeepTiledInputFile::Data
 
     Compressor*     sampleCountTableComp;           // the decompressor for sample count table
 
-    uint64_t           maxSampleCountTableSize;        // the max size in bytes for a pixel
+    uint64_t        maxSampleCountTableSize;        // the max size in bytes for a pixel
                                                     // sample count table
     int             combinedSampleSize;             // total size of all channels combined to check sampletable size
     static const int gLargeChunkTableSize = 1024*1024;

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -388,7 +388,7 @@ class DeepTiledInputFile : public GenericInputFile
     void                rawTileData (int &dx, int &dy,
                                      int &lx, int &ly,
                                      char *pixelData,
-                                     Int64 &dataSize) const;
+                                     uint64_t &dataSize) const;
 
     //------------------------------------------------------------------
     // Read pixel sample counts into a slice in the frame buffer.

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.cpp
@@ -233,7 +233,7 @@ void
 DeepTiledInputPart::rawTileData (int &dx, int &dy,
                                  int &lx, int &ly,
                                  char * pixelData,
-                                 Int64 & dataSize) const
+                                 uint64_t & dataSize) const
 {
     file->rawTileData(dx, dy, lx, ly, pixelData, dataSize );
 }

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.h
@@ -340,7 +340,7 @@ class DeepTiledInputPart
     void                rawTileData (int &dx, int &dy,
                                    int &lx, int &ly,
                                    char *data,
-                                   Int64 &dataSize
+                                   uint64_t &dataSize
                                    ) const;
 
     //------------------------------------------------------------------

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
@@ -175,10 +175,10 @@ struct TileCoord
 struct BufferedTile
 {
     char *      pixelData;
-    uint64_t         pixelDataSize;
-    uint64_t         unpackedDataSize;
+    uint64_t    pixelDataSize;
+    uint64_t    unpackedDataSize;
     char *      sampleCountTableData;
-    uint64_t         sampleCountTableSize;
+    uint64_t    sampleCountTableSize;
 
     BufferedTile (const char *data, int size, int unpackedSize,
                   const char *tableData, int tableSize):
@@ -215,12 +215,12 @@ struct TileBuffer
 {
     Array<char>         buffer;
     const char *        dataPtr;
-    uint64_t               dataSize;
-    uint64_t               uncompressedSize;
+    uint64_t            dataSize;
+    uint64_t            uncompressedSize;
     Compressor *        compressor;
     Array<char>         sampleCountTableBuffer;
     const char *        sampleCountTablePtr;
-    uint64_t               sampleCountTableSize;
+    uint64_t            sampleCountTableSize;
     Compressor*         sampleCountTableCompressor;
     TileCoord           tileCoord;
     bool                hasException;
@@ -272,7 +272,7 @@ struct DeepTiledOutputFile::Data
     bool                multipart;              // file is multipart
     TileDescription     tileDesc;               // describes the tile layout
     DeepFrameBuffer     frameBuffer;            // framebuffer to write into
-    uint64_t               previewPosition;
+    uint64_t            previewPosition;
     LineOrder           lineOrder;              // the file's lineorder
     int                 minX;                   // data window's min x coord
     int                 maxX;                   // data window's max x coord
@@ -292,7 +292,7 @@ struct DeepTiledOutputFile::Data
 
     vector<TileBuffer*> tileBuffers;
 
-    uint64_t               tileOffsetsPosition;    // position of the tile index
+    uint64_t            tileOffsetsPosition;    // position of the tile index
 
     TileMap             tileMap;                // the map of buffered tiles
     TileCoord           nextTileToWrite;
@@ -306,7 +306,7 @@ struct DeepTiledOutputFile::Data
     int                 sampleCountXTileCoords; // using x coordinates relative to current tile
     int                 sampleCountYTileCoords; // using y coordinates relative to current tile
 
-    uint64_t                 maxSampleCountTableSize;// the max size in bytes for a pixel
+    uint64_t            maxSampleCountTableSize;// the max size in bytes for a pixel
                                                 // sample count table
     OutputStreamMutex*  _streamData;
     bool                _deleteStream;

--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -134,7 +134,6 @@
 #include "ImfStandardAttributes.h"
 #include "ImfHeader.h"
 #include "ImfHuf.h"
-#include "ImfInt64.h"
 #include "ImfIntAttribute.h"
 #include "ImfIO.h"
 #include "ImfMisc.h"
@@ -160,6 +159,7 @@
 
 #include <cstddef>
 
+#include <cstdint>
 
 // Windows specific addition to prevent the indirect import of the redefined min/max macros
 #if defined _WIN32 || defined _WIN64
@@ -1965,7 +1965,7 @@ DwaCompressor::compress
         _outBuffer = new char[outBufferSize];
     }
 
-    char *outDataPtr = &_outBuffer[NUM_SIZES_SINGLE * sizeof(OPENEXR_IMF_NAMESPACE::Int64) +
+    char *outDataPtr = &_outBuffer[NUM_SIZES_SINGLE * sizeof(uint64_t) +
                                    channelRuleSize];
 
     //
@@ -1980,21 +1980,21 @@ DwaCompressor::compress
     if (_packedDcBuffer)
         packedDcEnd = _packedDcBuffer;
 
-    #define OBIDX(x) (Int64 *)&_outBuffer[x * sizeof (Int64)]
+    #define OBIDX(x) (uint64_t *)&_outBuffer[x * sizeof (uint64_t)]
 
-    Int64 *version                 = OBIDX (VERSION);
-    Int64 *unknownUncompressedSize = OBIDX (UNKNOWN_UNCOMPRESSED_SIZE);
-    Int64 *unknownCompressedSize   = OBIDX (UNKNOWN_COMPRESSED_SIZE);
-    Int64 *acCompressedSize        = OBIDX (AC_COMPRESSED_SIZE);
-    Int64 *dcCompressedSize        = OBIDX (DC_COMPRESSED_SIZE);
-    Int64 *rleCompressedSize       = OBIDX (RLE_COMPRESSED_SIZE);
-    Int64 *rleUncompressedSize     = OBIDX (RLE_UNCOMPRESSED_SIZE);
-    Int64 *rleRawSize              = OBIDX (RLE_RAW_SIZE);
+    uint64_t *version                 = OBIDX (VERSION);
+    uint64_t *unknownUncompressedSize = OBIDX (UNKNOWN_UNCOMPRESSED_SIZE);
+    uint64_t *unknownCompressedSize   = OBIDX (UNKNOWN_COMPRESSED_SIZE);
+    uint64_t *acCompressedSize        = OBIDX (AC_COMPRESSED_SIZE);
+    uint64_t *dcCompressedSize        = OBIDX (DC_COMPRESSED_SIZE);
+    uint64_t *rleCompressedSize       = OBIDX (RLE_COMPRESSED_SIZE);
+    uint64_t *rleUncompressedSize     = OBIDX (RLE_UNCOMPRESSED_SIZE);
+    uint64_t *rleRawSize              = OBIDX (RLE_RAW_SIZE);
 
-    Int64 *totalAcUncompressedCount = OBIDX (AC_UNCOMPRESSED_COUNT);
-    Int64 *totalDcUncompressedCount = OBIDX (DC_UNCOMPRESSED_COUNT);
+    uint64_t *totalAcUncompressedCount = OBIDX (AC_UNCOMPRESSED_COUNT);
+    uint64_t *totalDcUncompressedCount = OBIDX (DC_UNCOMPRESSED_COUNT);
 
-    Int64 *acCompression            = OBIDX (AC_COMPRESSION);
+    uint64_t *acCompression            = OBIDX (AC_COMPRESSION);
 
     int minX   = range.min.x;
     int maxX   = std::min(range.max.x, _max[0]);
@@ -2005,7 +2005,7 @@ DwaCompressor::compress
     // Zero all the numbers in the chunk header
     //
 
-    memset (_outBuffer, 0, NUM_SIZES_SINGLE * sizeof (Int64));
+    memset (_outBuffer, 0, NUM_SIZES_SINGLE * sizeof (uint64_t));
 
     //
     // Setup the AC compression strategy and the version in the data block,
@@ -2018,7 +2018,7 @@ DwaCompressor::compress
 
     if (fileVersion >= 2) 
     {
-        char *writePtr = &_outBuffer[NUM_SIZES_SINGLE * sizeof(OPENEXR_IMF_NAMESPACE::Int64)];
+        char *writePtr = &_outBuffer[NUM_SIZES_SINGLE * sizeof(uint64_t)];
         Xdr::write<CharPtrIO> (writePtr, channelRuleSize);
         
         for (size_t i = 0; i < channelRules.size(); ++i) 
@@ -2314,8 +2314,8 @@ DwaCompressor::compress
 
     for (int i = 0; i < NUM_SIZES_SINGLE; ++i)
     {
-        Int64  src = *(((Int64 *)_outBuffer) + i);
-        char  *dst = (char *)(((Int64 *)_outBuffer) + i);
+        uint64_t  src = *(((uint64_t *)_outBuffer) + i);
+        char  *dst = (char *)(((uint64_t *)_outBuffer) + i);
 
         Xdr::write<CharPtrIO> (dst, src);
     }
@@ -2368,8 +2368,8 @@ DwaCompressor::uncompress
     int minY = range.min.y;
     int maxY = std::min (range.max.y, _max[1]);
 
-    Int64 iSize = static_cast<Int64>( inSize );
-    Int64 headerSize = NUM_SIZES_SINGLE*sizeof(Int64);
+    uint64_t iSize = static_cast<uint64_t>( inSize );
+    uint64_t headerSize = NUM_SIZES_SINGLE*sizeof(uint64_t);
     if (iSize < headerSize) 
     {
         throw IEX_NAMESPACE::InputExc("Error uncompressing DWA data"
@@ -2382,8 +2382,8 @@ DwaCompressor::uncompress
 
     for (int i = 0; i < NUM_SIZES_SINGLE; ++i)
     {
-        Int64      *dst =  (((Int64 *)inPtr) + i);
-        const char *src = (char *)(((Int64 *)inPtr) + i);
+        uint64_t      *dst =  (((uint64_t *)inPtr) + i);
+        const char *src = (char *)(((uint64_t *)inPtr) + i);
 
         Xdr::read<CharPtrIO> (src, *dst);
     }
@@ -2392,28 +2392,28 @@ DwaCompressor::uncompress
     // Unwind all the counter info
     //
 
-    const Int64 *inPtr64 = (const Int64*) inPtr;
+    const uint64_t *inPtr64 = (const uint64_t*) inPtr;
 
-    Int64 version                  = *(inPtr64 + VERSION);
-    Int64 unknownUncompressedSize  = *(inPtr64 + UNKNOWN_UNCOMPRESSED_SIZE);
-    Int64 unknownCompressedSize    = *(inPtr64 + UNKNOWN_COMPRESSED_SIZE);
-    Int64 acCompressedSize         = *(inPtr64 + AC_COMPRESSED_SIZE);
-    Int64 dcCompressedSize         = *(inPtr64 + DC_COMPRESSED_SIZE);
-    Int64 rleCompressedSize        = *(inPtr64 + RLE_COMPRESSED_SIZE);
-    Int64 rleUncompressedSize      = *(inPtr64 + RLE_UNCOMPRESSED_SIZE);
-    Int64 rleRawSize               = *(inPtr64 + RLE_RAW_SIZE);
+    uint64_t version                  = *(inPtr64 + VERSION);
+    uint64_t unknownUncompressedSize  = *(inPtr64 + UNKNOWN_UNCOMPRESSED_SIZE);
+    uint64_t unknownCompressedSize    = *(inPtr64 + UNKNOWN_COMPRESSED_SIZE);
+    uint64_t acCompressedSize         = *(inPtr64 + AC_COMPRESSED_SIZE);
+    uint64_t dcCompressedSize         = *(inPtr64 + DC_COMPRESSED_SIZE);
+    uint64_t rleCompressedSize        = *(inPtr64 + RLE_COMPRESSED_SIZE);
+    uint64_t rleUncompressedSize      = *(inPtr64 + RLE_UNCOMPRESSED_SIZE);
+    uint64_t rleRawSize               = *(inPtr64 + RLE_RAW_SIZE);
  
-    Int64 totalAcUncompressedCount = *(inPtr64 + AC_UNCOMPRESSED_COUNT); 
-    Int64 totalDcUncompressedCount = *(inPtr64 + DC_UNCOMPRESSED_COUNT); 
+    uint64_t totalAcUncompressedCount = *(inPtr64 + AC_UNCOMPRESSED_COUNT); 
+    uint64_t totalDcUncompressedCount = *(inPtr64 + DC_UNCOMPRESSED_COUNT); 
 
-    Int64 acCompression            = *(inPtr64 + AC_COMPRESSION); 
+    uint64_t acCompression            = *(inPtr64 + AC_COMPRESSION); 
 
-    Int64 compressedSize           = unknownCompressedSize + 
+    uint64_t compressedSize           = unknownCompressedSize + 
                                      acCompressedSize +
                                      dcCompressedSize +
                                      rleCompressedSize;
 
-    const char *dataPtr            = inPtr + NUM_SIZES_SINGLE * sizeof(Int64);
+    const char *dataPtr            = inPtr + NUM_SIZES_SINGLE * sizeof(uint64_t);
 
     /* Both the sum and individual sizes are checked in case of overflow. */
     if (iSize < (headerSize + compressedSize) ||
@@ -2426,15 +2426,15 @@ DwaCompressor::uncompress
                             "(truncated file).");
     }
 
-    if ((SInt64)unknownUncompressedSize < 0  ||
-        (SInt64)unknownCompressedSize < 0    ||
-        (SInt64)acCompressedSize < 0         ||
-        (SInt64)dcCompressedSize < 0         ||
-        (SInt64)rleCompressedSize < 0        ||
-        (SInt64)rleUncompressedSize < 0      ||
-        (SInt64)rleRawSize < 0               ||
-        (SInt64)totalAcUncompressedCount < 0 ||
-        (SInt64)totalDcUncompressedCount < 0)
+    if ((int64_t)unknownUncompressedSize < 0  ||
+        (int64_t)unknownCompressedSize < 0    ||
+        (int64_t)acCompressedSize < 0         ||
+        (int64_t)dcCompressedSize < 0         ||
+        (int64_t)rleCompressedSize < 0        ||
+        (int64_t)rleUncompressedSize < 0      ||
+        (int64_t)rleRawSize < 0               ||
+        (int64_t)totalAcUncompressedCount < 0 ||
+        (int64_t)totalDcUncompressedCount < 0)
     {
         throw IEX_NAMESPACE::InputExc("Error uncompressing DWA data"
                             " (corrupt header).");
@@ -2623,7 +2623,7 @@ DwaCompressor::uncompress
                                 "(corrupt header).");
         }
 
-        if (static_cast<Int64>(_zip->uncompress
+        if (static_cast<uint64_t>(_zip->uncompress
                     (compressedDcBuf, (int)dcCompressedSize, _packedDcBuffer))
             != totalDcUncompressedCount * sizeof (unsigned short))
         {
@@ -2667,7 +2667,7 @@ DwaCompressor::uncompress
         if (dstLen != rleUncompressedSize)
             throw IEX_NAMESPACE::BaseExc("RLE data corrupted");
 
-        if (static_cast<Int64>(rleUncompress
+        if (static_cast<uint64_t>(rleUncompress
                 ((int)rleUncompressedSize, 
                  (int)rleRawSize,
                  (signed char *)_rleBuffer,
@@ -2966,20 +2966,20 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // of channels we have. 
     //
 
-    Int64 maxOutBufferSize  = 0;
-    Int64 numLossyDctChans  = 0;
-    Int64 unknownBufferSize = 0;
-    Int64 rleBufferSize     = 0;
+    uint64_t maxOutBufferSize  = 0;
+    uint64_t numLossyDctChans  = 0;
+    uint64_t unknownBufferSize = 0;
+    uint64_t rleBufferSize     = 0;
 
-    Int64 maxLossyDctAcSize = static_cast<Int64>(ceil ((float)numScanLines() / 8.0f)) *
-                            static_cast<Int64>(ceil ((float)(_max[0] - _min[0] + 1) / 8.0f)) *
+    uint64_t maxLossyDctAcSize = static_cast<uint64_t>(ceil ((float)numScanLines() / 8.0f)) *
+                            static_cast<uint64_t>(ceil ((float)(_max[0] - _min[0] + 1) / 8.0f)) *
                             63 * sizeof (unsigned short);
 
-    Int64 maxLossyDctDcSize = static_cast<Int64>(ceil ((float)numScanLines() / 8.0f)) *
-                            static_cast<Int64>(ceil ((float)(_max[0] - _min[0] + 1) / 8.0f)) *
+    uint64_t maxLossyDctDcSize = static_cast<uint64_t>(ceil ((float)numScanLines() / 8.0f)) *
+                            static_cast<uint64_t>(ceil ((float)(_max[0] - _min[0] + 1) / 8.0f)) *
                             sizeof (unsigned short);
 
-    Int64 pixelCount = static_cast<Int64>(numScanLines()) * static_cast<Int64>(_max[0] - _min[0] + 1);
+    uint64_t pixelCount = static_cast<uint64_t>(numScanLines()) * static_cast<uint64_t>(_max[0] - _min[0] + 1);
 
     for (unsigned int chan = 0; chan < _channelData.size(); ++chan)
     {
@@ -2996,7 +2996,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
 
             maxOutBufferSize += std::max(
                             2lu * maxLossyDctAcSize + 65536lu,
-                            static_cast<Int64>(compressBound (maxLossyDctAcSize)) );
+                            static_cast<uint64_t>(compressBound (maxLossyDctAcSize)) );
             numLossyDctChans++;
             break;
 
@@ -3007,7 +3007,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
                 // of the source data.
                 //
 
-                Int64 rleAmount = 2 * pixelCount * OPENEXR_IMF_NAMESPACE::pixelTypeSize (_channelData[chan].type);
+                uint64_t rleAmount = 2 * pixelCount * OPENEXR_IMF_NAMESPACE::pixelTypeSize (_channelData[chan].type);
 
                 rleBufferSize += rleAmount;
             }
@@ -3033,13 +3033,13 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // which could take slightly more space
     //
 
-    maxOutBufferSize += static_cast<Int64>(compressBound (rleBufferSize));
+    maxOutBufferSize += static_cast<uint64_t>(compressBound (rleBufferSize));
     
     //
     // And the same goes for the UNKNOWN data
     //
 
-    maxOutBufferSize += static_cast<Int64>(compressBound (unknownBufferSize));
+    maxOutBufferSize += static_cast<uint64_t>(compressBound (unknownBufferSize));
 
     //
     // Allocate a zip/deflate compressor big enought to hold the DC data
@@ -3063,7 +3063,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // write out the size of our various packed and compressed data.
     //
 
-    maxOutBufferSize += NUM_SIZES_SINGLE * sizeof (Int64); 
+    maxOutBufferSize += NUM_SIZES_SINGLE * sizeof (uint64_t); 
                     
 
     //
@@ -3125,7 +3125,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     // all in one swoop (for each compression scheme).
     //
 
-    Int64 planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
+    uint64_t planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
     for (int i=0; i<NUM_COMPRESSOR_SCHEMES; ++i)
         planarUncBufferSize[i] = 0;
 
@@ -3160,7 +3160,7 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     if (planarUncBufferSize[UNKNOWN] > 0)
     {
         planarUncBufferSize[UNKNOWN] =
-                static_cast<Int64>( compressBound (planarUncBufferSize[UNKNOWN]) );
+                static_cast<uint64_t>( compressBound (planarUncBufferSize[UNKNOWN]) );
     }
 
     for (int i = 0; i < NUM_COMPRESSOR_SCHEMES; ++i)

--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -2382,7 +2382,7 @@ DwaCompressor::uncompress
 
     for (int i = 0; i < NUM_SIZES_SINGLE; ++i)
     {
-        uint64_t      *dst =  (((uint64_t *)inPtr) + i);
+        uint64_t   *dst =  (((uint64_t *)inPtr) + i);
         const char *src = (char *)(((uint64_t *)inPtr) + i);
 
         Xdr::read<CharPtrIO> (src, *dst);

--- a/src/lib/OpenEXR/ImfDwaCompressor.h
+++ b/src/lib/OpenEXR/ImfDwaCompressor.h
@@ -171,15 +171,15 @@ class DwaCompressor: public Compressor
     std::vector<Classifier>    _channelRules;
 
     char*             _packedAcBuffer;
-    uint64_t             _packedAcBufferSize;
+    uint64_t          _packedAcBufferSize;
     char*             _packedDcBuffer;
-    uint64_t             _packedDcBufferSize;
+    uint64_t          _packedDcBufferSize;
     char*             _rleBuffer;
-    uint64_t             _rleBufferSize;
+    uint64_t          _rleBufferSize;
     char*             _outBuffer;
-    uint64_t             _outBufferSize;
+    uint64_t          _outBufferSize;
     char*             _planarUncBuffer[NUM_COMPRESSOR_SCHEMES];
-    uint64_t             _planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
+    uint64_t          _planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
 
     Zip              *_zip;
     float             _dwaCompressionLevel;

--- a/src/lib/OpenEXR/ImfDwaCompressor.h
+++ b/src/lib/OpenEXR/ImfDwaCompressor.h
@@ -40,14 +40,15 @@
 //
 //------------------------------------------------------------------------------
 
-#include <vector>
 #include <half.h>
 
-#include "ImfInt64.h"
 #include "ImfZip.h"
 #include "ImfChannelList.h"
 #include "ImfCompressor.h"
 #include "ImfNamespace.h"
+
+#include <vector>
+#include <cstdint>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
@@ -170,15 +171,15 @@ class DwaCompressor: public Compressor
     std::vector<Classifier>    _channelRules;
 
     char*             _packedAcBuffer;
-    Int64             _packedAcBufferSize;
+    uint64_t             _packedAcBufferSize;
     char*             _packedDcBuffer;
-    Int64             _packedDcBufferSize;
+    uint64_t             _packedDcBufferSize;
     char*             _rleBuffer;
-    Int64             _rleBufferSize;
+    uint64_t             _rleBufferSize;
     char*             _outBuffer;
-    Int64             _outBufferSize;
+    uint64_t             _outBufferSize;
     char*             _planarUncBuffer[NUM_COMPRESSOR_SCHEMES];
-    Int64             _planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
+    uint64_t             _planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
 
     Zip              *_zip;
     float             _dwaCompressionLevel;

--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -81,21 +81,21 @@ FastHufDecoder::FastHufDecoder
     // the symbol.
     //
 
-    std::vector<Int64> symbols;
+    std::vector<uint64_t> symbols;
 
     //
     // The 'base' table is the minimum code at each code length. base[i]
     // is the smallest code (numerically) of length i.
     //
 
-    Int64 base[MAX_CODE_LEN + 1];     
+    uint64_t base[MAX_CODE_LEN + 1];     
 
     //
     // The 'offset' table is the position (in sorted order) of the first id
     // of a given code lenght. Array is indexed by code length, like base.  
     //
 
-    Int64 offset[MAX_CODE_LEN + 1];   
+    uint64_t offset[MAX_CODE_LEN + 1];   
 
     //
     // Count of how many codes at each length there are. Array is 
@@ -118,14 +118,14 @@ FastHufDecoder::FastHufDecoder
     //
 
     const char *currByte     = table;
-    Int64       currBits     = 0;
+    uint64_t       currBits     = 0;
     int         currBitCount = 0;
 
     const int SHORT_ZEROCODE_RUN = 59;
     const int LONG_ZEROCODE_RUN  = 63;
     const int SHORTEST_LONG_RUN  = 2 + LONG_ZEROCODE_RUN - SHORT_ZEROCODE_RUN;
 
-    for (Int64 symbol = static_cast<Int64>(minSymbol); symbol <= static_cast<Int64>(maxSymbol); symbol++)
+    for (uint64_t symbol = static_cast<uint64_t>(minSymbol); symbol <= static_cast<uint64_t>(maxSymbol); symbol++)
     {
         if (currByte - table >= numBytes)
         {
@@ -140,9 +140,9 @@ FastHufDecoder::FastHufDecoder
         //       63    (run of n 0's, with n is the next 8 bits)
         //
 
-        Int64 codeLen = readBits (6, currBits, currBitCount, currByte);
+        uint64_t codeLen = readBits (6, currBits, currBitCount, currByte);
 
-        if (codeLen == (Int64) LONG_ZEROCODE_RUN)
+        if (codeLen == (uint64_t) LONG_ZEROCODE_RUN)
         {
             if (currByte - table >= numBytes)
             {
@@ -153,7 +153,7 @@ FastHufDecoder::FastHufDecoder
             int runLen = readBits (8, currBits, currBitCount, currByte) +
                          SHORTEST_LONG_RUN;
 
-            if (symbol + runLen > static_cast<Int64>(maxSymbol + 1))
+            if (symbol + runLen > static_cast<uint64_t>(maxSymbol + 1))
             {
                 throw IEX_NAMESPACE::InputExc ("Error decoding Huffman table "
                                                "(Run beyond end of table).");
@@ -162,11 +162,11 @@ FastHufDecoder::FastHufDecoder
             symbol += runLen - 1;
 
         }
-        else if (codeLen >= static_cast<Int64>(SHORT_ZEROCODE_RUN))
+        else if (codeLen >= static_cast<uint64_t>(SHORT_ZEROCODE_RUN))
         {
             int runLen = codeLen - SHORT_ZEROCODE_RUN + 2;
 
-            if (symbol + runLen > static_cast<Int64>(maxSymbol + 1))
+            if (symbol + runLen > static_cast<uint64_t>(maxSymbol + 1))
             {
                 throw IEX_NAMESPACE::InputExc ("Error decoding Huffman table "
                                                "(Run beyond end of table).");
@@ -217,7 +217,7 @@ FastHufDecoder::FastHufDecoder
             
             tmp /= (double)(2ll << (_maxCodeLength - l));
 
-            base[l] = (Int64)ceil (tmp);
+            base[l] = (uint64_t)ceil (tmp);
         }
 
         delete [] countTmp;
@@ -242,20 +242,20 @@ FastHufDecoder::FastHufDecoder
 
     _idToSymbol = new int[_numSymbols];
 
-    Int64 mapping[MAX_CODE_LEN + 1];
+    uint64_t mapping[MAX_CODE_LEN + 1];
     for (int i = 0; i < MAX_CODE_LEN + 1; ++i) 
         mapping[i] = -1;
     for (int i = _minCodeLength; i <= _maxCodeLength; ++i)
         mapping[i] = offset[i];
 
-    for (std::vector<Int64>::const_iterator i = symbols.begin(); 
+    for (std::vector<uint64_t>::const_iterator i = symbols.begin(); 
          i != symbols.end();
          ++i)
     {
         int codeLen = *i & 63;
         int symbol  = *i >> 6;
 
-        if (mapping[codeLen] >= static_cast<Int64>(_numSymbols))
+        if (mapping[codeLen] >= static_cast<uint64_t>(_numSymbols))
         {
             delete[] _idToSymbol;
             _idToSymbol = NULL;
@@ -301,14 +301,14 @@ FastHufDecoder::~FastHufDecoder()
 //
 
 #define READ64(c) \
-    ((Int64)(c)[0] << 56) | ((Int64)(c)[1] << 48) | ((Int64)(c)[2] << 40) | \
-    ((Int64)(c)[3] << 32) | ((Int64)(c)[4] << 24) | ((Int64)(c)[5] << 16) | \
-    ((Int64)(c)[6] <<  8) | ((Int64)(c)[7] ) 
+    ((uint64_t)(c)[0] << 56) | ((uint64_t)(c)[1] << 48) | ((uint64_t)(c)[2] << 40) | \
+    ((uint64_t)(c)[3] << 32) | ((uint64_t)(c)[4] << 24) | ((uint64_t)(c)[5] << 16) | \
+    ((uint64_t)(c)[6] <<  8) | ((uint64_t)(c)[7] ) 
 
 #ifdef __INTEL_COMPILER // ICC built-in swap for LE hosts
     #if defined (__i386__) || defined(__x86_64__)
         #undef  READ64
-        #define READ64(c) _bswap64 (*(const Int64*)(c))
+        #define READ64(c) _bswap64 (*(const uint64_t*)(c))
     #endif
 #endif
 
@@ -359,7 +359,7 @@ FastHufDecoder::enabled()
 //
 
 void
-FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
+FastHufDecoder::buildTables (uint64_t *base, uint64_t *offset)
 {
     //
     // Build the 'left justified' base table, by shifting base left..
@@ -397,9 +397,9 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
     // short codes ( <= TABLE_LOOKUP_BITS long)
     //
 
-    for (Int64 i = 0; i < 1 << TABLE_LOOKUP_BITS; ++i)
+    for (uint64_t i = 0; i < 1 << TABLE_LOOKUP_BITS; ++i)
     {
-        Int64 value = i << (64 - TABLE_LOOKUP_BITS);
+        uint64_t value = i << (64 - TABLE_LOOKUP_BITS);
 
         _tableSymbol[i]  = 0xffff;
         _tableCodeLen[i] = 0; 
@@ -410,8 +410,8 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
             {
                 _tableCodeLen[i] = codeLen;
 
-                Int64 id = _ljOffset[codeLen] + (value >> (64 - codeLen));
-                if (id < static_cast<Int64>(_numSymbols))
+                uint64_t id = _ljOffset[codeLen] + (value >> (64 - codeLen));
+                if (id < static_cast<uint64_t>(_numSymbols))
                 {
                     _tableSymbol[i] = _idToSymbol[id];
                 }
@@ -453,7 +453,7 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
 
 
 // 
-// For decoding, we're holding onto 2 Int64's. 
+// For decoding, we're holding onto 2 uint64_t's. 
 //
 // The first (buffer), holds the next bits from the bitstream to be 
 // decoded. For certain paths in the decoder, we only need TABLE_LOOKUP_BITS
@@ -462,12 +462,12 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
 //
 // When we need to refill 'buffer', we could pull bits straight from 
 // the bitstream. But this is very slow and requires lots of book keeping
-// (what's the next bit in the next byte?). Instead, we keep another Int64
+// (what's the next bit in the next byte?). Instead, we keep another uint64_t
 // around that we use to refill from. While this doesn't cut down on the
 // book keeping (still need to know how many valid bits), it does cut
 // down on some of the bit shifting crazy and byte access. 
 //
-// The refill Int64 (bufferBack) gets left-shifted after we've pulled
+// The refill uint64_t (bufferBack) gets left-shifted after we've pulled
 // off bits. If we run out of bits in the input bit stream, we just
 // shift in 0's to bufferBack. 
 //
@@ -478,9 +478,9 @@ FastHufDecoder::buildTables (Int64 *base, Int64 *offset)
 
 inline void
 FastHufDecoder::refill
-    (Int64 &buffer,
+    (uint64_t &buffer,
      int numBits,                       // number of bits to refill
-     Int64 &bufferBack,                 // the next 64-bits, to refill from
+     uint64_t &bufferBack,                 // the next 64-bits, to refill from
      int &bufferBackNumBits,            // number of bits left in bufferBack
      const unsigned char *&currByte,    // current byte in the bitstream
      int &currBitsLeft)                 // number of bits left in the bitsream
@@ -506,8 +506,8 @@ FastHufDecoder::refill
         {
             bufferBack        = READ64 (currByte); 
             bufferBackNumBits = 64;
-            currByte         += sizeof (Int64);
-            currBitsLeft     -= 8 * sizeof (Int64);
+            currByte         += sizeof (uint64_t);
+            currBitsLeft     -= 8 * sizeof (uint64_t);
 
         }
         else
@@ -515,11 +515,11 @@ FastHufDecoder::refill
             bufferBack        = 0;
             bufferBackNumBits = 64; 
 
-            Int64 shift = 56;
+            uint64_t shift = 56;
             
             while (currBitsLeft > 0)
             {
-                bufferBack |= ((Int64)(*currByte)) << shift;
+                bufferBack |= ((uint64_t)(*currByte)) << shift;
 
                 currByte++;
                 shift        -= 8;
@@ -564,10 +564,10 @@ FastHufDecoder::refill
 // (bufferNumBits).  Bitstream pointer (currByte) will be advanced when needed.
 //
 
-inline Int64 
+inline uint64_t 
 FastHufDecoder::readBits
     (int numBits,
-     Int64 &buffer,             // c
+     uint64_t &buffer,             // c
      int &bufferNumBits,        // lc
      const char *&currByte)     // in
 {
@@ -608,22 +608,22 @@ FastHufDecoder::decode
     // (after the first buffer fill)
     //
 
-    const unsigned char *currByte = src + 2 * sizeof (Int64);
+    const unsigned char *currByte = src + 2 * sizeof (uint64_t);
 
-    numSrcBits -= 8 * 2 * sizeof (Int64);
+    numSrcBits -= 8 * 2 * sizeof (uint64_t);
 
     //
     // 64-bit buffer holding the current bits in the stream
     //
 
-    Int64 buffer            = READ64 (src); 
+    uint64_t buffer            = READ64 (src); 
     int   bufferNumBits     = 64;
 
     //
     // 64-bit buffer holding the next bits in the stream
     //
 
-    Int64 bufferBack        = READ64 ((src + sizeof (Int64))); 
+    uint64_t bufferBack        = READ64 ((src + sizeof (uint64_t))); 
     int   bufferBackNumBits = 64;
 
     int dstIdx = 0;
@@ -688,8 +688,8 @@ FastHufDecoder::decode
                                                "(Decoded an invalid symbol).");
             }
 
-            Int64 id = _ljOffset[codeLen] + (buffer >> (64 - codeLen));
-            if (id < static_cast<Int64>(_numSymbols))
+            uint64_t id = _ljOffset[codeLen] + (buffer >> (64 - codeLen));
+            if (id < static_cast<uint64_t>(_numSymbols))
             {
                 symbol = _idToSymbol[id];
             }

--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -118,7 +118,7 @@ FastHufDecoder::FastHufDecoder
     //
 
     const char *currByte     = table;
-    uint64_t       currBits     = 0;
+    uint64_t    currBits     = 0;
     int         currBitCount = 0;
 
     const int SHORT_ZEROCODE_RUN = 59;

--- a/src/lib/OpenEXR/ImfFastHuf.h
+++ b/src/lib/OpenEXR/ImfFastHuf.h
@@ -151,7 +151,7 @@ class FastHufDecoder
 
     int            _tableSymbol[1 << TABLE_LOOKUP_BITS];
     unsigned char  _tableCodeLen[1 << TABLE_LOOKUP_BITS];
-    uint64_t          _tableMin;
+    uint64_t       _tableMin;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/lib/OpenEXR/ImfFastHuf.h
+++ b/src/lib/OpenEXR/ImfFastHuf.h
@@ -34,9 +34,10 @@
 #ifndef INCLUDED_IMF_FAST_HUF_H
 #define INCLUDED_IMF_FAST_HUF_H
 
-#include "ImfInt64.h"
 #include "ImfNamespace.h"
 #include "ImfExport.h"
+
+#include <cstdint>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
@@ -108,9 +109,9 @@ class FastHufDecoder
 
   private:
 
-    void  buildTables (Int64*, Int64*);
-    void  refill (Int64&, int, Int64&, int&, const unsigned char *&, int&);
-    Int64 readBits (int, Int64&, int&, const char *&);
+    void  buildTables (uint64_t*, uint64_t*);
+    void  refill (uint64_t&, int, uint64_t&, int&, const unsigned char *&, int&);
+    uint64_t readBits (int, uint64_t&, int&, const char *&);
 
     int             _rleSymbol;        // RLE symbol written by the encoder.
                                        // This could be 65536, so beware
@@ -127,11 +128,11 @@ class FastHufDecoder
                                        // the same length. Ids run from 0
                                        // to mNumSymbols-1.
 
-    Int64 _ljBase[MAX_CODE_LEN + 1];   // the 'left justified base' table.
+    uint64_t _ljBase[MAX_CODE_LEN + 1];   // the 'left justified base' table.
                                        // Takes base[i] (i = code length)
-                                       // and 'left justifies' it into an Int64
+                                       // and 'left justifies' it into an uint64_t
 
-    Int64 _ljOffset[MAX_CODE_LEN +1 ]; // There are some other terms that can 
+    uint64_t _ljOffset[MAX_CODE_LEN +1 ]; // There are some other terms that can 
                                        // be folded into constants when taking
                                        // the 'left justified' decode path. This
                                        // holds those constants, indexed by
@@ -150,7 +151,7 @@ class FastHufDecoder
 
     int            _tableSymbol[1 << TABLE_LOOKUP_BITS];
     unsigned char  _tableCodeLen[1 << TABLE_LOOKUP_BITS];
-    Int64          _tableMin;
+    uint64_t          _tableMin;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -827,10 +827,10 @@ Header::sanityCheck (bool isTiled, bool isMultipartFile) const
     // (only reachable for unknown types or damaged files: will have thrown earlier
     //  for regular image types)
     if( maxImageHeight>0 && maxImageWidth>0 && 
-	hasChunkCount() && static_cast<Int64>(chunkCount())>Int64(maxImageWidth)*Int64(maxImageHeight))
+	hasChunkCount() && static_cast<uint64_t>(chunkCount())>uint64_t(maxImageWidth)*uint64_t(maxImageHeight))
     {
 	THROW (IEX_NAMESPACE::ArgExc, "chunkCount exceeds maximum area of "
-	       << Int64(maxImageWidth)*Int64(maxImageHeight) << " pixels." );
+	       << uint64_t(maxImageWidth)*uint64_t(maxImageHeight) << " pixels." );
        
     }
 
@@ -1127,7 +1127,7 @@ Header::readsNothing()
 }
 
 
-Int64
+uint64_t
 Header::writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, bool isTiled) const
 {
     //
@@ -1142,7 +1142,7 @@ Header::writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, bool isTiled) cons
     // keep track of its position in the file.
     //
 
-    Int64 previewPosition = 0;
+    uint64_t previewPosition = 0;
 
     const Attribute *preview =
 	    findTypedAttribute <PreviewImageAttribute> ("preview");

--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -47,7 +47,6 @@
 #include "ImfCompression.h"
 #include "ImfName.h"
 #include "ImfTileDescription.h"
-#include "ImfInt64.h"
 #include "ImathVec.h"
 #include "ImathBox.h"
 #include "IexBaseExc.h"
@@ -59,6 +58,7 @@
 #include <map>
 #include <iosfwd>
 #include <string>
+#include <cstdint>
 
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -488,7 +488,7 @@ class Header
 
 
     IMF_EXPORT
-    Int64			writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os,
+    uint64_t			writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os,
 					 bool isTiled = false) const;
 
     IMF_EXPORT

--- a/src/lib/OpenEXR/ImfHuf.cpp
+++ b/src/lib/OpenEXR/ImfHuf.cpp
@@ -46,13 +46,14 @@
 //-----------------------------------------------------------------------------
 
 #include <ImfHuf.h>
-#include <ImfInt64.h>
 #include "ImfAutoArray.h"
 #include "ImfFastHuf.h"
 #include "Iex.h"
 #include <cstring>
 #include <cassert>
 #include <algorithm>
+#include <cstdint>
+
 
 
 using namespace std;
@@ -145,22 +146,22 @@ invalidTableEntry ()
 }
 
 
-inline Int64
-hufLength (Int64 code)
+inline uint64_t
+hufLength (uint64_t code)
 {
     return code & 63;
 }
 
 
-inline Int64
-hufCode (Int64 code)
+inline uint64_t
+hufCode (uint64_t code)
 {
     return code >> 6;
 }
 
 
 inline void
-outputBits (int nBits, Int64 bits, Int64 &c, int &lc, char *&out)
+outputBits (int nBits, uint64_t bits, uint64_t &c, int &lc, char *&out)
 {
     c <<= nBits;
     lc += nBits;
@@ -172,8 +173,8 @@ outputBits (int nBits, Int64 bits, Int64 &c, int &lc, char *&out)
 }
 
 
-inline Int64
-getBits (int nBits, Int64 &c, int &lc, const char *&in)
+inline uint64_t
+getBits (int nBits, uint64_t &c, int &lc, const char *&in)
 {
     while (lc < nBits)
     {
@@ -208,13 +209,13 @@ getBits (int nBits, Int64 &c, int &lc, const char *&in)
 
 #if !defined (OPENEXR_IMF_HAVE_LARGE_STACK)
 void
-hufCanonicalCodeTable (Int64 *hcode)
+hufCanonicalCodeTable (uint64_t *hcode)
 #else
 void
-hufCanonicalCodeTable (Int64 hcode[HUF_ENCSIZE])
+hufCanonicalCodeTable (uint64_t hcode[HUF_ENCSIZE])
 #endif
 {
-    Int64 n[59];
+    uint64_t n[59];
 
     //
     // For each i from 0 through 58, count the
@@ -234,11 +235,11 @@ hufCanonicalCodeTable (Int64 hcode[HUF_ENCSIZE])
     // store that code in n[i].
     //
 
-    Int64 c = 0;
+    uint64_t c = 0;
 
     for (int i = 58; i > 0; --i)
     {
-	Int64 nc = ((c + n[i]) >> 1);
+	uint64_t nc = ((c + n[i]) >> 1);
 	n[i] = c;
 	c = nc;
     }
@@ -277,7 +278,7 @@ hufCanonicalCodeTable (Int64 hcode[HUF_ENCSIZE])
 
 struct FHeapCompare
 {
-    bool operator () (Int64 *a, Int64 *b)
+    bool operator () (uint64_t *a, uint64_t *b)
     {
         return ((*a > *b) || ((*a == *b) && (a > b)));
     }
@@ -286,7 +287,7 @@ struct FHeapCompare
 
 void
 hufBuildEncTable
-    (Int64*	frq,	// io: input frequencies [HUF_ENCSIZE], output table
+    (uint64_t*	frq,	// io: input frequencies [HUF_ENCSIZE], output table
      int*	im,	//  o: min frq index
      int*	iM)	//  o: max frq index
 {
@@ -312,7 +313,7 @@ hufBuildEncTable
     //
 
     AutoArray <int, HUF_ENCSIZE> hlink;
-    AutoArray <Int64 *, HUF_ENCSIZE> fHeap;
+    AutoArray <uint64_t *, HUF_ENCSIZE> fHeap;
 
     *im = 0;
 
@@ -374,8 +375,8 @@ hufBuildEncTable
 
     make_heap (&fHeap[0], &fHeap[nf], FHeapCompare());
 
-    AutoArray <Int64, HUF_ENCSIZE> scode;
-    memset (scode, 0, sizeof (Int64) * HUF_ENCSIZE);
+    AutoArray <uint64_t, HUF_ENCSIZE> scode;
+    memset (scode, 0, sizeof (uint64_t) * HUF_ENCSIZE);
 
     while (nf > 1)
     {
@@ -453,7 +454,7 @@ hufBuildEncTable
     //
 
     hufCanonicalCodeTable (scode);
-    memcpy (frq, scode, sizeof (Int64) * HUF_ENCSIZE);
+    memcpy (frq, scode, sizeof (uint64_t) * HUF_ENCSIZE);
 }
 
 
@@ -480,13 +481,13 @@ const int LONGEST_LONG_RUN   = 255 + SHORTEST_LONG_RUN;
 
 void
 hufPackEncTable
-    (const Int64*	hcode,		// i : encoding table [HUF_ENCSIZE]
+    (const uint64_t*	hcode,		// i : encoding table [HUF_ENCSIZE]
      int		im,		// i : min hcode index
      int		iM,		// i : max hcode index
      char**		pcode)		//  o: ptr to packed table (updated)
 {
     char *p = *pcode;
-    Int64 c = 0;
+    uint64_t c = 0;
     int lc = 0;
 
     for (; im <= iM; im++)
@@ -540,12 +541,12 @@ hufUnpackEncTable
      int		ni,		// i : input size (in bytes)
      int		im,		// i : min hcode index
      int		iM,		// i : max hcode index
-     Int64*		hcode)		//  o: encoding table [HUF_ENCSIZE]
+     uint64_t*		hcode)		//  o: encoding table [HUF_ENCSIZE]
 {
-    memset (hcode, 0, sizeof (Int64) * HUF_ENCSIZE);
+    memset (hcode, 0, sizeof (uint64_t) * HUF_ENCSIZE);
 
     const char *p = *pcode;
-    Int64 c = 0;
+    uint64_t c = 0;
     int lc = 0;
 
     for (; im <= iM; im++)
@@ -553,9 +554,9 @@ hufUnpackEncTable
 	if (p - *pcode > ni)
 	    unexpectedEndOfTable();
 
-	Int64 l = hcode[im] = getBits (6, c, lc, p); // code length
+	uint64_t l = hcode[im] = getBits (6, c, lc, p); // code length
 
-	if (l == (Int64) LONG_ZEROCODE_RUN)
+	if (l == (uint64_t) LONG_ZEROCODE_RUN)
 	{
 	    if (p - *pcode > ni)
 		unexpectedEndOfTable();
@@ -570,7 +571,7 @@ hufUnpackEncTable
 
 	    im--;
 	}
-	else if (l >= (Int64) SHORT_ZEROCODE_RUN)
+	else if (l >= (uint64_t) SHORT_ZEROCODE_RUN)
 	{
 	    int zerun = l - SHORT_ZEROCODE_RUN + 2;
 
@@ -617,7 +618,7 @@ hufClearDecTable
 
 void
 hufBuildDecTable
-    (const Int64*	hcode,		// i : encoding table
+    (const uint64_t*	hcode,		// i : encoding table
      int		im,		// i : min index in hcode
      int		iM,		// i : max index in hcode
      HufDec *		hdecod)		//  o: (allocated by caller)
@@ -630,7 +631,7 @@ hufBuildDecTable
 
     for (; im <= iM; im++)
     {
-	Int64 c = hufCode (hcode[im]);
+	uint64_t c = hufCode (hcode[im]);
 	int l = hufLength (hcode[im]);
 
 	if (c >> l)
@@ -689,7 +690,7 @@ hufBuildDecTable
 
 	    HufDec *pl = hdecod + (c << (HUF_DECBITS - l));
 
-	    for (Int64 i = 1 << (HUF_DECBITS - l); i > 0; i--, pl++)
+	    for (uint64_t i = 1 << (HUF_DECBITS - l); i > 0; i--, pl++)
 	    {
 		if (pl->len || pl->p)
 		{
@@ -732,15 +733,15 @@ hufFreeDecTable (HufDec *hdecod)	// io: Decoding table
 //
 
 inline void
-outputCode (Int64 code, Int64 &c, int &lc, char *&out)
+outputCode (uint64_t code, uint64_t &c, int &lc, char *&out)
 {
     outputBits (hufLength (code), hufCode (code), c, lc, out);
 }
 
 
 inline void
-sendCode (Int64 sCode, int runCount, Int64 runCode,
-	  Int64 &c, int &lc, char *&out)
+sendCode (uint64_t sCode, int runCount, uint64_t runCode,
+	  uint64_t &c, int &lc, char *&out)
 {
     //
     // Output a run of runCount instances of the symbol sCount.
@@ -770,14 +771,14 @@ sendCode (Int64 sCode, int runCount, Int64 runCode,
 
 int
 hufEncode				// return: output size (in bits)
-    (const Int64*  	    hcode,	// i : encoding table
+    (const uint64_t*  	    hcode,	// i : encoding table
      const unsigned short*  in,		// i : uncompressed input buffer
      const int     	    ni,		// i : input buffer size (in bytes)
      int           	    rlc,	// i : rl code
      char*         	    out)	//  o: compressed output buffer
 {
     char *outStart = out;
-    Int64 c = 0;	// bits not yet written to out
+    uint64_t c = 0;	// bits not yet written to out
     int lc = 0;		// number of valid bits in c (LSB)
     int s = in[0];
     int cs = 0;
@@ -873,7 +874,7 @@ hufEncode				// return: output size (in bits)
 
 void
 hufDecode
-    (const Int64 * 	hcode,	// i : encoding table
+    (const uint64_t * 	hcode,	// i : encoding table
      const HufDec * 	hdecod,	// i : decoding table
      const char* 	in,	// i : compressed input buffer
      int		ni,	// i : input size (in bits)
@@ -881,7 +882,7 @@ hufDecode
      int		no,	// i : expected output size (in bytes)
      unsigned short*	out)	//  o: uncompressed output buffer
 {
-    Int64 c = 0;
+    uint64_t c = 0;
     int lc = 0;
     unsigned short * outb = out;
     unsigned short * oe = out + no;
@@ -938,7 +939,7 @@ hufDecode
 		    if (lc >= l)
 		    {
 			if (hufCode (hcode[pl.p[j]]) ==
-				((c >> (lc - l)) & ((Int64(1) << l) - 1)))
+				((c >> (lc - l)) & ((uint64_t(1) << l) - 1)))
 			{
 			    //
 			    // Found : get long code
@@ -991,12 +992,12 @@ hufDecode
 
 #if !defined (OPENEXR_IMF_HAVE_LARGE_STACK)
 void
-countFrequencies (Int64 *freq,
+countFrequencies (uint64_t *freq,
 		  const unsigned short data[/*n*/],
 		  int n)
 #else
 void
-countFrequencies (Int64 freq[HUF_ENCSIZE],
+countFrequencies (uint64_t freq[HUF_ENCSIZE],
 		  const unsigned short data[/*n*/],
 		  int n)
 #endif
@@ -1048,7 +1049,7 @@ hufCompress (const unsigned short raw[],
     if (nRaw == 0)
 	return 0;
 
-    AutoArray <Int64, HUF_ENCSIZE> freq;
+    AutoArray <uint64_t, HUF_ENCSIZE> freq;
 
     countFrequencies (freq, raw, nRaw);
 
@@ -1131,7 +1132,7 @@ hufUncompress (const char compressed[],
     }
     else
     {
-        AutoArray <Int64, HUF_ENCSIZE> freq;
+        AutoArray <uint64_t, HUF_ENCSIZE> freq;
         AutoArray <HufDec, HUF_DECSIZE> hdec;
 
         hufClearDecTable (hdec);

--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -83,7 +83,7 @@ namespace
     }
     */
 
-    size_t getVariableLengthIntegerSize(Int64 value)
+    size_t getVariableLengthIntegerSize(uint64_t value)
     {    
 
        if(value < 1llu<<7)
@@ -127,13 +127,13 @@ namespace
        
     }
 
-    Int64 readVariableLengthInteger(const char*& readPtr,const char* endPtr)
+    uint64_t readVariableLengthInteger(const char*& readPtr,const char* endPtr)
     {
         // bytes are stored LSB first, so each byte that is read from the stream must be
         // shifted before mixing into the existing length
         int shift=0;
         unsigned char byte=0;
-        Int64 value=0;
+        uint64_t value=0;
         do{
             if(readPtr>=endPtr)
             {
@@ -143,13 +143,13 @@ namespace
             // top bit of byte isn't part of actual number, it just indicates there's more info to come
             // so take bottom 7 bits, shift them to the right place, and insert them
             //
-            value|=(Int64(byte&127)) << shift; 
+            value|=(uint64_t(byte&127)) << shift; 
             shift+=7;
         }while(byte&128); //while top bit set on previous byte, there is more to come
         return value;
     }
     
-    void writeVariableLengthInteger(char*& outPtr,Int64 value)
+    void writeVariableLengthInteger(char*& outPtr,uint64_t value)
     {
         do
         {
@@ -491,11 +491,11 @@ void IDManifest::init(const char* data, const char* endOfData)
        int tableSize;
        Xdr::read<CharPtrIO>(data,tableSize);
        
-       Int64 previousId=0;
+       uint64_t previousId=0;
        
        for(int entry = 0 ; entry < tableSize ; ++entry)
        {
-           Int64 id;
+           uint64_t id;
       
            switch(storageScheme)
            {
@@ -532,7 +532,7 @@ void IDManifest::init(const char* data, const char* endOfData)
            //
            // insert into table - insert tells us if it was already there
            //
-           pair< map< Int64, vector<string> >::iterator,bool> insertion = m._table.insert(make_pair(id,vector<string>()));
+           pair< map< uint64_t, vector<string> >::iterator,bool> insertion = m._table.insert(make_pair(id,vector<string>()));
            if(insertion.second==false)
            {
                throw IEX_NAMESPACE::InputExc("ID manifest contains multiple entries for the same ID");
@@ -810,13 +810,13 @@ void IDManifest::serialize(std::vector< char >& data) const
        outputSize += 1; // ID scheme
        outputSize += 4; // size of storage for number of 32 bit entries in ID table
        
-       Int64 previousId=0;       
-       Int64 IdStorageForVariableScheme = 0;
+       uint64_t previousId=0;       
+       uint64_t IdStorageForVariableScheme = 0;
        bool canUse32Bits = true;
        for( IDManifest::ChannelGroupManifest::IDTable::const_iterator i = m._table.begin(); i!=m._table.end(); ++i)
        {
        
-           Int64 idToStore = i->first-previousId;
+           uint64_t idToStore = i->first-previousId;
            IdStorageForVariableScheme+=getVariableLengthIntegerSize(idToStore);
            if(idToStore >= 1llu<<32)
            {
@@ -931,14 +931,14 @@ void IDManifest::serialize(std::vector< char >& data) const
        
        Xdr::write<CharPtrIO>(outPtr,int(m._table.size()));
        
-       Int64 previousId=0;     
+       uint64_t previousId=0;     
        //
        // table
        //
        for( IDManifest::ChannelGroupManifest::IDTable::const_iterator i = m._table.begin(); i!=m._table.end(); ++i)
        {
         
-           Int64 idToWrite = i->first-previousId;
+           uint64_t idToWrite = i->first-previousId;
            switch(scheme)
            {
                case 0 : Xdr::write<CharPtrIO>(outPtr, idToWrite);break;
@@ -1196,13 +1196,13 @@ IDManifest::ChannelGroupManifest::Iterator IDManifest::ChannelGroupManifest::end
 }
 
 IDManifest::ChannelGroupManifest::ConstIterator
-IDManifest::ChannelGroupManifest::find(Int64 idValue) const
+IDManifest::ChannelGroupManifest::find(uint64_t idValue) const
 {
     return IDManifest::ChannelGroupManifest::ConstIterator(_table.find(idValue));
 }
 
 void
-IDManifest::ChannelGroupManifest::erase(Int64 idValue)
+IDManifest::ChannelGroupManifest::erase(uint64_t idValue)
 {
    _table.erase(idValue);
 }
@@ -1214,12 +1214,12 @@ IDManifest::ChannelGroupManifest::size() const
 
 
 
-IDManifest::ChannelGroupManifest::Iterator IDManifest::ChannelGroupManifest::find(Int64 idValue)
+IDManifest::ChannelGroupManifest::Iterator IDManifest::ChannelGroupManifest::find(uint64_t idValue)
 {
     return IDManifest::ChannelGroupManifest::Iterator(_table.find(idValue));
 }
 
-std::vector< std::string >& IDManifest::ChannelGroupManifest::operator[](Int64 idValue)
+std::vector< std::string >& IDManifest::ChannelGroupManifest::operator[](uint64_t idValue)
 {
      return _table[idValue];
 }
@@ -1227,7 +1227,7 @@ std::vector< std::string >& IDManifest::ChannelGroupManifest::operator[](Int64 i
 
 
 IDManifest::ChannelGroupManifest::Iterator
-IDManifest::ChannelGroupManifest::insert(Int64 idValue, const std::string& text)
+IDManifest::ChannelGroupManifest::insert(uint64_t idValue, const std::string& text)
 {
     if(_components.size()!=1)
     {
@@ -1240,7 +1240,7 @@ IDManifest::ChannelGroupManifest::insert(Int64 idValue, const std::string& text)
 
 
 IDManifest::ChannelGroupManifest::Iterator
-IDManifest::ChannelGroupManifest::insert(Int64 idValue, const std::vector< std::string >& text)
+IDManifest::ChannelGroupManifest::insert(uint64_t idValue, const std::vector< std::string >& text)
 {
    if(_components.size()!=text.size())
    {
@@ -1251,10 +1251,10 @@ IDManifest::ChannelGroupManifest::insert(Int64 idValue, const std::vector< std::
 
 
 
-Int64
+uint64_t
 IDManifest::ChannelGroupManifest::insert(const std::vector< std::string >& text)
 {
-    Int64 hash;
+    uint64_t hash;
     if(_hashScheme == MURMURHASH3_32)
     {
         hash = MurmurHash32(text);
@@ -1272,10 +1272,10 @@ IDManifest::ChannelGroupManifest::insert(const std::vector< std::string >& text)
     
 }
 
-Int64
+uint64_t
 IDManifest::ChannelGroupManifest::insert(const std::string & text)
 {
-    Int64 hash;
+    uint64_t hash;
     if(_hashScheme == MURMURHASH3_32)
     {
         hash = MurmurHash32(text);
@@ -1295,7 +1295,7 @@ IDManifest::ChannelGroupManifest::insert(const std::string & text)
 
 
 IDManifest::ChannelGroupManifest&
-IDManifest::ChannelGroupManifest::operator<<(Int64 idValue)
+IDManifest::ChannelGroupManifest::operator<<(uint64_t idValue)
 {
    if(_insertingEntry)
    {
@@ -1615,10 +1615,10 @@ unsigned int IDManifest::MurmurHash32(const std::string & idString)
     return out;
 }
 
-Int64 IDManifest::MurmurHash64(const std::string& idString)
+uint64_t IDManifest::MurmurHash64(const std::string& idString)
 {
 
-    Int64 out[2];
+    uint64_t out[2];
     MurmurHash3_x64_128(idString.c_str(),idString.size(),0 , out);
     return out[0];
 }
@@ -1638,7 +1638,7 @@ unsigned int IDManifest::MurmurHash32(const vector< string >& idString)
  
  
     
-Int64 IDManifest::MurmurHash64(const vector< string >& idString)
+uint64_t IDManifest::MurmurHash64(const vector< string >& idString)
 {
     if(idString.size()==0)
     {

--- a/src/lib/OpenEXR/ImfIDManifest.h
+++ b/src/lib/OpenEXR/ImfIDManifest.h
@@ -341,7 +341,7 @@ public:
     Iterator &                         operator ++ ();
 
     IMF_EXPORT
-    uint64_t                              id() const;
+    uint64_t                           id() const;
     IMF_EXPORT
     std::vector<std::string>&          text();
     
@@ -371,7 +371,7 @@ public:
     ConstIterator &                         operator ++ ();
 
     IMF_EXPORT
-    uint64_t                              id() const;
+    uint64_t                                 id() const;
     IMF_EXPORT
     const std::vector<std::string>&          text() const;
     

--- a/src/lib/OpenEXR/ImfIDManifest.h
+++ b/src/lib/OpenEXR/ImfIDManifest.h
@@ -10,7 +10,7 @@
 //
 //-----------------------------------------------------------------------------
 #include "ImfNamespace.h"
-#include "ImfInt64.h"
+#include <cstdint>
 #include <map>
 #include <vector>
 #include <set>
@@ -92,7 +92,7 @@ public :
         std::string _hashScheme; //one of above strings or custom value e.g "nz.co.wetafx.cleverhash2"
         std::string _encodingScheme; //string identifying scheme to encode ID numbers within the image
 
-        typedef std::map<Int64, std::vector<std::string> > IDTable;
+        typedef std::map<uint64_t, std::vector<std::string> > IDTable;
         IDTable _table;
 
         // used for << operator to work: tracks the last item inserted into the Manifest 
@@ -164,38 +164,38 @@ public :
          
          // insert a new entry - text must contain same number of items as getComponents
          IMF_EXPORT
-         Iterator insert(Int64 idValue,  const std::vector<std::string>& text);
+         Iterator insert(uint64_t idValue,  const std::vector<std::string>& text);
          
          // insert a new entry - getComponents must be a single entry
          IMF_EXPORT
-         Iterator insert(Int64 idValue,  const std::string& text);
+         Iterator insert(uint64_t idValue,  const std::string& text);
          
          
          // compute hash of given entry, insert into manifest, and return 
          // the computed hash. Exception will be thrown if hash scheme isn't recognised
          IMF_EXPORT
-         Int64 insert(const std::vector<std::string>& text);
+         uint64_t insert(const std::vector<std::string>& text);
          IMF_EXPORT
-         Int64 insert(const std::string& text);
+         uint64_t insert(const std::string& text);
          
          IMF_EXPORT
-         Iterator find(Int64 idValue);
+         Iterator find(uint64_t idValue);
 
          IMF_EXPORT
-         ConstIterator find(Int64 idValue) const;
+         ConstIterator find(uint64_t idValue) const;
 
          IMF_EXPORT
-         void erase(Int64 idValue); 
+         void erase(uint64_t idValue); 
          
          // return reference to idName for given idValue. Adds the mapping to the vector if it doesn't exist
          IMF_EXPORT
-         std::vector<std::string>& operator[](Int64 idValue); 
+         std::vector<std::string>& operator[](uint64_t idValue); 
          
          // add a new entry to the manifest as an insertion operator: <<
          // the component strings must also be inserted using <<
          // throws an exception if the previous insert operation didn't insert the correct number of string components
          IMF_EXPORT
-         ChannelGroupManifest& operator<<(Int64 idValue);
+         ChannelGroupManifest& operator<<(uint64_t idValue);
          
          // insert a string as the next component of a previously inserted attribute
          IMF_EXPORT
@@ -283,9 +283,9 @@ public:
     static unsigned int MurmurHash32(const std::vector<std::string>& idString);
     
     IMF_EXPORT
-    static Int64 MurmurHash64(const std::string& idString);
+    static uint64_t MurmurHash64(const std::string& idString);
     IMF_EXPORT
-    static Int64 MurmurHash64(const std::vector<std::string>& idString);
+    static uint64_t MurmurHash64(const std::vector<std::string>& idString);
     
 
 };
@@ -341,12 +341,12 @@ public:
     Iterator &                         operator ++ ();
 
     IMF_EXPORT
-    Int64                              id() const;
+    uint64_t                              id() const;
     IMF_EXPORT
     std::vector<std::string>&          text();
     
 private:
-    std::map< Int64 , std::vector<std::string> >::iterator _i;
+    std::map< uint64_t , std::vector<std::string> >::iterator _i;
     
 };
 
@@ -371,13 +371,13 @@ public:
     ConstIterator &                         operator ++ ();
 
     IMF_EXPORT
-    Int64                              id() const;
+    uint64_t                              id() const;
     IMF_EXPORT
     const std::vector<std::string>&          text() const;
     
     private:
         
-    std::map< Int64 , std::vector<std::string> >::const_iterator _i;
+    std::map< uint64_t , std::vector<std::string> >::const_iterator _i;
 
     friend bool operator == (const ConstIterator &, const ConstIterator &);
     friend bool operator != (const ConstIterator &, const ConstIterator &);
@@ -392,7 +392,7 @@ inline IDManifest::ChannelGroupManifest::Iterator::Iterator() {}
 inline IDManifest::ChannelGroupManifest::Iterator::Iterator(const IDManifest::ChannelGroupManifest::IDTable::iterator &i) :_i(i) {}
 
 
-inline Int64
+inline uint64_t
 IDManifest::ChannelGroupManifest::Iterator::id() const { return _i->first;}
 
 inline  std::vector<std::string>&
@@ -413,7 +413,7 @@ inline IDManifest::ChannelGroupManifest::ConstIterator::ConstIterator() {}
 inline IDManifest::ChannelGroupManifest::ConstIterator::ConstIterator(const IDManifest::ChannelGroupManifest::Iterator &other) : _i(other._i) {}
 inline IDManifest::ChannelGroupManifest::ConstIterator::ConstIterator(const IDManifest::ChannelGroupManifest::IDTable::const_iterator &i) :_i(i) {}
 
-inline Int64
+inline uint64_t
 IDManifest::ChannelGroupManifest::ConstIterator::id() const { return _i->first;}
 
 inline const  std::vector<std::string>&

--- a/src/lib/OpenEXR/ImfIO.h
+++ b/src/lib/OpenEXR/ImfIO.h
@@ -42,11 +42,11 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "ImfInt64.h"
 #include "ImfNamespace.h"
 #include "ImfExport.h"
 
 #include <string>
+#include <cstdint>
 
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -114,7 +114,7 @@ class IStream
     // read the first byte in the file, tellg() returns 0.
     //--------------------------------------------------------
 
-    virtual Int64	tellg () = 0;
+    virtual uint64_t	tellg () = 0;
 
 
     //-------------------------------------------
@@ -122,7 +122,7 @@ class IStream
     // After calling seekg(i), tellg() returns i.
     //-------------------------------------------
 
-    virtual void	seekg (Int64 pos) = 0;
+    virtual void	seekg (uint64_t pos) = 0;
 
 
     //------------------------------------------------------
@@ -190,7 +190,7 @@ class OStream
     // returns 0.
     //---------------------------------------------------------
 
-    virtual Int64	tellp () = 0;
+    virtual uint64_t	tellp () = 0;
 
 
     //-------------------------------------------
@@ -198,7 +198,7 @@ class OStream
     // After calling seekp(i), tellp() returns i.
     //-------------------------------------------
 
-    virtual void	seekp (Int64 pos) = 0;
+    virtual void	seekp (uint64_t pos) = 0;
 
 
     //------------------------------------------------------

--- a/src/lib/OpenEXR/ImfInputPartData.h
+++ b/src/lib/OpenEXR/ImfInputPartData.h
@@ -51,7 +51,7 @@ struct InputPartData
         int                     partNumber;
         int                     version;
         InputStreamMutex*       mutex;
-        std::vector<uint64_t>      chunkOffsets;
+        std::vector<uint64_t>   chunkOffsets;
         bool                    completed;
 
         IMF_EXPORT

--- a/src/lib/OpenEXR/ImfInputPartData.h
+++ b/src/lib/OpenEXR/ImfInputPartData.h
@@ -51,7 +51,7 @@ struct InputPartData
         int                     partNumber;
         int                     version;
         InputStreamMutex*       mutex;
-        std::vector<Int64>      chunkOffsets;
+        std::vector<uint64_t>      chunkOffsets;
         bool                    completed;
 
         IMF_EXPORT

--- a/src/lib/OpenEXR/ImfInputStreamMutex.h
+++ b/src/lib/OpenEXR/ImfInputStreamMutex.h
@@ -55,7 +55,7 @@ struct InputStreamMutex
 #endif
 {
     OPENEXR_IMF_INTERNAL_NAMESPACE::IStream* is = nullptr;
-    Int64 currentPosition = 0;
+    uint64_t currentPosition = 0;
 };
 
 

--- a/src/lib/OpenEXR/ImfInt64.h
+++ b/src/lib/OpenEXR/ImfInt64.h
@@ -37,7 +37,8 @@
 
 //----------------------------------------------------------------------------
 //
-//	Int64 -- unsigned 64-bit integers, imported from namespace Imath
+//	Deprecated Int64/SInt64 unsigned 64-bit integer type.
+//      Use int64_t and uint64_t instead.
 //
 //----------------------------------------------------------------------------
 
@@ -46,8 +47,11 @@
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
-using IMATH_NAMESPACE::Int64;
-using IMATH_NAMESPACE::SInt64;
+IMATH_DEPRECATED("use int64_t")
+typedef IMATH_NAMESPACE::Int64 Int64;
+
+IMATH_DEPRECATED("use sint64_t")
+typedef IMATH_NAMESPACE::SInt64 Sint64;
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 

--- a/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
@@ -509,7 +509,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
     // Reconstruct broken chunk offset tables. Stop once we received any exception.
     //
 
-    Int64 position = is.tellg();
+    uint64_t position = is.tellg();
 
     
     //
@@ -590,7 +590,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
         // 
         //
         
-        Int64 chunk_start = position;
+        uint64_t chunk_start = position;
         for (size_t i = 0; i < total_chunks ; i++)
         {
             //
@@ -614,7 +614,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
 
             // size of chunk NOT including multipart field
             
-            Int64 size_of_chunk=0;
+            uint64_t size_of_chunk=0;
 
             if (isTiled(header.type()))
             {
@@ -649,8 +649,8 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 // ones
                 if(header.type()==DEEPTILE)
                 {
-                    Int64 packed_offset;
-                    Int64 packed_sample;
+                    uint64_t packed_offset;
+                    uint64_t packed_sample;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_offset);
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
                     
@@ -674,7 +674,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                           throw IEX_NAMESPACE::IoExc("Invalid chunk size");
                     }
 
-                    size_of_chunk=static_cast<Int64>(chunksize) + 20ll;
+                    size_of_chunk=static_cast<uint64_t>(chunksize) + 20ll;
                 }
             }
             else
@@ -699,8 +699,8 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                 
                 if(header.type()==DEEPSCANLINE)
                 {
-                    Int64 packed_offset;
-                    Int64 packed_sample;
+                    uint64_t packed_offset;
+                    uint64_t packed_sample;
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_offset);
                     OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample);
 
@@ -724,7 +724,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
                     {
                           throw IEX_NAMESPACE::IoExc("Invalid chunk size");
                     }
-                    size_of_chunk=static_cast<Int64>(chunksize) + 8ll;
+                    size_of_chunk=static_cast<uint64_t>(chunksize) + 8ll;
                 }
                 
             }
@@ -762,7 +762,7 @@ MultiPartInputFile::Data::chunkOffsetReconstruction(OPENEXR_IMF_INTERNAL_NAMESPA
         if(tileOffsets[partNumber])
         {
             size_t pos=0;
-            vector<vector<vector <Int64> > > offsets = tileOffsets[partNumber]->getOffsets();
+            vector<vector<vector <uint64_t> > > offsets = tileOffsets[partNumber]->getOffsets();
             for (size_t l = 0; l < offsets.size(); l++)
                 for (size_t y = 0; y < offsets[l].size(); y++)
                     for (size_t x = 0; x < offsets[l][y].size(); x++)
@@ -808,9 +808,9 @@ MultiPartInputFile::Data::readChunkOffsetTables(bool reconstructChunkOffsetTable
         //
         if (chunkOffsetTableSize > gLargeChunkTableSize)
         {
-            Int64 pos = is->tellg();
-            is->seekg(pos + (chunkOffsetTableSize-1)*sizeof(Int64));
-            Int64 temp;
+            uint64_t pos = is->tellg();
+            is->seekg(pos + (chunkOffsetTableSize-1)*sizeof(uint64_t));
+            uint64_t temp;
             OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*is, temp);
             is->seekg(pos);
 

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
@@ -501,9 +501,9 @@ MultiPartOutputFile::Data::writeChunkTableOffsets (vector<OutputPartData*> &part
     {
         int chunkTableSize = getChunkOffsetTableSize(parts[i]->header);
 
-        Int64 pos = os->tellp();
+        uint64_t pos = os->tellp();
 
-        if (pos == static_cast<Int64>(-1))
+        if (pos == static_cast<uint64_t>(-1))
             IEX_NAMESPACE::throwErrnoExc ("Cannot determine current file position (%T).");
 
         parts[i]->chunkOffsetTablePosition = os->tellp();
@@ -514,7 +514,7 @@ MultiPartOutputFile::Data::writeChunkTableOffsets (vector<OutputPartData*> &part
 
         for (int j = 0; j < chunkTableSize; j++)
         {
-            Int64 empty = 0;
+            uint64_t empty = 0;
             OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::write <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*os, empty);
         }
     }

--- a/src/lib/OpenEXR/ImfOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfOutputFile.cpp
@@ -178,7 +178,7 @@ struct OutputFile::Data
     Header		 header;		// the image header
     bool                 multiPart;		// is the file multipart?
     int			 version;               // version attribute \todo NOT BEING WRITTEN PROPERLY
-    Int64		 previewPosition;       // file position for preview
+    uint64_t		 previewPosition;       // file position for preview
     FrameBuffer		 frameBuffer;           // framebuffer to write into
     int			 currentScanLine;       // next scanline to be written
     int			 missingScanLines;      // number of lines to write
@@ -187,7 +187,7 @@ struct OutputFile::Data
     int			 maxX;			// data window's max x coord
     int			 minY;			// data window's min y coord
     int			 maxY;			// data window's max x coord
-    vector<Int64>	 lineOffsets;		// stores offsets in file for
+    vector<uint64_t>	 lineOffsets;		// stores offsets in file for
 						// each scanline
     vector<size_t>	 bytesPerLine;          // combined size of a line over
                                                 // all channels
@@ -195,7 +195,7 @@ struct OutputFile::Data
                                                 // its linebuffer
     Compressor::Format	 format;                // compressor's data format
     vector<OutSliceInfo> slices;		// info about channels in file
-    Int64		 lineOffsetsPosition;   // file position for line
+    uint64_t		 lineOffsetsPosition;   // file position for line
                                                 // offset table
 
     vector<LineBuffer*>  lineBuffers;           // each holds one line buffer
@@ -250,12 +250,12 @@ OutputFile::Data::getLineBuffer (int number)
 
 namespace {
 
-Int64
-writeLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, const vector<Int64> &lineOffsets)
+uint64_t
+writeLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os, const vector<uint64_t> &lineOffsets)
 {
-    Int64 pos = os.tellp();
+    uint64_t pos = os.tellp();
 
-    if (pos == static_cast<Int64>(-1))
+    if (pos == static_cast<uint64_t>(-1))
 	IEX_NAMESPACE::throwErrnoExc ("Cannot determine current file position (%T).");
     
     for (unsigned int i = 0; i < lineOffsets.size(); i++)
@@ -278,7 +278,7 @@ writePixelData (OutputStreamMutex *filedata,
     // without calling tellp() (tellp() can be fairly expensive).
     //
 
-    Int64 currentPosition = filedata->currentPosition;
+    uint64_t currentPosition = filedata->currentPosition;
     filedata->currentPosition = 0;
 
     if (currentPosition == 0)
@@ -864,7 +864,7 @@ OutputFile::~OutputFile ()
 #if ILMTHREAD_THREADING_ENABLED
             std::lock_guard<std::mutex> lock(*_data->_streamData);
 #endif
-            Int64 originalPosition = _data->_streamData->os->tellp();
+            uint64_t originalPosition = _data->_streamData->os->tellp();
 
             if (_data->lineOffsetsPosition > 0)
             {
@@ -1377,7 +1377,7 @@ OutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     // preview image, and jump back to the saved file position.
     //
 
-    Int64 savedPosition = _data->_streamData->os->tellp();
+    uint64_t savedPosition = _data->_streamData->os->tellp();
 
     try
     {
@@ -1400,7 +1400,7 @@ OutputFile::breakScanLine  (int y, int offset, int length, char c)
 #if ILMTHREAD_THREADING_ENABLED
     std::lock_guard<std::mutex> lock (*_data->_streamData);
 #endif
-    Int64 position = 
+    uint64_t position = 
 	_data->lineOffsets[(y - _data->minY) / _data->linesInBuffer];
 
     if (!position)

--- a/src/lib/OpenEXR/ImfOutputPartData.h
+++ b/src/lib/OpenEXR/ImfOutputPartData.h
@@ -45,8 +45,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 struct OutputPartData
 {
     Header                  header;
-    uint64_t                   chunkOffsetTablePosition;
-    uint64_t                   previewPosition;
+    uint64_t                chunkOffsetTablePosition;
+    uint64_t                previewPosition;
     int                     numThreads;
     int                     partNumber;
     bool                    multipart;

--- a/src/lib/OpenEXR/ImfOutputPartData.h
+++ b/src/lib/OpenEXR/ImfOutputPartData.h
@@ -45,8 +45,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 struct OutputPartData
 {
     Header                  header;
-    Int64                   chunkOffsetTablePosition;
-    Int64                   previewPosition;
+    uint64_t                   chunkOffsetTablePosition;
+    uint64_t                   previewPosition;
     int                     numThreads;
     int                     partNumber;
     bool                    multipart;

--- a/src/lib/OpenEXR/ImfOutputStreamMutex.h
+++ b/src/lib/OpenEXR/ImfOutputStreamMutex.h
@@ -56,7 +56,7 @@ struct OutputStreamMutex
 #endif
 {
     OPENEXR_IMF_INTERNAL_NAMESPACE::OStream* os = nullptr;
-    Int64 currentPosition = 0;
+    uint64_t currentPosition = 0;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/lib/OpenEXR/ImfPreviewImageAttribute.cpp
+++ b/src/lib/OpenEXR/ImfPreviewImageAttribute.cpp
@@ -89,7 +89,7 @@ PreviewImageAttribute::readValueFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &i
     }
 
     // total attribute size should be four bytes per pixel + 8 bytes for width and height dimensions
-    if (static_cast<Int64>(width) * static_cast<Int64>(height) * 4l + 8l != static_cast<Int64>(size) )
+    if (static_cast<uint64_t>(width) * static_cast<uint64_t>(height) * 4l + 8l != static_cast<uint64_t>(size) )
     {
         throw IEX_NAMESPACE::InputExc("Mismatch between Preview Image Attribute size and dimensions");
     }

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -220,7 +220,7 @@ struct ScanLineInputFile::Data
     int			maxX;		    // data window's max x coord
     int			minY;		    // data window's min y coord
     int			maxY;		    // data window's max x coord
-    vector<Int64>	lineOffsets;	    // stores offsets in file for
+    vector<uint64_t>	lineOffsets;	    // stores offsets in file for
 					    // each line
     bool		fileIsComplete;	    // True if no scanlines are missing
     					    // in the file
@@ -290,15 +290,15 @@ namespace {
 void
 reconstructLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 			LineOrder lineOrder,
-			vector<Int64> &lineOffsets)
+			vector<uint64_t> &lineOffsets)
 {
-    Int64 position = is.tellg();
+    uint64_t position = is.tellg();
 
     try
     {
 	for (unsigned int i = 0; i < lineOffsets.size(); i++)
 	{
-	    Int64 lineOffset = is.tellg();
+	    uint64_t lineOffset = is.tellg();
 
 	    int y;
 	    OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, y);
@@ -337,7 +337,7 @@ reconstructLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 void
 readLineOffsets (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,
 		 LineOrder lineOrder,
-		 vector<Int64> &lineOffsets,
+		 vector<uint64_t> &lineOffsets,
 		 bool &complete)
 {
     for (unsigned int i = 0; i < lineOffsets.size(); i++)
@@ -392,7 +392,7 @@ readPixelData (InputStreamMutex *streamData,
     if (lineBufferNumber < 0 || lineBufferNumber >= int(ifd->lineOffsets.size()))
         THROW (IEX_NAMESPACE::InputExc, "Invalid scan line " << minY << " requested or missing.");
 
-    Int64 lineOffset = ifd->lineOffsets[lineBufferNumber];
+    uint64_t lineOffset = ifd->lineOffsets[lineBufferNumber];
 
     if (lineOffset == 0)
 	THROW (IEX_NAMESPACE::InputExc, "Scan line " << minY << " is missing.");
@@ -1144,9 +1144,9 @@ void ScanLineInputFile::initialize(const Header& header)
         //
         if (lineOffsetSize * _data->linesInBuffer > gLargeChunkTableSize)
         {
-            Int64 pos = _streamData->is->tellg();
-            _streamData->is->seekg(pos + (lineOffsetSize-1)*sizeof(Int64));
-            Int64 temp;
+            uint64_t pos = _streamData->is->tellg();
+            _streamData->is->seekg(pos + (lineOffsetSize-1)*sizeof(uint64_t));
+            uint64_t temp;
             OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
             _streamData->is->seekg(pos);
 

--- a/src/lib/OpenEXR/ImfStdIO.cpp
+++ b/src/lib/OpenEXR/ImfStdIO.cpp
@@ -272,7 +272,7 @@ StdIFStream::read (char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 StdIFStream::tellg ()
 {
     return std::streamoff (_is->tellg());
@@ -280,7 +280,7 @@ StdIFStream::tellg ()
 
 
 void
-StdIFStream::seekg (Int64 pos)
+StdIFStream::seekg (uint64_t pos)
 {
     _is->seekg (pos);
     checkError (*_is);
@@ -311,7 +311,7 @@ StdISStream::read (char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 StdISStream::tellg ()
 {
     return std::streamoff (_is.tellg());
@@ -319,7 +319,7 @@ StdISStream::tellg ()
 
 
 void
-StdISStream::seekg (Int64 pos)
+StdISStream::seekg (uint64_t pos)
 {
     _is.seekg (pos);
     checkError (_is);
@@ -386,7 +386,7 @@ StdOFStream::write (const char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 StdOFStream::tellp ()
 {
     return std::streamoff (_os->tellp());
@@ -394,7 +394,7 @@ StdOFStream::tellp ()
 
 
 void
-StdOFStream::seekp (Int64 pos)
+StdOFStream::seekp (uint64_t pos)
 {
     _os->seekp (pos);
     checkError (*_os);
@@ -416,7 +416,7 @@ StdOSStream::write (const char c[/*n*/], int n)
 }
 
 
-Int64
+uint64_t
 StdOSStream::tellp ()
 {
     return std::streamoff (_os.tellp());
@@ -424,7 +424,7 @@ StdOSStream::tellp ()
 
 
 void
-StdOSStream::seekp (Int64 pos)
+StdOSStream::seekp (uint64_t pos)
 {
     _os.seekp (pos);
     checkError (_os);

--- a/src/lib/OpenEXR/ImfStdIO.h
+++ b/src/lib/OpenEXR/ImfStdIO.h
@@ -87,9 +87,9 @@ class StdIFStream: public OPENEXR_IMF_INTERNAL_NAMESPACE::IStream
     IMF_EXPORT
     virtual bool	read (char c[/*n*/], int n);
     IMF_EXPORT
-    virtual Int64	tellg ();
+    virtual uint64_t	tellg ();
     IMF_EXPORT
-    virtual void	seekg (Int64 pos);
+    virtual void	seekg (uint64_t pos);
     IMF_EXPORT
     virtual void	clear ();
 
@@ -115,9 +115,9 @@ class StdISStream: public OPENEXR_IMF_INTERNAL_NAMESPACE::IStream
     IMF_EXPORT
     virtual bool	read (char c[/*n*/], int n);
     IMF_EXPORT
-    virtual Int64	tellg ();
+    virtual uint64_t	tellg ();
     IMF_EXPORT
-    virtual void	seekg (Int64 pos);
+    virtual void	seekg (uint64_t pos);
     IMF_EXPORT
     virtual void	clear ();
 
@@ -168,9 +168,9 @@ class StdOFStream: public OPENEXR_IMF_INTERNAL_NAMESPACE::OStream
     IMF_EXPORT
     virtual void	write (const char c[/*n*/], int n);
     IMF_EXPORT
-    virtual Int64	tellp ();
+    virtual uint64_t	tellp ();
     IMF_EXPORT
-    virtual void	seekp (Int64 pos);
+    virtual void	seekp (uint64_t pos);
 
   private:
 
@@ -194,9 +194,9 @@ class StdOSStream: public OPENEXR_IMF_INTERNAL_NAMESPACE::OStream
     IMF_EXPORT
     virtual void	write (const char c[/*n*/], int n);
     IMF_EXPORT
-    virtual Int64	tellp ();
+    virtual uint64_t	tellp ();
     IMF_EXPORT
-    virtual void	seekp (Int64 pos);
+    virtual void	seekp (uint64_t pos);
 
     IMF_EXPORT
     std::string		str () const;

--- a/src/lib/OpenEXR/ImfTestFile.cpp
+++ b/src/lib/OpenEXR/ImfTestFile.cpp
@@ -138,7 +138,7 @@ isOpenExrFile
 {
     try
     {
-	Int64 pos = is.tellg();
+	uint64_t pos = is.tellg();
 
 	if (pos != 0)
 	    is.seekg (0);

--- a/src/lib/OpenEXR/ImfTileOffsets.cpp
+++ b/src/lib/OpenEXR/ImfTileOffsets.cpp
@@ -122,7 +122,7 @@ TileOffsets::findTiles (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, bool isMult
 	{
 	    for (unsigned int dx = 0; dx < _offsets[l][dy].size(); ++dx)
 	    {
-		Int64 tileOffset = is.tellg();
+		uint64_t tileOffset = is.tellg();
 
 		if (isMultiPartFile)
 		{
@@ -144,8 +144,8 @@ TileOffsets::findTiles (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, bool isMult
 
                 if(isDeep)
                 {
-                     Int64 packed_offset_table_size;
-                     Int64 packed_sample_size;
+                     uint64_t packed_offset_table_size;
+                     uint64_t packed_sample_size;
                      
                      OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_offset_table_size);
                      OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (is, packed_sample_size);
@@ -159,7 +159,7 @@ TileOffsets::findTiles (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, bool isMult
                           throw IEX_NAMESPACE::IoExc("Invalid deep tile size");
                      }
 
-                     // next Int64 is unpacked sample size - skip that too
+                     // next uint64_t is unpacked sample size - skip that too
                      Xdr::skip <StreamIO> (is, packed_offset_table_size+packed_sample_size+8);
                     
                 }
@@ -197,7 +197,7 @@ TileOffsets::reconstructFromFile (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,bo
     // of the tiles we find.
     //
 
-    Int64 position = is.tellg();
+    uint64_t position = is.tellg();
 
     try
     {
@@ -257,7 +257,7 @@ TileOffsets::readFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is, bool &comple
 
 
 void
-TileOffsets::readFrom (std::vector<Int64> chunkOffsets,bool &complete)
+TileOffsets::readFrom (std::vector<uint64_t> chunkOffsets,bool &complete)
 {
     size_t totalSize = 0;
  
@@ -284,7 +284,7 @@ TileOffsets::readFrom (std::vector<Int64> chunkOffsets,bool &complete)
 }
 
 
-Int64
+uint64_t
 TileOffsets::writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os) const
 {
     //
@@ -293,9 +293,9 @@ TileOffsets::writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os) const
     // in the file.
     //
     
-    Int64 pos = os.tellp();
+    uint64_t pos = os.tellp();
 
-    if (pos == static_cast<Int64>(-1))
+    if (pos == static_cast<uint64_t>(-1))
 	IEX_NAMESPACE::throwErrnoExc ("Cannot determine current file position (%T).");
 
     for (unsigned int l = 0; l < _offsets.size(); ++l)
@@ -308,7 +308,7 @@ TileOffsets::writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os) const
 
 namespace {
 struct tilepos{
-    Int64 filePos;
+    uint64_t filePos;
     int dx;
     int dy;
     int l;
@@ -479,7 +479,7 @@ TileOffsets::isValidTile (int dx, int dy, int lx, int ly) const
 }
 
 
-Int64 &
+uint64_t &
 TileOffsets::operator () (int dx, int dy, int lx, int ly)
 {
     //
@@ -509,14 +509,14 @@ TileOffsets::operator () (int dx, int dy, int lx, int ly)
 }
 
 
-Int64 &
+uint64_t &
 TileOffsets::operator () (int dx, int dy, int l)
 {
     return operator () (dx, dy, l, l);
 }
 
 
-const Int64 &
+const uint64_t &
 TileOffsets::operator () (int dx, int dy, int lx, int ly) const
 {
     //
@@ -546,13 +546,13 @@ TileOffsets::operator () (int dx, int dy, int lx, int ly) const
 }
 
 
-const Int64 &
+const uint64_t &
 TileOffsets::operator () (int dx, int dy, int l) const
 {
     return operator () (dx, dy, l, l);
 }
 
-const std::vector<std::vector<std::vector <Int64> > >&
+const std::vector<std::vector<std::vector <uint64_t> > >&
 TileOffsets::getOffsets() const
 {
     return _offsets;

--- a/src/lib/OpenEXR/ImfTileOffsets.h
+++ b/src/lib/OpenEXR/ImfTileOffsets.h
@@ -43,11 +43,12 @@
 //-----------------------------------------------------------------------------
 
 #include "ImfTileDescription.h"
-#include "ImfInt64.h"
 #include <vector>
 #include "ImfNamespace.h"
 #include "ImfForward.h"
 #include "ImfExport.h"
+
+#include <cstdint>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
@@ -70,9 +71,9 @@ class TileOffsets
     IMF_EXPORT
     void		readFrom (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream &is,  bool &complete,bool isMultiPart,bool isDeep);
     IMF_EXPORT
-    void        readFrom (std::vector<Int64> chunkOffsets,bool &complete);
+    void        readFrom (std::vector<uint64_t> chunkOffsets,bool &complete);
     IMF_EXPORT
-    Int64		writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os) const;
+    uint64_t		writeTo (OPENEXR_IMF_INTERNAL_NAMESPACE::OStream &os) const;
 
 
     //-----------------------------------------------------------
@@ -98,17 +99,17 @@ class TileOffsets
     //-----------------------
 
     IMF_EXPORT
-    Int64 &		operator () (int dx, int dy, int lx, int ly);
+    uint64_t &		operator () (int dx, int dy, int lx, int ly);
     IMF_EXPORT
-    Int64 &		operator () (int dx, int dy, int l);
+    uint64_t &		operator () (int dx, int dy, int l);
     IMF_EXPORT
-    const Int64 &	operator () (int dx, int dy, int lx, int ly) const;
+    const uint64_t &	operator () (int dx, int dy, int lx, int ly) const;
     IMF_EXPORT
-    const Int64 &	operator () (int dx, int dy, int l) const;
+    const uint64_t &	operator () (int dx, int dy, int l) const;
     IMF_EXPORT
     bool        isValidTile (int dx, int dy, int lx, int ly) const;
     IMF_EXPORT
-    const std::vector<std::vector<std::vector <Int64> > >& getOffsets() const;
+    const std::vector<std::vector<std::vector <uint64_t> > >& getOffsets() const;
     
   private:
 
@@ -123,7 +124,7 @@ class TileOffsets
     int			_numXLevels;
     int			_numYLevels;
 
-    std::vector<std::vector<std::vector <Int64> > > _offsets;
+    std::vector<std::vector<std::vector <uint64_t> > > _offsets;
     
 };
 

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -321,7 +321,7 @@ void
 TiledInputFile::Data::validateStreamSize()
 {
     const TileDescription& td = header.tileDescription();
-    Int64 chunkCount;
+    uint64_t chunkCount;
 
     if (td.mode==RIPMAP_LEVELS)
     {
@@ -335,11 +335,11 @@ TiledInputFile::Data::validateStreamSize()
         // but 'chunkCount' can be less than the real offset table size for a meaningful sanity check
         //
         const Box2i &dataWindow = header.dataWindow();
-        Int64 tileWidth = td.xSize;
-        Int64 tileHeight = td.ySize;
+        uint64_t tileWidth = td.xSize;
+        uint64_t tileHeight = td.ySize;
 
-        Int64 tilesX = (static_cast<Int64>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
-        Int64 tilesY = (static_cast<Int64>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;
+        uint64_t tilesX = (static_cast<uint64_t>(dataWindow.max.x+1-dataWindow.min.x) + tileWidth -1) / tileWidth;
+        uint64_t tilesY = (static_cast<uint64_t>(dataWindow.max.y+1-dataWindow.min.y) + tileHeight -1) / tileHeight;
 
         chunkCount = tilesX*tilesY;
     }
@@ -347,9 +347,9 @@ TiledInputFile::Data::validateStreamSize()
     if (chunkCount > gLargeChunkTableSize)
     {
 
-       Int64 pos = _streamData->is->tellg();
-       _streamData->is->seekg(pos + (chunkCount-1)*sizeof(Int64));
-       Int64 temp;
+       uint64_t pos = _streamData->is->tellg();
+       _streamData->is->seekg(pos + (chunkCount-1)*sizeof(uint64_t));
+       uint64_t temp;
        OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read <OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (*_streamData->is, temp);
        _streamData->is->seekg(pos);
     }
@@ -378,7 +378,7 @@ readTileData (InputStreamMutex *streamData,
     // seek to that position if necessary
     //
     
-    Int64 tileOffset = ifd->tileOffsets (dx, dy, lx, ly);
+    uint64_t tileOffset = ifd->tileOffsets (dx, dy, lx, ly);
 
     if (tileOffset == 0)
     {

--- a/src/lib/OpenEXR/ImfTiledMisc.cpp
+++ b/src/lib/OpenEXR/ImfTiledMisc.cpp
@@ -138,7 +138,7 @@ calculateBytesPerLine (const Header &header,
                        int minY, int maxY,
                        std::vector<int>& xOffsets,
                        std::vector<int>& yOffsets,
-                       std::vector<Int64>& bytesPerLine)
+                       std::vector<uint64_t>& bytesPerLine)
 {
     const ChannelList &channels = header.channels();
 
@@ -304,7 +304,7 @@ calculateNumTiles (int *numTiles,
     for (int i = 0; i < numLevels; i++)
     {
         // use 64 bits to avoid int overflow if size is large.
-        Int64 l = levelSize (min, max, i, rmode);
+        uint64_t l = levelSize (min, max, i, rmode);
         numTiles[i] = (l + size - 1) / size;
     }
 }
@@ -367,7 +367,7 @@ getTiledChunkOffsetTableSize(const Header& header)
         //
         // Calculate lineOffsetSize.
         //
-        Int64 lineOffsetSize = 0;
+        uint64_t lineOffsetSize = 0;
         const TileDescription &desc = header.tileDescription();
         switch (desc.mode)
         {
@@ -375,8 +375,8 @@ getTiledChunkOffsetTableSize(const Header& header)
             case MIPMAP_LEVELS:
                 for (int i = 0; i < numXLevels; i++)
                 {
-                    lineOffsetSize += static_cast<Int64>(numXTiles[i]) * static_cast<Int64>(numYTiles[i]);
-                    if ( lineOffsetSize > static_cast<Int64>(std::numeric_limits<int>::max()) )
+                    lineOffsetSize += static_cast<uint64_t>(numXTiles[i]) * static_cast<uint64_t>(numYTiles[i]);
+                    if ( lineOffsetSize > static_cast<uint64_t>(std::numeric_limits<int>::max()) )
                     {
                         throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
                     }
@@ -387,8 +387,8 @@ getTiledChunkOffsetTableSize(const Header& header)
                 {
                     for (int j = 0; j < numYLevels; j++)
                     {
-                        lineOffsetSize += static_cast<Int64>(numXTiles[i]) * static_cast<Int64>(numYTiles[j]);
-                        if ( lineOffsetSize > static_cast<Int64>(std::numeric_limits<int>::max()) )
+                        lineOffsetSize += static_cast<uint64_t>(numXTiles[i]) * static_cast<uint64_t>(numYTiles[j]);
+                        if ( lineOffsetSize > static_cast<uint64_t>(std::numeric_limits<int>::max()) )
                         {
                             throw IEX_NAMESPACE::LogicExc("Maximum number of tiles exceeded");
                         }

--- a/src/lib/OpenEXR/ImfTiledMisc.h
+++ b/src/lib/OpenEXR/ImfTiledMisc.h
@@ -88,7 +88,7 @@ void calculateBytesPerLine (const Header &header,
                             int minY, int maxY,
                             std::vector<int>& xOffsets,
                             std::vector<int>& yOffsets,
-                            std::vector<Int64>& bytesPerLine);
+                            std::vector<uint64_t>& bytesPerLine);
 
 IMF_EXPORT 
 void precalculateTileInfo (const TileDescription& tileDesc,

--- a/src/lib/OpenEXR/ImfTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledOutputFile.cpp
@@ -248,7 +248,7 @@ struct TiledOutputFile::Data
     bool                multipart;              // part came from a multipart file
     TileDescription	tileDesc;		// describes the tile layout
     FrameBuffer		frameBuffer;		// framebuffer to write into
-    Int64		previewPosition;
+    uint64_t		previewPosition;
     LineOrder		lineOrder;		// the file's lineorder
     int			minX;			// data window's min x coord
     int			maxX;			// data window's max x coord
@@ -273,7 +273,7 @@ struct TiledOutputFile::Data
     vector<TileBuffer*> tileBuffers;
     size_t		tileBufferSize;         // size of a tile buffer
 
-    Int64		tileOffsetsPosition;	// position of the tile index
+    uint64_t		tileOffsetsPosition;	// position of the tile index
     
     TileMap		tileMap;
     TileCoord		nextTileToWrite;
@@ -458,7 +458,7 @@ writeTileData (OutputStreamMutex *streamData,
     // without calling tellp() (tellp() can be fairly expensive).
     //
 
-    Int64 currentPosition = streamData->currentPosition;
+    uint64_t currentPosition = streamData->currentPosition;
     streamData->currentPosition = 0;
 
     if (currentPosition == 0)
@@ -1080,7 +1080,7 @@ TiledOutputFile::~TiledOutputFile ()
 #if ILMTHREAD_THREADING_ENABLED
             std::lock_guard<std::mutex> lock(*_streamData);
 #endif
-            Int64 originalPosition = _streamData->os->tellp();
+            uint64_t originalPosition = _streamData->os->tellp();
 
             if (_data->tileOffsetsPosition > 0)
             {
@@ -1826,7 +1826,7 @@ TiledOutputFile::updatePreviewImage (const PreviewRgba newPixels[])
     // preview image, and jump back to the saved file position.
     //
 
-    Int64 savedPosition = _streamData->os->tellp();
+    uint64_t savedPosition = _streamData->os->tellp();
 
     try
     {
@@ -1854,7 +1854,7 @@ TiledOutputFile::breakTile
 #if ILMTHREAD_THREADING_ENABLED
     std::lock_guard<std::mutex> lock (*_streamData);
 #endif
-    Int64 position = _data->tileOffsets (dx, dy, lx, ly);
+    uint64_t position = _data->tileOffsets (dx, dy, lx, ly);
 
     if (!position)
 	THROW (IEX_NAMESPACE::ArgExc,

--- a/src/lib/OpenEXR/ImfXdr.h
+++ b/src/lib/OpenEXR/ImfXdr.h
@@ -103,10 +103,10 @@
 //
 //----------------------------------------------------------------------------
 
-#include "ImfInt64.h"
 #include "IexMathExc.h"
 #include "half.h"
 #include <limits.h>
+#include <cstdint>
 
 #include "ImfNamespace.h"
 
@@ -163,7 +163,7 @@ write (T &out, unsigned long v);
 
     template <class S, class T>
     void
-    write (T &out, Int64 v);
+    write (T &out, uint64_t v);
 
 #endif
 
@@ -246,7 +246,7 @@ read (T &in, unsigned long &v);
 
     template <class S, class T>
     void
-    read (T &in, Int64 &v);
+    read (T &in, uint64_t &v);
 
 #endif
 
@@ -500,7 +500,7 @@ write (T &out, unsigned long v)
 
     template <class S, class T>
     void
-    write (T &out, Int64 v)
+    write (T &out, uint64_t v)
     {
         unsigned char b[8];
 
@@ -541,7 +541,7 @@ template <class S, class T>
 void
 write (T &out, double v)
 {
-    union {Int64 i; double d;} u;
+    union {uint64_t i; double d;} u;
     u.d = v;
 
     unsigned char b[8];
@@ -782,20 +782,20 @@ read (T &in, unsigned long &v)
 
     template <class S, class T>
     void
-    read (T &in, Int64 &v)
+    read (T &in, uint64_t &v)
     {
         unsigned char b[8];
 
         readUnsignedChars<S> (in, b, 8);
 
-        v =  ((Int64) b[0]        & 0x00000000000000ffLL) |
-	    (((Int64) b[1] << 8)  & 0x000000000000ff00LL) |
-	    (((Int64) b[2] << 16) & 0x0000000000ff0000LL) |
-	    (((Int64) b[3] << 24) & 0x00000000ff000000LL) |
-	    (((Int64) b[4] << 32) & 0x000000ff00000000LL) |
-	    (((Int64) b[5] << 40) & 0x0000ff0000000000LL) |
-	    (((Int64) b[6] << 48) & 0x00ff000000000000LL) |
-	    ((Int64) b[7] << 56);
+        v =  ((uint64_t) b[0]        & 0x00000000000000ffLL) |
+	    (((uint64_t) b[1] << 8)  & 0x000000000000ff00LL) |
+	    (((uint64_t) b[2] << 16) & 0x0000000000ff0000LL) |
+	    (((uint64_t) b[3] << 24) & 0x00000000ff000000LL) |
+	    (((uint64_t) b[4] << 32) & 0x000000ff00000000LL) |
+	    (((uint64_t) b[5] << 40) & 0x0000ff0000000000LL) |
+	    (((uint64_t) b[6] << 48) & 0x00ff000000000000LL) |
+	    ((uint64_t) b[7] << 56);
     }
 
 #endif
@@ -828,16 +828,16 @@ read (T &in, double &v)
 
     readUnsignedChars<S> (in, b, 8);
 
-    union {Int64 i; double d;} u;
+    union {uint64_t i; double d;} u;
 
-    u.i = ((Int64) b[0]        & 0x00000000000000ffULL) |
-	 (((Int64) b[1] << 8)  & 0x000000000000ff00ULL) |
-	 (((Int64) b[2] << 16) & 0x0000000000ff0000ULL) |
-	 (((Int64) b[3] << 24) & 0x00000000ff000000ULL) |
-	 (((Int64) b[4] << 32) & 0x000000ff00000000ULL) |
-	 (((Int64) b[5] << 40) & 0x0000ff0000000000ULL) |
-	 (((Int64) b[6] << 48) & 0x00ff000000000000ULL) |
-	  ((Int64) b[7] << 56);
+    u.i = ((uint64_t) b[0]        & 0x00000000000000ffULL) |
+	 (((uint64_t) b[1] << 8)  & 0x000000000000ff00ULL) |
+	 (((uint64_t) b[2] << 16) & 0x0000000000ff0000ULL) |
+	 (((uint64_t) b[3] << 24) & 0x00000000ff000000ULL) |
+	 (((uint64_t) b[4] << 32) & 0x000000ff00000000ULL) |
+	 (((uint64_t) b[5] << 40) & 0x0000ff0000000000ULL) |
+	 (((uint64_t) b[6] << 48) & 0x00ff000000000000ULL) |
+	  ((uint64_t) b[7] << 56);
 
     v = u.d;
 }

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -31,11 +31,11 @@ using Imath::Box2i;
 //
 // limits for reduceMemory mode
 //
-const Int64 gMaxScanlineWidth= 1000000;
-const Int64 gMaxTilePixelsPerScanline = 8000000;
-const Int64 gMaxTileSize = 1000*1000;
-const Int64 gMaxSamplesPerDeepPixel = 1000;
-const Int64 gMaxSamplesPerScanline = 1<<12;
+const uint64_t gMaxScanlineWidth= 1000000;
+const uint64_t gMaxTilePixelsPerScanline = 8000000;
+const uint64_t gMaxTileSize = 1000*1000;
+const uint64_t gMaxSamplesPerDeepPixel = 1000;
+const uint64_t gMaxSamplesPerScanline = 1<<12;
 
 //
 // limits for reduceTime mode
@@ -503,10 +503,10 @@ readDeepTile(T& in,bool reduceMemory , bool reduceTime)
         Box2i dataWindow = fileHeader.dataWindow();
 
         //
-        // use Int64 for dimensions, since dataWindow+1 could overflow int storage
+        // use uint64_t for dimensions, since dataWindow+1 could overflow int storage
         //
-        Int64 height = static_cast<Int64>(dataWindow.size().y)+1;
-        Int64 width = static_cast<Int64>(dataWindow.size().x)+1;
+        uint64_t height = static_cast<uint64_t>(dataWindow.size().y)+1;
+        uint64_t width = static_cast<uint64_t>(dataWindow.size().x)+1;
 
         const TileDescription& td = in.header().tileDescription();
         int tileWidth = td.xSize;
@@ -532,7 +532,7 @@ readDeepTile(T& in,bool reduceMemory , bool reduceTime)
         //
         // memOffset is difference in bytes between theoretical address of pixel (0,0) and the origin of the data window
         //
-        Int64 memOffset = sizeof(unsigned int) * (static_cast<Int64>(dataWindow.min.x) + static_cast<Int64>(dataWindow.min.y) * width);
+        uint64_t memOffset = sizeof(unsigned int) * (static_cast<uint64_t>(dataWindow.min.x) + static_cast<uint64_t>(dataWindow.min.y) * width);
 
         //
         // Use integer arithmetic instead of pointer arithmetic to compute offset into array.
@@ -738,7 +738,7 @@ readMultiPart(MultiPartInputFile& in,bool reduceMemory,bool reduceTime)
         bool widePart = false;
         bool largeTiles = false;
         Box2i b = in.header( part ).dataWindow();
-        Int64 imageWidth = static_cast<Int64>(b.max.x) - static_cast<Int64>(b.min.x) + 1ll;
+        uint64_t imageWidth = static_cast<uint64_t>(b.max.x) - static_cast<uint64_t>(b.min.x) + 1ll;
 
          //
          // very wide scanline parts take excessive memory to read.
@@ -760,8 +760,8 @@ readMultiPart(MultiPartInputFile& in,bool reduceMemory,bool reduceTime)
         {
             const TileDescription& tileDescription = in.header( part ).tileDescription();
 
-            Int64 tilesPerScanline = ( imageWidth + tileDescription.xSize - 1ll) / tileDescription.xSize;
-            Int64 tileSize = static_cast<Int64>(tileDescription.xSize) * static_cast<Int64>(tileDescription.ySize);
+            uint64_t tilesPerScanline = ( imageWidth + tileDescription.xSize - 1ll) / tileDescription.xSize;
+            uint64_t tileSize = static_cast<uint64_t>(tileDescription.xSize) * static_cast<uint64_t>(tileDescription.ySize);
 
             if ( tileSize * tilesPerScanline > gMaxTilePixelsPerScanline )
             {
@@ -909,11 +909,11 @@ class PtrIStream: public IStream
 
     }
 
-    virtual Int64	tellg ()
+    virtual uint64_t	tellg ()
     {
         return (current - base);
     }
-    virtual void	seekg (Int64 pos)
+    virtual void	seekg (uint64_t pos)
     {
 
         if( pos < 0 )
@@ -985,7 +985,7 @@ runChecks(T& source,bool reduceMemory,bool reduceTime)
       {
          MultiPartInputFile multi(source);
          Box2i b = multi.header(0).dataWindow();
-         Int64 imageWidth = static_cast<Int64>(b.max.x) - static_cast<Int64>(b.min.x) + 1ll;
+         uint64_t imageWidth = static_cast<uint64_t>(b.max.x) - static_cast<uint64_t>(b.min.x) + 1ll;
 
          // confirm first part is small enough to read without using excessive memory
          if ( imageWidth <= gMaxScanlineWidth )
@@ -1004,8 +1004,8 @@ runChecks(T& source,bool reduceMemory,bool reduceTime)
          if (isTiled(firstPartType))
          {
              const TileDescription& tileDescription = multi.header(0).tileDescription();
-             Int64 tilesPerScanline = ( imageWidth + tileDescription.xSize - 1ll) / tileDescription.xSize;
-             Int64 tileSize = static_cast<Int64>(tileDescription.xSize) * static_cast<Int64>(tileDescription.ySize);
+             uint64_t tilesPerScanline = ( imageWidth + tileDescription.xSize - 1ll) / tileDescription.xSize;
+             uint64_t tileSize = static_cast<uint64_t>(tileDescription.xSize) * static_cast<uint64_t>(tileDescription.ySize);
              if ( tileSize * tilesPerScanline > gMaxTilePixelsPerScanline )
              {
                  firstPartWide = true;

--- a/src/test/OpenEXRFuzzTest/fuzzFile.cpp
+++ b/src/test/OpenEXRFuzzTest/fuzzFile.cpp
@@ -56,7 +56,7 @@ using namespace IMATH_NAMESPACE;
 
 namespace {
 
-Int64
+uint64_t
 lengthOfFile (const char fileName[])
 {
     ifstream ifs;
@@ -74,8 +74,8 @@ lengthOfFile (const char fileName[])
 void
 fuzzFile (const char goodFile[],
           const char brokenFile[],
-	  Int64 offset,
-	  Int64 windowSize,
+	  uint64_t offset,
+	  uint64_t windowSize,
 	  Rand48 &random,
 	  double fuzzAmount)
 {
@@ -91,7 +91,7 @@ fuzzFile (const char goodFile[],
 	THROW_ERRNO ("Cannot open file " << goodFile << " (%T).");
 
     ifs.seekg (0, ios_base::end);
-    Int64 fileLength = ifs.tellg();
+    uint64_t fileLength = ifs.tellg();
     ifs.seekg (0, ios_base::beg);
 
     Array<char> data (fileLength);
@@ -105,7 +105,7 @@ fuzzFile (const char goodFile[],
     // in a window of size windowSize, starting at the specified offset.
     // 
 
-    for (Int64 i = offset; i < offset + windowSize; ++i)
+    for (uint64_t i = offset; i < offset + windowSize; ++i)
     {
 	if (random.nextf() < fuzzAmount)
 	    data[i] = char (random.nexti());
@@ -160,9 +160,9 @@ fuzzFile (const char goodFile[],
     //
 
     {
-	Int64 fileSize = lengthOfFile (goodFile);
-	Int64 windowSize = fileSize * 2 / nSlidingWindow;
-	Int64 lastWindowOffset = fileSize - windowSize;
+	uint64_t fileSize = lengthOfFile (goodFile);
+	uint64_t windowSize = fileSize * 2 / nSlidingWindow;
+	uint64_t lastWindowOffset = fileSize - windowSize;
 
 	cout << "sliding " << windowSize << "-byte window" << endl;
 
@@ -171,7 +171,7 @@ fuzzFile (const char goodFile[],
 	    if (i % 100 == 0)
 		cout << i << "\r" << flush;
 
-	    Int64 offset = lastWindowOffset * i / (nSlidingWindow - 1);
+	    uint64_t offset = lastWindowOffset * i / (nSlidingWindow - 1);
 	    double fuzzAmount = random.nextf (0.0, 0.1);
 
 	    fuzzFile (goodFile, brokenFile,
@@ -185,7 +185,7 @@ fuzzFile (const char goodFile[],
     }
 
     {
-	Int64 windowSize = 2048;
+	uint64_t windowSize = 2048;
 
 	cout << windowSize << "-byte window at start of file" << endl;
 

--- a/src/test/OpenEXRTest/testDeepScanLineHuge.cpp
+++ b/src/test/OpenEXRTest/testDeepScanLineHuge.cpp
@@ -138,7 +138,7 @@ generateRandomFile (int channelCount,
 
     
     // count total size of all pixels
-    Int64 bytes_per_sample = 0;
+    uint64_t bytes_per_sample = 0;
     for (int i = 0; i < channelCount; i++)
     {
         PixelType type = NUM_PIXELTYPES;
@@ -176,13 +176,13 @@ generateRandomFile (int channelCount,
 
     cout << "writing file " << endl;
 
-    Int64 total_number_of_samples = 0;
+    uint64_t total_number_of_samples = 0;
     
     // compute ideal number of samples per pixel assuming we want abotut 5GiB of data
-    // int samples_per_pixel = int(5l*1024l*1024l*1024l/Int64(width*height)) / bytes_per_sample;
+    // int samples_per_pixel = int(5l*1024l*1024l*1024l/uint64_t(width*height)) / bytes_per_sample;
 
     // compute ideal number of samples per pixel assuming we want abotut 15GiB of data
-    int samples_per_pixel = int(numGib*1024l*1024l*1024l/Int64(width*height)) / bytes_per_sample;
+    int samples_per_pixel = int(numGib*1024l*1024l*1024l/uint64_t(width*height)) / bytes_per_sample;
     
     cout << "  generating approx. " << samples_per_pixel << " samples per pixel\n";
     
@@ -210,7 +210,7 @@ generateRandomFile (int channelCount,
     
 
     
-    Int64 write_pointer=0;
+    uint64_t write_pointer=0;
     
     for (int i = 0; i < height; i++)
     {
@@ -300,7 +300,7 @@ readFile (int channelCount, bool bulkRead, const std::string & fn)
                                         sizeof (unsigned int) * 1,          // xStride// 9
                                         sizeof (unsigned int) * width));    // yStride// 10
 
-    Int64 bytes_per_sample=0;
+    uint64_t bytes_per_sample=0;
     
     for (int i = 0; i < channelCount; i++)
     {
@@ -338,7 +338,7 @@ readFile (int channelCount, bool bulkRead, const std::string & fn)
     file.setFrameBuffer(frameBuffer);
 
     file.readPixelSampleCounts(dataWindow.min.y, dataWindow.max.y);
-    Int64 total_pixel_count = 0;
+    uint64_t total_pixel_count = 0;
     
     for (int i = 0; i < dataWindow.max.y - dataWindow.min.y + 1; i++)
     {
@@ -352,7 +352,7 @@ readFile (int channelCount, bool bulkRead, const std::string & fn)
     
     vector<char> localstorage(total_pixel_count*bytes_per_sample);
     
-    Int64 write_pointer=0;
+    uint64_t write_pointer=0;
     
     for (int i = 0; i < height; i++)
     {

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -128,8 +128,8 @@ class MMIFStream: public OPENEXR_IMF_NAMESPACE::IStream
   private:
 
     char*               _buffer;
-    uint64_t               _length;
-    uint64_t               _pos;
+    uint64_t            _length;
+    uint64_t            _pos;
 };
 
 

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -121,15 +121,15 @@ class MMIFStream: public OPENEXR_IMF_NAMESPACE::IStream
 
     virtual bool	read (char c[/*n*/], int n);
     virtual char*       readMemoryMapped (int n);
-    virtual Int64	tellg () {return _pos;}
-    virtual void	seekg (Int64 pos) {_pos = pos;}
+    virtual uint64_t	tellg () {return _pos;}
+    virtual void	seekg (uint64_t pos) {_pos = pos;}
     virtual void	clear () {}
 
   private:
 
     char*               _buffer;
-    Int64               _length;
-    Int64               _pos;
+    uint64_t               _length;
+    uint64_t               _pos;
 };
 
 
@@ -179,7 +179,7 @@ MMIFStream::read (char c[/*n*/], int n)
     if (_pos >= _length && n != 0)
 	throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
         
-    Int64 n2 = n;
+    uint64_t n2 = n;
     bool retVal = true;
 
     if (_length - _pos <= n2)

--- a/src/test/OpenEXRTest/testMultiPartFileMixingBasic.cpp
+++ b/src/test/OpenEXRTest/testMultiPartFileMixingBasic.cpp
@@ -1433,8 +1433,8 @@ killOffsetTables (const std::string & fn)
     fsetpos (f, &position);
     
     // write blank offset table
-    vector<Int64> new_offset_tables(size);
-    fwrite(&new_offset_tables[0],sizeof(Int64),size,f);
+    vector<uint64_t> new_offset_tables(size);
+    fwrite(&new_offset_tables[0],sizeof(uint64_t),size,f);
 
     fclose(f);
     

--- a/src/test/OpenEXRTest/testXdr.cpp
+++ b/src/test/OpenEXRTest/testXdr.cpp
@@ -96,8 +96,8 @@ writeData (ostream &os)
     Xdr::write<CharIO>    (os, (signed long) -2045678901);
     Xdr::write<CharIO>    (os, (unsigned long) 1345678901u);
     Xdr::write<CharIO>    (os, (unsigned long) 2456789012u);
-    Xdr::write<CharIO>    (os, (Int64) 0x1122334455667788ll);
-    Xdr::write<CharIO>    (os, (Int64) 0xf1f2f3f4f5f6f7f8ll);
+    Xdr::write<CharIO>    (os, (uint64_t) 0x1122334455667788ll);
+    Xdr::write<CharIO>    (os, (uint64_t) 0xf1f2f3f4f5f6f7f8ll);
     Xdr::write<CharIO>    (os, (float) 0.0f);
     Xdr::write<CharIO>    (os, (float) 3.141592653589793f);
     Xdr::write<CharIO>    (os, (float) 6.141592653589793f);
@@ -199,8 +199,8 @@ readData (istream &is)
     check (is, (signed long) -2045678901);
     check (is, (unsigned long) 1345678901u);
     check (is, (unsigned long) 2456789012u);
-    check (is, (Int64) 0x1122334455667788ll);
-    check (is, (Int64) 0xf1f2f3f4f5f6f7f8ll);
+    check (is, (uint64_t) 0x1122334455667788ll);
+    check (is, (uint64_t) 0xf1f2f3f4f5f6f7f8ll);
     check (is, (float) 0.0f);
     check (is, (float) 3.141592653589793f);
     check (is, (float) 6.141592653589793f);
@@ -235,7 +235,7 @@ testXdr (const std::string&)
 
     try
     {
-	assert (sizeof (Int64) == 8);
+	assert (sizeof (uint64_t) == 8);
 
 #if defined (__GNUC__) && __GNUC__ == 2
 	strstream s;


### PR DESCRIPTION
Leave the Int64/SInt64 types in place in ImfInt64.h with deprecation warnings, in case external code relies on them.

Signed-off-by: Cary Phillips <cary@ilm.com>