### PR TITLE
Fix compile errors with MSVC 2022

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -15,7 +15,8 @@
 /**************************************/
 
 /* for testing, we include a bunch of internal stuff into the unit tests which are in c++ */
-#if defined __has_include
+/* Visual Studio 2022 has stdatomic.h, but does not yet support it when compiling as C. */
+#if defined __has_include && !defined(_MSC_VER)
 #    if __has_include(<stdatomic.h>)
 #        define EXR_HAS_STD_ATOMICS 1
 #    endif

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -35,7 +35,8 @@
 #    include <atomic>
 using atomic_uintptr_t = std::atomic_uintptr_t;
 #else
-#    if defined __has_include
+/* Visual Studio 2022 has stdatomic.h, but does not yet support it when compiling as C. */
+#    if defined __has_include && !defined(_MSC_VER)
 #        if __has_include(<stdatomic.h>)
 #            define EXR_HAS_STD_ATOMICS 1
 #        endif


### PR DESCRIPTION
The latest windows compiler ships with stdatomic.h, but does not yet allow
to build C code with it which results in an error. Workaround this for
now by tweaking the detection logic.