### PR TITLE
Fixed regression in `Imath::succf()` and `Imath::predf()` when negative values are given (for 2.4)

### DIFF
--- a/IlmBase/Imath/ImathFun.cpp
+++ b/IlmBase/Imath/ImathFun.cpp
@@ -54,7 +54,7 @@ succf (float f)
 
         u.i = 0x00000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
         // Incrementing the largest positive float
@@ -89,7 +89,7 @@ predf (float f)
 
         u.i = 0x80000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
 


### PR DESCRIPTION
The issue was introduced in OpenEXR 2.4.0 as part of https://github.com/AcademySoftwareFoundation/openexr/commit/c8a7f6a5ebce9a6d5bd9a3320bc746221789f407#diff-f09c17d3ab2fe5564e547c8461f1a43a6fe1109ebaf663a8463d1a9643c20ee0, where the type of a member of a union was changed from signed to unsigned, breaking comparison against `> 0` a few lines below.

Since OpenEXR 2.4.0, `Imath::predf(-2)` returns `-1.9999998807907104` instead of `-2.000000238418579`.

Test coverage has been added for this regression.

Fixes #999 (for the 2.4 line).

---

EDIT:

This PR is going to be abandoned. See https://github.com/AcademySoftwareFoundation/openexr/pull/1013 for v2.4 and https://github.com/AcademySoftwareFoundation/Imath/pull/140 for v3. (Another PR will have to be created for v2.5.)
