### PR TITLE
Simplify the definition for bswap_32 for NetBSD

### DIFF
--- a/src/test/OpenEXRTest/bswap_32.h
+++ b/src/test/OpenEXRTest/bswap_32.h
@@ -20,10 +20,8 @@
 #define bswap_32(x) swap32(x)
 #elif defined(__NetBSD__)
 #include <sys/types.h>
-#include <machine/bswap.h>
-#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#include <sys/bswap.h>
 #define bswap_32(x) bswap32(x)
-#endif
 #else
 #include <byteswap.h>
 #endif


### PR DESCRIPTION
It should be the same on all NetBSD architectures.

The old code does not build on many non-x86_64 architectures (I tested sparc64).