### PR TITLE
Corrected the check to enable SSE2 when building with Visual Studio.

### DIFF
--- a/src/lib/OpenEXR/ImfSimd.h
+++ b/src/lib/OpenEXR/ImfSimd.h
@@ -14,7 +14,7 @@
 
 
 // GCC and Visual Studio SSE2 compiler flags
-#if defined __SSE2__ || (_MSC_VER >= 1300 && !_M_CEE_PURE)
+#if defined __SSE2__ || (_MSC_VER >= 1300 && (_M_IX86 || _M_X64))
     #define IMF_HAVE_SSE2 1
 #endif
 

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <zlib.h>
 
-#if defined __SSE2__ || (_MSC_VER >= 1300 && !_M_CEE_PURE)
+#if defined __SSE2__ || (_MSC_VER >= 1300 && (_M_IX86 || _M_X64))
 #    define IMF_HAVE_SSE2 1
 #    include <emmintrin.h>
 #    include <mmintrin.h>


### PR DESCRIPTION
This pull requests corrects the check to enable SSE2 when building with Visual Studio. The `emmintrin.h` header file has a check to only allows `_M_IX86` or `_M_X64`. When building on ARM64 the define will be `_M_ARM64` instead and this project will fail to build. 

I have removed the `_M_CEE_PURE` check because this is deprecated since Visual Studio 2015 and I wonder if this is still required. 