### PR TITLE
Fix building of the project on ARM64 with VisualStudio

### DIFF
--- a/src/lib/OpenEXRCore/internal_coding.h
+++ b/src/lib/OpenEXRCore/internal_coding.h
@@ -143,7 +143,7 @@ half_to_float (uint16_t hv)
     else if (hexpmant != 0)
     {
         uint32_t lc;
-#    if defined(_MSC_VER)
+#    if defined(_MSC_VER) && (_M_IX86 || _M_X64)
         lc = __lzcnt (hexpmant);
 #    elif defined(__GNUC__) || defined(__clang__)
         lc = (uint32_t) __builtin_clz (hexpmant);


### PR DESCRIPTION
This pull requests adds a missing check to fix building with VisualStudio on ARM64. The `__lzcnt` method is only supported on x86 or x64.