### PR TITLE
reduce iterations in testIDManifest to speed up

### DIFF
--- a/src/test/OpenEXRTest/testIDManifest.cpp
+++ b/src/test/OpenEXRTest/testIDManifest.cpp
@@ -318,9 +318,9 @@ namespace
         const string fn = tempDir + "id_manifest.exr";
         random_reseed(1);
         //
-        // generate 100 random files, looking for trouble
+        // generate 20 random files, looking for trouble
         
-        for(int pass=0;pass<100;++pass)
+        for(int pass=0;pass<20;++pass)
         {
         
             //
@@ -380,7 +380,7 @@ namespace
                 //
                 // insert entries - each will have the correct number of components
                 //
-                int entriesInGroup = random_int(300*(pass+1));
+                int entriesInGroup = random_int(1200*(pass+1));
                 
                 cerr << entriesInGroup << ' ';
                 cerr.flush();


### PR DESCRIPTION
testIDManifest was timing out on slow processors due to 1500 second test limit.
This change runs 20 different random manifests instead of 100 to speed it up. On Raspberry Pi with ARM7 architecture, testIDManifest now completes in around 500 seconds. (Slowest test is now testHuf, at just over 1000s)

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>