### PR TITLE
WIP: Bazel-Support: Give Bazel build job a name and pin it to Ubuntu 20.04

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -5,13 +5,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Linux Ubuntu 20.04 Bazel build <GCC 9.3.0>
+    runs-on: ubuntu-20.04
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Mount bazel cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: "/home/runner/.cache/bazel"
         key: bazel


### PR DESCRIPTION
 Give Bazel build job a name and pin it to Ubuntu 20.04