### PR TITLE
Remove throw from ~IlmThread

### DIFF
--- a/src/lib/IlmThread/IlmThread.cpp
+++ b/src/lib/IlmThread/IlmThread.cpp
@@ -76,7 +76,6 @@ Thread::Thread ()
 
 Thread::~Thread ()
 {
-    throw IEX_NAMESPACE::NoImplExc ("Threads not supported / enabled on this platform.");
 }
 
 


### PR DESCRIPTION
It's unnecessary and it causes a warning.

Signed-off-by: Cary Phillips <cary@ilm.com>