### PR TITLE
Remove deprecated argument to getChunkOffsetTableSize()

### DIFF
--- a/src/bin/exrmaketiled/makeTiled.cpp
+++ b/src/bin/exrmaketiled/makeTiled.cpp
@@ -561,7 +561,7 @@ makeTiled (const char inFileName[],
             // set tileDescription, type, and chunckcount for multipart
             //
             header.setType(TILEDIMAGE);
-            int chunkcount = getChunkOffsetTableSize(header, true);
+            int chunkcount = getChunkOffsetTableSize(header);
             header.setChunkCount(chunkcount);
 
             headers.push_back(header);

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -1843,7 +1843,7 @@ int
 getTiledChunkOffsetTableSize(const Header& header);
 
 int
-getChunkOffsetTableSize(const Header& header,bool)
+getChunkOffsetTableSize(const Header& header)
 {
     //
     // if there is a type in the header which indicates the part is not a currently supported type,

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -442,7 +442,7 @@ bool usesLongNames (const Header &header);
 //
 
 IMF_EXPORT
-int getChunkOffsetTableSize(const Header& header,bool deprecated_attribute=false);
+int getChunkOffsetTableSize(const Header& header);
 
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -434,11 +434,10 @@ bool usesLongNames (const Header &header);
 
 //
 // compute size of chunk offset table - for existing types, computes
-// the chunk size from the image size, compression type, and tile description
-// (for tiled types). If the type is not supported, uses the chunkCount attribute
-// if present, or throws an exception otherwise
-// deprecated_attribute is no longer used by this function
-//
+// the chunk size from the image size, compression type, and tile
+// description (for tiled types). If the type is not supported, uses
+// the chunkCount attribute if present, or throws an exception
+// otherwise
 //
 
 IMF_EXPORT

--- a/src/test/OpenEXRTest/testFutureProofing.cpp
+++ b/src/test/OpenEXRTest/testFutureProofing.cpp
@@ -368,7 +368,7 @@ generateRandomHeaders (int partCount, vector<Header>& headers)
         // future types MUST have a chunkCount attribute - ommitting causes the library
         // to raise an exception (can't compute chunkOffsetTable) and prevents us from reading
         // the rest of the image
-        header.setChunkCount(getChunkOffsetTableSize(header,true));
+        header.setChunkCount(getChunkOffsetTableSize(header));
         headers.push_back(header);
     }
 }


### PR DESCRIPTION
Resolves #740 in time for the 3.0 release.

Signed-off-by: Cary Phillips <cary@ilm.com>