### PR TITLE
Replace Doxygen/Sphinx targets with "docs"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,8 @@ if(NOT OPENEXR_IS_SUBPROJECT)
 endif()
 
 option(DOCS "Set ON to build html documentation")
-if (DOCS)
+if (DOCS AND NOT OPENEXR_IS_SUBPROJECT)
+  option(INSTALL_DOCS "Set ON to install html documentation" ON)
   add_subdirectory(docs)
 endif()
+

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -26,8 +26,6 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
                    COMMENT "Running doxygen"
                    VERBATIM)
 
-add_custom_target(Doxygen ALL DEPENDS ${DOXYGEN_INDEX_FILE})
-
 add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
                    COMMAND 
                      ${SPHINX_EXECUTABLE} -b html
@@ -39,9 +37,11 @@ add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
                    MAIN_DEPENDENCY conf.py
                    COMMENT "Generating documentation with Sphinx")
 
-add_custom_target(Sphinx ALL DEPENDS ${SPHINX_INDEX_FILE})
+add_custom_target(docs ALL DEPENDS ${SPHINX_INDEX_FILE} ${DOXYGEN_INDEX_FILE})
 
 # Add an install target to install the docs
-include(GNUInstallDirs)
-install(DIRECTORY ${SPHINX_BUILD}
-DESTINATION ${CMAKE_INSTALL_DOCDIR})
+if(INSTALL_DOCS)
+    include(GNUInstallDirs)
+    install(DIRECTORY ${SPHINX_BUILD}
+    DESTINATION ${CMAKE_INSTALL_DOCDIR})
+endif()


### PR DESCRIPTION
Similar to
https://github.com/AcademySoftwareFoundation/Imath/pull/222, this
avoids a race condition bug in Doxygen
(https://github.com/doxygen/doxygen/issues/6293) when CMake builds
simultaneously for multiple architectures.

Also, don't include the docs when OpenEXR is a subproject, because the
target can conflict with a target in the parent project, and the
parent project shouldn't need the OpenEXR docs, anyway.

Signed-off-by: Cary Phillips <cary@ilm.com>