### PR TITLE
Bump version on master branch to 3.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 # configuration files
 #######################################
 
-project(OpenEXR VERSION 3.1.0 LANGUAGES C CXX)
+project(OpenEXR VERSION 3.2.0 LANGUAGES C CXX)
 
 set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for OpenEXR build, such as -dev, -beta1, etc.")
 
@@ -43,7 +43,7 @@ set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
 #   2. API added:     CURRENT+1.0.AGE+1
 #   3. API changed:   CURRENT+1.0.0
 #
-set(OPENEXR_LIBTOOL_CURRENT 29)
+set(OPENEXR_LIBTOOL_CURRENT 31)
 set(OPENEXR_LIBTOOL_REVISION 0)
 set(OPENEXR_LIBTOOL_AGE 0)
 set(OPENEXR_LIB_VERSION "${OPENEXR_LIBTOOL_CURRENT}.${OPENEXR_LIBTOOL_REVISION}.${OPENEXR_LIBTOOL_AGE}")


### PR DESCRIPTION
With the v3.1.0 release, the master branch will build version "3.2.0", with soversion 31.0.0.

Signed-off-by: Cary Phillips <cary@ilm.com>