### PR TITLE
fix casts in readUInt shifts

### DIFF
--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -919,9 +919,9 @@ writeUInt (uint8_t* b, uint32_t i)
 static inline uint32_t
 readUInt (const uint8_t* b)
 {
-    return (
-        ((uint32_t) (b[0])) | ((uint32_t) (b[1] << 8)) |
-        ((uint32_t) (b[2] << 16)) | ((uint32_t) (b[3] << 24)));
+     return (
+        ((uint32_t) b[0]) | (((uint32_t) b[1]) << 8u) |
+        (((uint32_t) b[2]) << 16u) | (((uint32_t) b[3]) << 24u));
 }
 
 /**************************************/


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=39579
Change order of casts to prevent automatic cast to signed integer, which reports as undefined behavior if value overflows INT_MAX

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>