### PR TITLE
Update Imath to 3.1.0 for Bazel build

### DIFF
--- a/bazel/third_party/Imath.BUILD
+++ b/bazel/third_party/Imath.BUILD
@@ -3,21 +3,22 @@
 
 load("@openexr//:bazel/third_party/generate_header.bzl", "generate_header")
 
-# generate "ImathConfig.h"
 generate_header(
     name = "ImathConfig.h",
     substitutions = {
-        "@IMATH_INTERNAL_NAMESPACE@": "Imath_3_0",
-        "@IMATH_LIB_VERSION@": "3.0.5",
+        "@IMATH_INTERNAL_NAMESPACE@": "Imath_3_1",
+        "@IMATH_LIB_VERSION@": "3.1.0",
         "@IMATH_NAMESPACE_CUSTOM@": "0",
         "@IMATH_NAMESPACE@": "Imath",
-        "@IMATH_PACKAGE_NAME@": "Imath 3.0.5",
+        "@IMATH_PACKAGE_NAME@": "Imath 3.1.0",
         "@IMATH_VERSION_MAJOR@": "3",
-        "@IMATH_VERSION_MINOR@": "0",
-        "@IMATH_VERSION_PATCH@": "5",
-        "@IMATH_VERSION@": "3.0.5",
-        "#cmakedefine IMATH_ENABLE_API_VISIBILITY": "",
-        "#cmakedefine IMATH_HAVE_LARGE_STACK": "",
+        "@IMATH_VERSION_MINOR@": "1",
+        "@IMATH_VERSION_PATCH@": "0",
+        "@IMATH_VERSION@": "3.1.0",
+        "#cmakedefine IMATH_HALF_USE_LOOKUP_TABLE": "#define IMATH_HALF_USE_LOOKUP_TABLE",
+        "#cmakedefine IMATH_ENABLE_API_VISIBILITY": "#define IMATH_ENABLE_API_VISIBILITY",
+        "#cmakedefine IMATH_HAVE_LARGE_STACK": "/* #undef IMATH_HAVE_LARGE_STACK */",
+        "#cmakedefine01 IMATH_USE_NOEXCEPT": "#define IMATH_USE_NOEXCEPT 1",
     },
     template = "config/ImathConfig.h.in",
 )
@@ -29,7 +30,6 @@ cc_library(
         "src/Imath/ImathFun.cpp",
         "src/Imath/ImathMatrixAlgo.cpp",
         "src/Imath/ImathRandom.cpp",
-        "src/Imath/eLut.h",
         "src/Imath/half.cpp",
         "src/Imath/toFloat.h",
     ],

--- a/bazel/third_party/openexr_deps.bzl
+++ b/bazel/third_party/openexr_deps.bzl
@@ -22,14 +22,14 @@ def openexr_deps():
     )
 
     # sha256 was determined using:
-    # curl -sL https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.0.5.tar.gz --output Imath-3.0.5.tar.gz
-    # sha256sum Imath-3.0.5.tar.gz
+    # curl -sL https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.0.tar.gz --output Imath-3.1.0.tar.gz
+    # sha256sum Imath-3.1.0.tar.gz
     # If the hash is incorrect Bazel will report an error and show the actual hash of the file.
     maybe(
         http_archive,
         name = "Imath",
         build_file = "@openexr//:bazel/third_party/Imath.BUILD",
-        strip_prefix = "Imath-3.0.5",
-        sha256 = "38b94c840c6400959ccf647bc1631f96f3170cb081021d774813803e798208bd",
-        urls = ["https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.0.5.tar.gz"],
+        strip_prefix = "Imath-3.1.0",
+        sha256 = "211c907ab26d10bd01e446da42f073ee7381e1913d8fa48084444bc4e1b4ef87",
+        urls = ["https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.0.tar.gz"],
     )


### PR DESCRIPTION
This PR only affects the Bazel build:
* Bump Imath version for Bazel build to "3.1.0"