### PR TITLE
Don't install ImfB44Compressor.h

### DIFF
--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -157,7 +157,6 @@ openexr_define_library(OpenEXR
     ImfRgbaYca.h
     ImfTestFile.h
     ImfThreading.h
-    ImfB44Compressor.h
     ImfStringVectorAttribute.h
     ImfMultiView.h
     ImfAcesFile.h


### PR DESCRIPTION
Address #947: ImfB44Compressor.h was being installed since it was listed in the header section of CMakeLists.txt. It was only intended to be an internal header file. Since it depends on ImfCompressor.h, which is not installed, it is not possible to #include it, so should be removed.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>