### PR TITLE
fix/extend part number validation in MultiPart methods

### DIFF
--- a/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
@@ -186,6 +186,10 @@ template DeepTiledInputFile* MultiPartInputFile::getInputPart<DeepTiledInputFile
 InputPartData*
 MultiPartInputFile::getPart(int partNumber)
 {
+    if(partNumber<0 || partNumber >= _data->_headers.size())
+    {
+        THROW ( IEX_NAMESPACE::ArgExc , "MultiPartInputFile::getPart called with invalid part " << partNumber << " on file with " << _data->_headers.size() << " parts");
+    }
     return _data->getPart(partNumber);
 }
 
@@ -194,6 +198,10 @@ MultiPartInputFile::getPart(int partNumber)
 const Header &
  MultiPartInputFile::header(int n) const
 {
+    if(n<0 || n >= _data->_headers.size())
+    {
+        THROW ( IEX_NAMESPACE::ArgExc , " MultiPartInputFile::header called with invalid part " << n << " on file with " << _data->_headers.size() << " parts");
+    }
     return _data->_headers[n];
 }
 
@@ -753,7 +761,9 @@ InputPartData*
 MultiPartInputFile::Data::getPart(int partNumber)
 {
     if (partNumber < 0 || partNumber >= (int) parts.size())
-        throw IEX_NAMESPACE::ArgExc ("Part number is not in valid range.");
+    {
+            THROW ( IEX_NAMESPACE::ArgExc , "MultiPartInputFile::getPart called with invalid part " << partNumber << " on file with " << parts.size() << " parts");
+    }
     return parts[partNumber];
 }
 
@@ -823,6 +833,11 @@ MultiPartInputFile::version() const
 bool 
 MultiPartInputFile::partComplete(int part) const
 {
+
+    if(part<0 || part >= _data->_headers.size())
+    {
+        THROW ( IEX_NAMESPACE::ArgExc , "MultiPartInputFile::partComplete called with invalid part " << part << " on file with " << _data->_headers.size() << " parts");
+    }
   return _data->parts[part]->completed;
 }
 

--- a/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
@@ -186,10 +186,6 @@ template DeepTiledInputFile* MultiPartInputFile::getInputPart<DeepTiledInputFile
 InputPartData*
 MultiPartInputFile::getPart(int partNumber)
 {
-    if(partNumber<0 || partNumber >= _data->_headers.size())
-    {
-        THROW ( IEX_NAMESPACE::ArgExc , "MultiPartInputFile::getPart called with invalid part " << partNumber << " on file with " << _data->_headers.size() << " parts");
-    }
     return _data->getPart(partNumber);
 }
 

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
@@ -263,9 +263,9 @@ MultiPartOutputFile::MultiPartOutputFile(OStream& os,
 const Header &
 MultiPartOutputFile::header(int n) const
 {
-    if(n<0 || n>int(_data->_headers.size()))
+    if(n<0 || n >= int(_data->_headers.size()))
     {
-        throw IEX_NAMESPACE::ArgExc("MultiPartOutputFile::header called with invalid part number");
+        THROW ( IEX_NAMESPACE::ArgExc , "MultiPartOutputFile::header called with invalid part number " << n << " on file with " << _data->_headers.size() << " parts");
     }
     return _data->_headers[n];
 }
@@ -292,6 +292,12 @@ template <class T>
 T*
 MultiPartOutputFile::getOutputPart(int partNumber)
 {
+
+    if(partNumber<0 || partNumber >= int(_data->_headers.size()))
+    {
+        THROW ( IEX_NAMESPACE::ArgExc , "MultiPartOutputFile::getOutputPart called with invalid part number  " << partNumber << " on file with " << _data->_headers.size() << " parts");
+    }
+
 #if ILMTHREAD_THREADING_ENABLED
     std::lock_guard<std::mutex> lock(*_data);
 #endif


### PR DESCRIPTION
Fixes #1031
Adds extra bounds checks to MultiPartInputFile and MultiPartOutputFile methods that take part indexes, and fixes an off-by-one in an existing check

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>