### PR TITLE
Add explicit casts around the usage of zlib datatypes to avoid warnings on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ build/
 build-win/
 build-nuget/
 *~
+.vscode

--- a/src/lib/OpenEXR/ImfPxr24Compressor.cpp
+++ b/src/lib/OpenEXR/ImfPxr24Compressor.cpp
@@ -341,13 +341,14 @@ Pxr24Compressor::compress (
         }
     }
 
-    uLongf outSize = int (ceil ((tmpBufferEnd - _tmpBuffer) * 1.01)) + 100;
+    uLong inBufferSize = static_cast<uLong> (tmpBufferEnd - _tmpBuffer);
+    uLong outSize = compressBound (inBufferSize);
 
     if (Z_OK != ::compress (
-                    (Bytef*) _outBuffer,
+                    reinterpret_cast<Bytef*> (_outBuffer),
                     &outSize,
-                    (const Bytef*) _tmpBuffer,
-                    tmpBufferEnd - _tmpBuffer))
+                    reinterpret_cast<const Bytef*> (_tmpBuffer),
+                    inBufferSize))
     {
         throw IEX_NAMESPACE::BaseExc ("Data compression (zlib) failed.");
     }
@@ -366,11 +367,14 @@ Pxr24Compressor::uncompress (
         return 0;
     }
 
-    uLongf tmpSize = _maxScanLineSize * _numScanLines;
+    uLong tmpSize = static_cast<uLong> (_maxScanLineSize * _numScanLines);
 
     if (Z_OK !=
         ::uncompress (
-            (Bytef*) _tmpBuffer, &tmpSize, (const Bytef*) inPtr, inSize))
+            reinterpret_cast<Bytef*> (_tmpBuffer),
+            &tmpSize,
+            reinterpret_cast<const Bytef*> (inPtr),
+            inSize))
     {
         throw IEX_NAMESPACE::InputExc ("Data decompression (zlib) failed.");
     }
@@ -408,7 +412,7 @@ Pxr24Compressor::uncompress (
                     ptr[3]       = ptr[2] + n;
                     tmpBufferEnd = ptr[3] + n;
 
-                    if ((uLongf) (tmpBufferEnd - _tmpBuffer) > tmpSize)
+                    if (static_cast<uLong> (tmpBufferEnd - _tmpBuffer) > tmpSize)
                         notEnoughData ();
 
                     for (int j = 0; j < n; ++j)
@@ -433,7 +437,7 @@ Pxr24Compressor::uncompress (
                     ptr[1]       = ptr[0] + n;
                     tmpBufferEnd = ptr[1] + n;
 
-                    if ((uLongf) (tmpBufferEnd - _tmpBuffer) > tmpSize)
+                    if (static_cast<uLong> (tmpBufferEnd - _tmpBuffer) > tmpSize)
                         notEnoughData ();
 
                     for (int j = 0; j < n; ++j)
@@ -456,7 +460,7 @@ Pxr24Compressor::uncompress (
                     ptr[2]       = ptr[1] + n;
                     tmpBufferEnd = ptr[2] + n;
 
-                    if ((uLongf) (tmpBufferEnd - _tmpBuffer) > tmpSize)
+                    if (static_cast<uLong> (tmpBufferEnd - _tmpBuffer) > tmpSize)
                         notEnoughData ();
 
                     for (int j = 0; j < n; ++j)
@@ -479,7 +483,7 @@ Pxr24Compressor::uncompress (
         }
     }
 
-    if ((uLongf) (tmpBufferEnd - _tmpBuffer) < tmpSize) tooMuchData ();
+    if (static_cast<uLong> (tmpBufferEnd - _tmpBuffer) < tmpSize) tooMuchData ();
 
     outPtr = _outBuffer;
     return writePtr - _outBuffer;

--- a/src/lib/OpenEXR/ImfZip.cpp
+++ b/src/lib/OpenEXR/ImfZip.cpp
@@ -93,13 +93,14 @@ Zip::compress (const char* raw, int rawSize, char* compressed)
     // Compress the data using zlib
     //
 
-    uLongf outSize = int (ceil (rawSize * 1.01)) + 100;
+    uLong inSize = static_cast<uLong> (rawSize);
+    uLong outSize = compressBound (inSize);
 
     if (Z_OK != ::compress2 (
-                    (Bytef*) compressed,
+                    reinterpret_cast<Bytef*> (compressed),
                     &outSize,
-                    (const Bytef*) _tmpBuffer,
-                    rawSize,
+                    reinterpret_cast<const Bytef*> (_tmpBuffer),
+                    inSize,
                     _zipLevel))
     {
         throw IEX_NAMESPACE::BaseExc ("Data compression (zlib) failed.");
@@ -240,13 +241,14 @@ Zip::uncompress (const char* compressed, int compressedSize, char* raw)
     // Decompress the data using zlib
     //
 
-    uLongf outSize = _maxRawSize;
+    uLong outSize = static_cast<uLong> (_maxRawSize);
+    uLong inSize = static_cast<uLong> (compressedSize);
 
     if (Z_OK != ::uncompress (
-                    (Bytef*) _tmpBuffer,
+                    reinterpret_cast<Bytef*> (_tmpBuffer),
                     &outSize,
-                    (const Bytef*) compressed,
-                    compressedSize))
+                    reinterpret_cast<const Bytef*> (compressed),
+                    inSize))
     {
         throw IEX_NAMESPACE::InputExc ("Data decompression (zlib) failed.");
     }

--- a/src/lib/OpenEXRCore/internal_pxr24.c
+++ b/src/lib/OpenEXRCore/internal_pxr24.c
@@ -92,7 +92,7 @@ apply_pxr24_impl (exr_encode_pipeline_t* encode)
     uint8_t*       out       = encode->scratch_buffer_1;
     uint64_t       nOut      = 0;
     const uint8_t* lastIn    = encode->packed_buffer;
-    uLongf         compbufsz = encode->compressed_alloc_size;
+    uLong          compbufsz = (uLong) encode->compressed_alloc_size;
 
     for (int y = 0; y < encode->chunk.height; ++y)
     {
@@ -219,7 +219,7 @@ apply_pxr24_impl (exr_encode_pipeline_t* encode)
                     (Bytef*) encode->compressed_buffer,
                     &compbufsz,
                     (const Bytef*) encode->scratch_buffer_1,
-                    nOut))
+                    (uLong) nOut))
     {
         return EXR_ERR_CORRUPT_CHUNK;
     }
@@ -229,7 +229,7 @@ apply_pxr24_impl (exr_encode_pipeline_t* encode)
             encode->compressed_buffer,
             encode->packed_buffer,
             encode->packed_bytes);
-        compbufsz = encode->packed_bytes;
+        compbufsz = (uLong) encode->packed_bytes;
     }
     encode->compressed_bytes = compbufsz;
     return EXR_ERR_SUCCESS;
@@ -262,7 +262,7 @@ undo_pxr24_impl (
     void*                  scratch_data,
     uint64_t               scratch_size)
 {
-    uLongf         outSize = (uLongf) uncompressed_size;
+    uLong          outSize = (uLong) uncompressed_size;
     int            rstat;
     uint8_t*       out    = uncompressed_data;
     uint64_t       nOut   = 0;

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -158,7 +158,7 @@ undo_zip_impl (
     void*       scratch_data,
     uint64_t    scratch_size)
 {
-    uLongf outSize = (uLongf) uncompressed_size;
+    uLong  outSize = (uLong) uncompressed_size;
     int    rstat;
 
     if (scratch_size < uncompressed_size) return EXR_ERR_INVALID_ARGUMENT;
@@ -226,7 +226,7 @@ apply_zip_impl (exr_encode_pipeline_t* encode)
     const uint8_t* raw  = encode->packed_buffer;
     const uint8_t* stop = raw + encode->packed_bytes;
     int            p, level;
-    uLongf         compbufsz = encode->compressed_alloc_size;
+    uLong          compbufsz = (uLong) encode->compressed_alloc_size;
     exr_result_t   rv        = EXR_ERR_SUCCESS;
 
     rv = exr_get_zip_compression_level (
@@ -257,7 +257,7 @@ apply_zip_impl (exr_encode_pipeline_t* encode)
                     (Bytef*) encode->compressed_buffer,
                     &compbufsz,
                     (const Bytef*) encode->scratch_buffer_1,
-                    encode->packed_bytes,
+                    (uLong) encode->packed_bytes,
                     level))
     {
         return EXR_ERR_CORRUPT_CHUNK;

--- a/src/test/OpenEXRTest/testIDManifest.cpp
+++ b/src/test/OpenEXRTest/testIDManifest.cpp
@@ -136,14 +136,15 @@ doReadWriteManifest (const IDManifest& mfst, const string& fn, bool dump)
     //
     // allocate a buffer which is guaranteed to be big enough for compression
     //
-    uLongf       compressedDataSize = compressBound (str.str ().size ());
+    uLong        sourceDataSize = static_cast<uLong> (str.str ().size ());
+    uLong        compressedDataSize = compressBound (sourceDataSize);
     vector<char> compressed (compressedDataSize);
 
     ::compress (
-        (Bytef*) &compressed[0],
+        reinterpret_cast<Bytef*> (compressed.data ()),
         &compressedDataSize,
-        (const Bytef*) str.str ().c_str (),
-        str.str ().size ());
+        reinterpret_cast<const Bytef*> (str.str ().c_str ()),
+        sourceDataSize);
 
     cerr << "simple zip size: " << compressedDataSize << ' ';
 #endif


### PR DESCRIPTION
Windows defines 'long' to be 32-bits, even for 64-bit builds. This causes MSVC to complain about most of the code surrounding calls to the zlib API.

Luckily OpenEXR uses a minimal set of calls from zlib:
  * compress2
  * compressBound
  * uncompress

This change focuses on preserving the current behavior, but adds explicit casts to the appropriate types. Future attemps to address this should grep for uLong and the three functions above.

As part of this cleanup, I also found a few places that had bespoke implementations of compressBound which I replaced with a call the real function.

Cleaned up a stray use of halfLimits.h which is a deprecated header and is not required.
