### PR TITLE
don't validate chunk size when file_size unknown

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -70,7 +70,8 @@ extract_chunk_table (
             return ctxt->report_error (
                 ctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid file with no chunks");
 
-        if (chunkbytes + chunkoff > (uint64_t) ctxt->file_size)
+        if (ctxt->file_size > 0 &&
+             chunkbytes + chunkoff > (uint64_t) ctxt->file_size)
            return ctxt->print_error (
                ctxt,
                EXR_ERR_INVALID_ARGUMENT,


### PR DESCRIPTION
When file_size is unknown, skip the test of the chunk table size that was added in #1161 

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>