### PR TITLE
Bump version to 3.2.0 on the main branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 # configuration files
 #######################################
 
-project(OpenEXR VERSION 3.1.0 LANGUAGES C CXX)
+project(OpenEXR VERSION 3.2.0 LANGUAGES C CXX)
 
 set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for OpenEXR build, such as -dev, -beta1, etc.")
 


### PR DESCRIPTION
This only affects main, it should not be merged to a release branch,
each of which set the version explicitly.  The main branch version
should stay set to the next minor release, which is the best
approximation of the state of the main branch code.

Signed-off-by: Cary Phillips <cary@ilm.com>