### PR TITLE
the HufDec struct used during decompression also contains a pointer

### DIFF
--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -1333,8 +1333,9 @@ testHUF (const std::string& tempdir)
 {
     uint64_t esize = internal_exr_huf_compress_spare_bytes ();
     uint64_t dsize = internal_exr_huf_decompress_spare_bytes ();
-    EXRCORE_TEST (esize == 65537 * (8 + 8 + sizeof(void*) + 4));
-    EXRCORE_TEST (dsize == (65537 * 8 + (1 << 14) * 16));
+    EXRCORE_TEST (esize == 65537 * (8 + 8 + sizeof (uint64_t*) + 4));
+    EXRCORE_TEST (
+        dsize == (65537 * 8 + (1 << 14) * (sizeof (uint32_t*) + 4 + 4)));
 
     std::vector<uint8_t> hspare;
 


### PR DESCRIPTION
Account for that for 32-bit machines in the unit / coverage test.
After some testing on a pi w/ armv7, the tests appear to pass fully now, which should address #1135 

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>