### PR TITLE
enforce xSampling/ySampling==1 in CompositeDeepScanLine

### DIFF
--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
@@ -238,6 +238,20 @@ CompositeDeepScanLine::setFrameBuffer(const FrameBuffer& fr)
     
     for(FrameBuffer::ConstIterator q=fr.begin();q!=fr.end();q++)
     {
+
+        //
+        // Frame buffer must have xSampling and ySampling set to 1
+        // (Sampling in FrameBuffers must match sampling in file,
+        //  and Header::sanityCheck enforces sampling in deep files is 1)
+        //
+
+        if(q.slice().xSampling!=1 || q.slice().ySampling!=1)
+        {
+             THROW (IEX_NAMESPACE::ArgExc, "X and/or y subsampling factors "
+				"of \"" << q.name() << "\" channel in framebuffer "
+				"are not 1");
+        }
+
         string name(q.name());
         if(name=="ZBack")
         {


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41416

OpenEXR API generally enforces that FrameBuffer xSampling and ySampling match whatever is in the file. For deep scanline and tile images, xSampling and ySampling must be 1, so the FrameBuffer passed to CompositeDeepScanLine::setFrameBuffer should also enforce that 

The test file in this case is a deep file with "Y" and "BY" channels, both with sampling 1, so RgbaInputFile API composites the deep data to a regular scanline image, then attempts a FromYCA conversion, which requires "BY" and "RY" have sampling set to 2. Although OpenEXR doesn't support chroma-subsampled deep files, it does support luma-only deepscanline files with a "Y" channel, and those should be readable using the RgbaInputFile API into an Rgba pixel.


Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>