### PR TITLE
Switch default Zip compression level from 6 to 4

### DIFF
--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -65,7 +65,7 @@ using IMATH_NAMESPACE::V2f;
 namespace
 {
 
-static int   s_DefaultZipCompressionLevel = Z_DEFAULT_COMPRESSION;
+static int   s_DefaultZipCompressionLevel = 4;
 static float s_DefaultDwaCompressionLevel = 45.f;
 
 struct CompressionRecord
@@ -358,12 +358,15 @@ Header::Header (const Header& other)
     {
 	insert (*i->first, *i->second);
     }
+    copyCompressionRecord(this, &other);
 }
 
 Header::Header (Header&& other)
     : _map (std::move (other._map))
     , _readsNothing (other._readsNothing)
-{}
+{
+    copyCompressionRecord(this, &other);
+}
 
 Header::~Header ()
 {


### PR DESCRIPTION
Kinda related to #1002 but this one does not add any new libraries or compressors. After #1149 added controllable zip compression levels, this makes the **default zip level change; from 6 to 4**.

In my test of 18 various exr files (total raw data size 1057MB):
- zip 6: 2.452x ratio, 206MB/s compression
- zip 4: 2.421x ratio, 437MB/s compression

So a tiny drop of compression ratio, but compression is more than 2x faster. This makes writing zip faster than writing uncompressed (386MB/s). Decompression speed unaffected.

A longer writeup of all this, with data graphs: https://aras-p.info/blog/2021/08/05/EXR-Zip-compression-levels/

<img width="647" alt="Screenshot 2021-08-05 at 09 24 57" src="https://user-images.githubusercontent.com/348087/128302102-581cd1f4-7be8-4736-85bb-a4f7b41324f0.png">
