### PR TITLE
Fix OSS Fuzz 43763, 43745

### DIFF
--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -494,14 +494,14 @@ hufUnpackEncTable (
     for (; im <= iM; im++)
     {
         nr = (((uintptr_t) p) - ((uintptr_t) *pcode));
-        if (nr > ni) return EXR_ERR_OUT_OF_MEMORY;
+        if (lc < 6 && nr >= ni) return EXR_ERR_OUT_OF_MEMORY;
 
         uint64_t l = hcode[im] = getBits (6, &c, &lc, &p); // code length
 
         if (l == (uint64_t) LONG_ZEROCODE_RUN)
         {
             nr = (((uintptr_t) p) - ((uintptr_t) *pcode));
-            if (nr > ni) return EXR_ERR_OUT_OF_MEMORY;
+            if (lc < 8 && nr >= ni) return EXR_ERR_OUT_OF_MEMORY;
 
             uint64_t zerun = getBits (8, &c, &lc, &p) + SHORTEST_LONG_RUN;
 

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2002,6 +2002,8 @@ internal_exr_compute_tile_information (
         w = ((int64_t) dw.max.x) - ((int64_t) dw.min.x) + 1;
         h = ((int64_t) dw.max.y) - ((int64_t) dw.min.y) + 1;
 
+        if (tiledesc->x_size == 0 || tiledesc->y_size == 0)
+            return ctxt->standard_error (ctxt, EXR_ERR_INVALID_ATTR);
         switch (EXR_GET_TILE_LEVEL_MODE ((*tiledesc)))
         {
             case EXR_TILE_ONE_LEVEL: numX = numY = 1; break;
@@ -2032,7 +2034,9 @@ internal_exr_compute_tile_information (
                 }
                 break;
             case EXR_TILE_LAST_TYPE:
-            default: return -1;
+            default:
+                return ctxt->standard_error (
+                    ctxt, EXR_ERR_INVALID_ATTR);
         }
 
         curpart->num_tile_levels_x = numX;


### PR DESCRIPTION
This fixes the following two reports:

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43745
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=43763

One is an insufficient test against a short buffer read, the other is a missing check for an invalid tile description