### PR TITLE
prevent overflow in initialization of RLE Compressor

### DIFF
--- a/src/lib/OpenEXR/ImfRleCompressor.cpp
+++ b/src/lib/OpenEXR/ImfRleCompressor.cpp
@@ -24,6 +24,10 @@ RleCompressor::RleCompressor (const Header &hdr, size_t maxScanLineSize):
     _tmpBuffer (0),
     _outBuffer (0)
 {
+    if(maxScanLineSize > std::numeric_limits<int>::max())
+    {
+            throw IEX_NAMESPACE::OverflowExc ("ScanLine size too large for RleCompressor");
+    }
     _tmpBuffer = new char [maxScanLineSize];
     _outBuffer = new char [uiMult (maxScanLineSize, size_t (3)) / 2];
 }


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41669
RLE cannot uncompress more than INT_MAX bytes, otherwise an integer overflow occurs.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>