### PR TITLE
validate dwaCompressionLevel attribute type

### DIFF
--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -443,7 +443,7 @@ Header::insert (const char name[], const Attribute &attribute)
 	THROW (IEX_NAMESPACE::ArgExc, "Image attribute name cannot be an empty string.");
 
     AttributeMap::iterator i = _map.find (name);
-    if (!strcmp (name, "dwaCompressionLevel"))
+    if (!strcmp (name, "dwaCompressionLevel") && !strcmp (attribute.typeName(),"float") )
     {
         const TypedAttribute<float>& dwaattr =
             dynamic_cast<const TypedAttribute<float>&> (attribute);


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39342
Ephemeral handling of dwaCompressionLevel attributes in file headers assumed it was always a floatAttribute, causing exception to be thrown and potential memory leak in other cases.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>