### PR TITLE
Cherry-pick PRs

### DIFF
--- a/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepScanLineInputFile.cpp
@@ -647,6 +647,11 @@ LineBufferTask::execute ()
 
                 _lineBuffer->format = Compressor::XDR;
                 _lineBuffer->uncompressedData = _lineBuffer->buffer;
+
+                if(_lineBuffer->packedDataSize!=maxBytesPerLine)
+                {
+                    THROW (IEX_NAMESPACE::InputExc, "Incorrect size for uncompressed data. Expected " << maxBytesPerLine << " got " << _lineBuffer->packedDataSize << " bytes");
+                }
             }
         }
 

--- a/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
+++ b/OpenEXR/IlmImf/ImfDeepTiledInputFile.cpp
@@ -929,7 +929,7 @@ DeepTiledInputFile::compatibilityInitialize(OPENEXR_IMF_INTERNAL_NAMESPACE::IStr
 void
 DeepTiledInputFile::multiPartInitialize(InputPartData* part)
 {
-    if (isTiled(part->header.type()) == false)
+     if (part->header.type() != DEEPTILE)
         THROW (IEX_NAMESPACE::ArgExc, "Can't build a DeepTiledInputFile from a part of type " << part->header.type());
 
     _data->_streamData = part->mutex;

--- a/OpenEXR/IlmImf/ImfRle.cpp
+++ b/OpenEXR/IlmImf/ImfRle.cpp
@@ -146,6 +146,11 @@ rleUncompress (int inLength, int maxLength, const signed char in[], char out[])
 	    if (0 > (maxLength -= count + 1))
 		return 0;
 
+        // check the input buffer is big enough to contain
+        // byte to be duplicated
+        if (inLength < 0)
+          return 0;
+
         memset(out, *(char*)in, count+1);
         out += count+1;
 


### PR DESCRIPTION
Port following PRs to RB2.5:

  * #872 : using DeepTiledInputFile to open a multipart file where the first part was a tiledimage, or DeepTiledInputPart to open a tiledimage part should fail - only deeptiled data is supported
  * detect buffer overflows in RleUncompress (#1036)
  * verify data size in deepscanlines with NO_COMPRESSION (#1037) 
