### PR TITLE
Refactor ImfCheckFile and oss-fuzz tests

### DIFF
--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -1270,6 +1270,21 @@ Header::setMaxTileSize (int maxWidth, int maxHeight)
     maxTileHeight = maxHeight;
 }
 
+void
+Header::getMaxImageSize (int& maxWidth, int& maxHeight)
+{
+    maxWidth = maxImageWidth;
+    maxHeight = maxImageHeight;
+}
+
+void
+Header::getMaxTileSize (int& maxWidth, int& maxHeight)
+{
+    maxWidth = maxTileWidth;
+    maxHeight= maxTileHeight;
+}
+
+
 bool
 Header::readsNothing ()
 {

--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -446,6 +446,11 @@ public:
     static void setMaxImageSize (int maxWidth, int maxHeight);
     IMF_EXPORT
     static void setMaxTileSize (int maxWidth, int maxHeight);
+    IMF_EXPORT
+    static void getMaxImageSize (int& maxWidth, int& maxHeight);
+    IMF_EXPORT
+    static void getMaxTileSize (int& maxWidth, int& maxHeight);
+
 
     //
     // Check if the header reads nothing.

--- a/src/lib/OpenEXRUtil/ImfCheckFile.h
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.h
@@ -25,13 +25,14 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 // if reduceTime is true and an error is found within the file, then future tests are reduced for speed.
 // This may hide errors within the library.
 //
+// if runCoreCheck is true, only uses the OpenEXRCore (C) API, otherwise uses the OpenEXR (C++) API
 //
 
 IMFUTIL_EXPORT bool checkOpenEXRFile (
     const char* fileName,
     bool        reduceMemory    = false,
     bool        reduceTime      = false,
-    bool        enableCoreCheck = false);
+    bool        runCoreCheck = false);
 
 //
 // overloaded version of checkOpenEXRFile that takes a pointer to in-memory data
@@ -42,7 +43,7 @@ IMFUTIL_EXPORT bool checkOpenEXRFile (
     size_t      numBytes,
     bool        reduceMemory    = false,
     bool        reduceTime      = false,
-    bool        enableCoreCheck = false);
+    bool        runCoreCheck = false);
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 

--- a/src/test/OpenEXRFuzzTest/oss-fuzz/openexr_exrcorecheck_fuzzer.cc
+++ b/src/test/OpenEXRFuzzTest/oss-fuzz/openexr_exrcorecheck_fuzzer.cc
@@ -14,7 +14,7 @@
 using OPENEXR_IMF_NAMESPACE::checkOpenEXRFile;
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    checkOpenEXRFile ((const char*) data , size , true , true, false);
+    checkOpenEXRFile ((const char*) data , size , true , true, true);
     return 0;
 }
 


### PR DESCRIPTION
Address https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=46459 by reorganizing Imf::CheckFile and tests.

CheckFile's logic for reducing memory usage hadn't been updated to support reading multiple parts using the RgbaFile API.
To reduce code spaghetti, CheckFile now uses the built-in limits for image and tile size rather than its own checks. Static methods to read those values have been added to Imf::Header to allow CheckFile to restore the original values before returning. (This extends the API and ABI but is backwards compatible)

Additionally, the interpretation of 'enableCoreChecks' (and exrcheck's "-c" flag) have been changed to run _only_ the Core API tests, and not the C++ API tests. Previously, only files which were considered 'valid' by the Core API would be tested with the C++ API.

This change also splits the Core and C++ API tests into two separate binaries with the oss-fuzz suite: the new binary runs just the Core API. This should prevent timeout errors and also help to triage where issues may be occurring. The downside of this change is that fuzz tests will abort earlier when run on large images, so will be less able to detect vulnerabilities that may be present without those limits set.

Note oss-fuzz 46413 and 46432 may also be marked as resolved by this PR, but nothing has been done here to address those issues, so new related fuzz reports will likely appear

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>