### PR TITLE
Fix document cross-references in .rst files and other gotchas

### DIFF
--- a/docs/MultiViewOpenEXR.rst
+++ b/docs/MultiViewOpenEXR.rst
@@ -1,3 +1,5 @@
+.. _storing-multi-view-images-in-openexr-files-label:
+   
 Storing Multi-View Images in OpenEXR Files
 ##########################################
 
@@ -141,7 +143,7 @@ For example, the following table shows several different combinations of
      - channel names
    * - ``left right``
      - ``R`` ``G`` ``B`` ``A``
-       ``right.R`` ``right.G`` ``right.B`` ``right.A
+       ``right.R`` ``right.G`` ``right.B`` ``right.A``
    * - ``right left``
      - ``R`` ``G`` ``B`` ``A
        ``left.R`` ``left.G`` ``left.B`` ``left.A``
@@ -176,7 +178,7 @@ interaction or other external information.
 Library Support
 ===============
 
-The OpenEXR file I/O library, IlmImf, provides utility functions to
+The OpenEXR file I/O library, OpenEXR, provides utility functions to
 support reading and writing multi-view files. Header file
 ``ImfStandardAttributes.h`` defines functions to add a ``multiView``
 attribute to a file header, to test if a file header contains a

--- a/docs/MultiViewOpenEXR.rst
+++ b/docs/MultiViewOpenEXR.rst
@@ -1,5 +1,3 @@
-.. _storing-multi-view-images-in-openexr-files-label:
-   
 Storing Multi-View Images in OpenEXR Files
 ##########################################
 

--- a/docs/OpenEXRFileLayout.rst
+++ b/docs/OpenEXRFileLayout.rst
@@ -1,3 +1,5 @@
+.. _openexr-file-layout-label:
+
 OpenEXR File Layout
 ###################
 
@@ -10,11 +12,11 @@ deep data is handled.
 
 The text assumes that the reader is familiar with OpenEXR terms such as
 "channel", "attribute", "data window" or "chunk". For an explanation of
-those terms see :doc:`Technical Introduction to OpenEXR`.
+those terms see :ref:`technical-introduction-to-openexr-label`.
 
 **Note:** This document does not define the OpenEXR file format.  OpenEXR is
-defined as the file format that is read and written by the IlmImf open-source
-C++ library. If this document and the IlmImf library disagree, then the library
+defined as the file format that is read and written by the OpenEXR open-source
+C++ library. If this document and the OpenEXR library disagree, then the library
 takes precedence.
 
 Backwards Compatibility and New or Changed Functionality
@@ -412,7 +414,7 @@ The ``attribute size``, of type ``int``, indicates the size (in bytes) of
 the attribute value.
 
 The layout of the ``attribute value`` depends on the attribute
-type. The IlmImf library predefines several different attribute
+type. The OpenEXR library predefines several different attribute
 types. Application programs can define and store additional attribute
 types.
 
@@ -444,8 +446,8 @@ attributes:
    * - ``screenWindowWidth``
      - ``float``
 
-For descriptions of what these attributes are for, see the
-:doc:`Technical Introduction to OpenEXR`.
+For descriptions of what these attributes are for, see
+:ref:`technical-introduction-to-openexr-label`.
 
 Tile Header Attribute
 ---------------------
@@ -464,7 +466,7 @@ one or more tiles:
      - Determines the size of the tiles and the number of resolution levels
        in the file. 
 
-       **Note:** The IlmImf library ignores tile description attributes in
+       **Note:** The OpenEXR library ignores tile description attributes in
        scan line based files. The decision whether the file contains scan
        lines or tiles is based on the value of bit 9 in the file's version
        field, not on the presence of a tile description attribute.
@@ -522,8 +524,8 @@ deep data OpenEXR files.
      - ``tileDesc``
      - Required for parts of type ``tiledimage`` and ``deeptile``.
 
-Deep Data Header Attributes (New in 2.0)
-----------------------------------------
+Deep Data Header Attributes
+---------------------------
 
 These attributes are required in the header for all files which contain
 deep data (deepscanline or deeptile):
@@ -553,8 +555,9 @@ deep data (deepscanline or deeptile):
      - ``string``
      - Must be set to ``deepscanline`` or ``deeptile``.
 
-For information about channel layout and a list of reserved channel names, see
-the _`Technical Introduction to OpenEXR` document, _`Channel Names` section.
+For information about channel layout and a list of reserved channel
+names, see :ref:`channel-names-label` in
+:ref:`technical-introduction-to-openexr-label`.
 
 Component Four: Offset Tables
 =============================
@@ -595,8 +598,8 @@ For tiles, the offset table is a sequence of tile offsets, one offset
 per tile. In the table, scan line offsets are sorted the same way as
 tiles in ``INCREASING_Y`` order.
 
-Multi-part (New in 2.0)
------------------------
+Multi-Part
+----------
 
 For multi-part files, each part defined in the header component has a
 corresponding chunk offset table.
@@ -649,8 +652,6 @@ same format:
    * - deep tile
      - indicated by a type attribute of “deeptile”
      - See `Deep tiled layout`_.
-
-For more information about data types, see XXX.
 
 Regular Scan Line Blocks
 ------------------------
@@ -720,7 +721,7 @@ whichever is smaller.
 The layout of the compressed data depends on which compression method
 was applied. The compressed formats are not described here. For
 information on the compressed data formats, see the source code for the
-IlmImf library.
+OpenEXR library.
 
 Regular ImageTiles
 ------------------
@@ -857,7 +858,7 @@ data:
 Predefined Attribute Types
 ==========================
 
-The IlmImf library predefines the following attribute types:
+The OpenEXR library predefines the following attribute types:
 
 +--------------------+----------------------------------------------------------------+
 | type name          | data                                                           |
@@ -940,7 +941,7 @@ The IlmImf library predefines the following attribute types:
 |                    | represented as a string length, of type ``int``, followed by a |
 |                    | sequence of ``chars``. The number of strings can be inferred   |
 |                    | from the total attribute size                                  |
-|                    | (see the `Attribute Layout`_ section.                          |
+|                    | (see the `Attribute Layout`_ section).                         |
 +--------------------+----------------------------------------------------------------+
 | ``tiledesc``       | Two ``unsigned int``\ 's: ``xSize``, ``ySize``, followed       |
 |                    | by ``mode``, of type ``unsigned char``, where                  |

--- a/docs/OpenEXRFileLayout.rst
+++ b/docs/OpenEXRFileLayout.rst
@@ -1,5 +1,3 @@
-.. _openexr-file-layout-label:
-
 OpenEXR File Layout
 ###################
 
@@ -12,7 +10,7 @@ deep data is handled.
 
 The text assumes that the reader is familiar with OpenEXR terms such as
 "channel", "attribute", "data window" or "chunk". For an explanation of
-those terms see :ref:`technical-introduction-to-openexr-label`.
+those terms see :doc:`TechnicalIntroduction`.
 
 **Note:** This document does not define the OpenEXR file format.  OpenEXR is
 defined as the file format that is read and written by the OpenEXR open-source
@@ -447,7 +445,7 @@ attributes:
      - ``float``
 
 For descriptions of what these attributes are for, see
-:ref:`technical-introduction-to-openexr-label`.
+:doc:`TechnicalIntroduction`.
 
 Tile Header Attribute
 ---------------------
@@ -556,8 +554,7 @@ deep data (deepscanline or deeptile):
      - Must be set to ``deepscanline`` or ``deeptile``.
 
 For information about channel layout and a list of reserved channel
-names, see :ref:`channel-names-label` in
-:ref:`technical-introduction-to-openexr-label`.
+names, see :ref:`channel-names-label` in :doc:`TechnicalIntroduction`.
 
 Component Four: Offset Tables
 =============================

--- a/docs/OpenEXRFileLayout.rst
+++ b/docs/OpenEXRFileLayout.rst
@@ -10,7 +10,7 @@ deep data is handled.
 
 The text assumes that the reader is familiar with OpenEXR terms such as
 "channel", "attribute", "data window" or "chunk". For an explanation of
-those terms see the `Technical Introduction to OpenEXR`_.
+those terms see :doc:`Technical Introduction to OpenEXR`.
 
 **Note:** This document does not define the OpenEXR file format.  OpenEXR is
 defined as the file format that is read and written by the IlmImf open-source
@@ -444,8 +444,8 @@ attributes:
    * - ``screenWindowWidth``
      - ``float``
 
-For descriptions of what these attributes are for, see the _`Technical
-Introduction to OpenEXR`.
+For descriptions of what these attributes are for, see the
+:doc:`Technical Introduction to OpenEXR`.
 
 Tile Header Attribute
 ---------------------
@@ -484,8 +484,8 @@ This attribute can be used in the header for multi-part files:
      - ``text``
      -
 
-Multi-Part and Deep Data Header Attributes (New in 2.0)
--------------------------------------------------------
+Multi-Part and Deep Data Header Attributes
+------------------------------------------
 
 These attributes are required in the header for all multi-part and/or
 deep data OpenEXR files.
@@ -604,8 +604,8 @@ corresponding chunk offset table.
 Component Five: Pixel data
 ==========================
 
-Chunk Layout (New in 2.0)
--------------------------
+Chunk Layout
+------------
 
 A “chunk” is a general term for a pixel data block. The scan line and
 tile images have the same format that they did in OpenEXR 1.7. OpenEXR
@@ -639,16 +639,16 @@ same format:
      - indicated by a type attribute of “scanlineimage”
      - Each chunk stores a scan line block, with the minimum y coordinate of the
        scan line(s) within the chunk.
-       See `Regular scan line image block layout`.
+       See `Regular scan line image block layout`_.
    * - tiled
      - indicated by a type attribute of “tiledimage”
-     - See _`Regular image tile layout`.
+     - See `Regular image tile layout`_.
    * - deep scan line
      - indicated by a type attribute of “deepscanline”
-     - See _`Deep scan line layout`.
+     - See `Deep scan line layout`_.
    * - deep tile
      - indicated by a type attribute of “deeptile”
-     - See _`Deep tiled layout`.
+     - See `Deep tiled layout`_.
 
 For more information about data types, see XXX.
 
@@ -752,8 +752,8 @@ shorter scan lines. Similarly, if the height of a resolution level is
 not a multiple of the file's tile height, then tiles at the bottom edge
 of the resolution level have fewer scan lines.
 
-Deep Data (New in 2.0)
-----------------------
+Deep Data
+---------
 
 Deep images store an arbitrarily long list of data at each pixel
 location (each pixel contains a list of samples, and each sample

--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -9,14 +9,14 @@ This document shows how to write C++ code that reads and writes OpenEXR
 
 The text assumes that the reader is familiar with OpenEXR terms like
 “channel”, “attribute”, “data window” or “deep data”. For an explanation
-of those terms see the :ref:`technical-introduction-to-openexr-label` document.
+of those terms see the :doc:`TechnicalIntroduction` document.
 
 The OpenEXR source distribution contains a subdirectory, OpenEXRExamples,
 with most of the code examples below. A Makefile is also provided, so
 that the examples can easily be compiled and run.
 
 A description of the file structure and format is provided in
-:ref:`openexr-file-layout-label`.
+:doc:`OpenEXRFileLayout`.
 
 Scan Line Based and Tiled OpenEXR files
 =======================================

--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -9,14 +9,14 @@ This document shows how to write C++ code that reads and writes OpenEXR
 
 The text assumes that the reader is familiar with OpenEXR terms like
 “channel”, “attribute”, “data window” or “deep data”. For an explanation
-of those terms see the :doc:`Technical Introduction to OpenEXR` document.
+of those terms see the :ref:`technical-introduction-to-openexr-label` document.
 
 The OpenEXR source distribution contains a subdirectory, OpenEXRExamples,
 with most of the code examples below. A Makefile is also provided, so
 that the examples can easily be compiled and run.
 
-A description of the file structure and format is provided in `OpenEXR
-File Layout`_.
+A description of the file structure and format is provided in
+:ref:`openexr-file-layout-label`.
 
 Scan Line Based and Tiled OpenEXR files
 =======================================
@@ -67,8 +67,8 @@ worrying about complications related to tiling and multiple resolutions.
 When a multi-resolution file is read via a scan line interface, only the
 highest-resolution version of the image is accessible.
 
-Multi-Part and Deep Data (New in 2.0)
--------------------------------------
+Multi-Part and Deep Data
+------------------------
 
 The procedure for writing multi-part and deep data files is similar to
 writing scan line and tile. Though there is no simplified interface,
@@ -1101,8 +1101,8 @@ or by calling a six-argument version of ``readTiles()``:
 
     in.readTiles (tileXMin, tileXMax, tileYMin, tileYMax, levelX, levelY);
 
-Deep Data Files (New in 2.0)
-============================
+Deep Data Files
+===============
 
 Writing a Deep Scan Line File
 -----------------------------

--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -9,7 +9,7 @@ This document shows how to write C++ code that reads and writes OpenEXR
 
 The text assumes that the reader is familiar with OpenEXR terms like
 “channel”, “attribute”, “data window” or “deep data”. For an explanation
-of those terms see the `Technical Introduction to OpenEXR`_ document.
+of those terms see the :doc:`Technical Introduction to OpenEXR` document.
 
 The OpenEXR source distribution contains a subdirectory, OpenEXRExamples,
 with most of the code examples below. A Makefile is also provided, so

--- a/docs/TechnicalIntroduction.rst
+++ b/docs/TechnicalIntroduction.rst
@@ -1,5 +1,3 @@
-.. _technical-introduction-to-openexr-label:
-
 Technical Introduction to OpenEXR
 #################################
 
@@ -565,7 +563,7 @@ This attribute is required in the header for multi-view OpenEXR files.
        contains information not dependent on a particular eye. 
 
 For more information about multi-view files, see
-:ref:`storing-multi-view-images-in-openexr-files-label`.
+:doc:`MultiViewOpenEXR`.
 
 Multi-part and Deep Data Attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -591,7 +589,7 @@ deep data OpenEXR files.
        4. Deep tiled images:  indicated by a type attribute of ``deeptile``.      
    * - ``version``
      - version 1 data for all part types is described in
-       :ref:`openexr-file-layout-label`.
+       :doc:`OpenEXRFileLayout`.
    * - ``chunkCount``
      - ``chunkCount`` indicates the number of chunks in this part. 
        Required if the multipart bit (12) is set.
@@ -1049,7 +1047,7 @@ stacking order or any compositing operations for combining the layers
 into a final image.
 
 For another example of a channel naming convention, see
-:ref:`storing-multi-view-images-in-openexr-files-label`.
+:doc:`MultiViewOpenEXR`.
 
 Deep Data - Special Purpose Channels and Reserved Channel Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/TechnicalIntroduction.rst
+++ b/docs/TechnicalIntroduction.rst
@@ -1,3 +1,5 @@
+.. _technical-introduction-to-openexr-label:
+
 Technical Introduction to OpenEXR
 #################################
 
@@ -452,8 +454,8 @@ and the view header attribute. This is usually used to store stereo
 files, with one view for each eye. Views can be stored in separate
 files, or together in a single file.
 
-Part (New in 2.0)
-~~~~~~~~~~~~~~~~~
+Part
+~~~~
 
 A *part* is made up of a header and an associated offset table and
 pixels. In a single-part file, there is one header, one offset table,
@@ -464,8 +466,8 @@ corresponding pixel data.
 **Note:** This is different from a multi-view file, though you can
 store views as separate parts if you wish.
 
-Deep data (New in 2.0)
-~~~~~~~~~~~~~~~~~~~~~~
+Deep Data
+~~~~~~~~~
 
 OpenEXR 2.0 supports *deep data*. Deep data images store an
 arbitrarily long list of data at each pixel location. This is
@@ -562,11 +564,11 @@ This attribute is required in the header for multi-view OpenEXR files.
        If there is no ``view`` attribute in the header, the entire part
        contains information not dependent on a particular eye. 
 
-For more information about multi-view files, see `Storing Multi-View Image in
-OpenEXR Files`_.
+For more information about multi-view files, see
+:ref:`storing-multi-view-images-in-openexr-files-label`.
 
-Multi-part and deep data attributes (New in 2.0)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Multi-part and Deep Data Attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These attributes are required in the header for all multi-part and/or
 deep data OpenEXR files.
@@ -588,15 +590,16 @@ deep data OpenEXR files.
        3. Deep scan line images:  indicated by a type attribute of ``deepscanline``. 
        4. Deep tiled images:  indicated by a type attribute of ``deeptile``.      
    * - ``version``
-     - version 1 data for all part types is described in `OpenEXR File Layout`_.
+     - version 1 data for all part types is described in
+       :ref:`openexr-file-layout-label`.
    * - ``chunkCount``
      - ``chunkCount`` indicates the number of chunks in this part. 
        Required if the multipart bit (12) is set.
    * - ``tiles``
      - Required for parts of type ``tiledimage`` and ``deeptile``.
 
-Deep data header attributes (New in 2.0)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Deep Data Header Attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These attributes are required in the header for all files which contain
 deep data (deepscanline or deeptile):
@@ -993,6 +996,8 @@ attribute with the following values:
 | white | 1/3, 1/3       |
 +-------+----------------+
 
+.. _channel-names-label:
+   
 Channel Names
 -------------
 
@@ -1043,10 +1048,10 @@ Note that this naming convention does not describe a back-to-front
 stacking order or any compositing operations for combining the layers
 into a final image.
 
-For another example of a channel naming convention, see `Storing
-Multi-View Images in OpenEXR Files`_.
+For another example of a channel naming convention, see
+:ref:`storing-multi-view-images-in-openexr-files-label`.
 
-Deep Data - Ppecial Purpose Channels and Reserved Channel Names
+Deep Data - Special Purpose Channels and Reserved Channel Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Deep data parts reserve a set of channel names for sorts of data often


### PR DESCRIPTION
- The :ref: directive is the only one that Sphinx seems to recognize for cross-document references.
- Also, remove the "(New in 2.0)" in section headers. 2.0 was 8 years ago. 
- Also, change a few stray references to "IlmImf" to "OpenEXR".
    
