### PR TITLE
Fix issue with unpacked size computation

### DIFF
--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -97,7 +97,8 @@ struct _internal_exr_part
     int32_t* tile_level_tile_size_y;
 
     uint64_t unpacked_size_per_chunk;
-    int32_t  lines_per_chunk;
+    int16_t  lines_per_chunk;
+    int16_t  chan_has_line_sampling;
 
     int32_t          chunk_count;
     uint64_t         chunk_table_offset;

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2134,7 +2134,7 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
     }
     else
     {
-        uint64_t linePerChunk;
+        uint64_t linePerChunk, h;
         switch (curpart->comp_type)
         {
             case EXR_COMPRESSION_NONE:
@@ -2176,7 +2176,8 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
         curpart->lines_per_chunk         = ((int16_t) linePerChunk);
         curpart->chan_has_line_sampling  = ((int16_t) hasLineSample);
 
-        retval = (int32_t) ((w + linePerChunk - 1) / linePerChunk);
+        h      = (uint64_t) dw.max.y - (uint64_t) dw.min.y + 1;
+        retval = (int32_t) ((h + linePerChunk - 1) / linePerChunk);
     }
     return retval;
 }

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2072,10 +2072,10 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
     const exr_attr_box2i_t   dw           = curpart->data_window;
     const exr_attr_chlist_t* channels     = curpart->channels->chlist;
     uint64_t                 unpackedsize = 0;
-    int64_t                  w;
+    uint64_t                 w;
     int                      hasLineSample = 0;
 
-    w = ((int64_t) dw.max.x) - ((int64_t) dw.min.x) + 1;
+    w = (uint64_t) (((int64_t) dw.max.x) - ((int64_t) dw.min.x) + 1);
 
     if (curpart->tiles)
     {
@@ -2112,20 +2112,18 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
 
         for (int c = 0; c < channels->num_channels; ++c)
         {
-            int32_t  xsamp  = channels->entries[c].x_sampling;
-            int32_t  ysamp  = channels->entries[c].y_sampling;
+            uint64_t xsamp  = (uint64_t) channels->entries[c].x_sampling;
+            uint64_t ysamp  = (uint64_t) channels->entries[c].y_sampling;
             uint64_t cunpsz = 0;
             if (channels->entries[c].pixel_type == EXR_PIXEL_HALF)
                 cunpsz = 2;
             else
                 cunpsz = 4;
-            cunpsz *=
-                (uint64_t) (((uint64_t) tiledesc->x_size + (uint64_t) xsamp - 1) / (uint64_t) xsamp);
+            cunpsz *= (((uint64_t) tiledesc->x_size + xsamp - 1) / xsamp);
             if (ysamp > 1)
             {
                 hasLineSample = 1;
-                cunpsz *=
-                    (uint64_t) (((uint64_t) tiledesc->y_size + (uint64_t) ysamp - 1) / (uint64_t) ysamp);
+                cunpsz *= (((uint64_t) tiledesc->y_size + ysamp - 1) / ysamp);
             }
             else
                 cunpsz *= (uint64_t) tiledesc->y_size;
@@ -2136,7 +2134,7 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
     }
     else
     {
-        int linePerChunk;
+        uint64_t linePerChunk;
         switch (curpart->comp_type)
         {
             case EXR_COMPRESSION_NONE:
@@ -2157,20 +2155,19 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
 
         for (int c = 0; c < channels->num_channels; ++c)
         {
-            int32_t  xsamp  = channels->entries[c].x_sampling;
-            int32_t  ysamp  = channels->entries[c].y_sampling;
+            uint64_t xsamp  = (uint64_t) channels->entries[c].x_sampling;
+            uint64_t ysamp  = (uint64_t) channels->entries[c].y_sampling;
             uint64_t cunpsz = 0;
             if (channels->entries[c].pixel_type == EXR_PIXEL_HALF)
                 cunpsz = 2;
             else
                 cunpsz = 4;
-            cunpsz *= (uint64_t) (w / xsamp);
-            cunpsz *= ((uint64_t) linePerChunk);
+            cunpsz *= w / xsamp;
+            cunpsz *= linePerChunk;
             if (ysamp > 1)
             {
                 hasLineSample = 1;
-                if (linePerChunk > 1)
-                    cunpsz *= (uint64_t) (linePerChunk / ysamp);
+                if (linePerChunk > 1) cunpsz *= linePerChunk / ysamp;
             }
             unpackedsize += cunpsz;
         }
@@ -2179,9 +2176,7 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
         curpart->lines_per_chunk         = ((int16_t) linePerChunk);
         curpart->chan_has_line_sampling  = ((int16_t) hasLineSample);
 
-        /* h = max - min + 1, but to do size / divide by round,
-         * we'd do linePerChunk - 1, so the math cancels */
-        retval = (dw.max.y - dw.min.y + linePerChunk) / linePerChunk;
+        retval = (int32_t) ((w + linePerChunk - 1) / linePerChunk);
     }
     return retval;
 }


### PR DESCRIPTION
This was an issue with any compression type that encodes a single
scanline per chunk, the unpacked size would end up incorrect.

Fixes #1137 

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>