### PR TITLE
Enable ephemeral compression levels

### DIFF
--- a/cmake/OpenEXRConfig.h.in
+++ b/cmake/OpenEXRConfig.h.in
@@ -147,4 +147,16 @@
 
 #endif
 
+#if defined(__cplusplus) && (__cplusplus >= 201402L)
+# define OPENEXR_DEPRECATED(msg) [[deprecated(msg)]]
+#endif
+
+#ifndef OPENEXR_DEPRECATED
+# ifdef _MSC_VER
+#  define OPENEXR_DEPRECATED(msg) __declspec(deprecated(msg))
+# else
+#  define OPENEXR_DEPRECATED(msg) __attribute__((deprecated(msg)))
+# endif
+#endif
+
 #endif // INCLUDED_OPENEXR_CONFIG_H

--- a/src/lib/OpenEXR/ImfCompression.h
+++ b/src/lib/OpenEXR/ImfCompression.h
@@ -49,6 +49,13 @@ enum IMF_EXPORT_ENUM Compression
     NUM_COMPRESSION_METHODS	// number of different compression methods
 };
 
+/// Controls the default zip compression level used. Zip is used for
+/// the 2 zip levels as well as some modes of the DWAA/B compression.
+IMF_EXPORT void setDefaultZipCompressionLevel (int level);
+
+/// Controls the default quality level for the DWA lossy compression
+IMF_EXPORT void setDefaultDwaCompressionLevel (float level);
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 

--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -1804,16 +1804,17 @@ DwaCompressor::DwaCompressor
     _maxScanLineSize(maxScanLineSize),
     _numScanLines(numScanLines),
     _channels(hdr.channels()),
-    _packedAcBuffer(0),
+    _packedAcBuffer(nullptr),
     _packedAcBufferSize(0),
-    _packedDcBuffer(0),
+    _packedDcBuffer(nullptr),
     _packedDcBufferSize(0),
-    _rleBuffer(0),
+    _rleBuffer(nullptr),
     _rleBufferSize(0),
-    _outBuffer(0),
+    _outBuffer(nullptr),
     _outBufferSize(0),
-    _zip(0),
-    _dwaCompressionLevel(45.0)
+    _zip(nullptr),
+    _zipLevel(hdr.zipCompressionLevel()),
+    _dwaCompressionLevel(hdr.dwaCompressionLevel())
 {
     _min[0] = hdr.dataWindow().min.x;
     _min[1] = hdr.dataWindow().min.y;
@@ -1825,13 +1826,6 @@ DwaCompressor::DwaCompressor
         _planarUncBuffer[i] = 0;
         _planarUncBufferSize[i] = 0;
     }
-    
-    //
-    // Check the header for a quality attribute
-    //
-
-    if (hasDwaCompressionLevel (hdr))
-        _dwaCompressionLevel = dwaCompressionLevel (hdr);
 }
 
 
@@ -3020,11 +3014,11 @@ DwaCompressor::initializeBuffers (size_t &outBufferSize)
     //
 
     if (_zip == 0) 
-        _zip = new Zip (maxLossyDctDcSize * numLossyDctChans);
+        _zip = new Zip (maxLossyDctDcSize * numLossyDctChans, _zipLevel);
     else if (_zip->maxRawSize() < static_cast<size_t>(maxLossyDctDcSize * numLossyDctChans))
     {
         delete _zip;
-        _zip = new Zip (maxLossyDctDcSize * numLossyDctChans);
+        _zip = new Zip (maxLossyDctDcSize * numLossyDctChans, _zipLevel);
     }
 
 

--- a/src/lib/OpenEXR/ImfDwaCompressor.h
+++ b/src/lib/OpenEXR/ImfDwaCompressor.h
@@ -144,8 +144,9 @@ class DwaCompressor: public Compressor
     char*             _planarUncBuffer[NUM_COMPRESSOR_SCHEMES];
     uint64_t          _planarUncBufferSize[NUM_COMPRESSOR_SCHEMES];
 
-    Zip              *_zip;
-    float             _dwaCompressionLevel;
+    Zip*  _zip;
+    int   _zipLevel;
+    float _dwaCompressionLevel;
 
     int compress (const char              *inPtr,
                   int                     inSize,

--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -65,13 +65,17 @@ using IMATH_NAMESPACE::V2f;
 namespace
 {
 
-static const int   kDefaultZipCompressionLevel = Z_DEFAULT_COMPRESSION;
-static const float kDefaultDwaCompressionLevel = 45.f;
+static int   s_DefaultZipCompressionLevel = Z_DEFAULT_COMPRESSION;
+static float s_DefaultDwaCompressionLevel = 45.f;
 static std::mutex s_globCompressionMutex;
 struct CompressionRecord
 {
-    int zip_level = kDefaultZipCompressionLevel;
-    float dwa_level = kDefaultDwaCompressionLevel;
+    CompressionRecord()
+        : zip_level (s_DefaultZipCompressionLevel),
+          dwa_level (s_DefaultDwaCompressionLevel)
+    {}
+    int zip_level;
+    float dwa_level;
 };
 static std::map<const void *, CompressionRecord> s_globCompressionStore;
 
@@ -164,6 +168,16 @@ sanityCheckDisplayWindow (int width, int height)
 }
 
 } // namespace
+
+void setDefaultZipCompressionLevel (int level)
+{
+    s_DefaultZipCompressionLevel = level;
+}
+
+void setDefaultDwaCompressionLevel (float level)
+{
+    s_DefaultDwaCompressionLevel = level;
+}
 
 Header::Header (
     int         width,

--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -490,9 +490,6 @@ class IMF_EXPORT_TYPE Header
 private:
     AttributeMap _map;
 
-    int   _zipCompressionLevel;
-    float _dwaCompressionLevel;
-
     bool _readsNothing;
 };
 

--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -91,8 +91,9 @@ class IMF_EXPORT_TYPE Header
     //-----------------
 
     IMF_EXPORT
-    Header (const Header &other);
-
+    Header (const Header& other);
+    IMF_EXPORT
+    Header (Header&& other);
 
     //-----------
     // Destructor
@@ -107,8 +108,9 @@ class IMF_EXPORT_TYPE Header
     //-----------
 
     IMF_EXPORT
-    Header &			operator = (const Header &other);
-
+    Header& operator= (const Header& other);
+    IMF_EXPORT
+    Header& operator= (Header&& other);
 
     //---------------------------------------------------------------
     // Add an attribute:
@@ -271,6 +273,25 @@ class IMF_EXPORT_TYPE Header
     IMF_EXPORT
     const Compression &		compression () const;
 
+    //-----------------------------------------------------
+    // The header object allows one to store a compression level to be
+    // used when writing a file.
+    //
+    // NB: These are NOT attributes, and will not be written to the
+    // file, but are instead ephemeral settings to be used for this
+    // instance of the header object.
+    //
+    // -----------------------------------------------------
+    IMF_EXPORT
+    void resetDefaultCompressionLevels ();
+    IMF_EXPORT
+    int& zipCompressionLevel ();
+    IMF_EXPORT
+    int zipCompressionLevel () const;
+    IMF_EXPORT
+    float& dwaCompressionLevel ();
+    IMF_EXPORT
+    float dwaCompressionLevel () const;
 
     //-----------------------------------------------------
     // Access to required attributes for multipart files
@@ -466,11 +487,13 @@ class IMF_EXPORT_TYPE Header
         			          int &version);
     
 
-  private:
+private:
+    AttributeMap _map;
 
-    AttributeMap		_map;
+    int   _zipCompressionLevel;
+    float _dwaCompressionLevel;
 
-    bool                        _readsNothing;
+    bool _readsNothing;
 };
 
 

--- a/src/lib/OpenEXR/ImfStandardAttributes.h
+++ b/src/lib/OpenEXR/ImfStandardAttributes.h
@@ -45,19 +45,38 @@
 #define IMF_HAS_SUFFIX(suffix) has##suffix
 #define IMF_NAME_ATTRIBUTE(name) name##Attribute
 
-#define IMF_STD_ATTRIBUTE_DEF(name,suffix,object)                            \
-                                                                             \
-    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER                              \
-    IMF_EXPORT void           IMF_ADD_SUFFIX(suffix) (Header &header, const object &v); \
-    IMF_EXPORT bool           IMF_HAS_SUFFIX(suffix) (const Header &header);     \
-    IMF_EXPORT const TypedAttribute<object> &                                \
-                              IMF_NAME_ATTRIBUTE(name) (const Header &header); \
-    IMF_EXPORT TypedAttribute<object> &                                      \
-                              IMF_NAME_ATTRIBUTE(name) (Header &header);     \
-    IMF_EXPORT const object &                                                \
-                              name (const Header &header);                   \
-    IMF_EXPORT object &       name (Header &header);                         \
-    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT                               \
+#define IMF_STD_ATTRIBUTE_DEF(name, suffix, object)                            \
+                                                                               \
+    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER                                \
+    IMF_EXPORT void IMF_ADD_SUFFIX (suffix) (                                  \
+        Header & header, const object& v);                                     \
+    IMF_EXPORT bool  IMF_HAS_SUFFIX (suffix) (const Header& header);           \
+    IMF_EXPORT const TypedAttribute<object>& IMF_NAME_ATTRIBUTE (name) (       \
+        const Header& header);                                                 \
+    IMF_EXPORT TypedAttribute<object>& IMF_NAME_ATTRIBUTE (name) (             \
+        Header & header);                                                      \
+    IMF_EXPORT const object& name (const Header& header);                      \
+    IMF_EXPORT object& name (Header& header);                                  \
+    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#define IMF_STD_ATTRIBUTE_DEF_DEPRECATED(name, suffix, object, msg)            \
+                                                                               \
+    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER                                \
+    OPENEXR_DEPRECATED (msg)                                                   \
+    IMF_EXPORT void IMF_ADD_SUFFIX (suffix) (                                  \
+        Header & header, const object& v);                                     \
+    OPENEXR_DEPRECATED (msg)                                                   \
+    IMF_EXPORT bool IMF_HAS_SUFFIX (suffix) (const Header& header);            \
+    OPENEXR_DEPRECATED (msg)                                                   \
+    IMF_EXPORT const TypedAttribute<object>& IMF_NAME_ATTRIBUTE (name) (       \
+        const Header& header);                                                 \
+    OPENEXR_DEPRECATED (msg)                                                   \
+    IMF_EXPORT TypedAttribute<object>& IMF_NAME_ATTRIBUTE (name) (             \
+        Header & header);                                                      \
+    OPENEXR_DEPRECATED (msg)                                                   \
+    IMF_EXPORT const object&            name (const Header& header);           \
+    OPENEXR_DEPRECATED (msg) IMF_EXPORT object& name (Header& header);         \
+    OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 //
 // chromaticities -- for RGB images, specifies the CIE (x,y)
@@ -350,8 +369,12 @@ IMF_STD_ATTRIBUTE_DEF
 // dwaCompressionLevel -- sets the quality level for images compressed
 // with the DWAA or DWAB method.
 //
-
-IMF_STD_ATTRIBUTE_DEF (dwaCompressionLevel, DwaCompressionLevel, float)
+// DEPRECATED: use the methods directly in the header
+IMF_STD_ATTRIBUTE_DEF_DEPRECATED (
+    dwaCompressionLevel,
+    DwaCompressionLevel,
+    float,
+    "use compression method in ImfHeader")
 
 //
 // ID Manifest

--- a/src/lib/OpenEXR/ImfZip.cpp
+++ b/src/lib/OpenEXR/ImfZip.cpp
@@ -14,16 +14,18 @@
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-Zip::Zip(size_t maxRawSize):
+Zip::Zip(size_t maxRawSize, int level):
     _maxRawSize(maxRawSize),
-    _tmpBuffer(0)
+    _tmpBuffer(0),
+    _zipLevel(level)
 {
     _tmpBuffer = new char[_maxRawSize];
 }
 
-Zip::Zip(size_t maxScanLineSize, size_t numScanLines):
+Zip::Zip(size_t maxScanLineSize, size_t numScanLines, int level):
     _maxRawSize(0),
-    _tmpBuffer(0)
+    _tmpBuffer(0),
+    _zipLevel(level)
 {
     _maxRawSize = uiMult (maxScanLineSize, numScanLines);
     _tmpBuffer  = new char[_maxRawSize];
@@ -98,8 +100,8 @@ Zip::compress(const char *raw, int rawSize, char *compressed)
 
     uLongf outSize = int(ceil(rawSize * 1.01)) + 100;
 
-    if (Z_OK != ::compress ((Bytef *)compressed, &outSize,
-                (const Bytef *) _tmpBuffer, rawSize))
+    if (Z_OK != ::compress2 ((Bytef *)compressed, &outSize,
+                             (const Bytef *) _tmpBuffer, rawSize, _zipLevel))
     {
         throw IEX_NAMESPACE::BaseExc ("Data compression (zlib) failed.");
     }

--- a/src/lib/OpenEXR/ImfZip.h
+++ b/src/lib/OpenEXR/ImfZip.h
@@ -16,8 +16,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 class Zip
 {
     public:
-        explicit Zip(size_t rawMaxSize);
-        Zip(size_t maxScanlineSize, size_t numScanLines);
+        explicit Zip (size_t rawMaxSize, int level);
+        Zip (size_t maxScanlineSize, size_t numScanLines, int level);
         ~Zip();
 
         Zip (const Zip& other) = delete;
@@ -44,6 +44,7 @@ class Zip
     private:
         size_t _maxRawSize;
         char  *_tmpBuffer;
+        int    _zipLevel;
 };
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/lib/OpenEXR/ImfZipCompressor.cpp
+++ b/src/lib/OpenEXR/ImfZipCompressor.cpp
@@ -15,6 +15,7 @@
 #include "Iex.h"
 #include <zlib.h>
 #include "ImfNamespace.h"
+#include "ImfHeader.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -28,7 +29,7 @@ ZipCompressor::ZipCompressor
     _maxScanLineSize (maxScanLineSize),
     _numScanLines (numScanLines),
     _outBuffer (0),
-    _zip(maxScanLineSize, numScanLines)
+    _zip(maxScanLineSize, numScanLines, hdr.zipCompressionLevel())
 {
     // TODO: Remove this when we can change the ABI
     (void) _maxScanLineSize;

--- a/src/lib/OpenEXRCore/CMakeLists.txt
+++ b/src/lib/OpenEXRCore/CMakeLists.txt
@@ -5,6 +5,8 @@ openexr_define_library(OpenEXRCore
   PRIV_EXPORT OPENEXRCORE_EXPORTS
   CURDIR ${CMAKE_CURRENT_SOURCE_DIR}
   SOURCES
+    # old versions of structures
+    backward_compatibility.h
     #NB: If you make any of these public, make sure to update the
     # locking macros in the relative source files
     internal_attr.h

--- a/src/lib/OpenEXRCore/backward_compatibility.h
+++ b/src/lib/OpenEXRCore/backward_compatibility.h
@@ -1,0 +1,26 @@
+/*
+** SPDX-License-Identifier: BSD-3-Clause
+** Copyright Contributors to the OpenEXR Project.
+*/
+
+#ifndef OPENEXR_BACKWARD_COMPATIBILITY_H
+#define OPENEXR_BACKWARD_COMPATIBILITY_H
+
+struct _exr_context_initializer_v1
+{
+    size_t size;
+    exr_error_handler_cb_t error_handler_fn;
+    exr_memory_allocation_func_t alloc_fn;
+    exr_memory_free_func_t free_fn;
+    void* user_data;
+    exr_read_func_ptr_t read_fn;
+    exr_query_size_func_ptr_t size_fn;
+    exr_write_func_ptr_t write_fn;
+    exr_destroy_stream_func_ptr_t destroy_fn;
+    int max_image_width;
+    int max_image_height;
+    int max_tile_width;
+    int max_tile_height;
+};
+
+#endif /* OPENEXR_BACKWARD_COMPATIBILITY_H */

--- a/src/lib/OpenEXRCore/base.c
+++ b/src/lib/OpenEXRCore/base.c
@@ -119,8 +119,7 @@ const char*
 exr_get_error_code_as_string (exr_result_t code)
 {
     int idx = (int) code;
-    if (idx < 0 || idx >= the_error_code_count)
-        idx = the_error_code_count - 1;
+    if (idx < 0 || idx >= the_error_code_count) idx = the_error_code_count - 1;
     return the_error_code_names[idx];
 }
 
@@ -170,4 +169,44 @@ exr_get_default_maximum_tile_size (int* w, int* h)
 {
     if (w) *w = sTileMaxW;
     if (h) *h = sTileMaxH;
+}
+
+/**************************************/
+
+static int sDefaultZipLevel = -1;
+
+void
+exr_set_default_zip_compression_level (int l)
+{
+    if (l < 0) l = -1;
+    if (l > 9) l = 9;
+    sDefaultZipLevel = l;
+}
+
+/**************************************/
+
+void
+exr_get_default_zip_compression_level (int* l)
+{
+    if (l) *l = sDefaultZipLevel;
+}
+
+/**************************************/
+
+static float sDefaultDwaLevel = 45.f;
+
+void
+exr_set_default_dwa_compression_quality (float q)
+{
+    if (q < 0.f) q = 0.f;
+    if (q > 100.f) q = 100.f;
+    sDefaultDwaLevel = q;
+}
+
+/**************************************/
+
+void
+exr_get_default_dwa_compression_quality (float* q)
+{
+    if (q) *q = sDefaultDwaLevel;
 }

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -7,6 +7,7 @@
 #include "internal_attr.h"
 #include "internal_constants.h"
 #include "internal_memory.h"
+#include "backward_compatibility.h"
 
 #include <IlmThreadConfig.h>
 
@@ -249,8 +250,8 @@ internal_exr_add_part (
     part->display_window.max.y = -1;
     part->chunk_count          = -1;
 
-    part->zip_compression_level = -1;
-    part->dwa_compression_level = 45.f;
+    part->zip_compression_level = f->default_zip_level;
+    part->dwa_compression_level = f->default_dwa_quality;
 
     /* put it into the part table */
     if (ncount > 1)
@@ -390,6 +391,16 @@ internal_exr_alloc_context (
         if (ret->max_tile_h > 0 && gmaxh > 0 && ret->max_tile_h &&
             ret->max_tile_h > gmaxh)
             ret->max_tile_h = gmaxh;
+
+        exr_get_default_zip_compression_level (&ret->default_zip_level);
+        exr_get_default_dwa_compression_quality (&ret->default_dwa_quality);
+        if (initializers->size >= sizeof(struct _exr_context_initializer_v2))
+        {
+            if (initializers->zip_level >= 0)
+                ret->default_zip_level = initializers->zip_level;
+            if (initializers->dwa_quality >= 0.f)
+                ret->default_dwa_quality = initializers->dwa_quality;
+        }
 
         ret->file_size       = -1;
         ret->max_name_length = EXR_SHORTNAME_MAXLEN;

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -249,6 +249,9 @@ internal_exr_add_part (
     part->display_window.max.y = -1;
     part->chunk_count          = -1;
 
+    part->zip_compression_level = -1;
+    part->dwa_compression_level = 45.f;
+
     /* put it into the part table */
     if (ncount > 1)
     {

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -89,6 +89,9 @@ struct _internal_exr_part
     exr_compression_t comp_type;
     exr_lineorder_t   lineorder;
 
+    int32_t  zip_compression_level;
+    float    dwa_compression_level;
+
     int32_t  num_tile_levels_x;
     int32_t  num_tile_levels_y;
     int32_t* tile_level_tile_count_x;

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -170,6 +170,9 @@ struct _internal_exr_context
     int max_tile_w;
     int max_tile_h;
 
+    int default_zip_level;
+    float default_dwa_quality;
+
     void*                         real_user_data;
     void*                         user_data;
     exr_destroy_stream_func_ptr_t destroy_fn;

--- a/src/lib/OpenEXRCore/openexr_base.h
+++ b/src/lib/OpenEXRCore/openexr_base.h
@@ -107,6 +107,42 @@ EXR_EXPORT void exr_set_default_maximum_tile_size (int w, int h);
  */
 EXR_EXPORT void exr_get_default_maximum_tile_size (int* w, int* h);
 
+/** @} */
+
+/**
+ * @defgroup CompressionDefaults Provides default compression settings
+ * @{
+ */
+
+/** @brief Assigns a default zip compression level.
+ *
+ * This value may be controlled separately on each part, but this
+ * global control determines the initial value.
+ */
+EXR_EXPORT void exr_set_default_zip_compression_level (int l);
+
+/** @brief Retrieve the global default zip compression value
+ */
+EXR_EXPORT void exr_get_default_zip_compression_level (int* l);
+
+/** @brief Assigns a default DWA compression quality level.
+ *
+ * This value may be controlled separately on each part, but this
+ * global control determines the initial value.
+ */
+EXR_EXPORT void exr_set_default_dwa_compression_quality (float q);
+
+/** @brief Retrieve the global default dwa compression quality
+ */
+EXR_EXPORT void exr_get_default_dwa_compression_quality (float* q);
+
+/** @} */
+
+/**
+ * @defgroup MemoryAllocators Provides global control over memory allocators
+ * @{
+ */
+
 /** @brief Function pointer used to hold a malloc-like routine.
  *
  * Providing these to a context will override what memory is used to

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 /** @file */
-    
+
 /** 
  * @defgroup Context Context related definitions
  *
@@ -185,7 +185,7 @@ typedef int64_t (*exr_write_func_ptr_t) (
  * \endcode
  *
  */
-typedef struct _exr_context_initializer
+typedef struct _exr_context_initializer_v2
 {
     /** @brief Size member to tag initializer for version stability.
      *
@@ -301,12 +301,25 @@ typedef struct _exr_context_initializer
      * understand how this interacts with global defaults.
      */
     int max_tile_height;
+
+    /** Initialize a field specifying what the default zip compression level should be
+     * for this context. See exr_set_default_zip_compresion_level() to
+     * set it for all contexts.
+     */
+    int zip_level;
+
+    /** Initialize the default dwa compression quality. See
+     * exr_set_default_dwa_compression_quality() to set the default
+     * for all contexts.
+     */
+    float dwa_quality;
 } exr_context_initializer_t;
 
 /** @brief Simple macro to initialize the context initializer with default values. */
 #define EXR_DEFAULT_CONTEXT_INITIALIZER                                        \
     {                                                                          \
-        sizeof (exr_context_initializer_t), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 \
+        sizeof (exr_context_initializer_t), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
+            0, -2, -1.f                                                        \
     }
 
 /** @} */ /* context function pointer declarations */
@@ -316,8 +329,7 @@ typedef struct _exr_context_initializer
  * has the correct magic number and can be read).
  */
 EXR_EXPORT exr_result_t exr_test_file_header (
-    const char*                      filename,
-    const exr_context_initializer_t* ctxtdata);
+    const char* filename, const exr_context_initializer_t* ctxtdata);
 
 /** @brief Close and free any internally allocated memory,
  * calling any provided destroy function for custom streams.

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -151,6 +151,52 @@ EXR_EXPORT exr_result_t exr_get_scanlines_per_chunk (
 EXR_EXPORT exr_result_t exr_get_chunk_unpacked_size (
     exr_const_context_t ctxt, int part_index, uint64_t* out);
 
+/** @brief Retrieve the zip compression level used for the specified part.
+ *
+ * This only applies when the compression method involves using zip
+ * compression (zip, zips, some modes of DWAA/DWAB).
+ *
+ * This value is NOT persisted in the file, and only exists for the
+ * lifetime of the context, so will be at the default value when just
+ * reading a file.
+ */
+EXR_EXPORT exr_result_t exr_get_zip_compression_level (
+    exr_const_context_t ctxt, int part_index, int* level);
+
+/** @brief Set the zip compression method used for the specified part.
+ *
+ * This only applies when the compression method involves using zip
+ * compression (zip, zips, some modes of DWAA/DWAB).
+ *
+ * This value is NOT persisted in the file, and only exists for the
+ * lifetime of the context, so this value will be ignored when
+ * reading a file.
+ */
+EXR_EXPORT exr_result_t exr_set_zip_compression_level (
+    exr_context_t ctxt, int part_index, int level);
+
+/** @brief Retrieve the dwa compression level used for the specified part.
+ *
+ * This only applies when the compression method is DWAA/DWAB.
+ *
+ * This value is NOT persisted in the file, and only exists for the
+ * lifetime of the context, so will be at the default value when just
+ * reading a file.
+ */
+EXR_EXPORT exr_result_t exr_get_dwa_compression_level (
+    exr_const_context_t ctxt, int part_index, float* level);
+
+/** @brief Set the dwa compression method used for the specified part.
+ *
+ * This only applies when the compression method is DWAA/DWAB.
+ *
+ * This value is NOT persisted in the file, and only exists for the
+ * lifetime of the context, so this value will be ignored when
+ * reading a file.
+ */
+EXR_EXPORT exr_result_t exr_set_dwa_compression_level (
+    exr_context_t ctxt, int part_index, float level);
+
 /**************************************/
 
 /** @defgroup PartMetadata Functions to get and set metadata for a particular part.

--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -393,3 +393,88 @@ exr_get_chunk_unpacked_size (
     *out = sz;
     return EXR_ERR_SUCCESS;
 }
+
+/**************************************/
+
+exr_result_t exr_get_zip_compression_level (
+    exr_const_context_t ctxt, int part_index, int* level)
+{
+    int l;
+    EXR_PROMOTE_CONST_CONTEXT_AND_PART_OR_ERROR (ctxt, part_index);
+    l = part->zip_compression_level;
+    EXR_UNLOCK_WRITE (pctxt);
+
+    if (!level) return pctxt->standard_error (pctxt, EXR_ERR_INVALID_ARGUMENT);
+    *level = l;
+    return EXR_ERR_SUCCESS;
+}
+
+/**************************************/
+
+exr_result_t exr_set_zip_compression_level (
+    exr_context_t ctxt, int part_index, int level)
+{
+    exr_result_t rv;
+    EXR_PROMOTE_LOCKED_CONTEXT_AND_PART_OR_ERROR (ctxt, part_index);
+
+    if (pctxt->mode != EXR_CONTEXT_WRITE)
+        return EXR_UNLOCK_AND_RETURN_PCTXT (
+            pctxt->standard_error (pctxt, EXR_ERR_NOT_OPEN_WRITE));
+
+    if (level >= -1 && level < 10)
+    {
+        part->zip_compression_level = level;
+        rv = EXR_ERR_SUCCESS;
+    }
+    else
+    {
+        return EXR_UNLOCK_AND_RETURN_PCTXT (
+            pctxt->report_error (pctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid zip level specified"));
+    }
+
+    return EXR_UNLOCK_AND_RETURN_PCTXT (rv);
+}
+
+
+/**************************************/
+
+ exr_result_t exr_get_dwa_compression_level (
+     exr_const_context_t ctxt, int part_index, float* level)
+ {
+    float l;
+    EXR_PROMOTE_CONST_CONTEXT_AND_PART_OR_ERROR (ctxt, part_index);
+    l = part->dwa_compression_level;
+    EXR_UNLOCK_WRITE (pctxt);
+
+    if (!level) return pctxt->standard_error (pctxt, EXR_ERR_INVALID_ARGUMENT);
+    *level = l;
+    return EXR_ERR_SUCCESS;
+ }
+
+
+/**************************************/
+
+exr_result_t exr_set_dwa_compression_level (
+    exr_context_t ctxt, int part_index, float level)
+{
+    exr_result_t rv;
+    EXR_PROMOTE_LOCKED_CONTEXT_AND_PART_OR_ERROR (ctxt, part_index);
+
+    if (pctxt->mode != EXR_CONTEXT_WRITE)
+        return EXR_UNLOCK_AND_RETURN_PCTXT (
+            pctxt->standard_error (pctxt, EXR_ERR_NOT_OPEN_WRITE));
+
+    if (level > 0.f && level <= 100.f)
+    {
+        part->dwa_compression_level = level;
+        rv = EXR_ERR_SUCCESS;
+    }
+    else
+    {
+        return EXR_UNLOCK_AND_RETURN_PCTXT (
+            pctxt->report_error (pctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid dwa quality level specified"));
+    }
+
+    return EXR_UNLOCK_AND_RETURN_PCTXT (rv);
+}
+

--- a/src/test/OpenEXRCoreTest/read.cpp
+++ b/src/test/OpenEXRCoreTest/read.cpp
@@ -155,6 +155,22 @@ testReadMeta (const std::string& tempdir)
     EXRCORE_TEST_RVAL (exr_get_user_data (f, &udata));
     EXRCORE_TEST (udata == NULL);
 
+    int zlev = -2;
+    EXRCORE_TEST_RVAL (
+        exr_get_zip_compression_level (f, 0, &zlev));
+    EXRCORE_TEST (zlev == -1);
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_NOT_OPEN_WRITE,
+        exr_set_zip_compression_level (f, 0, 4));
+
+    float dlev = -3.f;
+    EXRCORE_TEST_RVAL (
+        exr_get_dwa_compression_level (f, 0, &dlev));
+    EXRCORE_TEST (dlev == 45.f);
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_NOT_OPEN_WRITE,
+        exr_set_dwa_compression_level (f, 0, 42.f));
+
     exr_finish (&f);
 }
 

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -350,10 +350,84 @@ testWriteBaseHeader (const std::string& tempdir)
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_NAME_TOO_LONG, exr_set_longname_support (outf, 0));
 
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_get_zip_compression_level (NULL, 1, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_zip_compression_level (outf, -1, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_zip_compression_level (outf, 5, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_get_zip_compression_level (outf, 0, NULL));
+    int zlev = -2;
+    EXRCORE_TEST_RVAL (
+        exr_get_zip_compression_level (outf, 0, &zlev));
+    EXRCORE_TEST (zlev == -1);
+
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_set_zip_compression_level (NULL, 0, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_zip_compression_level (outf, -1, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_zip_compression_level (outf, 5, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_zip_compression_level (outf, 0, -2));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_zip_compression_level (outf, 0, 42));
+    EXRCORE_TEST_RVAL (
+        exr_set_zip_compression_level (outf, 0, 4));
+    EXRCORE_TEST_RVAL (
+        exr_get_zip_compression_level (outf, 0, &zlev));
+    EXRCORE_TEST (zlev == 4);
+
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_get_dwa_compression_level (NULL, 0, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_dwa_compression_level (outf, -1, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_dwa_compression_level (outf, 5, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_get_dwa_compression_level (outf, 0, NULL));
+    float dlev = -3.f;
+    EXRCORE_TEST_RVAL (
+        exr_get_dwa_compression_level (outf, 0, &dlev));
+    EXRCORE_TEST (dlev == 45.f);
+
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_set_dwa_compression_level (NULL, 0, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_dwa_compression_level (outf, -1, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_dwa_compression_level (outf, 5, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_dwa_compression_level (outf, 0, -2.f));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_dwa_compression_level (outf, 0, 420.f));
+    EXRCORE_TEST_RVAL (
+        exr_set_dwa_compression_level (outf, 0, 42.f));
+    EXRCORE_TEST_RVAL (
+        exr_get_dwa_compression_level (outf, 0, &dlev));
+    EXRCORE_TEST (dlev == 42.f);
+
     EXRCORE_TEST_RVAL (exr_finish (&outf));
     remove (outfn.c_str ());
-
-    ////
 
     EXRCORE_TEST_RVAL (exr_start_write (
         &outf, outfn.c_str (), EXR_WRITE_FILE_DIRECTLY, &cinit));

--- a/src/test/OpenEXRTest/testCompression.cpp
+++ b/src/test/OpenEXRTest/testCompression.cpp
@@ -196,6 +196,7 @@ writeRead (pixelArray& array1,
 		        V2i (xOffset + width - 1, yOffset + height - 1))));
 
     hdr.compression() = comp;
+	hdr.zipCompressionLevel() = 4;
 
     hdr.channels().insert ("I",			// name
 			   Channel (IMF::UINT,	// type


### PR DESCRIPTION
This adds temporary settings to ImfHeader to control the compression levels used.
