### PR TITLE
Include <x86intrin.h> only if defined(__x86_64__)

### DIFF
--- a/src/lib/OpenEXRCore/internal_coding.h
+++ b/src/lib/OpenEXRCore/internal_coding.h
@@ -24,8 +24,8 @@
 #    include <half.h>
 #endif
 
-#if defined(__has_include) 
-#    if __has_include(<x86intrin.h>) && defined(__x86_64__)
+#if defined(__has_include) && defined(__x86_64__)
+#    if __has_include(<x86intrin.h>)
 #        include <x86intrin.h>
 #    elif __has_include(<intrin.h>)
 #        include <intrin.h>

--- a/src/lib/OpenEXRCore/internal_coding.h
+++ b/src/lib/OpenEXRCore/internal_coding.h
@@ -24,8 +24,8 @@
 #    include <half.h>
 #endif
 
-#if defined(__has_include)
-#    if __has_include(<x86intrin.h>)
+#if defined(__has_include) 
+#    if __has_include(<x86intrin.h>) && defined(__x86_64__)
 #        include <x86intrin.h>
 #    elif __has_include(<intrin.h>)
 #        include <intrin.h>

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -11,6 +11,7 @@
 
 #include <limits.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <zlib.h>
 


### PR DESCRIPTION
Hopefully address #1105?

Signed-off-by: Cary Phillips <cary@ilm.com>