### PR TITLE
Fix #1039 The vtable for TiledRgbaInputFile was not properly tagged

### DIFF
--- a/src/lib/OpenEXR/ImfTiledRgbaFile.h
+++ b/src/lib/OpenEXR/ImfTiledRgbaFile.h
@@ -305,7 +305,7 @@ class IMF_EXPORT_TYPE TiledRgbaOutputFile
 // Tiled RGBA input file
 //
 
-class TiledRgbaInputFile
+class IMF_EXPORT_TYPE TiledRgbaInputFile
 {
   public:
 


### PR DESCRIPTION
with the new hidden export table mechanism, the vtable will be missing under some compilers if not exported.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>