### PR TITLE
Fail when the user provides a preview image that has a zero size

### DIFF
--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -720,7 +720,7 @@ extract_attr_preview (
             sz[0],
             sz[1]);
 
-    if (fsize > 0 && bytes >= (uint64_t) fsize)
+    if (bytes == 0 || (fsize > 0 && bytes >= (uint64_t) fsize))
     {
         return ctxt->print_error (
             ctxt,


### PR DESCRIPTION
when a coordinate has 0 bytes, that is a semi-undefined allocation, or seems to trip up the various sanitizers. It's also an invalid thing, so let the user know about it.

oss fuzz 39399

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>