### PR TITLE
Include exported OpenEXR headers with "" instead of <>

### DIFF
--- a/src/lib/OpenEXR/ImfAttribute.h
+++ b/src/lib/OpenEXR/ImfAttribute.h
@@ -18,7 +18,7 @@
 #include "ImfIO.h"
 #include "ImfXdr.h"
 
-#include <IexBaseExc.h>
+#include "IexBaseExc.h"
 
 #include <typeinfo>
 #include <cstring>

--- a/src/lib/OpenEXRCore/openexr_conf.h
+++ b/src/lib/OpenEXRCore/openexr_conf.h
@@ -7,7 +7,7 @@
 #define OPENEXR_CONF_H
 #pragma once
 
-#include <OpenEXRConfig.h>
+#include "OpenEXRConfig.h"
 
 /// \addtogroup ExportMacros
 /// @{

--- a/src/lib/OpenEXRUtil/ImfDeepImage.h
+++ b/src/lib/OpenEXRUtil/ImfDeepImage.h
@@ -19,7 +19,7 @@
 #include "ImfImage.h"
 #include "ImfUtilExport.h"
 
-#include <ImfTileDescription.h>
+#include "ImfTileDescription.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 

--- a/src/lib/OpenEXRUtil/ImfFlatImage.h
+++ b/src/lib/OpenEXRUtil/ImfFlatImage.h
@@ -19,7 +19,7 @@
 #include "ImfImage.h"
 #include "ImfUtilExport.h"
 
-#include <ImfTileDescription.h>
+#include "ImfTileDescription.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 

--- a/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
@@ -20,8 +20,8 @@
 #include "ImfUtilExport.h"
 #include "ImfImageLevel.h"
 
-#include <ImfPixelType.h>
-#include <ImfFrameBuffer.h>
+#include "ImfPixelType.h"
+#include "ImfFrameBuffer.h"
 #include <ImathBox.h>
 #include <half.h>
 

--- a/src/lib/OpenEXRUtil/ImfImage.h
+++ b/src/lib/OpenEXRUtil/ImfImage.h
@@ -67,8 +67,8 @@
 #include "ImfNamespace.h"
 
 #include "ImfImageLevel.h"
-#include <ImfTileDescription.h>
-#include <ImfArray.h>
+#include "ImfTileDescription.h"
+#include "ImfArray.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 

--- a/src/lib/OpenEXRUtil/ImfImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfImageChannel.h
@@ -18,9 +18,9 @@
 #include "ImfUtilExport.h"
 
 #include <IexBaseExc.h>
-#include <ImfPixelType.h>
-#include <ImfFrameBuffer.h>
-#include <ImfChannelList.h>
+#include "ImfPixelType.h"
+#include "ImfFrameBuffer.h"
+#include "ImfChannelList.h"
 #include <ImathBox.h>
 #include <half.h>
 

--- a/src/lib/OpenEXRUtil/ImfImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfImageChannel.h
@@ -17,10 +17,10 @@
 
 #include "ImfUtilExport.h"
 
-#include <IexBaseExc.h>
 #include "ImfPixelType.h"
 #include "ImfFrameBuffer.h"
 #include "ImfChannelList.h"
+#include "IexBaseExc.h"
 #include <ImathBox.h>
 #include <half.h>
 

--- a/src/lib/OpenEXRUtil/ImfImageChannelRenaming.h
+++ b/src/lib/OpenEXRUtil/ImfImageChannelRenaming.h
@@ -13,7 +13,7 @@
 //
 //----------------------------------------------------------------------------
 
-#include <ImfNamespace.h>
+#include "ImfNamespace.h"
 #include <string>
 #include <map>
 

--- a/src/lib/OpenEXRUtil/ImfImageDataWindow.h
+++ b/src/lib/OpenEXRUtil/ImfImageDataWindow.h
@@ -14,7 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "ImfUtilExport.h"
-#include <ImfNamespace.h>
+#include "ImfNamespace.h"
 #include <ImathBox.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER


### PR DESCRIPTION
Signed-off-by: Cary Phillips <cary@ilm.com>