### PR TITLE
prevent double-free of RgbaInputFile::_inputPart

### DIFF
--- a/src/lib/OpenEXR/ImfRgbaFile.cpp
+++ b/src/lib/OpenEXR/ImfRgbaFile.cpp
@@ -1301,7 +1301,7 @@ void
 RgbaInputFile::setLayerName (const string& layerName)
 {
     delete _fromYca;
-    _fromYca = 0;
+    _fromYca = nullptr;
 
     _channelNamePrefix = prefixFromLayerName (layerName, _inputPart->header ());
 
@@ -1320,6 +1320,8 @@ RgbaInputFile::setPartAndLayer (int part, const string& layerName)
     delete _fromYca;
     _fromYca = nullptr;
     delete _inputPart;
+    _inputPart = nullptr;
+
     _inputPart         = new InputPart (*_multiPartFile, part);
     _channelNamePrefix = prefixFromLayerName (layerName, _inputPart->header ());
     ;


### PR DESCRIPTION
Address:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45716
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45718

_inputPart pointer wasn't being set to `nullptr` after delete. If the following line throws, _inputPart won't get updated, so the destructor will try to delete the already deleted object.

(Bug introduced by #1201)

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>