### PR TITLE
Fix TimeCode.frame max value to be 29 instead of 59

### DIFF
--- a/src/lib/OpenEXR/ImfTimeCode.cpp
+++ b/src/lib/OpenEXR/ImfTimeCode.cpp
@@ -211,7 +211,7 @@ TimeCode::frame () const
 void
 TimeCode::setFrame (int value)
 {
-    if (value < 0 || value > 59)
+    if (value < 0 || value > 29)
 	throw IEX_NAMESPACE::ArgExc ("Cannot set frame field in time code. "
 			   "New value is out of range.");
 


### PR DESCRIPTION
As defined in the header file

https://github.com/AcademySoftwareFoundation/openexr/blob/931618b9088fd03ed4fe30cade55664da94a5854/src/lib/OpenEXR/ImfTimeCode.h#L24-L26

closes #1006 
