### PR TITLE
Fix typos in `src/lib/OpenEXR/` 

### DIFF
--- a/src/lib/OpenEXR/ImfArray.h
+++ b/src/lib/OpenEXR/ImfArray.h
@@ -178,14 +178,14 @@ Array<T>::resizeEraseUnsafe (long size)
 template <class T>
 inline Array2D<T>::Array2D () : _sizeX (0), _sizeY (0), _data (0)
 {
-    // emtpy
+    // empty
 }
 
 template <class T>
 inline Array2D<T>::Array2D (long sizeX, long sizeY)
     : _sizeX (sizeX), _sizeY (sizeY), _data (new T[sizeX * sizeY])
 {
-    // emtpy
+    // empty
 }
 
 template <class T> inline Array2D<T>::~Array2D ()

--- a/src/lib/OpenEXR/ImfB44Compressor.cpp
+++ b/src/lib/OpenEXR/ImfB44Compressor.cpp
@@ -214,7 +214,7 @@ pack (
     //
     // Compute a set of running differences, r[0] ... r[14]:
     // Find a shift value such that after rounding off the
-    // rightmost bits and shifting all differenes are between
+    // rightmost bits and shifting all differences are between
     // -32 and +31.  Then bias the differences so that they
     // end up between 0 and 63.
     //
@@ -588,7 +588,7 @@ B44Compressor::compress (
     }
 
     //
-    // For each channel, detemine how many pixels are stored
+    // For each channel, determine how many pixels are stored
     // in the input buffer, and where those pixels will be
     // placed in _tmpBuffer.
     //

--- a/src/lib/OpenEXR/ImfChannelList.h
+++ b/src/lib/OpenEXR/ImfChannelList.h
@@ -48,7 +48,7 @@ struct IMF_EXPORT_TYPE Channel
     // human perception of the quantity represented by this channel
     // is closer to linear or closer to logarithmic.  Compression
     // methods may optimize image quality by adjusting pixel data
-    // quantization acording to this hint.
+    // quantization according to this hint.
     // For example, perception of red, green, blue and luminance is
     // approximately logarithmic; the difference between 0.1 and 0.2
     // is perceived to be roughly the same as the difference between

--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -1100,11 +1100,11 @@ newLineBufferTask (
 
 //
 // when handling files with dataWindows with a large number of pixels,
-// the sampleCount values are not precached and Data::sampleCount is not asigned
-// instead, the sampleCount is read every time readPixels() is called
+// the sampleCount values are not precached and Data::sampleCount is not
+// assigned instead, the sampleCount is read every time readPixels() is called
 // and sample counts are stored in LineBuffer::_tempCountBuffer instead
 // (A square image that is 16k by 16k pixels has gBigFileDataWindowSize pixels,
-//  andthe sampleCount table would take 1GiB of memory to store)
+//  and the sampleCount table would take 1GiB of memory to store)
 //
 const uint64_t gBigFileDataWindowSize = (1 << 28);
 
@@ -1303,7 +1303,7 @@ DeepScanLineInputFile::DeepScanLineInputFile (
     }
 
     //
-    // not multiPart - allocate stream data and intialise as normal
+    // not multiPart - allocate stream data and initialise as normal
     //
     try
     {
@@ -1376,7 +1376,7 @@ DeepScanLineInputFile::DeepScanLineInputFile (
     }
 
     //
-    // not multiPart - allocate stream data and intialise as normal
+    // not multiPart - allocate stream data and initialise as normal
     //
     try
     {
@@ -1764,7 +1764,7 @@ DeepScanLineInputFile::readPixels (int scanLine1, int scanLine2)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // LineBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
@@ -1364,7 +1364,7 @@ DeepScanLineOutputFile::writePixels (int numScanLines)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // LineBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -1386,7 +1386,7 @@ DeepTiledInputFile::readTiles (
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // TileBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -301,7 +301,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly)-1]
     //
     //   lx must lie in the interval [0, numXLevels()-1]
-    //   ly must lie in the inverval [0, numYLevels()-1]
+    //   ly must lie in the interval [0, numYLevels()-1]
     //
     // readTile(dx, dy, level) is a convenience function used
     // for ONE_LEVEL and MIPMAP_LEVELS files.  It calls
@@ -354,7 +354,7 @@ public:
     // dy must lie in the interval [0, numYTiles(ly)-1]
     //
     // lx must lie in the interval [0, numXLevels()-1]
-    // ly must lie in the inverval [0, numYLevels()-1]
+    // ly must lie in the interval [0, numYLevels()-1]
     //
     // readPixelSampleCounts(dx1, dx2, dy1, dy2, lx, ly) reads all
     // the sample counts for tiles within range

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.h
@@ -257,7 +257,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly)-1]
     //
     //   lx must lie in the interval [0, numXLevels()-1]
-    //   ly must lie in the inverval [0, numYLevels()-1]
+    //   ly must lie in the interval [0, numYLevels()-1]
     //
     // readTile(dx, dy, level) is a convenience function used
     // for ONE_LEVEL and MIPMAP_LEVELS files.  It calls
@@ -310,7 +310,7 @@ public:
     // dy must lie in the interval [0, numYTiles(ly)-1]
     //
     // lx must lie in the interval [0, numXLevels()-1]
-    // ly must lie in the inverval [0, numYLevels()-1]
+    // ly must lie in the interval [0, numYLevels()-1]
     //
     // readPixelSampleCounts(dx1, dx2, dy1, dy2, lx, ly) reads all
     // the sample counts for tiles within range

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
@@ -911,7 +911,7 @@ TileBufferTask::execute ()
                     int yOffsetForData = slice.yTileCoords ? tileRange.min.y
                                                            : 0;
 
-                    // (TOOD) treat sample count offsets differently.
+                    // (TODO) treat sample count offsets differently.
                     copyFromDeepFrameBuffer (
                         writePtr,
                         slice.base,
@@ -1629,7 +1629,7 @@ DeepTiledOutputFile::writeTiles (
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // TileBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.h
@@ -295,7 +295,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly) - 1]
     //
     //   lx must lie in the interval [0, numXLevels() - 1]
-    //   ly must lie in the inverval [0, numYLevels() - 1]
+    //   ly must lie in the interval [0, numYLevels() - 1]
     //
     // writeTile(dx, dy, level) is a convenience function
     // used for ONE_LEVEL and MIPMAP_LEVEL files.  It calls

--- a/src/lib/OpenEXR/ImfDeepTiledOutputPart.h
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputPart.h
@@ -238,7 +238,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly) - 1]
     //
     //   lx must lie in the interval [0, numXLevels() - 1]
-    //   ly must lie in the inverval [0, numYLevels() - 1]
+    //   ly must lie in the interval [0, numYLevels() - 1]
     //
     // writeTile(dx, dy, level) is a convenience function
     // used for ONE_LEVEL and MIPMAP_LEVEL files.  It calls

--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -18,11 +18,11 @@
 // into the start of the data block, making a self-contained file.
 // If initializeDefaultChannelRules() doesn't quite suite your naming
 // conventions, you can adjust the rules without breaking decoder
-// compatability.
+// compatibility.
 //
 // If we're going to lossy compress R, G, or B channels, it's easier
 // to toss bits in a more perceptual uniform space. One could argue
-// at length as to what constitutes perceptually uniform, expecially
+// at length as to what constitutes perceptually uniform, especially
 // when storing either scene/input/focal plane referred and output referred
 // data.
 //
@@ -56,8 +56,8 @@
 // For each DCT component, we want to find a quantized value that
 // is within +- the per-component error. Pick the quantized value
 // that has the fewest bits set in its' binary representation.
-// Brute-forcing the search would make for extremly inefficient
-// compression. Fortunatly, we can precompute a table to assist
+// Brute-forcing the search would make for extremely inefficient
+// compression. Fortunately, we can precompute a table to assist
 // with this search.
 //
 // For each 16-bit float value, there are at most 15 other values with
@@ -148,7 +148,7 @@ namespace
 {
 
 //
-// Function pointer to dispatch to an approprate
+// Function pointer to dispatch to an appropriate
 // convertFloatToHalf64_* impl, based on runtime cpu checking.
 // Should be initialized in DwaCompressor::initializeFuncs()
 //
@@ -1608,7 +1608,7 @@ DwaCompressor::LossyDctEncoderBase::quantize (half src, float errorTolerance)
 // differs from the jpeg EOB case, since EOB just indicates that
 // the rest of the block is zero. In our case, we have lots of
 // NaN symbols, which shouldn't be allowed to occur in DCT
-// coefficents - so we'll use them for encoding runs.
+// coefficients - so we'll use them for encoding runs.
 //
 // If the high byte is 0xff, then we have a run of 0's, of length
 // given by the low byte. For example, 0xff03 would be a run
@@ -2008,7 +2008,7 @@ DwaCompressor::compress (
 
                 //
                 // For RLE, bash the bytes up so that the first bytes of each
-                // pixel are contingous, as are the second bytes, and so on.
+                // pixel are contiguous, as are the second bytes, and so on.
                 //
 
                 for (unsigned int y = 0; y < rowPtrs[chan].size (); ++y)
@@ -2922,8 +2922,8 @@ DwaCompressor::initializeBuffers (size_t& outBufferSize)
         static_cast<uint64_t> (compressBound (static_cast<uLong> (unknownBufferSize)));
 
     //
-    // Allocate a zip/deflate compressor big enought to hold the DC data
-    // and include it's compressed results in the size requirements
+    // Allocate a zip/deflate compressor big enough to hold the DC data
+    // and include its compressed results in the size requirements
     // for our output buffer
     //
 
@@ -3161,7 +3161,7 @@ DwaCompressor::relevantChannelRules (std::vector<Classifier>& rules) const
 //
 // Take our initial list of channels, and cache the contents.
 //
-// Determine approprate compression schemes for each channel,
+// Determine appropriate compression schemes for each channel,
 // and figure out which sets should potentially be CSC'ed
 // prior to lossy compression.
 //

--- a/src/lib/OpenEXR/ImfDwaCompressor.h
+++ b/src/lib/OpenEXR/ImfDwaCompressor.h
@@ -166,7 +166,7 @@ private:
     // Populate our cached version of the channel data with
     // data from the real channel list. We want to
     // copy over attributes, determine compression schemes
-    // releveant for the channel type, and find sets of
+    // relevant for the channel type, and find sets of
     // channels to be compressed from Y'CbCr data instead
     // of R'G'B'.
     //

--- a/src/lib/OpenEXR/ImfDwaCompressorSimd.h
+++ b/src/lib/OpenEXR/ImfDwaCompressorSimd.h
@@ -412,7 +412,7 @@ convertFloatToHalf64_f16c (unsigned short* dst, float* src)
     //
     // Now, it's quite likely that we'll find ourselves in situations
     // where we want to build *without* VEX, in order to maintain
-    // maximum compatability. But to get there with intrinsics,
+    // maximum compatibility. But to get there with intrinsics,
     // we'd need to break out code into a separate file. Bleh.
     // I'll take the asm.
     //
@@ -594,7 +594,7 @@ fromHalfZigZag_scalar (unsigned short* src, float* dst)
 // the even rows are in descending order.
 //
 // If we 'fold' the bottom half up into the top, we can preserve ordered
-// runs accross rows, and still keep all the correct values in columns.
+// runs across rows, and still keep all the correct values in columns.
 // After transposing, we'll need to rotate things back into place.
 // This gives us:
 //
@@ -680,7 +680,7 @@ fromHalfZigZag_f16c (unsigned short* src, float* dst)
 
          /* Reverse the even rows. We're not using PSHUFB as
             * that requires loading an extra constant all the time,
-            * and we're alreadly pretty memory bound.
+            * and we're already pretty memory bound.
             */
 
          "vpshuflw $0x1b, %%xmm0, %%xmm0          \n"
@@ -1288,7 +1288,7 @@ dctInverse8x8_sse2 (float* data)
  * they depend.
  *
  * This should work for the cases where we have 2-8 full rows.
- * the 1-row case is special, and we'll handle it seperately.  
+ * the 1-row case is special, and we'll handle it separately.
  */
 #define IDCT_AVX_BODY \
     /* ==============================================               

--- a/src/lib/OpenEXR/ImfEnvmap.h
+++ b/src/lib/OpenEXR/ImfEnvmap.h
@@ -27,7 +27,7 @@
 //	values.
 //
 //	For each possible EnvmapAttribute value, this header file also
-//	defines a set of convienience functions to convert between 3D
+//	defines a set of convenience functions to convert between 3D
 //	directions and 2D pixel locations.
 //
 //	Most of the convenience functions defined below require a

--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -63,7 +63,7 @@ FastHufDecoder::FastHufDecoder (
 
     //
     // The 'offset' table is the position (in sorted order) of the first id
-    // of a given code lenght. Array is indexed by code length, like base.
+    // of a given code length. Array is indexed by code length, like base.
     //
 
     uint64_t offset[MAX_CODE_LEN + 1];
@@ -507,7 +507,7 @@ FastHufDecoder::refill (
     //
     // We can have cases where the previous shift of bufferBack is << 64 -
     // this is an undefined operation but tends to create just zeroes.
-    // so if we won't have any bits left, zero out bufferBack insetad of computing the shift
+    // so if we won't have any bits left, zero out bufferBack instead of computing the shift
     //
 
     if (bufferBackNumBits <= numBits) { bufferBack = 0; }
@@ -546,7 +546,7 @@ FastHufDecoder::readBits (
 // small-ish table to accelerate decoding of short codes.
 //
 // If possible, try looking up codes into the acceleration table.
-// This has a few benifits - there's no search involved; We don't
+// This has a few benefits - there's no search involved; We don't
 // need an additional lookup to map id to symbol; we don't need
 // a full 64-bits (so less refilling).
 //
@@ -669,7 +669,7 @@ FastHufDecoder::decode (
         bufferNumBits -= codeLen;
 
         //
-        // If we recieved a RLE symbol (_rleSymbol), then we need
+        // If we received a RLE symbol (_rleSymbol), then we need
         // to read ahead 8 bits to know how many times to repeat
         // the previous symbol. Need to ensure we at least have
         // 8 bits of data in the buffer

--- a/src/lib/OpenEXR/ImfFastHuf.h
+++ b/src/lib/OpenEXR/ImfFastHuf.h
@@ -22,7 +22,7 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 //
 // The premise is that instead of working directly with the coded
 // symbols, we create a new ordering based on the frequency of symbols.
-// Less frequent symbols (and thus longer codes) are ordered earler.
+// Less frequent symbols (and thus longer codes) are ordered earlier.
 // We're calling the values in this ordering 'Ids', as oppsed to
 // 'Symbols' - which are the short values we eventually want decoded.
 //

--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -417,7 +417,7 @@ public:
     //-------------------------------------------------------------
     // Sanity check -- examines the header, and throws an exception
     // if it finds something wrong (empty display window, negative
-    // pixel aspect ratio, unknown compression sceme etc.)
+    // pixel aspect ratio, unknown compression scheme etc...)
     //
     // set isTiled to true if you are checking a tiled/multi-res
     // header
@@ -427,7 +427,7 @@ public:
     void sanityCheck (bool isTiled = false, bool isMultipartFile = false) const;
 
     //----------------------------------------------------------------
-    // Maximum image size and maximim tile size:
+    // Maximum image size and maximum tile size:
     //
     // sanityCheck() will throw an exception if the width or height of
     // the data window exceeds the maximum image width or height, or

--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -358,7 +358,7 @@ IDManifest::init (const char* data, const char* endOfData)
 
     //
     // decode mapping table from indices in table to indices in string list
-    // the mapping uses smaller indices for more commonly occuring strings, since these are encoded with fewer bits
+    // the mapping uses smaller indices for more commonly occurring strings, since these are encoded with fewer bits
     // comments in serialize function describe the format
     //
 

--- a/src/lib/OpenEXR/ImfInputFile.cpp
+++ b/src/lib/OpenEXR/ImfInputFile.cpp
@@ -177,7 +177,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
     //
     // bufferedReadPixels reads each row of tiles that intersect the
     // scan-line range (scanLine1 to scanLine2). The previous row of
-    // tiles is cached in order to prevent redundent tile reads when
+    // tiles is cached in order to prevent redundant tile reads when
     // accessing scanlines sequentially.
     //
 

--- a/src/lib/OpenEXR/ImfKeyCode.h
+++ b/src/lib/OpenEXR/ImfKeyCode.h
@@ -11,7 +11,7 @@
 //	class KeyCode
 //
 // 	A KeyCode object uniquely identifies a motion picture film frame.
-// 	The following fields specifiy film manufacturer, film type, film
+// 	The following fields specify film manufacturer, film type, film
 // 	roll and the frame's position within the roll:
 //
 //	    filmMfcCode		film manufacturer code

--- a/src/lib/OpenEXR/ImfOptimizedPixelReading.h
+++ b/src/lib/OpenEXR/ImfOptimizedPixelReading.h
@@ -30,7 +30,7 @@ public:
 #    ifdef IMF_HAVE_SSE2
 
 //------------------------------------------------------------------------
-// Test for SSE pointer alignemnt
+// Test for SSE pointer alignment
 //------------------------------------------------------------------------
 EXR_FORCEINLINE
 bool

--- a/src/lib/OpenEXR/ImfOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfOutputFile.cpp
@@ -1182,7 +1182,7 @@ OutputFile::writePixels (int numScanLines)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // LineBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfPizCompressor.cpp
+++ b/src/lib/OpenEXR/ImfPizCompressor.cpp
@@ -180,7 +180,7 @@ PizCompressor::PizCompressor (
     //
     // We can support uncompressed data in the machine's native format
     // if all image channels are of type HALF, and if the Xdr and the
-    // native represenations of a half have the same size.
+    // native representations of a half have the same size.
     //
 
     if (onlyHalfChannels && (sizeof (half) == pixelTypeSize (HALF)))

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -885,7 +885,7 @@ LineBufferTaskIIF::execute ()
             //
 
             // Set the readPtr to read at the start of uncompressedData
-            // but with an offet based on calculated array.
+            // but with an offset based on calculated array.
             // _ifd->offsetInLineBuffer contains offsets based on which
             // line we are currently processing.
             // Stride will be taken into consideration later.
@@ -1348,7 +1348,7 @@ ScanLineInputFile::version () const
 namespace
 {
 
-// returns the optimization state for the given arrangement of frame bufers
+// returns the optimization state for the given arrangement of frame buffers
 // this assumes:
 //   both the file and framebuffer are half float data
 //   both the file and framebuffer have xSampling and ySampling=1
@@ -1709,7 +1709,7 @@ ScanLineInputFile::readPixels (int scanLine1, int scanLine2)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // LineBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfTileOffsets.cpp
+++ b/src/lib/OpenEXR/ImfTileOffsets.cpp
@@ -457,7 +457,7 @@ TileOffsets::operator() (int dx, int dy, int lx, int ly)
     //
     // Looks up the value of the tile with tile coordinate (dx, dy)
     // and level number (lx, ly) in the _offsets array, and returns
-    // the cooresponding offset.
+    // the corresponding offset.
     //
 
     switch (_mode)
@@ -484,7 +484,7 @@ TileOffsets::operator() (int dx, int dy, int lx, int ly) const
     //
     // Looks up the value of the tile with tile coordinate (dx, dy)
     // and level number (lx, ly) in the _offsets array, and returns
-    // the cooresponding offset.
+    // the corresponding offset.
     //
 
     switch (_mode)

--- a/src/lib/OpenEXR/ImfTileOffsets.h
+++ b/src/lib/OpenEXR/ImfTileOffsets.h
@@ -57,7 +57,7 @@ public:
     //-----------------------------------------------------------
     // populate 'list' with tiles coordinates in the order they appear
     // in the offset table (assumes full table!
-    // each array myst be at leat totalTiles long
+    // each array myst be at least totalTiles long
     //-----------------------------------------------------------
     IMF_EXPORT
     void getTileOrder (

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -1354,7 +1354,7 @@ TiledInputFile::readTiles (int dx1, int dx2, int dy1, int dy2, int lx, int ly)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // TileBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfTiledInputFile.h
@@ -301,7 +301,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly)-1]
     //
     //   lx must lie in the interval [0, numXLevels()-1]
-    //   ly must lie in the inverval [0, numYLevels()-1]
+    //   ly must lie in the interval [0, numYLevels()-1]
     //
     // readTile(dx, dy, level) is a convenience function used
     // for ONE_LEVEL and MIPMAP_LEVELS files.  It calls

--- a/src/lib/OpenEXR/ImfTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledOutputFile.cpp
@@ -1351,7 +1351,7 @@ TiledOutputFile::writeTiles (int dx1, int dx2, int dy1, int dy2, int lx, int ly)
         }
 
         //
-        // Exeption handling:
+        // Exception handling:
         //
         // TileBufferTask::execute() may have encountered exceptions, but
         // those exceptions occurred in another thread, not in the thread

--- a/src/lib/OpenEXR/ImfTiledOutputFile.h
+++ b/src/lib/OpenEXR/ImfTiledOutputFile.h
@@ -296,7 +296,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly) - 1]
     //
     //   lx must lie in the interval [0, numXLevels() - 1]
-    //   ly must lie in the inverval [0, numYLevels() - 1]
+    //   ly must lie in the interval [0, numYLevels() - 1]
     //
     // writeTile(dx, dy, level) is a convenience function
     // used for ONE_LEVEL and MIPMAP_LEVEL files.  It calls

--- a/src/lib/OpenEXR/ImfTiledRgbaFile.h
+++ b/src/lib/OpenEXR/ImfTiledRgbaFile.h
@@ -219,7 +219,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly)-1]
     //
     //   lx must lie in the interval [0, numXLevels()-1]
-    //   ly must lie in the inverval [0, numYLevels()-1]
+    //   ly must lie in the interval [0, numYLevels()-1]
     //
     // writeTile(dx, dy, level) is a convenience function
     // used for ONE_LEVEL and MIPMAP_LEVEL files.  It calls
@@ -455,7 +455,7 @@ public:
     //   dy must lie in the interval [0, numYTiles(ly)-1]
     //
     //   lx must lie in the interval [0, numXLevels()-1]
-    //   ly must lie in the inverval [0, numYLevels()-1]
+    //   ly must lie in the interval [0, numYLevels()-1]
     //
     // readTile(dx, dy, level) is a convenience function used
     // for ONE_LEVEL and MIPMAP_LEVELS files.  It calls

--- a/src/lib/OpenEXR/ImfWav.cpp
+++ b/src/lib/OpenEXR/ImfWav.cpp
@@ -118,7 +118,7 @@ wav2Encode (
     int  p2  = 2; // == 1 << (level+1)
 
     //
-    // Hierachical loop on smaller dimension n
+    // Hierarchical loop on smaller dimension n
     //
 
     while (p2 <= n)

--- a/src/lib/OpenEXR/dwaLookups.cpp
+++ b/src/lib/OpenEXR/dwaLookups.cpp
@@ -440,7 +440,7 @@ cpuCount ()
 //
 // This gives us num_bits(input)-1 values per input. If we alloc
 // space for everything, that's like a 2MB table. We can do better
-// by compressing all the values to be contigious and using offset
+// by compressing all the values to be contiguous and using offset
 // pointers.
 //
 // After we've found the candidates with fewer bits set, sort them

--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1328,12 +1328,12 @@ exr_read_chunk (
         return pctxt->report_error (
             pctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "mis-matched storage type for chunk block info");
+            "mismatched storage type for chunk block info");
     if (cinfo->compression != (uint8_t) part->comp_type)
         return pctxt->report_error (
             pctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "mis-matched compression type for chunk block info");
+            "mismatched compression type for chunk block info");
 
     dataoffset = cinfo->data_offset;
     if (pctxt->file_size > 0 && dataoffset > (uint64_t) pctxt->file_size)
@@ -1396,12 +1396,12 @@ exr_read_deep_chunk (
         return pctxt->report_error (
             pctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "mis-matched storage type for chunk block info");
+            "mismatched storage type for chunk block info");
     if (cinfo->compression != (uint8_t) part->comp_type)
         return pctxt->report_error (
             pctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "mis-matched compression type for chunk block info");
+            "mismatched compression type for chunk block info");
 
     if (pctxt->file_size > 0 &&
         cinfo->sample_count_data_offset > (uint64_t) pctxt->file_size)

--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -231,7 +231,7 @@ decompress_data (
             return pctxt->report_error (
                 pctxt,
                 EXR_ERR_INVALID_ARGUMENT,
-                "no compresssion set but still trying to decompress");
+                "no compression set but still trying to decompress");
 
         case EXR_COMPRESSION_RLE:
             rv = internal_exr_undo_rle (

--- a/src/lib/OpenEXRCore/encoding.c
+++ b/src/lib/OpenEXRCore/encoding.c
@@ -34,7 +34,7 @@ default_compress_chunk (exr_encode_pipeline_t* encode)
             return pctxt->report_error (
                 pctxt,
                 EXR_ERR_INVALID_ARGUMENT,
-                "no compresssion set but still trying to compress");
+                "no compression set but still trying to compress");
 
         case EXR_COMPRESSION_RLE: rv = internal_exr_apply_rle (encode); break;
         case EXR_COMPRESSION_ZIP:

--- a/src/lib/OpenEXRCore/internal_b44.c
+++ b/src/lib/OpenEXRCore/internal_b44.c
@@ -126,7 +126,7 @@ pack (const uint16_t s[16], uint8_t b[14], int flatfields, int exactmax)
     //
     // Compute a set of running differences, r[0] ... r[14]:
     // Find a shift value such that after rounding off the
-    // rightmost bits and shifting all differenes are between
+    // rightmost bits and shifting all differences are between
     // -32 and +31.  Then bias the differences so that they
     // end up between 0 and 63.
     //

--- a/src/lib/OpenEXRCore/internal_piz.c
+++ b/src/lib/OpenEXRCore/internal_piz.c
@@ -177,7 +177,7 @@ wav_2D_encode (uint16_t* in, int nx, int ox, int ny, int oy, uint16_t mx)
     int p2  = 2; // == 1 << (level+1)
 
     //
-    // Hierachical loop on smaller dimension n
+    // Hierarchical loop on smaller dimension n
     //
 
     while (p2 <= n)

--- a/src/lib/OpenEXRCore/validation.c
+++ b/src/lib/OpenEXRCore/validation.c
@@ -420,7 +420,7 @@ validate_part_type (
         if (f->is_singlepart_tiled &&
             curpart->storage_mode != EXR_STORAGE_TILED)
         {
-            // mis-match between type attr and file flag. c++ believed the
+            // mismatch between type attr and file flag. c++ believed the
             // flag first and foremost
             curpart->storage_mode = EXR_STORAGE_TILED;
 

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -1249,7 +1249,7 @@ readCoreScanlinePart (
             for (int c = 0; c < decoder.channel_count; c++)
             {
                 exr_coding_channel_info_t& outc = decoder.channels[c];
-                // fake addr for default rouines
+                // fake addr for default routines
                 outc.decode_to_ptr     = (uint8_t*) 0x1000;
                 outc.user_pixel_stride = outc.user_bytes_per_element;
                 outc.user_line_stride  = outc.user_pixel_stride * width;
@@ -1398,7 +1398,7 @@ readCoreTiledPart (
                         {
                             exr_coding_channel_info_t& outc =
                                 decoder.channels[c];
-                            // fake addr for default rouines
+                            // fake addr for default routines
                             outc.decode_to_ptr = (uint8_t*) 0x1000 + bytes;
                             outc.user_pixel_stride =
                                 outc.user_bytes_per_element;

--- a/src/lib/OpenEXRUtil/ImfSampleCountChannel.h
+++ b/src/lib/OpenEXRUtil/ImfSampleCountChannel.h
@@ -158,7 +158,7 @@ public:
     //
     // Application code must take make sure that each call to beginEdit()
     // is followed by a corresponding endEdit() call, even if an
-    // exception occurs while the sample counts are acessed.  In order to
+    // exception occurs while the sample counts are accessed.  In order to
     // do that, application code may want to create a temporary Edit
     //  object instead of calling beginEdit() and endEdit() directly.
     //

--- a/src/lib/OpenEXRUtil/README
+++ b/src/lib/OpenEXRUtil/README
@@ -68,7 +68,7 @@ each level of a deep image has a sample count channel with a single value
 per pixel; this value determines how many values each of the other channels
 in the same level has at the same pixel location.
 
-The Image, ImageLevel and ImageChannel classes are abstact base classes.
+The Image, ImageLevel and ImageChannel classes are abstract base classes.
 Two sets of classes, one for flat images and one for deep images, are
 derived from the base classes.  The FlatImageChannel and DeepImageChannel
 classes, derived from ImageChannel, are themselves base classes for the


### PR DESCRIPTION
Fix typos in source comments and doxygen content. Found via `codespell -q 3 -S CHANGES.md,./ASWF/tsc-meetings -L dout,nnumber,offsetp` 