### PR TITLE
Improve handling of #include <*intrin.h>

### DIFF
--- a/src/lib/OpenEXRCore/internal_coding.h
+++ b/src/lib/OpenEXRCore/internal_coding.h
@@ -24,13 +24,12 @@
 #    include <half.h>
 #endif
 
-#if defined(__has_include) && defined(__x86_64__)
-#    if __has_include(<x86intrin.h>)
-#        include <x86intrin.h>
-#    elif __has_include(<intrin.h>)
+#ifdef _WIN32
 #        include <intrin.h>
-#    endif
+#elif defined(__x86_64__)
+#        include <x86intrin.h>
 #endif
+
 #include <math.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Don't use __has_include, it may report files exist when they don't.

Signed-off-by: Cary Phillips <cary@ilm.com>