### PR TITLE
Add check for decompressed deepscanline datasize

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -802,6 +802,12 @@ LineBufferTask::execute ()
                 _lineBuffer->packedDataSize = _lineBuffer->compressor->uncompress
                     (_lineBuffer->buffer, static_cast<int>(_lineBuffer->packedDataSize),
                      _lineBuffer->minY, _lineBuffer->uncompressedData);
+
+               if(_lineBuffer->unpackedDataSize != _lineBuffer->packedDataSize)
+               {
+                    THROW (IEX_NAMESPACE::InputExc, "Incorrect size for decompressed data. Expected " << _lineBuffer->unpackedDataSize << " got " << _lineBuffer->packedDataSize << " bytes");
+               }
+
             }
             else
             {


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42001
The compressed pixel data in DeepScanLineInputFile should match the size declared in unpackedDataSize.
The missing validity check meant a large amount (uninitialized) data is copied to the user buffer, even though the file is small, which takes a long time.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>