### PR TITLE
detect buffer overflows in RleUncompress

### DIFF
--- a/src/lib/OpenEXR/ImfRle.cpp
+++ b/src/lib/OpenEXR/ImfRle.cpp
@@ -117,6 +117,11 @@ rleUncompress (int inLength, int maxLength, const signed char in[], char out[])
 	    if (0 > (maxLength -= count + 1))
 		return 0;
 
+        // check the input buffer is big enough to contain
+        // byte to be duplicated
+        if (inLength < 0)
+          return 0;
+
         memset(out, *(char*)in, count+1);
         out += count+1;
 


### PR DESCRIPTION
Fixes buffer read overrun in RLE uncompress reported by chiba of topsec alphalab
(an RLE run requires two input bytes)
Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>