### PR TITLE
Fix unpack planar half float

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -417,7 +417,7 @@ unpack_16bit_3chan_planar (exr_decode_pipeline_t* decode)
     {
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
-        in2 = in1 + 1;
+        in2 = in1 + w;
         srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
 #if EXR_HOST_IS_NOT_LITTLE_ENDIAN
@@ -471,7 +471,7 @@ unpack_half_to_float_3chan_planar (exr_decode_pipeline_t* decode)
     {
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
-        in2 = in1 + 1;
+        in2 = in1 + w;
         srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
         half_to_float_buffer ((float*) out0, in0, w);

--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -144,11 +144,13 @@ static void (*half_to_float_buffer) (float*, const uint16_t*, int) =
 static void
 choose_half_to_float_impl ()
 {
+    // regs[2] in the extended block is ECX, where f16c indicator lives
 #        ifdef _WIN32
     int regs[4];
 
     __cpuid (regs, 0);
     if (regs[0] >= 1) { __cpuidex (regs, 1, 0); }
+    else regs[2] = 0;
 #        else
     unsigned int regs[4];
     __get_cpuid (0, &regs[0], &regs[1], &regs[2], &regs[3]);
@@ -156,9 +158,11 @@ choose_half_to_float_impl ()
     {
         __get_cpuid (1, &regs[0], &regs[1], &regs[2], &regs[3]);
     }
+    else
+        regs[2] = 0;
 #        endif
     /* F16C is indicated by bit 29 */
-    if (regs[0] & (1 << 29)) half_to_float_buffer = &half_to_float_buffer_f16c;
+    if (regs[2] & (1 << 29)) half_to_float_buffer = &half_to_float_buffer_f16c;
 }
 #    else
 /* when we explicitly compile against f16, force it in */


### PR DESCRIPTION
The special case conversion routines when converting half to float and unpacking to planar had a copy/paste error. Also, the f16c check routine was checking the incorrect register for the f16c bit