### PR TITLE
Enable policy 77 if possible.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()
 
+if(POLICY CMP0077)
+  # enable variables set outside to override options
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 #######################################
 # Create project and include cmake
 # configuration files


### PR DESCRIPTION
When using OpenEXR as a submodule, you currently can't set a variable
outside of it as the option will override it (so you need to set the
option.) With policy 77 in place, this works as expected. See also: https://cmake.org/cmake/help/latest/policy/CMP0077.html

Signed-off-by: Matthäus G. Chajdas <dev@anteru.net>