### PR TITLE
exrcheck -v prints OpenEXR and Imath versions and lib versions

### DIFF
--- a/cmake/OpenEXRConfig.h.in
+++ b/cmake/OpenEXRConfig.h.in
@@ -47,6 +47,8 @@
 #define OPENEXR_VERSION_PATCH @OPENEXR_VERSION_PATCH@
 #define OPENEXR_VERSION_EXTRA "@OPENEXR_VERSION_EXTRA@"
 
+#define OPENEXR_LIB_VERSION_STRING "@OPENEXR_LIB_VERSION@"
+
 // Version as a single hex number, e.g. 0x01000300 == 1.0.3
 #define OPENEXR_VERSION_HEX ((uint32_t(OPENEXR_VERSION_MAJOR) << 24) | \
                              (uint32_t(OPENEXR_VERSION_MINOR) << 16) | \

--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) Contributors to the OpenEXR Project.
 
 #include <ImfCheckFile.h>
-
+#include <ImathConfig.h>
 
 #include <iostream>
 #include <fstream>
@@ -30,6 +30,7 @@ usageMessage (const char argv0[])
     cerr << "  -m : avoid excessive memory allocation (some files will not be fully checked)\n";
     cerr << "  -t : avoid spending excessive time (some files will not be fully checked)\n";
     cerr << "  -s : use stream API instead of file API\n";
+    cerr << "  -v : print version info\n";
 
 }
 
@@ -97,6 +98,17 @@ main(int argc, char **argv)
         else if (!strcmp (argv[i],"-s"))
         {
             useStream = true;
+        }
+        else if (!strcmp (argv[i],"-v"))
+        {
+            std::cout << OPENEXR_PACKAGE_STRING
+                      << " Lib API: " << OPENEXR_LIB_VERSION_STRING
+                      << ", " << IMATH_PACKAGE_STRING
+#if defined(IMATH_LIB_VERSION_STRING)
+                      << " Lib API: " << IMATH_LIB_VERSION_STRING
+#endif
+                      << std::endl;
+            exit(0);
         }
         else
         {

--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -30,7 +30,7 @@ usageMessage (const char argv0[])
     cerr << "  -m : avoid excessive memory allocation (some files will not be fully checked)\n";
     cerr << "  -t : avoid spending excessive time (some files will not be fully checked)\n";
     cerr << "  -s : use stream API instead of file API\n";
-    cerr << "  -v : print version info\n";
+    cerr << "  -v : print OpenEXR and Imath software libary version info\n";
 
 }
 


### PR DESCRIPTION
A handy way to confirm how the project was built. This also exports OPENEXR_LIB_VERSION_STRING as a cpp macro.

Signed-off-by: Cary Phillips <cary@ilm.com>