### PR TITLE
Fix gcc 13 build

### DIFF
--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -4,6 +4,7 @@
 #include <ImathConfig.h>
 #include <ImfCheckFile.h>
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <string.h>

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -19,6 +19,7 @@
 
 #include "ImfTileDescription.h"
 
+#include <cstdint>
 #include <ImathBox.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.h
@@ -10,6 +10,7 @@
 
 #include "ImfTileDescription.h"
 
+#include <cstdint>
 #include <ImathBox.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER


### PR DESCRIPTION
`gcc-13` did a bit of implicit header inclusion hygiene. This exposed a few build failures in `openexr`. The change restores the build by adding `<cstdint>` includes.