### PR TITLE
Address OSS Fuzz Issues

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -409,8 +409,21 @@ read_and_validate_chunk_leader (
     if (part->storage_mode == EXR_STORAGE_SCANLINE ||
         part->storage_mode == EXR_STORAGE_DEEP_SCANLINE)
     {
-        *indexio = (leader.scanline_y - part->data_window.min.y) /
-                   part->lines_per_chunk;
+        int64_t chunk = (int64_t) leader.scanline_y;
+        chunk -= (int64_t) part->data_window.min.y;
+        chunk /= part->lines_per_chunk;
+        if (chunk < 0 || chunk > INT32_MAX)
+            return ctxt->print_error (
+                ctxt,
+                EXR_ERR_BAD_CHUNK_LEADER,
+                "Invalid chunk index: %" PRId64
+                " reading scanline %d (datawindow min %d) with lines per chunk %d",
+                chunk,
+                leader.scanline_y,
+                part->data_window.min.y,
+                part->lines_per_chunk);
+
+        *indexio = (int) chunk;
     }
     else
     {

--- a/src/lib/OpenEXRCore/coding.c
+++ b/src/lib/OpenEXRCore/coding.c
@@ -4,6 +4,7 @@
 */
 
 #include "internal_coding.h"
+#include "internal_util.h"
 
 #include <string.h>
 
@@ -40,16 +41,8 @@ internal_coding_fill_channel_info (
 
         decc->channel_name = curc->name.str;
 
-        if (curc->y_sampling > 1)
-        {
-            if (cinfo->height == 1)
-                decc->height = ((cinfo->start_y % curc->y_sampling) == 0) ? 1
-                                                                          : 0;
-            else
-                decc->height = cinfo->height / curc->y_sampling;
-        }
-        else
-            decc->height = cinfo->height;
+        decc->height = compute_sampled_lines (
+            cinfo->height, curc->y_sampling, cinfo->start_y);
 
         if (curc->x_sampling > 1)
             decc->width = cinfo->width / curc->x_sampling;
@@ -106,16 +99,8 @@ internal_coding_update_channel_info (
 
         ccic->channel_name = curc->name.str;
 
-        if (curc->y_sampling > 1)
-        {
-            if (cinfo->height == 1)
-                ccic->height = ((cinfo->start_y % curc->y_sampling) == 0) ? 1
-                                                                          : 0;
-            else
-                ccic->height = cinfo->height / curc->y_sampling;
-        }
-        else
-            ccic->height = cinfo->height;
+        ccic->height = compute_sampled_lines (
+            cinfo->height, curc->y_sampling, cinfo->start_y);
 
         if (curc->x_sampling > 1)
             ccic->width = cinfo->width / curc->x_sampling;

--- a/src/lib/OpenEXRCore/internal_b44.c
+++ b/src/lib/OpenEXRCore/internal_b44.c
@@ -345,10 +345,7 @@ compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
                 }
                 tmp += ((uint64_t) (y / curc->y_samples)) * bpl;
             }
-            else
-            {
-                tmp += ((uint64_t) y) * bpl;
-            }
+            else { tmp += ((uint64_t) y) * bpl; }
 
             memcpy (tmp, packed, bpl);
             if (curc->data_type == EXR_PIXEL_HALF) priv_to_native16 (tmp, nx);
@@ -607,6 +604,36 @@ uncompress_b44_impl (
     return EXR_ERR_SUCCESS;
 }
 
+/**************************************/
+
+static uint64_t
+compute_scratch_buffer_size (
+    exr_decode_pipeline_t* decode, uint64_t uncompressed_size)
+{
+    const exr_coding_channel_info_t* curc;
+    int                              nx, ny;
+    uint64_t                         ret  = uncompressed_size;
+    uint64_t                         comp = 0;
+
+    for (int c = 0; c < decode->channel_count; ++c)
+    {
+        curc = decode->channels + c;
+
+        nx = curc->width;
+        ny = curc->height;
+
+        if (nx % 4) nx += 4 - nx % 4;
+        if (ny % 4) ny += 4 - ny % 4;
+
+        comp += (uint64_t) (ny) * (uint64_t) (nx) *
+                (uint64_t) (curc->bytes_per_element);
+    }
+    if (comp > ret) ret = comp;
+    return ret;
+}
+
+/**************************************/
+
 exr_result_t
 internal_exr_undo_b44 (
     exr_decode_pipeline_t* decode,
@@ -621,7 +648,7 @@ internal_exr_undo_b44 (
         EXR_TRANSCODE_BUFFER_SCRATCH1,
         &(decode->scratch_buffer_1),
         &(decode->scratch_alloc_size_1),
-        uncompressed_size);
+        compute_scratch_buffer_size (decode, uncompressed_size));
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     return uncompress_b44_impl (
@@ -646,7 +673,7 @@ internal_exr_undo_b44a (
         EXR_TRANSCODE_BUFFER_SCRATCH1,
         &(decode->scratch_buffer_1),
         &(decode->scratch_alloc_size_1),
-        uncompressed_size);
+        compute_scratch_buffer_size (decode, uncompressed_size));
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     return uncompress_b44_impl (

--- a/src/lib/OpenEXRCore/internal_util.h
+++ b/src/lib/OpenEXRCore/internal_util.h
@@ -1,0 +1,40 @@
+/*
+** SPDX-License-Identifier: BSD-3-Clause
+** Copyright Contributors to the OpenEXR Project.
+*/
+
+#include <stdint.h>
+
+static inline int
+compute_sampled_lines (int height, int y_sampling, int start_y)
+{
+    int nlines;
+
+    if (y_sampling <= 1) return height;
+
+    if (height == 1)
+        nlines = (start_y % y_sampling) == 0 ? 1 : 0;
+    else
+    {
+        int start, end;
+
+        /* computed the number of times y % ysampling == 0, by
+         * computing interval based on first and last time that occurs
+         * on the given range
+         */
+        start = start_y % y_sampling;
+        if (start != 0)
+            start = start_y + (y_sampling - start);
+        else
+            start = start_y;
+        end = start_y + height - 1;
+        end -= (end % y_sampling);
+
+        if (start > end)
+            nlines = 0;
+        else
+            nlines = (end - start) / y_sampling + 1;
+    }
+
+    return nlines;
+}

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -158,7 +158,7 @@ undo_zip_impl (
     void*       scratch_data,
     uint64_t    scratch_size)
 {
-    uLong  outSize = (uLong) uncompressed_size;
+    uLong  outSize = (uLong) scratch_size;
     int    rstat;
 
     if (scratch_size < uncompressed_size) return EXR_ERR_INVALID_ARGUMENT;
@@ -200,12 +200,16 @@ internal_exr_undo_zip (
     uint64_t               uncompressed_size)
 {
     exr_result_t rv;
+    uint64_t scratchbufsz = uncompressed_size;
+    if ( comp_buf_size > scratchbufsz )
+        scratchbufsz = comp_buf_size;
+
     rv = internal_decode_alloc_buffer (
         decode,
         EXR_TRANSCODE_BUFFER_SCRATCH1,
         &(decode->scratch_buffer_1),
         &(decode->scratch_alloc_size_1),
-        uncompressed_size);
+        scratchbufsz);
     if (rv != EXR_ERR_SUCCESS) return rv;
     return undo_zip_impl (
         compressed_data,


### PR DESCRIPTION
Address:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47483
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47503
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47517

There was a set of issues when the y sampling of a file was odd and not 1 (as in not even, not just bogus), and further memory issues decoding very small files (i.e. width of 1)

