### PR TITLE
Turn src/examples/CMakeList.txt into standalone project

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -1,4 +1,4 @@
-name: BAZEL_BUILD
+name: Bazel
 
 on:
   push: {}

--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -1,4 +1,4 @@
-name: CI
+name: BAZEL_BUILD
 
 on:
   push: {}

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -207,7 +207,7 @@ jobs:
           mkdir _examples
       - name: Configure
         run: |
-          cmake ../. \
+          cmake .. \
                 -DCMAKE_INSTALL_PREFIX=../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
@@ -216,30 +216,27 @@ jobs:
                 -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
                 -DOPENEXR_BUILD_UTILS='ON' \
                 -DOPENEXR_RUN_FUZZ_TESTS='OFF' \
-                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }} \
-                -DPYTHON_EXECUTABLE=$(which python) 
+                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }}
         working-directory: _build
       - name: Build
         run: |
           cmake --build . \
                 --target install \
-                --config ${{ matrix.build-type }} \
-                -- -j4
+                --config ${{ matrix.build-type }}
         working-directory: _build
       - name: Examples
         run: |
-          # Build and run the examples as a standalone program linking 
-          # against the OpenEXR isntallation.
-          cmake -B . \
-                -S ../src/examples \
-                -DOpenEXR_DIR=../../_install/lib64/cmake/OpenEXR \
-                -DImath_DIR=../../_install/lib64/cmake/Imath \
+          # Make sure we can build the examples when configured as a
+          # standalone application linking against the just-installed
+          # OpenEXR library.
+          cmake ../src/examples \
+                -DCMAKE_PREFIX_PATH=../../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
                 -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }}
           cmake --build . \
-                --config ${{ matrix.build-type }} \
-                -- -j4
+                --config ${{ matrix.build-type }}
+          # Confirm the examples program runs
           ./OpenEXRExamples
         working-directory: _examples
       - name: Test
@@ -310,9 +307,10 @@ jobs:
         run: |
           mkdir _install
           mkdir _build
+          mkdir _examples
       - name: Configure
         run: |
-          cmake ../. \
+          cmake .. \
                 -DCMAKE_INSTALL_PREFIX=../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
@@ -326,9 +324,23 @@ jobs:
         run: |
           cmake --build . \
                 --target install \
-                --config ${{ matrix.build-type }} \
-                -- -j2
+                --config ${{ matrix.build-type }}
         working-directory: _build
+      - name: Examples
+        run: |
+          # Make sure we can build the examples when configured as a
+          # standalone application linking against the just-installed
+          # OpenEXR library.
+          cmake ../src/examples \
+                -DCMAKE_PREFIX_PATH=../../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }}
+          cmake --build . \
+                --config ${{ matrix.build-type }}
+          # Confirm the examples program runs
+          ./OpenEXRExamples
+        working-directory: _examples
       - name: Test
         run: |
           ctest -T Test ${{matrix.exclude-tests }} \
@@ -390,6 +402,7 @@ jobs:
         run: |
           mkdir _install
           mkdir _build
+          mkdir _examples
         shell: bash
       ## - name: Install Dependences
       ##   run: |
@@ -399,7 +412,7 @@ jobs:
       ##   shell: powershell
       - name: Configure
         run: |
-          cmake ../. \
+          cmake .. \
                 -DCMAKE_INSTALL_PREFIX=../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
@@ -417,6 +430,22 @@ jobs:
                 --config ${{ matrix.build-type }}
         shell: bash
         working-directory: _build
+      ## - name: Examples
+      ##  run: |
+      ##    # Make sure we can build the examples when configured as a
+      ##    # standalone application linking against the just-installed
+      ##    # OpenEXR library.
+      ##    cmake ../src/examples \
+      ##          -DCMAKE_PREFIX_PATH=../../_install \
+      ##          -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+      ##          -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+      ##          -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }}
+      ##    cmake --build . \
+      ##          --config ${{ matrix.build-type }}
+      ##    # Confirm the examples program runs
+      ##    ./OpenEXRExamples
+      ##  shell: bash
+      ##  working-directory: _examples
       - name: Test
         run: |
           ctest -T Test ${{ matrix.exclude-tests }} \

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -4,7 +4,7 @@
 # GitHub Actions workflow file
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
-name: CI_WORKFLOW
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -4,7 +4,7 @@
 # GitHub Actions workflow file
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
-name: CI
+name: CI_WORKFLOW
 
 on:
   push:
@@ -204,6 +204,7 @@ jobs:
         run: |
           mkdir _install
           mkdir _build
+          mkdir _examples
       - name: Configure
         run: |
           cmake ../. \
@@ -225,6 +226,22 @@ jobs:
                 --config ${{ matrix.build-type }} \
                 -- -j4
         working-directory: _build
+      - name: Examples
+        run: |
+          # Build and run the examples as a standalone program linking 
+          # against the OpenEXR isntallation.
+          cmake -B . \
+                -S ../src/examples \
+                -DOpenEXR_DIR=../../_install/lib64/cmake/OpenEXR \
+                -DImath_DIR=../../_install/lib64/cmake/Imath \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
+                -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }}
+          cmake --build . \
+                --config ${{ matrix.build-type }} \
+                -- -j4
+          ./OpenEXRExamples
+        working-directory: _examples
       - name: Test
         run: |
           ctest -T Test ${{ matrix.exclude-tests }} \

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors to the OpenEXR Project.
 
-# If the project name is set, this is being configured as a # part of
-# OpenEXR.  If there is no project name, it's being invoked as a 
+# If the project name is set, this is being configured as a part of
+# OpenEXR.  If there is no project name, it's being configured as a
 # standalone program linking against an already-installed OpenEXR
 # library.
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors to the OpenEXR Project.
 
+cmake_minimum_required(VERSION 3.12)
+
+project(OpenEXRExamples)
+
+find_package (OpenEXR)
+
 add_executable(OpenEXRExamples
   drawImage.cpp
   generalInterfaceExamples.cpp

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.12)
 
 project(OpenEXRExamples)
 
-find_package (OpenEXR)
+find_package(OpenEXR)
 
 add_executable(OpenEXRExamples
   drawImage.cpp

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors to the OpenEXR Project.
 
-cmake_minimum_required(VERSION 3.12)
+# If the project name is set, this is being configured as a # part of
+# OpenEXR.  If there is no project name, it's being invoked as a 
+# standalone program linking against an already-installed OpenEXR
+# library.
 
-project(OpenEXRExamples)
-
-find_package(OpenEXR)
+if("${CMAKE_PROJECT_NAME}" STREQUAL "")
+  cmake_minimum_required(VERSION 3.12)
+  project(OpenEXRExamples)
+  find_package(OpenEXR)
+endif()
 
 add_executable(OpenEXRExamples
   drawImage.cpp


### PR DESCRIPTION
By adding cmake_minimum_required(), project() and find_package()
statements, src/examples serves as a standalone project linking
against the OpenEXR library. This makes it a more representative
example for end users, but it also makes it suitable for a CI
validation step that builds against the already-installed library.

This preserves the behavior of installing the example code
as a part of the OpenEXR installation step.

Signed-off-by: Cary Phillips <cary@ilm.com>