### PR TITLE
Sort source files in CMake targets

### DIFF
--- a/src/bin/exrenvmap/CMakeLists.txt
+++ b/src/bin/exrenvmap/CMakeLists.txt
@@ -2,13 +2,13 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 add_executable( exrenvmap
+  blurImage.cpp
+  EnvmapImage.cpp
+  main.cpp
+  makeCubeMap.cpp
   makeLatLongMap.cpp
   readInputImage.cpp
   resizeImage.cpp
-  makeCubeMap.cpp
-  main.cpp
-  blurImage.cpp
-  EnvmapImage.cpp
 )
 
 target_link_libraries(exrenvmap OpenEXR::OpenEXR)

--- a/src/bin/exrmaketiled/CMakeLists.txt
+++ b/src/bin/exrmaketiled/CMakeLists.txt
@@ -2,9 +2,9 @@
 # Copyright (c) Contributors (c) to the OpenEXR Project.
 
 add_executable(exrmaketiled 
-  makeTiled.cpp
-  main.cpp
   Image.cpp
+  main.cpp
+  makeTiled.cpp
 )
 target_link_libraries(exrmaketiled OpenEXR::OpenEXR)
 set_target_properties(exrmaketiled PROPERTIES

--- a/src/bin/exrmultiview/CMakeLists.txt
+++ b/src/bin/exrmultiview/CMakeLists.txt
@@ -2,9 +2,9 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 add_executable(exrmultiview
-  makeMultiView.cpp
-  main.cpp
   Image.cpp
+  main.cpp
+  makeMultiView.cpp
 )
 target_link_libraries(exrmultiview OpenEXR::OpenEXR)
 set_target_properties(exrmultiview PROPERTIES

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -27,22 +27,22 @@ target_link_libraries(OpenEXRExamples OpenEXR::OpenEXR)
 # Examples
 install(
   FILES
-    main.cpp
     drawImage.cpp
-    rgbaInterfaceExamples.cpp
-    rgbaInterfaceTiledExamples.cpp
+    drawImage.h
     generalInterfaceExamples.cpp
-    lowLevelIoExamples.cpp
-    previewImageExamples.cpp
+    generalInterfaceExamples.h
     generalInterfaceTiledExamples.cpp
     generalInterfaceTiledExamples.h
-    drawImage.h
-    rgbaInterfaceExamples.h
-    generalInterfaceExamples.h
-    rgbaInterfaceTiledExamples.h
+    lowLevelIoExamples.cpp
     lowLevelIoExamples.h
-    previewImageExamples.h
+    main.cpp
     namespaceAlias.h
+    previewImageExamples.cpp
+    previewImageExamples.h
+    rgbaInterfaceExamples.cpp
+    rgbaInterfaceExamples.h
+    rgbaInterfaceTiledExamples.cpp
+    rgbaInterfaceTiledExamples.h
   DESTINATION
     ${CMAKE_INSTALL_DOCDIR}/examples
   )

--- a/src/lib/Iex/CMakeLists.txt
+++ b/src/lib/Iex/CMakeLists.txt
@@ -6,21 +6,21 @@ openexr_define_library(Iex
   CURDIR ${CMAKE_CURRENT_SOURCE_DIR}
   SOURCES
     IexBaseExc.cpp
-    IexThrowErrnoExc.cpp
     IexMathFloatExc.cpp
     IexMathFpu.cpp
+    IexThrowErrnoExc.cpp
   HEADERS
-    IexBaseExc.h
-    IexMathExc.h
-    IexThrowErrnoExc.h
-    IexErrnoExc.h
-    IexMacros.h
-    IexMathFloatExc.h
-    IexMathIeeeExc.h
     Iex.h
-    IexNamespace.h
+    IexBaseExc.h
+    IexErrnoExc.h
     IexExport.h
     IexForward.h
+    IexMacros.h
+    IexMathExc.h
+    IexMathFloatExc.h
+    IexMathIeeeExc.h
+    IexNamespace.h
+    IexThrowErrnoExc.h
   DEPENDENCIES
     OpenEXR::Config
   )

--- a/src/lib/IlmThread/CMakeLists.txt
+++ b/src/lib/IlmThread/CMakeLists.txt
@@ -8,18 +8,18 @@ openexr_define_library(IlmThread
     IlmThread.cpp
     IlmThreadPool.cpp
     IlmThreadSemaphore.cpp
-    IlmThreadSemaphorePosixCompat.cpp
-    IlmThreadSemaphorePosix.cpp
     IlmThreadSemaphoreOSX.cpp
+    IlmThreadSemaphorePosix.cpp
+    IlmThreadSemaphorePosixCompat.cpp
     IlmThreadSemaphoreWin32.cpp
   HEADERS
-    IlmThreadPool.h
     IlmThread.h
-    IlmThreadSemaphore.h
-    IlmThreadMutex.h
-    IlmThreadNamespace.h
     IlmThreadExport.h
     IlmThreadForward.h
+    IlmThreadMutex.h
+    IlmThreadNamespace.h
+    IlmThreadPool.h
+    IlmThreadSemaphore.h
   DEPENDENCIES
     OpenEXR::Config
     OpenEXR::Iex

--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -7,190 +7,190 @@ openexr_define_library(OpenEXR
   SOURCES
     b44ExpLogTable.h
     dwaLookups.h
+    ImfAcesFile.cpp
     ImfAttribute.cpp
+    ImfB44Compressor.cpp
     ImfBoxAttribute.cpp
-    ImfCRgbaFile.cpp
     ImfChannelList.cpp
     ImfChannelListAttribute.cpp
-    ImfFloatAttribute.cpp
-    ImfFrameBuffer.cpp
-    ImfHeader.cpp
-    ImfIO.cpp
-    ImfInputFile.cpp
-    ImfIntAttribute.cpp
-    ImfLineOrderAttribute.cpp
-    ImfMatrixAttribute.cpp
-    ImfOpaqueAttribute.cpp
-    ImfOutputFile.cpp
-    ImfRgbaFile.cpp
-    ImfStringAttribute.cpp
-    ImfVecAttribute.cpp
-    ImfHuf.cpp
-    ImfThreading.cpp
-    ImfWav.cpp
-    ImfLut.cpp
-    ImfCompressor.cpp
-    ImfRleCompressor.cpp
-    ImfZipCompressor.cpp
-    ImfPizCompressor.cpp
-    ImfB44Compressor.cpp
-    ImfDwaCompressor.cpp
-    ImfMisc.cpp
-    ImfCompressionAttribute.cpp
-    ImfDoubleAttribute.cpp
-    ImfConvert.cpp
-    ImfPreviewImage.cpp
-    ImfPreviewImageAttribute.cpp
-    ImfVersion.cpp
     ImfChromaticities.cpp
     ImfChromaticitiesAttribute.cpp
-    ImfKeyCode.cpp
-    ImfKeyCodeAttribute.cpp
-    ImfTimeCode.cpp
-    ImfTimeCodeAttribute.cpp
-    ImfRational.cpp
-    ImfRationalAttribute.cpp
-    ImfFramesPerSecond.cpp
-    ImfStandardAttributes.cpp
-    ImfStdIO.cpp
+    ImfCompositeDeepScanLine.cpp
+    ImfCompressionAttribute.cpp
+    ImfCompressor.cpp
+    ImfConvert.cpp
+    ImfCRgbaFile.cpp
+    ImfDeepCompositing.cpp
+    ImfDeepFrameBuffer.cpp
+    ImfDeepImageStateAttribute.cpp
+    ImfDeepScanLineInputFile.cpp
+    ImfDeepScanLineInputPart.cpp
+    ImfDeepScanLineOutputFile.cpp
+    ImfDeepScanLineOutputPart.cpp
+    ImfDeepTiledInputFile.cpp
+    ImfDeepTiledInputPart.cpp
+    ImfDeepTiledOutputFile.cpp
+    ImfDeepTiledOutputPart.cpp
+    ImfDoubleAttribute.cpp
+    ImfDwaCompressor.cpp
     ImfEnvmap.cpp
     ImfEnvmapAttribute.cpp
-    ImfScanLineInputFile.cpp
-    ImfTiledInputFile.cpp
-    ImfTiledMisc.cpp
-    ImfTiledOutputFile.cpp
-    ImfTiledRgbaFile.cpp
-    ImfTileDescriptionAttribute.cpp
-    ImfTileOffsets.cpp
-    ImfRgbaYca.cpp
-    ImfPxr24Compressor.cpp
-    ImfTestFile.cpp
-    ImfStringVectorAttribute.cpp
-    ImfMultiView.cpp
-    ImfAcesFile.cpp
-    ImfMultiPartOutputFile.cpp
-    ImfGenericOutputFile.cpp
-    ImfOutputPartData.cpp
-    ImfMultiPartInputFile.cpp
-    ImfGenericInputFile.cpp
-    ImfPartType.cpp
-    ImfInputPartData.cpp
-    ImfOutputPart.cpp
-    ImfTiledOutputPart.cpp
-    ImfInputPart.cpp
-    ImfTiledInputPart.cpp
-    ImfDeepScanLineInputPart.cpp
-    ImfDeepScanLineOutputPart.cpp
-    ImfDeepScanLineInputFile.cpp
-    ImfDeepScanLineOutputFile.cpp
-    ImfDeepTiledInputPart.cpp
-    ImfDeepTiledOutputPart.cpp
-    ImfDeepTiledInputFile.cpp
-    ImfDeepTiledOutputFile.cpp
-    ImfDeepFrameBuffer.cpp
-    ImfDeepCompositing.cpp
-    ImfCompositeDeepScanLine.cpp
-    ImfDeepImageStateAttribute.cpp
     ImfFastHuf.cpp
+    ImfFloatAttribute.cpp
     ImfFloatVectorAttribute.cpp
-    ImfRle.cpp
-    ImfSystemSpecific.cpp
-    ImfZip.cpp
+    ImfFrameBuffer.cpp
+    ImfFramesPerSecond.cpp
+    ImfGenericInputFile.cpp
+    ImfGenericOutputFile.cpp
+    ImfHeader.cpp
+    ImfHuf.cpp
     ImfIDManifest.cpp
     ImfIDManifestAttribute.cpp
+    ImfInputFile.cpp
+    ImfInputPart.cpp
+    ImfInputPartData.cpp
+    ImfIntAttribute.cpp
+    ImfIO.cpp
+    ImfKeyCode.cpp
+    ImfKeyCodeAttribute.cpp
+    ImfLineOrderAttribute.cpp
+    ImfLut.cpp
+    ImfMatrixAttribute.cpp
+    ImfMisc.cpp
+    ImfMultiPartInputFile.cpp
+    ImfMultiPartOutputFile.cpp
+    ImfMultiView.cpp
+    ImfOpaqueAttribute.cpp
+    ImfOutputFile.cpp
+    ImfOutputPart.cpp
+    ImfOutputPartData.cpp
+    ImfPartType.cpp
+    ImfPizCompressor.cpp
+    ImfPreviewImage.cpp
+    ImfPreviewImageAttribute.cpp
+    ImfPxr24Compressor.cpp
+    ImfRational.cpp
+    ImfRationalAttribute.cpp
+    ImfRgbaFile.cpp
+    ImfRgbaYca.cpp
+    ImfRle.cpp
+    ImfRleCompressor.cpp
+    ImfScanLineInputFile.cpp
+    ImfStandardAttributes.cpp
+    ImfStdIO.cpp
+    ImfStringAttribute.cpp
+    ImfStringVectorAttribute.cpp
+    ImfSystemSpecific.cpp
+    ImfTestFile.cpp
+    ImfThreading.cpp
+    ImfTileDescriptionAttribute.cpp
+    ImfTiledInputFile.cpp
+    ImfTiledInputPart.cpp
+    ImfTiledMisc.cpp
+    ImfTiledOutputFile.cpp
+    ImfTiledOutputPart.cpp
+    ImfTiledRgbaFile.cpp
+    ImfTileOffsets.cpp
+    ImfTimeCode.cpp
+    ImfTimeCodeAttribute.cpp
+    ImfVecAttribute.cpp
+    ImfVersion.cpp
+    ImfWav.cpp
+    ImfZip.cpp
+    ImfZipCompressor.cpp
   HEADERS
-    ImfForward.h
-    ImfExport.h
+    ImfAcesFile.h
+    ImfArray.h
     ImfAttribute.h
     ImfBoxAttribute.h
-    ImfCRgbaFile.h
     ImfChannelList.h
     ImfChannelListAttribute.h
-    ImfCompressionAttribute.h
-    ImfDoubleAttribute.h
-    ImfFloatAttribute.h
-    ImfFrameBuffer.h
-    ImfHeader.h
-    ImfIO.h
-    ImfInputFile.h
-    ImfIntAttribute.h
-    ImfLineOrderAttribute.h
-    ImfMatrixAttribute.h
-    ImfOpaqueAttribute.h
-    ImfOutputFile.h
-    ImfRgbaFile.h
-    ImfStringAttribute.h
-    ImfVecAttribute.h
-    ImfHuf.h
-    ImfWav.h
-    ImfLut.h
-    ImfArray.h
-    ImfCompression.h
-    ImfLineOrder.h
-    ImfName.h
-    ImfPixelType.h
-    ImfVersion.h
-    ImfXdr.h
-    ImfConvert.h
-    ImfPreviewImage.h
-    ImfPreviewImageAttribute.h
     ImfChromaticities.h
     ImfChromaticitiesAttribute.h
-    ImfKeyCode.h
-    ImfKeyCodeAttribute.h
-    ImfTimeCode.h
-    ImfTimeCodeAttribute.h
-    ImfRational.h
-    ImfRationalAttribute.h
-    ImfFramesPerSecond.h
-    ImfStandardAttributes.h
-    ImfStdIO.h
-    ImfEnvmap.h
-    ImfEnvmapAttribute.h
-    ImfInt64.h
-    ImfRgba.h
-    ImfTileDescription.h
-    ImfTileDescriptionAttribute.h
-    ImfTiledInputFile.h
-    ImfTiledOutputFile.h
-    ImfTiledRgbaFile.h
-    ImfRgbaYca.h
-    ImfTestFile.h
-    ImfThreading.h
-    ImfStringVectorAttribute.h
-    ImfMultiView.h
-    ImfAcesFile.h
-    ImfMultiPartOutputFile.h
-    ImfGenericOutputFile.h
-    ImfMultiPartInputFile.h
-    ImfGenericInputFile.h
-    ImfPartType.h
-    ImfPartHelper.h
-    ImfOutputPart.h
-    ImfTiledOutputPart.h
-    ImfInputPart.h
-    ImfTiledInputPart.h
-    ImfDeepScanLineOutputFile.h
-    ImfDeepScanLineOutputPart.h
+    ImfCompositeDeepScanLine.h
+    ImfCompression.h
+    ImfCompressionAttribute.h
+    ImfConvert.h
+    ImfCRgbaFile.h
+    ImfDeepCompositing.h
+    ImfDeepFrameBuffer.h
+    ImfDeepImageState.h
+    ImfDeepImageStateAttribute.h
     ImfDeepScanLineInputFile.h
     ImfDeepScanLineInputPart.h
+    ImfDeepScanLineOutputFile.h
+    ImfDeepScanLineOutputPart.h
     ImfDeepTiledInputFile.h
     ImfDeepTiledInputPart.h
     ImfDeepTiledOutputFile.h
     ImfDeepTiledOutputPart.h
-    ImfDeepFrameBuffer.h
-    ImfDeepCompositing.h
-    ImfCompositeDeepScanLine.h
-    ImfNamespace.h
-    ImfDeepImageState.h
-    ImfDeepImageStateAttribute.h
+    ImfDoubleAttribute.h
+    ImfEnvmap.h
+    ImfEnvmapAttribute.h
+    ImfExport.h
+    ImfFloatAttribute.h
     ImfFloatVectorAttribute.h
+    ImfForward.h
+    ImfFrameBuffer.h
+    ImfFramesPerSecond.h
+    ImfGenericInputFile.h
+    ImfGenericOutputFile.h
+    ImfHeader.h
+    ImfHuf.h
     ImfIDManifest.h
     ImfIDManifestAttribute.h
+    ImfInputFile.h
+    ImfInputPart.h
+    ImfInt64.h
+    ImfIntAttribute.h
+    ImfIO.h
+    ImfKeyCode.h
+    ImfKeyCodeAttribute.h
+    ImfLineOrder.h
+    ImfLineOrderAttribute.h
+    ImfLut.h
+    ImfMatrixAttribute.h
+    ImfMultiPartInputFile.h
+    ImfMultiPartOutputFile.h
+    ImfMultiView.h
+    ImfName.h
+    ImfNamespace.h
+    ImfOpaqueAttribute.h
+    ImfOutputFile.h
+    ImfOutputPart.h
+    ImfPartHelper.h
+    ImfPartType.h
+    ImfPixelType.h
+    ImfPreviewImage.h
+    ImfPreviewImageAttribute.h
+    ImfRational.h
+    ImfRationalAttribute.h
+    ImfRgba.h
+    ImfRgbaFile.h
+    ImfRgbaYca.h
+    ImfStandardAttributes.h
+    ImfStdIO.h
+    ImfStringAttribute.h
+    ImfStringVectorAttribute.h
+    ImfTestFile.h
+    ImfThreading.h
+    ImfTileDescription.h
+    ImfTileDescriptionAttribute.h
+    ImfTiledInputFile.h
+    ImfTiledInputPart.h
+    ImfTiledOutputFile.h
+    ImfTiledOutputPart.h
+    ImfTiledRgbaFile.h
+    ImfTimeCode.h
+    ImfTimeCodeAttribute.h
+    ImfVecAttribute.h
+    ImfVersion.h
+    ImfWav.h
+    ImfXdr.h
   DEPENDENCIES
+    Imath::Imath
     OpenEXR::Config
     OpenEXR::Iex
     OpenEXR::IlmThread
-    Imath::Imath
     ZLIB::ZLIB
   )

--- a/src/lib/OpenEXRUtil/CMakeLists.txt
+++ b/src/lib/OpenEXRUtil/CMakeLists.txt
@@ -5,39 +5,39 @@ openexr_define_library(OpenEXRUtil
   PRIV_EXPORT OPENEXRUTIL_EXPORTS
   CURDIR ${CMAKE_CURRENT_SOURCE_DIR}
   SOURCES
-    ImfImageChannel.cpp
-    ImfFlatImageChannel.cpp
-    ImfDeepImageChannel.cpp
-    ImfSampleCountChannel.cpp
-    ImfImageLevel.cpp
-    ImfFlatImageLevel.cpp
-    ImfDeepImageLevel.cpp
-    ImfImage.cpp
-    ImfFlatImage.cpp
-    ImfDeepImage.cpp
-    ImfImageIO.cpp
-    ImfFlatImageIO.cpp
-    ImfDeepImageIO.cpp
-    ImfImageDataWindow.cpp
     ImfCheckFile.cpp
+    ImfDeepImage.cpp
+    ImfDeepImageChannel.cpp
+    ImfDeepImageIO.cpp
+    ImfDeepImageLevel.cpp
+    ImfFlatImage.cpp
+    ImfFlatImageChannel.cpp
+    ImfFlatImageIO.cpp
+    ImfFlatImageLevel.cpp
+    ImfImage.cpp
+    ImfImageChannel.cpp
+    ImfImageDataWindow.cpp
+    ImfImageIO.cpp
+    ImfImageLevel.cpp
+    ImfSampleCountChannel.cpp
   HEADERS
-    ImfImageChannel.h
-    ImfFlatImageChannel.h
-    ImfDeepImageChannel.h
-    ImfSampleCountChannel.h
-    ImfImageLevel.h
-    ImfFlatImageLevel.h
-    ImfDeepImageLevel.h
-    ImfImage.h
-    ImfFlatImage.h
-    ImfDeepImage.h
-    ImfImageIO.h
-    ImfFlatImageIO.h
-    ImfDeepImageIO.h
-    ImfImageDataWindow.h
-    ImfImageChannelRenaming.h
-    ImfUtilExport.h
     ImfCheckFile.h
+    ImfDeepImage.h
+    ImfDeepImageChannel.h
+    ImfDeepImageIO.h
+    ImfDeepImageLevel.h
+    ImfFlatImage.h
+    ImfFlatImageChannel.h
+    ImfFlatImageIO.h
+    ImfFlatImageLevel.h
+    ImfImage.h
+    ImfImageChannel.h
+    ImfImageChannelRenaming.h
+    ImfImageDataWindow.h
+    ImfImageIO.h
+    ImfImageLevel.h
+    ImfSampleCountChannel.h
+    ImfUtilExport.h
   DEPENDENCIES
     OpenEXR::OpenEXR
 )

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -2,12 +2,12 @@
 # Copyright Contributors to the OpenEXR Project.
 
 add_executable(OpenEXRCoreTest
-  main.cpp
   base_units.cpp
+  compression.cpp
   general_attr.cpp
+  main.cpp
   read.cpp
   write.cpp
-  compression.cpp
   )
 target_compile_definitions(OpenEXRCoreTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/../OpenEXRTest/")
 # TODO: remove exr once we are happy everything is identical

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -6,7 +6,9 @@ add_executable(OpenEXRTest
   compareDwa.cpp
   compareFloat.cpp
   main.cpp
+  random.cpp
   testAttributes.cpp
+  testB44ExpLogTable.cpp
   testBackwardCompatibility.cpp
   testBadTypeAttributes.cpp
   testChannels.cpp
@@ -23,11 +25,14 @@ add_executable(OpenEXRTest
   testDeepScanLineMultipleRead.cpp
   testDeepTiledBasic.cpp
   testDwaCompressorSimd.cpp
+  testDwaLookups.cpp
   testExistingStreams.cpp
   testFutureProofing.cpp
   testHuf.cpp
+  testIDManifest.cpp
   testInputPart.cpp
   testIsComplete.cpp
+  testLargeDataWindowOffsets.cpp
   testLineOrder.cpp
   testLut.cpp
   testMagic.cpp
@@ -59,11 +64,6 @@ add_executable(OpenEXRTest
   testWav.cpp
   testXdr.cpp
   testYca.cpp
-  testLargeDataWindowOffsets.cpp
-  testB44ExpLogTable.cpp
-  testDwaLookups.cpp
-  testIDManifest.cpp
-  random.cpp
 )
 target_compile_definitions(OpenEXRTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
 target_link_libraries(OpenEXRTest OpenEXR::OpenEXR)


### PR DESCRIPTION
This PR sorts source files in CMake targets alphabetically.

Since filesystem tools usually show files in alphabetical order, this makes it easier to track down individual source files.
This PR is a pure refactoring PR. It only changes the order of source files in CMake targets.