### PR TITLE
prevent integer overflow in DeepScanlineInputFile with huge images

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -1186,9 +1186,22 @@ DeepScanLineInputFile::initialize (const Header& header)
         for (int i = 0; i < _data->maxY - _data->minY + 1; i++)
             _data->gotSampleCount[i] = false;
 
-        _data->maxSampleCountTableSize =
-            min (_data->linesInBuffer, _data->maxY - _data->minY + 1) *
-            (_data->maxX - _data->minX + 1) * sizeof (unsigned int);
+        int64_t imageHeight = static_cast<int64_t>(_data->maxY) - static_cast<int64_t>(_data->minY) + 1;
+        int64_t imageWidth = static_cast<int64_t>(_data->maxX) - static_cast<int64_t>(_data->minX) +1;
+
+        int64_t tableSize =  min (static_cast<int64_t>(_data->linesInBuffer), imageHeight) * imageWidth
+            * sizeof (unsigned int);
+
+        if (tableSize>std::numeric_limits<int>::max() )
+        {
+             THROW (IEX_NAMESPACE::ArgExc,
+                    "Deep scanline image size "
+                    << imageWidth << " x " <<  imageHeight
+                    << " exceeds maximum size");
+        }
+        _data->maxSampleCountTableSize =tableSize;
+
+
 
         _data->sampleCountTableBuffer.resizeErase (
             _data->maxSampleCountTableSize);


### PR DESCRIPTION
Address an overflow allocating sample count table in DeepScanLineInputFile (issue found by Nick C)

When there are more than 2^29 pixels in an image, the table allocation overflows, causing incorrect memory allocation of the table. Switching storage from Array<char> to std::vector<char> would allow for larger images, but the limit seems a reasonable one, so instead an explicit check for overflow is added. Larger images should still be readable using the core API (or, better still, written using the deeptile API)

Signed-off-by: Peter Hillman <peterh@wetafx.co.nz>