### PR TITLE
Improve Bazel Build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -351,7 +351,7 @@ cc_library(
         select({
             ":windows_x86_64": [],
             "//conditions:default": [
-                "-lpthread",
+                "-pthread",
             ],
         }),
     visibility = ["//visibility:public"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,9 +4,8 @@
 load("//:bazel/third_party/generate_header.bzl", "generate_header")
 
 config_setting(
-    name = "windows_x86_64",
-    values = {"cpu": "x64_windows"},
-    visibility = ["//visibility:public"],
+    name = "windows",
+    constraint_values = ["@platforms//os:windows"],
 )
 
 generate_header(
@@ -94,6 +93,10 @@ cc_library(
         "src/lib/Iex/IexNamespace.h",
         "src/lib/Iex/IexThrowErrnoExc.h",
     ],
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
     includes = ["src/lib/Iex"],
     deps = [
         ":IexConfig.h",
@@ -122,6 +125,10 @@ cc_library(
         "src/lib/IlmThread/IlmThreadPool.h",
         "src/lib/IlmThread/IlmThreadSemaphore.h",
     ],
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
     includes = ["src/lib/IlmThread"],
     deps = [
         ":Iex",
@@ -341,15 +348,19 @@ cc_library(
         "src/lib/OpenEXR/ImfZipCompressor.h",
     ],
     copts = select({
-        ":windows_x86_64": [],
+        ":windows": [],
         "//conditions:default": [
             "-Wno-error",
         ],
     }),
+    features = select({
+        ":windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
     includes = ["src/lib/OpenEXR"],
     linkopts =
         select({
-            ":windows_x86_64": [],
+            ":windows": [],
             "//conditions:default": [
                 "-pthread",
             ],


### PR DESCRIPTION
This PR improves the Bazel build (does not affect the CMake build):

1. It switches from using `lpthread` to `pthread`.  
There are good reasons to use `pthread` instead o `lpthread`.   Details [here](https://stackoverflow.com/questions/23250863/difference-between-pthread-and-lpthread-while-compiling).
2. If build as DLL on Windows: `windows_export_all_symbols` is enabled