### PR TITLE
Do Bazel CI builds also for pull requests

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -17,6 +17,14 @@ on:
     # Jobs are skipped when ONLY Markdown (*.md) files are changed
     paths-ignore:
       - '**.md'
+  pull_request:
+    branches-ignore:
+      - RB-2.*
+    tags-ignore:
+      - v1.*
+      - v2.*
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Currently, Bazel CI Builds run only after a merge. Therefore, during the PR is open no Bazel builds are performed an thus no Bazel build errors are shown - only when the PR is merged (when its to late).