### PR TITLE
Use Bazel standard convention for repository names

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -374,7 +374,7 @@ cc_library(
         ":OpenEXRConfig.h",
         ":OpenEXRConfigInternal.h",
         "@Imath",
-        "@zlib",
+        "@net_zlib_zlib//:zlib",
     ],
 )
 

--- a/bazel/third_party/openexr_deps.bzl
+++ b/bazel/third_party/openexr_deps.bzl
@@ -11,11 +11,14 @@ def openexr_deps():
 
     maybe(
         http_archive,
-        name = "zlib",
+        name = "net_zlib_zlib",
         build_file = "@openexr//:bazel/third_party/zlib.BUILD",
         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         strip_prefix = "zlib-1.2.11",
-        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+        urls = [
+            "https://zlib.net/zlib-1.2.11.tar.gz",
+            "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
+        ],
     )
 
     # sha256 was determined using:


### PR DESCRIPTION
This PR only influences the Bazel Build: 
* Use Bazel standard convention for repository names (zlib -> net_zlib_zlib)
* Add a second mirror URL