### PR TITLE
Fixed regression in Imath::succf() and Imath::predf() when negative values are given (for 2.4)

### DIFF
--- a/IlmBase/Imath/ImathFun.cpp
+++ b/IlmBase/Imath/ImathFun.cpp
@@ -54,7 +54,7 @@ succf (float f)
 
         u.i = 0x00000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
         // Incrementing the largest positive float
@@ -89,7 +89,7 @@ predf (float f)
 
         u.i = 0x80000001;
     }
-    else if (u.i > 0)
+    else if (u.f > 0)
     {
         // Positive float, normalized or denormalized.
 


### PR DESCRIPTION
Courtesy Christian Aguilera <christian.aguilera@foundry.com>

The issue was introduced in OpenEXR 2.4.0 as part of
c8a7f6a#diff-f09c17d3ab2fe5564e547c8461f1a43a6fe1109ebaf663a8463d1a9643c20ee0,
where the type of a member of a union was changed from signed to
unsigned, breaking comparison against > 0 a few lines below.

Since OpenEXR 2.4.0, Imath::predf(-2) returns -1.9999998807907104
instead of -2.000000238418579.

Test coverage has been added for this regression.

Fixes #999 (for the 2.4 line).

Signed-off-by: Cary Phillips <cary@ilm.com>