### PR TITLE
Remove an old check for bsd, all the bsd-ish OSes seem to have the leXXtoh functions

### DIFF
--- a/src/lib/OpenEXRCore/internal_xdr.h
+++ b/src/lib/OpenEXRCore/internal_xdr.h
@@ -59,20 +59,9 @@
 #  define le64toh(x) OSSwapLittleToHostInt64(x)
 #  define EXR_HOST_IS_NOT_LITTLE_ENDIAN (BYTE_ORDER != LITTLE_ENDIAN)
 
-#elif defined(__OpenBSD__)
+#elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 
 #  include <sys/endian.h>
-#  define EXR_HOST_IS_NOT_LITTLE_ENDIAN (__BYTE_ORDER != __LITTLE_ENDIAN)
-
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
-
-#  include <sys/endian.h>
-#  define be16toh(x) betoh16(x)
-#  define le16toh(x) letoh16(x)
-#  define be32toh(x) betoh32(x)
-#  define le32toh(x) letoh32(x)
-#  define be64toh(x) betoh64(x)
-#  define le64toh(x) letoh64(x)
 #  define EXR_HOST_IS_NOT_LITTLE_ENDIAN (__BYTE_ORDER != __LITTLE_ENDIAN)
 
 #else


### PR DESCRIPTION

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>