### PR TITLE
Update CI for VFX reference platform 2022

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -19,14 +19,14 @@ jobs:
   # ---------------------------------------------------------------------------
 
   linux_sonarcloud:
-    name: 'SonarCloud Linux CentOS 7 VFX CY2021 <GCC 6.3.1>'
+    name: 'SonarCloud Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
     if: github.repository == 'AcademySoftwareFoundation/openexr'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2021
+      image: aswf/ci-openexr:2022
     env:
       CXX: g++
       CC: gcc
@@ -87,14 +87,14 @@ jobs:
   #  Valgrind memcheck test
   # ------------------------------------------------------------------------------
   linux_valgrind:
-    name: 'Valgrind Linux CentOS 7 VFX CY2021 <GCC 6.3.1>'
+    name: 'Valgrind Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
     if: github.repository == 'AcademySoftwareFoundation/openexr'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2021
+      image: aswf/ci-openexr:2022
     env:
       CXX: g++
       CC: gcc
@@ -152,14 +152,14 @@ jobs:
   #  Fuzz test
   # ------------------------------------------------------------------------------
   linux_fuzz:
-    name: 'Fuzz Test ${{ matrix.build-descrip }} Linux CentOS 7 VFX CY2021 <GCC 6.3.1>'
+    name: 'Fuzz Test ${{ matrix.build-descrip }} Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
     if: github.repository == 'AcademySoftwareFoundation/openexr'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2021
+      image: aswf/ci-openexr:2022
     strategy:
       matrix:
         build: [1, 2]

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -58,8 +58,9 @@ jobs:
       matrix:
         build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         include:
+
           # -------------------------------------------------------------------
-          # VFX CY2022 - GCC, Release
+          # VFX CY2022 - GCC
           # -------------------------------------------------------------------
           # Shared, Release
           - build: 1
@@ -74,10 +75,7 @@ jobs:
             vfx-cy: 2022
             exclude-tests:
 
-          # -------------------------------------------------------------------
-          # VFX CY2021 - GCC
-          # -------------------------------------------------------------------
-          # Shared, Release
+          # Shared, Release, Threads OFF
           - build: 2
             build-type: Release
             build-shared: 'ON'
@@ -86,25 +84,12 @@ jobs:
             cc-compiler: gcc
             compiler-desc: gcc9.3.1
             label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2021
-            exclude-tests:
-
-          # Shared, Release, Threads OFF
-          - build: 3
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc9.3.1
-            label: 
             threads-enabled: 'OFF'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Shared, Debug
-          - build: 4
+          - build: 3
             build-type: Debug
             build-shared: 'ON'
             cxx-standard: 17
@@ -113,11 +98,11 @@ jobs:
             compiler-desc: gcc9.3.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Static, Release
-          - build: 5
+          - build: 4
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 17
@@ -126,11 +111,11 @@ jobs:
             compiler-desc: gcc9.3.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Static, Debug
-          - build: 6
+          - build: 5
             build-type: Debug
             build-shared: 'OFF'
             cxx-standard: 17
@@ -139,14 +124,14 @@ jobs:
             compiler-desc: gcc9.3.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # -------------------------------------------------------------------
           # VFX CY2021 - Clang
           # -------------------------------------------------------------------
           # Release
-          - build: 7
+          - build: 6
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 17
@@ -155,11 +140,11 @@ jobs:
             compiler-desc: clang10
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Debug
-          - build: 8
+          - build: 7
             build-type: Debug
             build-shared: 'ON'
             cxx-standard: 17
@@ -168,11 +153,11 @@ jobs:
             compiler-desc: clang10
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Static, Release
-          - build: 9
+          - build: 8
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 17
@@ -181,17 +166,33 @@ jobs:
             compiler-desc: clang10
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2021
+            vfx-cy: 2022
             exclude-tests:
 
           # Static, Debug
-          - build: 10
+          - build: 9
             build-type: Debug
             build-shared: 'OFF'
             cxx-standard: 17
             cxx-compiler: clang++
             cc-compiler: clang
             compiler-desc: clang10
+            label: 
+            threads-enabled: 'ON'
+            vfx-cy: 2022
+            exclude-tests:
+
+          # -------------------------------------------------------------------
+          # VFX CY2021 - GCC, Release
+          # -------------------------------------------------------------------
+          # Shared, Release
+          - build: 10
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: gcc9.3.1
             label: 
             threads-enabled: 'ON'
             vfx-cy: 2021
@@ -308,7 +309,7 @@ jobs:
   # TODO: Add ARM64/x86_64 (universal 2) build
   
   macos:
-    name: 'Mac VFXP-2021 macos-${{ matrix.osver }}
+    name: 'Mac VFXP-2022 macos-${{ matrix.osver }}
       <${{ matrix.compiler-desc }},
        C++${{ matrix.cxx-standard }},
        config=${{ matrix.build-type }},
@@ -321,7 +322,7 @@ jobs:
         build: [1, 2, 3]
         include:
           # -------------------------------------------------------------------
-          # VFX CY2021 - C++17 
+          # VFX CY2022 - C++17 
           # -------------------------------------------------------------------
           # Shared, Release
           - build: 1
@@ -407,7 +408,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # TODO: Debug mode is catatonically slow under windows
   windows:
-    name: 'Windows VFXP-2021
+    name: 'Windows VFXP-2022
       <${{ matrix.compiler-desc }},
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
@@ -419,7 +420,7 @@ jobs:
         build: [1, 2]
         include:
           # -------------------------------------------------------------------
-          # VFX CY2021 - C++17
+          # VFX CY2022 - C++17
           # -------------------------------------------------------------------
           # Shared, Release
           - build: 1


### PR DESCRIPTION
- Updated the multiple Linux builds to VFXP-2022.
- Kept single Linux release builds for 2021, 2020, 2019. (not sure if we need 2019 still?)
- Kept Linux legacy C++11 build - 2019 build with C++11 instead of C++14.
- Update Mac and Windows builds to VFXP-2022