### PR TITLE
Add utility function for ease of use in other libraries

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -478,7 +478,7 @@ exr_read_tile_block_info (
     int32_t*                   tdata;
     int32_t                    cidx, ntoread;
     uint64_t                   dataoff;
-    int64_t                    fsize;
+    int64_t                    fsize, tend, dend;
     const exr_attr_chlist_t*   chanlist;
     const exr_attr_tiledesc_t* tiledesc;
     int                        tilew, tileh, unpacksize = 0;
@@ -506,27 +506,25 @@ exr_read_tile_block_info (
     }
 
     tiledesc = part->tiles->tiledesc;
-    tilew    = part->tile_level_tile_size_x[levelx];
-    if (tiledesc->x_size < (uint32_t) tilew) tilew = (int) tiledesc->x_size;
-    tileh = part->tile_level_tile_size_y[levely];
-    if (tiledesc->y_size < (uint32_t) tileh) tileh = (int) tiledesc->y_size;
 
-    if (((int64_t) (tilex) * (int64_t) (tilew) + (int64_t) (tilew) +
-         (int64_t) (part->data_window.min.x) - 1) >
-        (int64_t) (part->data_window.max.x))
+    tilew = (int) (tiledesc->x_size);
+    dend  = ((int64_t) part->tile_level_tile_size_x[levelx]);
+    tend  = ((int64_t) tilew) * ((int64_t) (tilex + 1));
+    if (tend > dend)
     {
-        int64_t sz = (int64_t) (part->data_window.max.x) -
-                     (int64_t) (part->data_window.min.x) + 1;
-        tilew = (int) (sz - ((int64_t) (tilex) * (int64_t) (tilew)));
+        tend -= dend;
+        if (tend < tilew)
+            tilew = tilew - ((int) tend);
     }
 
-    if (((int64_t) (tiley) * (int64_t) (tileh) + (int64_t) (tileh) +
-         (int64_t) (part->data_window.min.y) - 1) >
-        (int64_t) (part->data_window.max.y))
+    tileh = (int) (tiledesc->y_size);
+    dend  = ((int64_t) part->tile_level_tile_size_y[levely]);
+    tend  = ((int64_t) tileh) * ((int64_t) (tiley + 1));
+    if (tend > dend)
     {
-        int64_t sz = (int64_t) (part->data_window.max.y) -
-                     (int64_t) (part->data_window.min.y) + 1;
-        tileh = (int) (sz - ((int64_t) (tiley) * (int64_t) (tileh)));
+        tend -= dend;
+        if (tend < tileh)
+            tileh = tileh - ((int) tend);
     }
 
     cidx = 0;

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -95,6 +95,26 @@ EXR_EXPORT exr_result_t exr_get_tile_sizes (
     int32_t*            tilew,
     int32_t*            tileh);
 
+/** @brief Query the data sizes for a particular level in the specified part.
+ *
+ * If the part is a tiled part, fills in the width / height for the
+ * specified levels
+ *
+ * return ERR_SUCCESS on sucess, an error otherwise (i.e. if the part
+ * is not tiled)
+ *
+ * it is valid to pass NULL to either of the levw or levh
+ * arguments, which enables testing if this part is a tiled part, or
+ * if you don't need both for some reason
+ */
+EXR_EXPORT exr_result_t exr_get_level_sizes (
+    exr_const_context_t ctxt,
+    int                 part_index,
+    int                 levelx,
+    int                 levely,
+    int32_t*            levw,
+    int32_t*            levh);
+
 /** Return the number of chunks contained in this part of the file
  *
  * This should be used as a basis for splitting up how a file is


### PR DESCRIPTION
Libraries / tools like OpenImageIO would otherwise need to have a lock
or other caches to know what the data dimension is for a particular
(mip/rip) level. Instead, expose that here since we can provide it for
free

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>