### PR TITLE
verify data size in deepscanlines which are not compressed

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -628,6 +628,11 @@ LineBufferTask::execute ()
 
                 _lineBuffer->format = Compressor::XDR;
                 _lineBuffer->uncompressedData = _lineBuffer->buffer;
+
+                if(_lineBuffer->packedDataSize!=maxBytesPerLine)
+                {
+                    THROW (IEX_NAMESPACE::InputExc, "Incorrect size for uncompressed data. Expected " << maxBytesPerLine << " got " << _lineBuffer->packedDataSize << " bytes");
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #1033 

If deep scanline data is not compressed, the input buffer size is read from file, and could be too small for the required data, causing a read buffer overrun when uncompressing data. When data is compressed, a sufficiently large buffer will always be allocated by the decompressor, so read bytes will always be valid. 

Note: Other image types (regular images and deep tiles) may also have similar issues.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>