### PR TITLE
prevent integer overflow of lineOffsetSize

### DIFF
--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -1151,9 +1151,10 @@ ScanLineInputFile::initialize (const Header& header)
 
     _data->linesInBuffer = numLinesInBuffer (comp);
 
-    int lineOffsetSize =
-        (dataWindow.max.y - dataWindow.min.y + _data->linesInBuffer) /
-        _data->linesInBuffer;
+    uint64_t lineOffsetSize =
+        (static_cast<int64_t>(dataWindow.max.y) - static_cast<int64_t>(dataWindow.min.y) + static_cast<int64_t>(_data->linesInBuffer)) /
+        static_cast<int64_t>(_data->linesInBuffer);
+
 
     //
     // avoid allocating excessive memory due to large lineOffsets and bytesPerLine table sizes.


### PR DESCRIPTION
Fix issue in Imf::ScanLineInputFile found by Nick C: overflow computing lineOffsetSize could cause it to be negative. This bypassed the test introduced by #824 and could also prevent very large files reading correctly.

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>