### PR TITLE
Remove dead code in ImfB44Compressor.cpp

### DIFF
--- a/src/lib/OpenEXR/ImfB44Compressor.cpp
+++ b/src/lib/OpenEXR/ImfB44Compressor.cpp
@@ -454,8 +454,6 @@ B44Compressor::B44Compressor
     _channels (hdr.channels()),
     _channelData (0)
 {
-    // TODO: Remove this when we can change the ABI
-    (void)_maxScanLineSize;
     //
     // Allocate buffers for compressed an uncompressed pixel data,
     // allocate a set of ChannelData structs to help speed up the


### PR DESCRIPTION
The comment indicates this should be removed, and 3.1 seems an
appropriate time. But does this line serve any purpose?

Signed-off-by: Cary Phillips <cary@ilm.com>