### PR TITLE
Use same struct scheme as box from imath for consistency

### DIFF
--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -24,20 +24,20 @@ print_attr (const exr_attribute_t* a, int verbose)
         case EXR_ATTR_BOX2I:
             printf (
                 "[ %d, %d - %d %d ] %d x %d",
-                a->box2i->x_min,
-                a->box2i->y_min,
-                a->box2i->x_max,
-                a->box2i->y_max,
-                a->box2i->x_max - a->box2i->x_min + 1,
-                a->box2i->y_max - a->box2i->y_min + 1);
+                a->box2i->min.x,
+                a->box2i->min.y,
+                a->box2i->max.x,
+                a->box2i->max.y,
+                a->box2i->max.x - a->box2i->min.x + 1,
+                a->box2i->max.y - a->box2i->min.y + 1);
             break;
         case EXR_ATTR_BOX2F:
             printf (
                 "[ %g, %g - %g %g ]",
-                (double) a->box2f->x_min,
-                (double) a->box2f->y_min,
-                (double) a->box2f->x_max,
-                (double) a->box2f->y_max);
+                (double) a->box2f->min.x,
+                (double) a->box2f->min.y,
+                (double) a->box2f->max.x,
+                (double) a->box2f->max.y);
             break;
         case EXR_ATTR_CHLIST:
             printf ("%d channels\n", a->chlist->num_channels);

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -243,10 +243,10 @@ internal_exr_add_part (
 
     /* assign appropriately invalid values */
     part->storage_mode         = EXR_STORAGE_LAST_TYPE;
-    part->data_window.x_max    = -1;
-    part->data_window.y_max    = -1;
-    part->display_window.x_max = -1;
-    part->display_window.y_max = -1;
+    part->data_window.max.x    = -1;
+    part->data_window.max.y    = -1;
+    part->display_window.max.x = -1;
+    part->display_window.max.y = -1;
     part->chunk_count          = -1;
 
     /* put it into the part table */

--- a/src/lib/OpenEXRCore/openexr_attr.h
+++ b/src/lib/OpenEXRCore/openexr_attr.h
@@ -106,24 +106,6 @@ typedef enum
  * structs to be tightly packed */
 #pragma pack(push, 1)
 
-/** @brief struct to hold an integer box / region definition */
-typedef struct
-{
-    int32_t x_min;
-    int32_t y_min;
-    int32_t x_max;
-    int32_t y_max;
-} exr_attr_box2i_t;
-
-/** @brief struct to hold a floating-point box / region definition */
-typedef struct
-{
-    float x_min;
-    float y_min;
-    float x_max;
-    float y_max;
-} exr_attr_box2f_t;
-
 /** @brief struct to hold color chromaticities to interpret the tristimulus color values in the image data */
 typedef struct
 {
@@ -264,6 +246,20 @@ typedef struct
         double arr[3];
     };
 } exr_attr_v3d_t;
+
+/** @brief struct to hold an integer box / region definition */
+typedef struct
+{
+    exr_attr_v2i_t min;
+    exr_attr_v2i_t max;
+} exr_attr_box2i_t;
+
+/** @brief struct to hold a floating-point box / region definition */
+typedef struct
+{
+    exr_attr_v2f_t min;
+    exr_attr_v2f_t max;
+} exr_attr_box2f_t;
 
 /** @brief Struct holding base tiledesc attribute type defined in spec
  *

--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -209,7 +209,7 @@ exr_initialize_required_attr_simple (
     int32_t           height,
     exr_compression_t ctype)
 {
-    exr_attr_box2i_t dispWindow = { 0, 0, width - 1, height - 1 };
+    exr_attr_box2i_t dispWindow = { .min={ .x=0, .y=0 }, .max={ .x=(width - 1), .y=(height - 1) } };
     exr_attr_v2f_t   swc        = { .x = 0.f, .y = 0.f };
     return exr_initialize_required_attr (
         ctxt,

--- a/src/lib/OpenEXRCore/validation.c
+++ b/src/lib/OpenEXRCore/validation.c
@@ -90,32 +90,32 @@ validate_image_dimensions (
     par = curpart->pixelAspectRatio->f;
     sww = curpart->screenWindowWidth->f;
 
-    w = (int64_t) dw.x_max - (int64_t) dw.x_min + 1;
-    h = (int64_t) dw.y_max - (int64_t) dw.y_min + 1;
+    w = (int64_t) dw.max.x - (int64_t) dw.min.x + 1;
+    h = (int64_t) dw.max.y - (int64_t) dw.min.y + 1;
 
-    if (dspw.x_min > dspw.x_max || dspw.y_min > dspw.y_max ||
-        dspw.x_min <= -kLargeVal || dspw.y_min <= -kLargeVal ||
-        dspw.x_max >= kLargeVal || dspw.y_max >= kLargeVal)
+    if (dspw.min.x > dspw.max.x || dspw.min.y > dspw.max.y ||
+        dspw.min.x <= -kLargeVal || dspw.min.y <= -kLargeVal ||
+        dspw.max.x >= kLargeVal || dspw.max.y >= kLargeVal)
         return f->print_error (
             f,
             EXR_ERR_INVALID_ATTR,
             "Invalid display window (%d, %d - %d, %d)",
-            dspw.x_min,
-            dspw.y_min,
-            dspw.x_max,
-            dspw.y_max);
+            dspw.min.x,
+            dspw.min.y,
+            dspw.max.x,
+            dspw.max.y);
 
-    if (dw.x_min > dw.x_max || dw.y_min > dw.y_max || dw.x_min <= -kLargeVal ||
-        dw.y_min <= -kLargeVal || dw.x_max >= kLargeVal ||
-        dw.y_max >= kLargeVal)
+    if (dw.min.x > dw.max.x || dw.min.y > dw.max.y || dw.min.x <= -kLargeVal ||
+        dw.min.y <= -kLargeVal || dw.max.x >= kLargeVal ||
+        dw.max.y >= kLargeVal)
         return f->print_error (
             f,
             EXR_ERR_INVALID_ATTR,
             "Invalid data window (%d, %d - %d, %d)",
-            dw.x_min,
-            dw.y_min,
-            dw.x_max,
-            dw.y_max);
+            dw.min.x,
+            dw.min.y,
+            dw.max.x,
+            dw.max.y);
 
     if (maxw > 0 && maxw < w)
         return f->print_error (
@@ -183,8 +183,8 @@ validate_channels (
             "request to validate channel list, but data window not set to validate against");
 
     dw = curpart->data_window;
-    w  = dw.x_max - dw.x_min + 1;
-    h  = dw.y_max - dw.y_min + 1;
+    w  = dw.max.x - dw.min.x + 1;
+    h  = dw.max.y - dw.min.y + 1;
     for (int c = 0; c < channels->num_channels; ++c)
     {
         int32_t xsamp = channels->entries[c].x_sampling;
@@ -203,21 +203,21 @@ validate_channels (
                 "channel '%s': y subsampling factor is invalid (%d)",
                 channels->entries[c].name.str,
                 ysamp);
-        if (dw.x_min % xsamp)
+        if (dw.min.x % xsamp)
             return f->print_error (
                 f,
                 EXR_ERR_INVALID_ATTR,
                 "channel '%s': minimum x coordinate (%d) of the data window is not a multiple of the x subsampling factor (%d)",
                 channels->entries[c].name.str,
-                dw.x_min,
+                dw.min.x,
                 xsamp);
-        if (dw.y_min % ysamp)
+        if (dw.min.y % ysamp)
             return f->print_error (
                 f,
                 EXR_ERR_INVALID_ATTR,
                 "channel '%s': minimum y coordinate (%d) of the data window is not a multiple of the y subsampling factor (%d)",
                 channels->entries[c].name.str,
-                dw.y_min,
+                dw.min.y,
                 ysamp);
         if (w % xsamp)
             return f->print_error (

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -759,10 +759,10 @@ doDecodeScan (exr_context_t f, pixels& p, int xs, int ys)
     bool                   first = true;
 
     EXRCORE_TEST_RVAL (exr_get_data_window (f, 0, &dw));
-    EXRCORE_TEST (dw.x_min == IMG_DATA_X * xs);
-    EXRCORE_TEST (dw.x_max == IMG_DATA_X * xs + IMG_WIDTH * xs - 1);
-    EXRCORE_TEST (dw.y_min == IMG_DATA_Y * ys);
-    EXRCORE_TEST (dw.y_max == IMG_DATA_Y * ys + IMG_HEIGHT * ys - 1);
+    EXRCORE_TEST (dw.min.x == IMG_DATA_X * xs);
+    EXRCORE_TEST (dw.max.x == IMG_DATA_X * xs + IMG_WIDTH * xs - 1);
+    EXRCORE_TEST (dw.min.y == IMG_DATA_Y * ys);
+    EXRCORE_TEST (dw.max.y == IMG_DATA_Y * ys + IMG_HEIGHT * ys - 1);
 
     EXRCORE_TEST_RVAL (exr_get_scanlines_per_chunk (f, 0, &scansperchunk));
 
@@ -771,7 +771,7 @@ doDecodeScan (exr_context_t f, pixels& p, int xs, int ys)
     EXRCORE_TEST (stortype == EXR_STORAGE_SCANLINE);
 
     //const uint8_t* tmp;
-    for (int y = dw.y_min; y <= dw.y_max; y += scansperchunk)
+    for (int y = dw.min.y; y <= dw.max.y; y += scansperchunk)
     {
         EXRCORE_TEST_RVAL (exr_read_scanline_block_info (f, 0, y, &cinfo));
         if (first)
@@ -783,7 +783,7 @@ doDecodeScan (exr_context_t f, pixels& p, int xs, int ys)
         {
             EXRCORE_TEST_RVAL (exr_decoding_update (f, 0, &cinfo, &decoder));
         }
-        int32_t idxoffset = ((y - dw.y_min) / ys) * p._stride_x;
+        int32_t idxoffset = ((y - dw.min.y) / ys) * p._stride_x;
 
         for (int c = 0; c < decoder.channel_count; ++c)
         {
@@ -1131,10 +1131,10 @@ doWriteRead (
     exr_context_initializer_t cinit = EXR_DEFAULT_CONTEXT_INITIALIZER;
     exr_attr_box2i_t          dataW;
 
-    dataW.x_min = dwx;
-    dataW.y_min = dwy;
-    dataW.x_max = dwx + fw - 1;
-    dataW.y_max = dwy + fh - 1;
+    dataW.min.x = dwx;
+    dataW.min.y = dwy;
+    dataW.max.x = dwx + fw - 1;
+    dataW.max.y = dwy + fh - 1;
 
     std::cout << "  " << pattern << " tiled: " << (tiled ? "yes" : "no")
               << " sampling " << xs << ", " << ys << " comp " << (int) comp

--- a/src/test/OpenEXRCoreTest/performance.cpp
+++ b/src/test/OpenEXRCoreTest/performance.cpp
@@ -89,8 +89,8 @@ read_pixels_raw (exr_context_t f)
     exr_attr_box2i_t dw;
     if (EXR_ERR_SUCCESS != exr_get_data_window (f, 0, &dw))
         throw std::logic_error ("Unable to query data window from part");
-    int64_t w = (int64_t) dw.x_max - (int64_t) dw.x_min + (int64_t) 1;
-    int64_t h = (int64_t) dw.x_max - (int64_t) dw.x_min + (int64_t) 1;
+    int64_t w = (int64_t) dw.max.x - (int64_t) dw.min.x + (int64_t) 1;
+    int64_t h = (int64_t) dw.max.x - (int64_t) dw.min.x + (int64_t) 1;
 
     if (w <= 0) return ret;
     if (h <= 0) return ret;
@@ -135,7 +135,7 @@ read_pixels_raw (exr_context_t f)
         TaskGroup   taskgroup;
         ThreadPool& tp = ThreadPool::globalThreadPool ();
 
-        for (int y = dw.y_min; y <= dw.y_max;)
+        for (int y = dw.min.y; y <= dw.max.y;)
         {
             tp.addTask (new CoreReadTask (&taskgroup, f, y, imgptr));
             imgptr += sizePerChunk;
@@ -145,13 +145,13 @@ read_pixels_raw (exr_context_t f)
 #else
         exr_chunk_block_info_t cinfo = { 0 };
         exr_decode_pipeline_t  chunk = { 0 };
-        for (int y = dw.y_min; y <= dw.y_max;)
+        for (int y = dw.min.y; y <= dw.max.y;)
         {
             exr_result_t rv = exr_read_scanline_block_info (f, 0, y, &cinfo);
             if (rv != EXR_ERR_SUCCESS)
                 throw std::runtime_error ("unable to init scanline block info");
 
-            if (y == dw.y_min)
+            if (y == dw.min.y)
                 rv = exr_initialize_decoding (f, 0, &cinfo, &chunk);
             else
                 rv = exr_decoding_update (f, 0, &cinfo, &chunk);
@@ -198,7 +198,7 @@ read_pixels_raw (exr_context_t f)
         uint8_t *imgptr = rawBuf.data();
 
         // random or increasing
-        for ( int y = dw.y_min; y <= dw.y_max; )
+        for ( int y = dw.min.y; y <= dw.max.y; )
         {
             exr_chunk_info_t chunk = {0};
             if ( exr_compute_chunk_for_scanline( f, 0, y, &chunk ) )

--- a/src/test/OpenEXRCoreTest/read.cpp
+++ b/src/test/OpenEXRCoreTest/read.cpp
@@ -275,11 +275,11 @@ testReadScans (const std::string& tempdir)
 
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT,
-        exr_read_scanline_block_info (f, 0, dw.y_min - 1, &cinfo));
+        exr_read_scanline_block_info (f, 0, dw.min.y - 1, &cinfo));
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT,
-        exr_read_scanline_block_info (f, 0, dw.y_max + 1, &cinfo));
-    EXRCORE_TEST_RVAL (exr_read_scanline_block_info (f, 0, dw.y_min, &cinfo));
+        exr_read_scanline_block_info (f, 0, dw.max.y + 1, &cinfo));
+    EXRCORE_TEST_RVAL (exr_read_scanline_block_info (f, 0, dw.min.y, &cinfo));
 
     uint64_t pchunksz = 0;
     EXRCORE_TEST_RVAL (exr_get_chunk_unpacked_size (f, 0, &pchunksz));

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -790,19 +790,19 @@ testWriteAttrs (const std::string& tempdir)
     {
         exr_attr_box2i_t tb2i = { 1, 2, 3, 4 };
         TEST_CORNER_CASE_NAME (box2i, tb2i, int);
-        EXRCORE_TEST (tb2i.x_min == 1);
-        EXRCORE_TEST (tb2i.y_min == 2);
-        EXRCORE_TEST (tb2i.x_max == 3);
-        EXRCORE_TEST (tb2i.y_max == 4);
+        EXRCORE_TEST (tb2i.min.x == 1);
+        EXRCORE_TEST (tb2i.min.y == 2);
+        EXRCORE_TEST (tb2i.max.x == 3);
+        EXRCORE_TEST (tb2i.max.y == 4);
     }
 
     {
         exr_attr_box2f_t tb2f = { 1.f, 2.f, 3.f, 4.f };
         TEST_CORNER_CASE_NAME (box2f, tb2f, int);
-        EXRCORE_TEST (tb2f.x_min == 1.f);
-        EXRCORE_TEST (tb2f.y_min == 2.f);
-        EXRCORE_TEST (tb2f.x_max == 3.f);
-        EXRCORE_TEST (tb2f.y_max == 4.f);
+        EXRCORE_TEST (tb2f.min.x == 1.f);
+        EXRCORE_TEST (tb2f.min.y == 2.f);
+        EXRCORE_TEST (tb2f.max.x == 3.f);
+        EXRCORE_TEST (tb2f.max.y == 4.f);
     }
 
     {
@@ -1165,10 +1165,10 @@ testWriteTiles (const std::string& tempdir)
 
     EXRCORE_TEST_RVAL (exr_get_data_window (outf, 0, &dw));
     ty = 0;
-    for (int32_t y = dw.y_min; y <= dw.y_max; y += levelsy)
+    for (int32_t y = dw.min.y; y <= dw.max.y; y += levelsy)
     {
         tx = 0;
-        for (int32_t x = dw.x_min; x <= dw.x_max; x += levelsx)
+        for (int32_t x = dw.min.x; x <= dw.max.x; x += levelsx)
         {
             exr_chunk_block_info_t cinfo;
             EXRCORE_TEST_RVAL (


### PR DESCRIPTION
Initially we did this differently so it was obvious it didn't have the
other functionality, but by having the same nested scheme of a box
having 2 vecs, enables us to add templated sfinae constructors to auto
convert the C type into c++ instead of just having to reinterpret cast

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>