### PR TITLE
Add missing #includes in OpenEXRFuzzTest

### DIFF
--- a/src/test/OpenEXRFuzzTest/testFuzzDeepTiles.cpp
+++ b/src/test/OpenEXRFuzzTest/testFuzzDeepTiles.cpp
@@ -15,6 +15,7 @@
 #include <ImfPartType.h>
 #include <ImfArray.h>
 #include <ImfThreading.h>
+#include <ImfHeader.h>
 #include <IlmThread.h>
 #include <Iex.h>
 #include <iostream>

--- a/src/test/OpenEXRFuzzTest/testFuzzTiles.cpp
+++ b/src/test/OpenEXRFuzzTest/testFuzzTiles.cpp
@@ -13,6 +13,8 @@
 #include <ImfTiledRgbaFile.h>
 #include <ImfArray.h>
 #include <ImfThreading.h>
+#include <ImfHeader.h>
+#include <ImfFrameBuffer.h>
 #include <IlmThread.h>
 #include <Iex.h>
 #include <iostream>


### PR DESCRIPTION
OpenEXRFuzzTest is failing to compile for me on Ubuntu and CentOS, are others seeing that error? 

Signed-off-by: Cary Phillips <cary@ilm.com>