### PR TITLE
Add size check to memory stream check program

### DIFF
--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -45,9 +45,23 @@ exrCheck(const char* filename, bool reduceMemory, bool reduceTime, bool useStrea
       // open file as stream, check size
       //
       ifstream instream(filename,ifstream::binary);
+
+      if ( ! instream )
+      {
+          cerr << "internal error: bad file '" << filename << "' for in-memory stream" << endl;
+          return true;
+      }
+
       instream.seekg(0,instream.end);
       streampos length = instream.tellg();
       instream.seekg(0,instream.beg);
+
+      const uintptr_t kMaxSize = uintptr_t(-1) / 4;
+      if (length < 0 || length > (streampos)kMaxSize)
+      {
+          cerr << "internal error: bad file length " << length << " for in-memory stream" << endl;
+          return true;
+      }
 
       //
       // read into memory


### PR DESCRIPTION
Accidentally giving a folder name to the program exposed that the c++
library returns very large results for seeking to the end of a directory
file node, handle and return quickly

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>