### PR TITLE
Clean up library VERSION and SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,28 @@ set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string f
 set(OPENEXR_VERSION ${OpenEXR_VERSION})
 set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
 
+# Library/shared-object version using libtool versioning policy.
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-set(OPENEXR_SOVERSION 29)
-set(OPENEXR_SOAGE 0) 
-set(OPENEXR_SOREVISION 0) 
-set(OPENEXR_LIB_VERSION "${OPENEXR_SOVERSION}.${OPENEXR_SOREVISION}.${OPENEXR_SOAGE}")
+#
+# Library API version (CMake's library VERSION attribute) is of the
+# form CURRENT.REVISION.AGE; the CMake SOVERSION attribute corresonds
+# to just CURRENT. These produce a .so and a symlink symlink, e.g.:
+# libOpenEXR-3_1.so.29 -> libOpenEXR-3_1.so.29.0.0
+#                    ^                       ^ ^ ^
+#                    |                       | | |
+#                    CURRENT                 | | AGE
+#                                            | REVISION 
+#                                            CURRENT
+# When updating:
+#   1. no API change: CURRENT.REVISION+1.AGE
+#   2. API added:     CURRENT+1.0.AGE+1
+#   3. API changed:   CURRENT+1.0.0
+#
+set(OPENEXR_LIBTOOL_CURRENT 29)
+set(OPENEXR_LIBTOOL_REVISION 0)
+set(OPENEXR_LIBTOOL_AGE 0)
+set(OPENEXR_LIB_VERSION "${OPENEXR_LIBTOOL_CURRENT}.${OPENEXR_LIBTOOL_REVISION}.${OPENEXR_LIBTOOL_AGE}")
+set(OPENEXR_LIB_SOVERSION ${OPENEXR_LIBTOOL_CURRENT})
 
 option(OPENEXR_INSTALL "Install OpenEXR libraries" ON)
 option(OPENEXR_INSTALL_TOOLS "Install OpenEXR tools" ON)

--- a/cmake/LibraryDefine.cmake
+++ b/cmake/LibraryDefine.cmake
@@ -65,7 +65,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
 
   if(BUILD_SHARED_LIBS)
     set_target_properties(${libname} PROPERTIES
-      SOVERSION ${OPENEXR_SOVERSION}
+      SOVERSION ${OPENEXR_LIB_SOVERSION}
       VERSION ${OPENEXR_LIB_VERSION}
     )
   endif()

--- a/cmake/OpenEXRLibraryDefine.cmake
+++ b/cmake/OpenEXRLibraryDefine.cmake
@@ -40,7 +40,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
 
   if(BUILD_SHARED_LIBS)
     set_target_properties(${libname} PROPERTIES
-      SOVERSION ${OPENEXR_SOVERSION}
+      SOVERSION ${OPENEXR_LIB_SOVERSION}
       VERSION ${OPENEXR_LIB_VERSION}
     )
   endif()


### PR DESCRIPTION
Reduce confusion between "VERSION", "REVISION", and "SOVERSION":
* Label the internal variable IMATH_LIBTOOL_* to indicate their purpose.
* Use terminology closer to the libtool description
* Add comment documenting the library update process

Signed-off-by: Cary Phillips <cary@ilm.com>