### PR TITLE
Prevent read when offset past the end of the memstream

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1494,8 +1494,8 @@ memstream_read (
     {
         memdata *md = static_cast<memdata *>( userdata );
         uint64_t left = sz;
-        if ( (offset + sz) > md->bytes )
-            left = md->bytes - offset;
+        if ((offset + sz) > md->bytes)
+            left = (offset < md->bytes) ? md->bytes - offset : 0;
         if ( left > 0 )
             memcpy( buffer, md->data + offset, left );
         rdsz = static_cast<int64_t>( left );


### PR DESCRIPTION
normal file semantics will return 0 for this indicating EOF

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>