### PR TITLE
Properly expose header files for float exceptions

### DIFF
--- a/src/lib/Iex/CMakeLists.txt
+++ b/src/lib/Iex/CMakeLists.txt
@@ -15,6 +15,8 @@ openexr_define_library(Iex
     IexThrowErrnoExc.h
     IexErrnoExc.h
     IexMacros.h
+    IexMathFloatExc.h
+    IexMathIeeeExc.h
     Iex.h
     IexNamespace.h
     IexExport.h

--- a/src/lib/Iex/IexMathFloatExc.cpp
+++ b/src/lib/Iex/IexMathFloatExc.cpp
@@ -13,6 +13,7 @@
 
 #include "IexMathFloatExc.h"
 #include "IexMacros.h"
+#include "IexMathExc.h"
 #include "IexMathFpu.h"
 
 #if 0

--- a/src/lib/Iex/IexMathFloatExc.h
+++ b/src/lib/Iex/IexMathFloatExc.h
@@ -9,7 +9,7 @@
 
 #include "IexExport.h"
 #include "IexNamespace.h"
-#include "IexMathExc.h"
+
 #include "IexMathIeeeExc.h"
 
 IEX_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/src/lib/Iex/IexMathFpu.h
+++ b/src/lib/Iex/IexMathFpu.h
@@ -24,7 +24,7 @@ IEX_INTERNAL_NAMESPACE_HEADER_ENTER
 // setFpExceptions() defines which floating
 // point exceptions cause SIGFPE signals.
 //-----------------------------------------
-IEX_EXPORT
+
 void setFpExceptions (int when = (IEEE_OVERFLOW | IEEE_DIVZERO | IEEE_INVALID));
 
 
@@ -32,7 +32,7 @@ void setFpExceptions (int when = (IEEE_OVERFLOW | IEEE_DIVZERO | IEEE_INVALID));
 // fpExceptions() tells you which floating
 // point exceptions cause SIGFPE signals.
 //----------------------------------------
-IEX_EXPORT
+
 int fpExceptions ();
 
 
@@ -42,7 +42,7 @@ int fpExceptions ();
 //------------------------------------------
 
 extern "C" typedef void (* FpExceptionHandler) (int type, const char explanation[]);
-IEX_EXPORT
+
 void setFpExceptionHandler (FpExceptionHandler handler);
 
 // -----------------------------------------
@@ -53,7 +53,7 @@ void setFpExceptionHandler (FpExceptionHandler handler);
 // allow trapping of exception register states
 // that can get set though no SIGFPE occurs.
 // -----------------------------------------
-IEX_EXPORT
+
 void handleExceptionsSetInRegisters();
 
 


### PR DESCRIPTION
After moving to Iex, properly expose header files so people can actually
use the floating point exception handling code.
Further, hide symbols that should be internal to the library

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>