### PR TITLE
Bazel build: Add some OpenEXR tools

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -398,6 +398,27 @@ cc_binary(
 )
 
 cc_binary(
+    name = "exrenvmap",
+    srcs = [
+        "src/bin/exrenvmap/EnvmapImage.cpp",
+        "src/bin/exrenvmap/blurImage.cpp",
+        "src/bin/exrenvmap/main.cpp",
+        "src/bin/exrenvmap/makeCubeMap.cpp",
+        "src/bin/exrenvmap/makeCubeMap.h",
+        "src/bin/exrenvmap/makeLatLongMap.cpp",
+        "src/bin/exrenvmap/readInputImage.cpp",
+        "src/bin/exrenvmap/readInputImage.h",
+        "src/bin/exrenvmap/resizeImage.cpp",
+    ],
+    includes = [
+        "src/bin/exrenvmap",
+    ],
+    deps = [
+        ":OpenEXR",
+    ],
+)
+
+cc_binary(
     name = "exrstdattr",
     srcs = ["src/bin/exrstdattr/main.cpp"],
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -388,3 +388,11 @@ cc_binary(
         ":OpenEXR",
     ],
 )
+
+cc_binary(
+    name = "exrstdattr",
+    srcs = ["src/bin/exrstdattr/main.cpp"],
+    deps = [
+        ":OpenEXR",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -380,3 +380,11 @@ cc_test(
         ":Iex",
     ],
 )
+
+cc_binary(
+    name = "exrheader",
+    srcs = ["src/bin/exrheader/main.cpp"],
+    deps = [
+        ":OpenEXR",
+    ],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -382,6 +382,14 @@ cc_test(
 )
 
 cc_binary(
+    name = "exr2aces",
+    srcs = ["src/bin/exr2aces/main.cpp"],
+    deps = [
+        ":OpenEXR",
+    ],
+)
+
+cc_binary(
     name = "exrheader",
     srcs = ["src/bin/exrheader/main.cpp"],
     deps = [


### PR DESCRIPTION
This PR adds to the Bazel build some OpenEXR tools:

- exr2aces
- exrheader
- exrenvmap
- exrstdattr

Example how to execute a tool:

    bazel run //:exrheader -- G:\dev\sphere_ref.exr
