### PR TITLE
handle potential overflow in CheckFile core reading

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1555,7 +1555,7 @@ memstream_read (
     {
         memdata* md   = static_cast<memdata*> (userdata);
         uint64_t left = sz;
-        if ((offset + sz) > md->bytes)
+        if (offset > md->bytes ||  sz > md->bytes || offset+sz > md->bytes)
             left = (offset < md->bytes) ? md->bytes - offset : 0;
         if (left > 0) memcpy (buffer, md->data + offset, left);
         rdsz = static_cast<int64_t> (left);


### PR DESCRIPTION
Fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46309
Handle very large offset or size values that may cause integer overflow in checks

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>