### PR TITLE
Reduce memory consumption with very large deepscanline images

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -1961,14 +1961,20 @@ readSampleCountForLineBlock(InputStreamMutex* streamData,
     // @TODO refactor the compressor code to ensure full 64-bit support.
     //
 
-    int compressorMaxDataSize = std::numeric_limits<int>::max();
-    if (sampleCountTableDataSize > uint64_t(compressorMaxDataSize))
+    uint64_t compressorMaxDataSize = static_cast<uint64_t>(std::numeric_limits<int>::max());
+    if (packedDataSize         > compressorMaxDataSize ||
+        unpackedDataSize > compressorMaxDataSize ||
+        sampleCountTableDataSize        > compressorMaxDataSize)
     {
-        THROW (IEX_NAMESPACE::ArgExc, "This version of the library does not "
-              << "support the allocation of data with size  > "
-              << compressorMaxDataSize
-              << " file table size    :" << sampleCountTableDataSize << ".\n");
+        THROW (IEX_NAMESPACE::ArgExc, "This version of the library does not"
+            << "support the allocation of data with size  > "
+            << compressorMaxDataSize
+            << " file table size    :" << sampleCountTableDataSize
+            << " file unpacked size :" << unpackedDataSize
+            << " file packed size   :" << packedDataSize << ".\n");
     }
+
+
     streamData->is->read(data->sampleCountTableBuffer, static_cast<int>(sampleCountTableDataSize));
     
     const char* readPtr;


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40423

DeepScanLineInputFile caches the sample counts between calls to `readSampleCounts()` and `readPixels()`
This cache table is a significant memory requirement for images with large dataWindows.
This change does not cache sampleCounts if the table would exceed 1GB of storage. In that case, readPixels() re-reads the sampleCounts and stores them in a smaller buffer in the LineBuffer object.

Tools which need to support large deep images may want to experiment with builds of OpenEXR with increased values of `gBigFileDataWindowSize` (or use the OpenEXRCore library for more efficient access to the deep scanlines)

`bin/OpenEXRTest testDeepScanLineBasic` has been updated to cover these changes, and to run more efficiently