### PR TITLE
Fix bazel build: Add missing headers to exrenvmap

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -415,12 +415,10 @@ cc_binary(
         "src/bin/exrenvmap/blurImage.cpp",
         "src/bin/exrenvmap/main.cpp",
         "src/bin/exrenvmap/makeCubeMap.cpp",
-        "src/bin/exrenvmap/makeCubeMap.h",
         "src/bin/exrenvmap/makeLatLongMap.cpp",
         "src/bin/exrenvmap/readInputImage.cpp",
-        "src/bin/exrenvmap/readInputImage.h",
         "src/bin/exrenvmap/resizeImage.cpp",
-    ],
+    ] + glob(["src/bin/exrenvmap/*.h"]),
     includes = [
         "src/bin/exrenvmap",
     ],


### PR DESCRIPTION
This PR only affects the Bazel build.

Bazel build is broken since the header files for `exrenvmap` where not defined.
This PR fixes the problem.

(I did my testing with Windows 10 where I did not have this issue - usually, I cross-check also on Linux - but the last time I didn't - in the future I will check on both platfrorms)