### PR TITLE
Do not do a Bazel Build on old OpenEXR branches

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -7,7 +7,16 @@
 name: Bazel
 
 on:
-  push: {}
+  push:
+    # Versioned branches and tags are ignored for OpenEXR <= 1.x.x
+    branches-ignore:
+      - RB-2.*
+    tags-ignore:
+      - v1.*
+      - v2.*
+    # Jobs are skipped when ONLY Markdown (*.md) files are changed
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:

--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+#
+# GitHub Actions workflow file
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
 name: Bazel
 
 on:


### PR DESCRIPTION
This PR 

- adds missing license information on Bazel CI build configuration
- Change Bazel CI Build: Do not perform CI Bazel builds on old OpenEXR versions