### PR TITLE
Fix loop iterators in ImfCheckFile.cpp

### DIFF
--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2196,7 +2196,7 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
         curpart->lines_per_chunk         = ((int16_t) linePerChunk);
         curpart->chan_has_line_sampling  = ((int16_t) hasLineSample);
 
-        h      = (uint64_t) dw.max.y - (uint64_t) dw.min.y + 1;
+        h      = (uint64_t) ((int64_t) dw.max.y - (int64_t) dw.min.y + 1);
         retval = (int32_t) ((h + linePerChunk - 1) / linePerChunk);
     }
     return retval;

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1319,10 +1319,10 @@ bool readCoreTiledPart(exr_context_t f, int part, bool reduceMemory, bool reduce
 
             int tx, ty;
             ty = 0;
-            for (int32_t cury = datawin.min.y; keepgoing && cury < levh; cury += curth, ++ty)
+            for (int64_t cury = datawin.min.y; keepgoing && cury < levh; cury += curth, ++ty)
             {
                 tx = 0;
-                for (int32_t curx = datawin.min.x; keepgoing && curx < levw; curx += curtw, ++tx)
+                for (int64_t curx = datawin.min.x; keepgoing && curx < levw; curx += curtw, ++tx)
                 {
                     rv = exr_read_tile_chunk_info (f, part, tx, ty, xlevel, ylevel, &cinfo);
                     if (rv != EXR_ERR_SUCCESS)

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1167,8 +1167,8 @@ bool readCoreScanlinePart(exr_context_t f, int part, bool reduceMemory, bool red
     if (rv != EXR_ERR_SUCCESS)
         return true;
 
-    uint64_t width  = (uint64_t)datawin.max.x - (uint64_t)datawin.min.x + 1;
-    uint64_t height = (uint64_t)datawin.max.y - (uint64_t)datawin.min.y + 1;
+    uint64_t width  = (uint64_t) ((int64_t)datawin.max.x - (int64_t)datawin.min.x + 1);
+    uint64_t height = (uint64_t) ((int64_t)datawin.max.y - (int64_t)datawin.min.y + 1);
 
     std::vector<uint8_t> imgdata;
     bool doread = false;

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1319,10 +1319,10 @@ bool readCoreTiledPart(exr_context_t f, int part, bool reduceMemory, bool reduce
 
             int tx, ty;
             ty = 0;
-            for (int64_t cury = datawin.min.y; keepgoing && cury < levh; cury += curth, ++ty)
+            for (int64_t cury = 0 ; keepgoing && cury < levh; cury += curth, ++ty)
             {
                 tx = 0;
-                for (int64_t curx = datawin.min.x; keepgoing && curx < levw; curx += curtw, ++tx)
+                for (int64_t curx = 0 ; keepgoing && curx < levw; curx += curtw, ++tx)
                 {
                     rv = exr_read_tile_chunk_info (f, part, tx, ty, xlevel, ylevel, &cinfo);
                     if (rv != EXR_ERR_SUCCESS)


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39323 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39397

Loop iterators should go from 0 to {width,height}, not datawin.min.{x,y} to {width,height}. Also switch to 64 bit to prevent infinite loop due to loop iterator overflowing. (Overflow occurred when tile_height+image_height > INT_MAX)

Also fix secondary sanitizer warning during width and height computation when datawin.min.{x,y} are negative