### PR TITLE
Docs: fixed wrong code examples in "how to read a file" section

### DIFF
--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -129,7 +129,7 @@ to ``(0,0) - (width-1, height-1)``. The channel list contains four channels,
 
 Line 5 specifies how the pixel data are laid out in memory. In our
 example, the ``pixels`` pointer is assumed to point to the beginning of an
-array of ``width``height* pixels. The pixels are represented as ``Rgba``
+array of ``width*height`` pixels. The pixels are represented as ``Rgba``
 structs, which are defined like this:
 
 .. code-block::
@@ -313,7 +313,7 @@ Reading an RGBA Image File
 
 Reading an RGBA image is almost as easy as writing one:
 
-.. literalinclude:: src/writeRgba1.cpp
+.. literalinclude:: src/readRgba1.cpp
    :language: c++
    :linenos:
                     
@@ -377,7 +377,7 @@ incrementally this way. With clever buffering of a few extra scan lines,
 incremental versions of operations that require access to neighboring
 pixels, like blurring or sharpening, are also possible.
 
-.. literalinclude:: src/writeRgba2.cpp
+.. literalinclude:: src/readRgba2.cpp
    :language: c++
    :linenos:
 


### PR DESCRIPTION
The "reading and writing image files" was including "write" example snippets where "read" snippets should have been.