### PR TITLE
Add disable reconstruct flag

### DIFF
--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -313,14 +313,15 @@ internal_exr_revert_add_part (
 
 /**************************************/
 
-exr_result_t internal_exr_context_restore_handlers(struct _internal_exr_context* ctxt, exr_result_t rv)
+exr_result_t
+internal_exr_context_restore_handlers (
+    struct _internal_exr_context* ctxt, exr_result_t rv)
 {
-    ctxt->standard_error   = &dispatch_standard_error;
-    ctxt->report_error     = &dispatch_error;
-    ctxt->print_error      = &dispatch_print_error;
+    ctxt->standard_error = &dispatch_standard_error;
+    ctxt->report_error   = &dispatch_error;
+    ctxt->print_error    = &dispatch_print_error;
     return rv;
 }
-
 
 /**************************************/
 
@@ -412,6 +413,9 @@ internal_exr_alloc_context (
             ret->strict_header = 1;
         if (initializers->flags & EXR_CONTEXT_FLAG_SILENT_HEADER_PARSE)
             ret->silent_header = 1;
+        ret->disable_chunk_reconstruct =
+            (initializers->flags &
+             EXR_CONTEXT_FLAG_DISABLE_CHUNK_RECONSTRUCTION);
 
         ret->file_size       = -1;
         ret->max_name_length = EXR_SHORTNAME_MAXLEN;

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -212,6 +212,7 @@ struct _internal_exr_context
     pthread_mutex_t mutex;
 #    endif
 #endif
+    uint8_t disable_chunk_reconstruct;
 };
 
 #define EXR_CTXT(c) ((struct _internal_exr_context*) (c))

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -332,6 +332,14 @@ typedef struct _exr_context_initializer_v3
  */
 #define EXR_CONTEXT_FLAG_SILENT_HEADER_PARSE (1 << 1)
 
+/** @brief Disables reconstruction logic upon corrupt / missing data chunks
+ *
+ * This will disable the reconstruction logic that searches through an
+ * incomplete file, and will instead just return errors at read
+ * time. This is only valid for reading contexts
+ */
+#define EXR_CONTEXT_FLAG_DISABLE_CHUNK_RECONSTRUCTION (1 << 2)
+
 /** @brief Simple macro to initialize the context initializer with default values. */
 #define EXR_DEFAULT_CONTEXT_INITIALIZER                                        \
     {                                                                          \

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -56,6 +56,8 @@ struct _internal_exr_seq_scratch
 
     exr_result_t (*sequential_read) (
         struct _internal_exr_seq_scratch*, void*, uint64_t);
+    exr_result_t (*sequential_skip) (
+        struct _internal_exr_seq_scratch*, uint64_t);
 
     struct _internal_exr_context* ctxt;
 };
@@ -157,6 +159,61 @@ scratch_seq_read (struct _internal_exr_seq_scratch* scr, void* buf, uint64_t sz)
     return rv;
 }
 
+static exr_result_t
+scratch_seq_skip (struct _internal_exr_seq_scratch* scr, uint64_t sz)
+{
+    uint64_t     nCopied = 0;
+    uint64_t     notdone = sz;
+    exr_result_t rv      = -1;
+
+    while (notdone > 0)
+    {
+        if (scr->navail > 0)
+        {
+            uint64_t nLeft = (uint64_t) scr->navail;
+            uint64_t nCopy = notdone;
+            if (nCopy > nLeft) nCopy = nLeft;
+            scr->curpos += nCopy;
+            scr->navail -= (int64_t) nCopy;
+            notdone -= nCopy;
+            nCopied += nCopy;
+        }
+        else
+        {
+            int64_t nread = 0;
+            rv            = scr->ctxt->do_read (
+                scr->ctxt,
+                scr->scratch,
+                SCRATCH_BUFFER_SIZE,
+                &(scr->fileoff),
+                &nread,
+                EXR_ALLOW_SHORT_READ);
+            if (nread > 0)
+            {
+                scr->navail = nread;
+                scr->curpos = 0;
+            }
+            else
+            {
+                if (nread == 0)
+                    rv = scr->ctxt->report_error (
+                        scr->ctxt,
+                        EXR_ERR_READ_IO,
+                        "End of file attempting to read header");
+                break;
+            }
+        }
+    }
+    if (rv == -1)
+    {
+        if (nCopied == sz)
+            rv = EXR_ERR_SUCCESS;
+        else
+            rv = EXR_ERR_READ_IO;
+    }
+    return rv;
+}
+
 /**************************************/
 
 static exr_result_t
@@ -169,6 +226,7 @@ priv_init_scratch (
     scr->navail          = 0;
     scr->fileoff         = offset;
     scr->sequential_read = &scratch_seq_read;
+    scr->sequential_skip = &scratch_seq_skip;
     scr->ctxt            = ctxt;
     scr->scratch         = ctxt->alloc_fn (SCRATCH_BUFFER_SIZE);
     if (scr->scratch == NULL)
@@ -803,17 +861,23 @@ check_populate_channels (
     exr_result_t      rv;
 
     if (curpart->channels)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'channels' encountered");
+    }
 
     if (0 != strcmp (tname, "chlist"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute 'channels': Invalid type '%s'",
             tname);
+    }
 
     rv = extract_attr_chlist (
         ctxt, scratch, &(tmpchans), EXR_REQ_CHANNELS_STR, tname, attrsz);
@@ -861,19 +925,25 @@ check_populate_compression (
     exr_result_t rv;
 
     if (curpart->compression)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_COMP_STR);
+    }
 
     if (0 != strcmp (tname, EXR_REQ_COMP_STR))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_COMP_STR,
             tname);
+    }
 
     rv = extract_attr_uint8 (
         ctxt,
@@ -919,19 +989,25 @@ check_populate_dataWindow (
     exr_result_t     rv;
 
     if (curpart->dataWindow)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_DATA_STR);
+    }
 
     if (0 != strcmp (tname, "box2i"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_DATA_STR,
             tname);
+    }
 
     rv = extract_attr_32bit (
         ctxt, scratch, &(tmpdata), EXR_REQ_DATA_STR, tname, attrsz, 4);
@@ -971,19 +1047,25 @@ check_populate_displayWindow (
     exr_result_t     rv;
 
     if (curpart->displayWindow)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_DISP_STR);
+    }
 
     if (0 != strcmp (tname, "box2i"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_DISP_STR,
             tname);
+    }
 
     rv = extract_attr_32bit (
         ctxt, scratch, &(tmpdata), EXR_REQ_DISP_STR, tname, attrsz, 4);
@@ -1023,19 +1105,25 @@ check_populate_lineOrder (
     exr_result_t rv;
 
     if (curpart->lineOrder)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_LO_STR);
+    }
 
     if (0 != strcmp (tname, EXR_REQ_LO_STR))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_LO_STR,
             tname);
+    }
 
     rv = extract_attr_uint8 (
         ctxt,
@@ -1085,27 +1173,36 @@ check_populate_pixelAspectRatio (
     } tpun;
 
     if (curpart->pixelAspectRatio)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_PAR_STR);
+    }
 
     if (0 != strcmp (tname, "float"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_PAR_STR,
             tname);
+    }
 
     if (attrsz != sizeof (float))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_SIZE_MISMATCH,
             "Required attribute '%s': Invalid size %d (exp 4)",
             EXR_REQ_PAR_STR,
             attrsz);
+    }
 
     rv = scratch->sequential_read (scratch, &(tpun.ival), sizeof (uint32_t));
     if (rv != EXR_ERR_SUCCESS)
@@ -1151,21 +1248,29 @@ check_populate_screenWindowCenter (
     exr_attr_v2f_t tmpdata;
 
     if (curpart->screenWindowCenter)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_SCR_WC_STR);
+    }
 
     if (0 != strcmp (tname, "v2f"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_SCR_WC_STR,
             tname);
+    }
 
     if (attrsz != sizeof (exr_attr_v2f_t))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_SIZE_MISMATCH,
@@ -1173,6 +1278,7 @@ check_populate_screenWindowCenter (
             EXR_REQ_SCR_WC_STR,
             attrsz,
             (uint64_t) sizeof (exr_attr_v2f_t));
+    }
 
     rv = scratch->sequential_read (scratch, &tmpdata, sizeof (exr_attr_v2f_t));
     if (rv != EXR_ERR_SUCCESS)
@@ -1222,27 +1328,36 @@ check_populate_screenWindowWidth (
     } tpun;
 
     if (curpart->screenWindowWidth)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute '%s' encountered",
             EXR_REQ_SCR_WW_STR);
+    }
 
     if (0 != strcmp (tname, "float"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute '%s': Invalid type '%s'",
             EXR_REQ_SCR_WW_STR,
             tname);
+    }
 
     if (attrsz != sizeof (float))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_SIZE_MISMATCH,
             "Required attribute '%s': Invalid size %d (exp 4)",
             EXR_REQ_SCR_WW_STR,
             attrsz);
+    }
 
     rv = scratch->sequential_read (scratch, &(tpun.ival), sizeof (uint32_t));
     if (rv != EXR_ERR_SUCCESS)
@@ -1288,25 +1403,34 @@ check_populate_tiles (
     exr_attr_tiledesc_t tmpdata = {0};
 
     if (curpart->tiles)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'tiles' encountered");
+    }
 
     if (0 != strcmp (tname, "tiledesc"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute 'tiles': Invalid type '%s'",
             tname);
+    }
 
     if (attrsz != sizeof (exr_attr_tiledesc_t))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute 'tiles': Invalid size %d (exp %" PRIu64 ")",
             attrsz,
             (uint64_t) sizeof (exr_attr_tiledesc_t));
+    }
 
     rv = scratch->sequential_read (scratch, &tmpdata, sizeof (tmpdata));
     if (rv != EXR_ERR_SUCCESS)
@@ -1353,17 +1477,23 @@ check_populate_name (
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     if (curpart->name)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'name' encountered");
+    }
 
     if (0 != strcmp (tname, "string"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "attribute 'name': Invalid type '%s'",
             tname);
+    }
 
     rv = exr_attr_list_add_static_name (
         (exr_context_t) ctxt,
@@ -1375,6 +1505,7 @@ check_populate_name (
         &(curpart->name));
     if (rv != EXR_ERR_SUCCESS)
     {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             rv,
@@ -1427,17 +1558,23 @@ check_populate_type (
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     if (curpart->type)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'type' encountered");
+    }
 
     if (0 != strcmp (tname, "string"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "Required attribute 'type': Invalid type '%s'",
             tname);
+    }
 
     rv = exr_attr_list_add_static_name (
         (exr_context_t) ctxt,
@@ -1449,6 +1586,7 @@ check_populate_type (
         &(curpart->type));
     if (rv != EXR_ERR_SUCCESS)
     {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             rv,
@@ -1515,24 +1653,33 @@ check_populate_version (
     exr_result_t rv;
 
     if (curpart->version)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'version' encountered");
+    }
 
     if (0 != strcmp (tname, "int"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "attribute 'version': Invalid type '%s'",
             tname);
+    }
 
     if (attrsz != sizeof (int32_t))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "attribute 'version': Invalid size %d (exp 4)",
             attrsz);
+    }
 
     rv = scratch->sequential_read (scratch, &attrsz, sizeof (int32_t));
     if (rv != EXR_ERR_SUCCESS)
@@ -1574,24 +1721,33 @@ check_populate_chunk_count (
     exr_result_t rv;
 
     if (curpart->chunkCount)
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Duplicate copy of required attribute 'chunkCount' encountered");
+    }
 
     if (0 != strcmp (tname, "int"))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_TYPE_MISMATCH,
             "attribute 'chunkCount': Invalid type '%s'",
             tname);
+    }
 
     if (attrsz != sizeof (int32_t))
+    {
+        scratch->sequential_skip (scratch, attrsz);
         return ctxt->print_error (
             ctxt,
             EXR_ERR_INVALID_ATTR,
             "Required attribute 'chunkCount': Invalid size %d (exp 4)",
             attrsz);
+    }
 
     rv = scratch->sequential_read (scratch, &attrsz, sizeof (int32_t));
     if (rv != EXR_ERR_SUCCESS)
@@ -2513,10 +2669,7 @@ internal_exr_parse_header (struct _internal_exr_context* ctxt)
             rv = pull_attr (ctxt, curpart, next_byte, &scratch);
         if (rv != EXR_ERR_SUCCESS)
         {
-            if (ctxt->strict_header)
-            {
-                break;
-            }
+            if (ctxt->strict_header) { break; }
             rv = EXR_ERR_SUCCESS;
         }
     } while (1);


### PR DESCRIPTION
this adds similar disable chunk offset reconstruction flag to the c++ multi input file class and additonally restores more silent behavior when reconstructing the chunk offsets. Additionally, fixes an issue with bad attributes not seeking in file header enough