### PR TITLE
Add additional test to ensure correct detection for threads

### DIFF
--- a/cmake/OpenEXRConfig.cmake.in
+++ b/cmake/OpenEXRConfig.cmake.in
@@ -1,9 +1,14 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-if (@OPENEXR_ENABLE_THREADING@)
+
+set(openexr_needthreads @OPENEXR_ENABLE_THREADING@)
+if (openexr_needthreads)
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_dependency(Threads REQUIRED)
 endif()
+unset(openexr_needthreads)
+
 find_dependency(ZLIB REQUIRED)
 find_dependency(Imath REQUIRED)
 


### PR DESCRIPTION
It would appear cmake doesn't preserve the prefer-pthread argument in
the generated find dependency call, also, ensure cmake is happy with the boolean
check.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>