### PR TITLE
Avoid div by zero with test for bad chromaticities in RGBtoXYZ

### DIFF
--- a/src/lib/OpenEXR/ImfChromaticities.cpp
+++ b/src/lib/OpenEXR/ImfChromaticities.cpp
@@ -14,6 +14,8 @@
 #include "ImfNamespace.h"
 #include <string.h>
 
+#include <stdexcept>
+
 #if defined(_MSC_VER)
 // suppress warning about non-exported base classes
 #pragma warning (disable : 4251)

--- a/src/lib/OpenEXR/ImfChromaticities.cpp
+++ b/src/lib/OpenEXR/ImfChromaticities.cpp
@@ -66,6 +66,11 @@ RGBtoXYZ (const Chromaticities &chroma, float Y)
     // X and Z values of RGB value (1, 1, 1), or "white"
     //
 
+    if (chroma.white.y==0.0f)
+    {
+        throw std::invalid_argument("Bad chromaticities: white.y cannot be zero");
+    }
+
     float X = chroma.white.x * Y / chroma.white.y;
     float Z = (1 - chroma.white.x - chroma.white.y) * Y / chroma.white.y;
 
@@ -76,6 +81,16 @@ RGBtoXYZ (const Chromaticities &chroma, float Y)
     float d = chroma.red.x   * (chroma.blue.y  - chroma.green.y) +
 	      chroma.blue.x  * (chroma.green.y - chroma.red.y) +
 	      chroma.green.x * (chroma.red.y   - chroma.blue.y);
+
+
+    if (d==0.0f)
+    {
+        // cannot generate matrix if all RGB primaries have the same y value
+        // or if they all have the an x value of zero
+        // in both cases, the primaries are colinear, which makes them unusable
+        throw std::invalid_argument("Bad chromaticities: RGBtoXYZ matrix is degenerate");
+    }
+
 
     float Sr = (X * (chroma.blue.y - chroma.green.y) -
 	        chroma.green.x * (Y * (chroma.blue.y - 1) +


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39084

Test case has identical x,y coordinates for all chromaticities, but RGBtoXYZ will cause a division by zero with other degenerate chromaticities. This change throws an exception before doing a divide by zero, which is undefined behavior.

Maybe there should be a method that does a more complete check that the chromaticities are valid, and Header::sanityCheck should use that to disallow writing files with nonsensical chromaticities. (Primaries must form a triangle with non-zero area, the white point must be inside that triangle, and cannot have a zero y coordinate)

RGBtoXYZ is used to read Yuv-encoded files with the Rgba interface, and to read files with non-ACES primaries using the AcesInputFile API.


Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>