### PR TITLE
Release notes for v3.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # OpenEXR Release Notes
 
+* [Version 3.1.0](#version-310-???) ???
 * [Version 3.0.5](#version-305-july-1-2021) July 1, 2021
 * [Version 3.0.4](#version-304-june-3-2021) June 3, 2021
 * [Version 3.0.3](#version-303-may-18-2021) May 18, 2021
@@ -48,6 +49,21 @@
 * [Version 1.0.2](#version-102)
 * [Version 1.0.1](#version-101)
 * [Version 1.0](#version-10)
+
+## Version 3.1.0 (???)
+
+Minor release introducing new an optimized C-language I/O core.
+
+* [1077](https://github.com/AcademySoftwareFoundation/openexr/pull/1077) Initial doxygen/sphinx/breathe/readthedocs docs
+* [1076](https://github.com/AcademySoftwareFoundation/openexr/pull/1076) Refactor deep tests to separate file, fix deep chunk reads, ripmap reading
+* [1074](https://github.com/AcademySoftwareFoundation/openexr/pull/1074) Add utility function for ease of use in other libraries
+* [1073](https://github.com/AcademySoftwareFoundation/openexr/pull/1073) Use same struct scheme as box from imath for consistency
+* [1062](https://github.com/AcademySoftwareFoundation/openexr/pull/1062) Add missing "throw" before InputExc in IDManifest::init()
+* [1045](https://github.com/AcademySoftwareFoundation/openexr/pull/1045) Fix #1039 The vtable for TiledRgbaInputFile was not properly tagged
+* [1038](https://github.com/AcademySoftwareFoundation/openexr/pull/1038) fix/extend part number validation in MultiPart methods
+* [1024](https://github.com/AcademySoftwareFoundation/openexr/pull/1024) Remove dead code in ImfB44Compressor.cpp
+* [1020](https://github.com/AcademySoftwareFoundation/openexr/pull/1020) Fix comparison of integer expressions of different signedness warning
+* [870](https://github.com/AcademySoftwareFoundation/openexr/pull/870) WIP: New C core
 
 ## Version 3.0.5 (July 1, 2021)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,6 +123,8 @@ Limitations:
   particular chunk is corrupt, this is handled such that the other
   chunks may be read without rendering the context unusable
 
+Merged Pull Requests:
+
 * [1097](https://github.com/AcademySoftwareFoundation/openexr/pull/1097) Include exported OpenEXR headers with "" instead of <>
 * [1092](https://github.com/AcademySoftwareFoundation/openexr/pull/1092) Document current standard optional attributes
 * [1088](https://github.com/AcademySoftwareFoundation/openexr/pull/1088) First draft of rst/readthedocs for C API/OpenEXRCore

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -123,11 +123,14 @@ Limitations:
   particular chunk is corrupt, this is handled such that the other
   chunks may be read without rendering the context unusable
 
-
+* [1088](https://github.com/AcademySoftwareFoundation/openexr/pull/1088) First draft of rst/readthedocs for C API/OpenEXRCore
+* [1087](https://github.com/AcademySoftwareFoundation/openexr/pull/1087) Edit doxygen comments for consistency and style
+* [1086](https://github.com/AcademySoftwareFoundation/openexr/pull/1086) Simplify names, improve error messages, fix imath usage in Core
 * [1077](https://github.com/AcademySoftwareFoundation/openexr/pull/1077) Initial doxygen/sphinx/breathe/readthedocs docs
 * [1076](https://github.com/AcademySoftwareFoundation/openexr/pull/1076) Refactor deep tests to separate file, fix deep chunk reads, ripmap reading
 * [1074](https://github.com/AcademySoftwareFoundation/openexr/pull/1074) Add utility function for ease of use in other libraries
 * [1073](https://github.com/AcademySoftwareFoundation/openexr/pull/1073) Use same struct scheme as box from imath for consistency
+* [1069](https://github.com/AcademySoftwareFoundation/openexr/pull/1069) Clean up library VERSION and SOVERSION
 * [1062](https://github.com/AcademySoftwareFoundation/openexr/pull/1062) Add missing "throw" before InputExc in IDManifest::init()
 * [1045](https://github.com/AcademySoftwareFoundation/openexr/pull/1045) Fix #1039 The vtable for TiledRgbaInputFile was not properly tagged
 * [1038](https://github.com/AcademySoftwareFoundation/openexr/pull/1038) fix/extend part number validation in MultiPart methods

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # OpenEXR Release Notes
 
-* [Version 3.1.0-beta](#version-310-beta-july-19-2021) July 19, 2021
+* [Version 3.1.0](#version-310-july-22-2021) July 22, 2021
 * [Version 3.0.5](#version-305-july-1-2021) July 1, 2021
 * [Version 3.0.4](#version-304-june-3-2021) June 3, 2021
 * [Version 3.0.3](#version-303-may-18-2021) May 18, 2021
@@ -50,7 +50,7 @@
 * [Version 1.0.1](#version-101)
 * [Version 1.0](#version-10)
 
-## Version 3.1.0-beta (July 19, 2021)
+## Version 3.1.0 (July 22, 2021)
 
 The 3.1 release of OpenEXR introduces a new library, OpenEXRCore,
 which is the result of a significant re-thinking of how OpenEXR
@@ -123,6 +123,8 @@ Limitations:
   particular chunk is corrupt, this is handled such that the other
   chunks may be read without rendering the context unusable
 
+* [1097](https://github.com/AcademySoftwareFoundation/openexr/pull/1097) Include exported OpenEXR headers with "" instead of <>
+* [1092](https://github.com/AcademySoftwareFoundation/openexr/pull/1092) Document current standard optional attributes
 * [1088](https://github.com/AcademySoftwareFoundation/openexr/pull/1088) First draft of rst/readthedocs for C API/OpenEXRCore
 * [1087](https://github.com/AcademySoftwareFoundation/openexr/pull/1087) Edit doxygen comments for consistency and style
 * [1086](https://github.com/AcademySoftwareFoundation/openexr/pull/1086) Simplify names, improve error messages, fix imath usage in Core


### PR DESCRIPTION
Note that v3.1.0 has very few changes other than the new OpenEXRCore library, since most recent fixes have been patched into 3.0.5 already.