### PR TITLE
Set OPENEXR_VERSION from OpenEXR_VERSION variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,24 +21,16 @@ endif()
 
 project(OpenEXR VERSION 3.1.0 LANGUAGES C CXX)
 
-set(OPENEXR_VERSION_EXTRA "dev" CACHE STRING "Extra version tag string for OpenEXR build")
+set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for OpenEXR build, such as -dev, -beta1, etc.")
+
+set(OPENEXR_VERSION ${OpenEXR_VERSION})
+set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
 
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 set(OPENEXR_SOVERSION 29)
 set(OPENEXR_SOAGE 0) 
 set(OPENEXR_SOREVISION 0) 
 set(OPENEXR_LIB_VERSION "${OPENEXR_SOVERSION}.${OPENEXR_SOREVISION}.${OPENEXR_SOAGE}")
-
-set(OPENEXR_VERSION_MAJOR ${CMAKE_PROJECT_VERSION_MAJOR})
-set(OPENEXR_VERSION_MINOR ${CMAKE_PROJECT_VERSION_MINOR})
-set(OPENEXR_VERSION_PATCH ${CMAKE_PROJECT_VERSION_PATCH})
-set(OPENEXR_VERSION ${CMAKE_PROJECT_VERSION})
-if (NOT OPENEXR_VERSION_EXTRA STREQUAL "")
-  set(OPENEXR_VERSION "${CMAKE_PROJECT_VERSION}-${OPENEXR_VERSION_EXTRA}")
-endif()
-set(OPENEXR_VERSION_API "${OPENEXR_VERSION_MAJOR}_${OPENEXR_VERSION_MINOR}")
-
-message(STATUS "Configure OpenEXR Version: ${OPENEXR_VERSION} Lib API: ${OPENEXR_LIB_VERSION}")
 
 option(OPENEXR_INSTALL "Install OpenEXR libraries" ON)
 option(OPENEXR_INSTALL_TOOLS "Install OpenEXR tools" ON)
@@ -49,6 +41,8 @@ endif()
 include(cmake/LibraryDefine.cmake)
 include(cmake/OpenEXRSetup.cmake)
 add_subdirectory(cmake)
+
+message(STATUS "Configure ${OPENEXR_PACKAGE_NAME}, library API version: ${OPENEXR_LIB_VERSION}")
 
 # Hint: This can be set to enable custom find_package
 # search paths, probably best to set it when configuring

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -23,7 +23,7 @@ set(tmp)
 set(OPENEXR_NAMESPACE_CUSTOM "0" CACHE STRING "Whether the namespace has been customized (so external users know)")
 set(OPENEXR_INTERNAL_IMF_NAMESPACE "Imf_${OPENEXR_VERSION_API}" CACHE STRING "Real namespace for Imath that will end up in compiled symbols")
 set(OPENEXR_IMF_NAMESPACE "Imf" CACHE STRING "Public namespace alias for OpenEXR")
-set(OPENEXR_PACKAGE_NAME "OpenEXR ${OPENEXR_VERSION}" CACHE STRING "Public string / label for displaying package")
+set(OPENEXR_PACKAGE_NAME "OpenEXR ${OPENEXR_VERSION}${OPENEXR_VERSION_RELEASE_TYPE}" CACHE STRING "Public string / label for displaying package")
 
 # Namespace-related settings, allows one to customize the
 # namespace generated, and to version the namespaces


### PR DESCRIPTION
* OPENEXR_VERSION_RELEASE_TYPE replaces OPENEXR_VERSION_EXTRA

* OPENEXR_VERSION_RELEASE_TYPE is used only to form OPENEXR_PACKAGE_NAME

Signed-off-by: Cary Phillips <cary@ilm.com>