### PR TITLE
Add maximumSampleCount limit to CompositeDeepScanLine

### DIFF
--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -113,7 +113,14 @@ main (int argc, char** argv)
         }
         else if (!strcmp (argv[i], "-m"))
         {
+            //
+            // note for further memory reduction, calls to the folowing could be added here
+            // CompositeDeepScanLine::setMaximumSampleCount();
+            // Header::setMaxImageSize();
+            // Header::setMaxTileSize();
+
             reduceMemory = true;
+
         }
         else if (!strcmp (argv[i], "-t"))
         {

--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
@@ -429,7 +429,7 @@ LineCompositeTask::execute ()
 
 
 namespace {
-int64_t maximumSampleCount = 1<<25;
+int64_t maximumSampleCount = 0;
 }
 
 void CompositeDeepScanLine::setMaximumSampleCount(int64_t c)
@@ -525,7 +525,7 @@ CompositeDeepScanLine::readPixels (int start, int end)
         overall_sample_count += total_sizes[ptr];
     }
 
-    if (maximumSampleCount >=0 &&  overall_sample_count > maximumSampleCount)
+    if (maximumSampleCount > 0 &&  overall_sample_count > maximumSampleCount)
     {
         throw IEX_NAMESPACE::ArgExc (
             "Cannot composite scanline: total sample count on scanline exceeds "

--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
@@ -427,6 +427,23 @@ LineCompositeTask::execute ()
 
 } // namespace
 
+
+namespace {
+int64_t maximumSampleCount = 1<<25;
+}
+
+void CompositeDeepScanLine::setMaximumSampleCount(int64_t c)
+{
+    maximumSampleCount = c;
+}
+
+int64_t CompositeDeepScanLine::getMaximumSampleCount()
+{
+    return maximumSampleCount;
+}
+
+
+
 void
 CompositeDeepScanLine::readPixels (int start, int end)
 {
@@ -507,6 +524,15 @@ CompositeDeepScanLine::readPixels (int start, int end)
         }
         overall_sample_count += total_sizes[ptr];
     }
+
+    if (maximumSampleCount >=0 &&  overall_sample_count > maximumSampleCount)
+    {
+        throw IEX_NAMESPACE::ArgExc (
+            "Cannot composite scanline: total sample count on scanline exceeds "
+            "limit set by CompositeDeepScanLine::setMaximumSampleCount()"
+        );
+    }
+
 
     //
     // allocate arrays for pixel data
@@ -598,5 +624,6 @@ CompositeDeepScanLine::frameBuffer () const
 {
     return _Data->_outputFrameBuffer;
 }
+
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.h
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.h
@@ -106,6 +106,23 @@ public:
 
     struct IMF_HIDDEN Data;
 
+
+    //
+    // set the maximum number of samples that will be composited.
+    // If a single scanline has more samples, readPixels will throw
+    // an exception. This mechanism prevents the library allocating
+    // excessive memory to composite deep scanline images.
+    // A value of 0 will cause deep compositing to be disabled entirely
+    // A negative value disables the limit, allowing images with
+    // arbitrarily large sample counts to be composited
+    //
+    IMF_EXPORT
+    static void setMaximumSampleCount(int64_t sampleCount);
+
+    IMF_EXPORT
+    static int64_t getMaximumSampleCount();
+
+
 private:
     struct Data* _Data;
 

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -5,6 +5,7 @@
 #include "Iex.h"
 #include "ImfArray.h"
 #include "ImfChannelList.h"
+#include "ImfCompositeDeepScanLine.h"
 #include "ImfCompressor.h"
 #include "ImfDeepFrameBuffer.h"
 #include "ImfDeepScanLineInputFile.h"
@@ -1612,9 +1613,22 @@ checkOpenEXRFile (
     bool        enableCoreCheck)
 {
     bool threw = false;
+
+    uint64_t oldMaxSampleCount = CompositeDeepScanLine::getMaximumSampleCount();
+
+    if( reduceMemory || reduceTime)
+    {
+        CompositeDeepScanLine::setMaximumSampleCount(1<<20);
+    }
+
     if (enableCoreCheck)
+    {
         threw = runCoreChecks (fileName, reduceMemory, reduceTime);
+    }
     if (!threw) threw = runChecks (fileName, reduceMemory, reduceTime);
+
+    CompositeDeepScanLine::setMaximumSampleCount(oldMaxSampleCount);
+
     return threw;
 }
 
@@ -1627,6 +1641,13 @@ checkOpenEXRFile (
     bool        enableCoreCheck)
 {
     bool threw = false;
+    uint64_t oldMaxSampleCount = CompositeDeepScanLine::getMaximumSampleCount();
+
+    if( reduceMemory || reduceTime)
+    {
+        CompositeDeepScanLine::setMaximumSampleCount(1<<20);
+    }
+
     if (enableCoreCheck)
         threw = runCoreChecks (data, numBytes, reduceMemory, reduceTime);
     if (!threw)
@@ -1634,6 +1655,9 @@ checkOpenEXRFile (
         PtrIStream stream (data, numBytes);
         threw = runChecks (stream, reduceMemory, reduceTime);
     }
+
+    CompositeDeepScanLine::setMaximumSampleCount(oldMaxSampleCount);
+
     return threw;
 }
 


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44084

This changes existing behavior by disabling deep compositing of scanlines with more than 2^25 pixels by default in CompositeDeepScanLine. This API is used by the InputPart, InputFile and RgbaInputFile APIs to composite deep scanline images automatically, so they can be read as if they were regular scanline images. Compositing scanline images with very many samples will take a long time and cause unanticipated excessive memory allocation. This change does not affect deep images read using DeepInputFile or DeepInputPart APIs.

The default limit is equivalent to 8k samples in every pixel of a 4k wide image, which should be high enough not to affect most genuine deep images, but should prevent excessive memory allocation by reading damaged or malicious deep files.

A new static function `CompositeDeepScanLine::setMaximumSampleCount()` can be use to adjust the limit or disable the check completely.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>