### PR TITLE
DeepScanlineInputFile now uses chunk size test from DeepTiledInputFile

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -1961,14 +1961,20 @@ readSampleCountForLineBlock(InputStreamMutex* streamData,
     // @TODO refactor the compressor code to ensure full 64-bit support.
     //
 
-    int compressorMaxDataSize = std::numeric_limits<int>::max();
-    if (sampleCountTableDataSize > uint64_t(compressorMaxDataSize))
+    uint64_t compressorMaxDataSize = static_cast<uint64_t>(std::numeric_limits<int>::max());
+    if (packedDataSize         > compressorMaxDataSize ||
+        unpackedDataSize > compressorMaxDataSize ||
+        sampleCountTableDataSize        > compressorMaxDataSize)
     {
-        THROW (IEX_NAMESPACE::ArgExc, "This version of the library does not "
-              << "support the allocation of data with size  > "
-              << compressorMaxDataSize
-              << " file table size    :" << sampleCountTableDataSize << ".\n");
+        THROW (IEX_NAMESPACE::ArgExc, "This version of the library does not"
+            << "support the allocation of data with size  > "
+            << compressorMaxDataSize
+            << " file table size    :" << sampleCountTableDataSize
+            << " file unpacked size :" << unpackedDataSize
+            << " file packed size   :" << packedDataSize << ".\n");
     }
+
+
     streamData->is->read(data->sampleCountTableBuffer, static_cast<int>(sampleCountTableDataSize));
     
     const char* readPtr;


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41075
The file format allows for deep scanline/tile chunks with more than 2GB of data, but this is not currently supported by the library, causing an integer overflow. DeepTiledInputFile was properly testing for large chunks, but DeepScanlineInputFile was only partially checking.
Copy/pasting the test from Scanline to Tile catches the issue before the overflow occurs.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>