### PR TITLE
Remove unused variable _maxScanLineSize from B44Compressor

### DIFF
--- a/src/lib/OpenEXR/ImfB44Compressor.cpp
+++ b/src/lib/OpenEXR/ImfB44Compressor.cpp
@@ -444,7 +444,6 @@ B44Compressor::B44Compressor
      bool optFlatFields)
 :
     Compressor (hdr),
-    _maxScanLineSize (static_cast<int>(maxScanLineSize)),
     _optFlatFields (optFlatFields),
     _format (XDR),
     _numScanLines (static_cast<int>(numScanLines)),

--- a/src/lib/OpenEXR/ImfB44Compressor.h
+++ b/src/lib/OpenEXR/ImfB44Compressor.h
@@ -72,7 +72,6 @@ class B44Compressor: public Compressor
 				    IMATH_NAMESPACE::Box2i range,
 				    const char *&outPtr);
 
-    int			_maxScanLineSize;
     bool		_optFlatFields;
     Format		_format;
     int			_numScanLines;


### PR DESCRIPTION
Remove unused variable _maxScanLineSize from B44Compressor