### PR TITLE
Prevent overflow in getScanlineChunkOffsetTableSize

### DIFF
--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -1828,12 +1828,17 @@ getScanlineChunkOffsetTableSize(const Header& header)
 {
     const Box2i &dataWindow = header.dataWindow();
 
-    int linesInBuffer = numLinesInBuffer ( header.compression() );
 
-    int lineOffsetSize = (dataWindow.max.y - dataWindow.min.y +
+    //
+    // use int64_t types to prevent overflow in lineOffsetSize for images with
+    // extremely high dataWindows
+    //
+    int64_t linesInBuffer = numLinesInBuffer ( header.compression() );
+
+    int64_t lineOffsetSize = (static_cast <int64_t>(dataWindow.max.y) - static_cast <int64_t>(dataWindow.min.y) +
                           linesInBuffer) / linesInBuffer;
 
-    return lineOffsetSize;
+    return static_cast <int>(lineOffsetSize);
 }
 
 //


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33741
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>