### PR TITLE
Adjust exec_prefix path for PyIlmBase's pkgconfig file

### DIFF
--- a/PyIlmBase/config/CMakeLists.txt
+++ b/PyIlmBase/config/CMakeLists.txt
@@ -15,7 +15,7 @@ if(PYILMBASE_INSTALL_PKG_CONFIG)
   # use a helper function to avoid variable pollution, but pretty simple
   function(pyilmbase_pkg_config_help pcinfile)
     set(prefix ${CMAKE_INSTALL_PREFIX})
-    set(exec_prefix ${CMAKE_INSTALL_BINDIR})
+    set(exec_prefix "\${prefix}")
     set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
     set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
     string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Closes: https://github.com/AcademySoftwareFoundation/openexr/issues/1252
Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>