### PR TITLE
Match cpp header checks

### DIFF
--- a/src/lib/OpenEXRCore/backward_compatibility.h
+++ b/src/lib/OpenEXRCore/backward_compatibility.h
@@ -23,4 +23,23 @@ struct _exr_context_initializer_v1
     int                           max_tile_height;
 };
 
+struct _exr_context_initializer_v2
+{
+    size_t                        size;
+    exr_error_handler_cb_t        error_handler_fn;
+    exr_memory_allocation_func_t  alloc_fn;
+    exr_memory_free_func_t        free_fn;
+    void*                         user_data;
+    exr_read_func_ptr_t           read_fn;
+    exr_query_size_func_ptr_t     size_fn;
+    exr_write_func_ptr_t          write_fn;
+    exr_destroy_stream_func_ptr_t destroy_fn;
+    int                           max_image_width;
+    int                           max_image_height;
+    int                           max_tile_width;
+    int                           max_tile_height;
+    int                           zip_level;
+    float                         dwa_quality;
+};
+
 #endif /* OPENEXR_BACKWARD_COMPATIBILITY_H */

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -4,7 +4,6 @@
 */
 
 #include "internal_structs.h"
-#include "backward_compatibility.h"
 #include "internal_attr.h"
 #include "internal_constants.h"
 #include "internal_memory.h"
@@ -314,6 +313,17 @@ internal_exr_revert_add_part (
 
 /**************************************/
 
+exr_result_t internal_exr_context_restore_handlers(struct _internal_exr_context* ctxt, exr_result_t rv)
+{
+    ctxt->standard_error   = &dispatch_standard_error;
+    ctxt->report_error     = &dispatch_error;
+    ctxt->print_error      = &dispatch_print_error;
+    return rv;
+}
+
+
+/**************************************/
+
 exr_result_t
 internal_exr_alloc_context (
     struct _internal_exr_context**   out,
@@ -393,13 +403,15 @@ internal_exr_alloc_context (
 
         exr_get_default_zip_compression_level (&ret->default_zip_level);
         exr_get_default_dwa_compression_quality (&ret->default_dwa_quality);
-        if (initializers->size >= sizeof (struct _exr_context_initializer_v2))
-        {
-            if (initializers->zip_level >= 0)
-                ret->default_zip_level = initializers->zip_level;
-            if (initializers->dwa_quality >= 0.f)
-                ret->default_dwa_quality = initializers->dwa_quality;
-        }
+        if (initializers->zip_level >= 0)
+            ret->default_zip_level = initializers->zip_level;
+        if (initializers->dwa_quality >= 0.f)
+            ret->default_dwa_quality = initializers->dwa_quality;
+
+        if (initializers->flags & EXR_CONTEXT_FLAG_STRICT_HEADER)
+            ret->strict_header = 1;
+        if (initializers->flags & EXR_CONTEXT_FLAG_SILENT_HEADER_PARSE)
+            ret->silent_header = 1;
 
         ret->file_size       = -1;
         ret->max_name_length = EXR_SHORTNAME_MAXLEN;

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -138,7 +138,8 @@ struct _internal_exr_context
     uint8_t has_nonimage_data;
     uint8_t is_multipart;
 
-    uint8_t pad[2];
+    uint8_t strict_header;
+    uint8_t silent_header;
 
     exr_attr_string_t filename;
     exr_attr_string_t tmp_filename;
@@ -344,6 +345,8 @@ exr_result_t internal_exr_add_part (
 void internal_exr_revert_add_part (
     struct _internal_exr_context*, struct _internal_exr_part**, int* new_index);
 
+exr_result_t internal_exr_context_restore_handlers (
+    struct _internal_exr_context* ctxt, exr_result_t rv);
 exr_result_t internal_exr_alloc_context (
     struct _internal_exr_context**   out,
     const exr_context_initializer_t* initializers,

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -185,7 +185,7 @@ typedef int64_t (*exr_write_func_ptr_t) (
  * \endcode
  *
  */
-typedef struct _exr_context_initializer_v2
+typedef struct _exr_context_initializer_v3
 {
     /** @brief Size member to tag initializer for version stability.
      *
@@ -313,13 +313,30 @@ typedef struct _exr_context_initializer_v2
      * for all contexts.
      */
     float dwa_quality;
+
+    /** Initialize with a bitwise or of the various context flags
+     */
+    int flags;
 } exr_context_initializer_t;
+
+/** @brief context flag which will enforce strict header validation
+ * checks and may prevent reading of files which could otherwise be
+ * processed.
+ */
+#define EXR_CONTEXT_FLAG_STRICT_HEADER (1 << 0)
+
+/** @brief Disables error messages while parsing headers
+ *
+ * The return values will remain the same, but error reporting will be
+ * skipped. This is only valid for reading contexts
+ */
+#define EXR_CONTEXT_FLAG_SILENT_HEADER_PARSE (1 << 1)
 
 /** @brief Simple macro to initialize the context initializer with default values. */
 #define EXR_DEFAULT_CONTEXT_INITIALIZER                                        \
     {                                                                          \
         sizeof (exr_context_initializer_t), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-            0, -2, -1.f                                                        \
+            0, -2, -1.f, 0                                                \
     }
 
 /** @} */ /* context function pointer declarations */

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -19,6 +19,34 @@
 
 /**************************************/
 
+static exr_result_t
+silent_error (
+    const struct _internal_exr_context* pctxt,
+    exr_result_t                        code,
+    const char*                         msg)
+{
+    return code;
+}
+
+static exr_result_t
+silent_standard_error (
+    const struct _internal_exr_context* pctxt, exr_result_t code)
+{
+    return code;
+}
+
+static exr_result_t
+silent_print_error (
+    const struct _internal_exr_context* pctxt,
+    exr_result_t                        code,
+    const char*                         msg,
+    ...)
+{
+    return code;
+}
+
+/**************************************/
+
 struct _internal_exr_seq_scratch
 {
     uint8_t* scratch;
@@ -2228,6 +2256,7 @@ update_chunk_offsets (
     ctxt->parts[0]->chunk_table_offset =
         scratch->fileoff - (uint64_t) scratch->navail;
     prevpart = ctxt->parts[0];
+
     for (int p = 0; p < ctxt->num_parts; ++p)
     {
         curpart = ctxt->parts[p];
@@ -2367,14 +2396,21 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
     uint8_t                          next_byte;
     exr_result_t                     rv = EXR_ERR_UNKNOWN;
 
+    if (ctxt->silent_header)
+    {
+        ctxt->standard_error = &silent_standard_error;
+        ctxt->report_error   = &silent_error;
+        ctxt->print_error    = &silent_print_error;
+    }
     rv = read_magic_and_flags (ctxt, &flags, &initpos);
-    if (rv != EXR_ERR_SUCCESS) return rv;
+    if (rv != EXR_ERR_SUCCESS)
+        return internal_exr_context_restore_handlers (ctxt, rv);
 
     rv = priv_init_scratch (ctxt, &scratch, initpos);
     if (rv != EXR_ERR_SUCCESS)
     {
         priv_destroy_scratch (&scratch);
-        return rv;
+        return internal_exr_context_restore_handlers (ctxt, rv);
     }
 
     curpart = ctxt->parts[0];
@@ -2383,27 +2419,42 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
         rv = ctxt->report_error (
             ctxt, EXR_ERR_INVALID_ARGUMENT, "Error during file initialization");
         priv_destroy_scratch (&scratch);
-        return rv;
+        return internal_exr_context_restore_handlers (ctxt, rv);
     }
 
     ctxt->is_singlepart_tiled = (flags & EXR_TILED_FLAG) ? 1 : 0;
-    ctxt->max_name_length     = (flags & EXR_LONG_NAMES_FLAG)
+    if (ctxt->strict_header)
+    {
+        ctxt->max_name_length = (flags & EXR_LONG_NAMES_FLAG)
                                     ? EXR_LONGNAME_MAXLEN
                                     : EXR_SHORTNAME_MAXLEN;
-    ctxt->has_nonimage_data   = (flags & EXR_NON_IMAGE_FLAG) ? 1 : 0;
-    ctxt->is_multipart        = (flags & EXR_MULTI_PART_FLAG) ? 1 : 0;
+    }
+    else
+    {
+        ctxt->max_name_length = EXR_LONGNAME_MAXLEN;
+    }
+    ctxt->has_nonimage_data = (flags & EXR_NON_IMAGE_FLAG) ? 1 : 0;
+    ctxt->is_multipart      = (flags & EXR_MULTI_PART_FLAG) ? 1 : 0;
     if (ctxt->is_singlepart_tiled)
     {
         if (ctxt->has_nonimage_data || ctxt->is_multipart)
         {
-            rv = ctxt->print_error (
-                ctxt,
-                EXR_ERR_FILE_BAD_HEADER,
-                "Invalid combination of version flags: single part found, but also marked as deep (%d) or multipart (%d)",
-                (int) ctxt->has_nonimage_data,
-                (int) ctxt->is_multipart);
-            priv_destroy_scratch (&scratch);
-            return rv;
+            if (ctxt->strict_header)
+            {
+                rv = ctxt->print_error (
+                    ctxt,
+                    EXR_ERR_FILE_BAD_HEADER,
+                    "Invalid combination of version flags: single part found, but also marked as deep (%d) or multipart (%d)",
+                    (int) ctxt->has_nonimage_data,
+                    (int) ctxt->is_multipart);
+                priv_destroy_scratch (&scratch);
+                return internal_exr_context_restore_handlers (ctxt, rv);
+            }
+            else
+            {
+                // assume multipart for now
+                ctxt->is_singlepart_tiled = 0;
+            }
         }
         curpart->storage_mode = EXR_STORAGE_TILED;
     }
@@ -2418,7 +2469,7 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
             rv = ctxt->report_error (
                 ctxt, EXR_ERR_FILE_BAD_HEADER, "Unable to extract header byte");
             priv_destroy_scratch (&scratch);
-            return rv;
+            return internal_exr_context_restore_handlers (ctxt, rv);
         }
 
         if (next_byte == '\0')
@@ -2427,7 +2478,7 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
             if (rv != EXR_ERR_SUCCESS)
             {
                 priv_destroy_scratch (&scratch);
-                return rv;
+                return internal_exr_context_restore_handlers (ctxt, rv);
             }
 
             if (!ctxt->is_multipart)
@@ -2444,7 +2495,7 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
                     EXR_ERR_FILE_BAD_HEADER,
                     "Unable to go to next part definition");
                 priv_destroy_scratch (&scratch);
-                return rv;
+                return internal_exr_context_restore_handlers (ctxt, rv);
             }
 
             if (next_byte == '\0')
@@ -2459,11 +2510,18 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
 
         if (rv == EXR_ERR_SUCCESS)
             rv = pull_attr (ctxt, curpart, next_byte, &scratch);
-        if (rv != EXR_ERR_SUCCESS) break;
+        if (rv != EXR_ERR_SUCCESS)
+        {
+            if (ctxt->strict_header)
+            {
+                break;
+            }
+            rv = EXR_ERR_SUCCESS;
+        }
     } while (1);
 
-    if (rv == EXR_ERR_SUCCESS) rv = update_chunk_offsets (ctxt, &scratch);
+    if (rv == EXR_ERR_SUCCESS) { rv = update_chunk_offsets (ctxt, &scratch); }
 
     priv_destroy_scratch (&scratch);
-    return rv;
+    return internal_exr_context_restore_handlers (ctxt, rv);
 }

--- a/src/lib/OpenEXRCore/validation.c
+++ b/src/lib/OpenEXRCore/validation.c
@@ -584,7 +584,7 @@ internal_exr_validate_read_part (
 {
     exr_result_t rv;
 
-    rv = validate_req_attr (f, curpart, 1);
+    rv = validate_req_attr (f, curpart, !f->strict_header);
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     rv = validate_image_dimensions (f, curpart);


### PR DESCRIPTION
This fixes a few issues noticed by PhilB around inconsistencies between what the c++ library would allow vs. the original "strict" mode of the C core. This adds (in a backwards compatible manner) flags to the context creation that allows the user to enable strict header parsing to restore the original behavior, and optionally a new "silent" parse mode that will suspend calls to the logging interface while parsing the header