### PR TITLE
Fix remaining typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
 # See https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 #
 # Library API version (CMake's library VERSION attribute) is of the
-# form CURRENT.REVISION.AGE; the CMake SOVERSION attribute corresonds
+# form CURRENT.REVISION.AGE; the CMake SOVERSION attribute corresponds
 # to just CURRENT. These produce a .so and a symlink symlink, e.g.:
 # libOpenEXR-3_1.so.29 -> libOpenEXR-3_1.so.29.0.0
 #                    ^                       ^ ^ ^
@@ -75,7 +75,7 @@ message(STATUS "Configure ${OPENEXR_PACKAGE_NAME}, library API version: ${OPENEX
 add_subdirectory(src/lib)
 add_subdirectory(src/bin)
 
-# Tell CMake where to find the OpenEXRConfig.cmake file. Makes it posible to call 
+# Tell CMake where to find the OpenEXRConfig.cmake file. Makes it possible to call 
 # find_package(OpenEXR) in downstream projects
 set(OpenEXR_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake" CACHE PATH "" FORCE)
 # Add an empty OpenEXRTargets.cmake file for the config to use. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ comments. Click that link to sign the form.
 
 The downloadable PDF's on the EasyCLA page are provided for reference
 only. To execute the signature, sign the form online through the
-releveant links.
+relevant links.
 
 The OpenEXR CLAs are the standard forms used by Linux Foundation
 projects and [recommended by the ASWF
@@ -426,7 +426,7 @@ All headers should contain:
 
 Because OpenEXR must deal properly with large images, whose width
 and/or height approach the maximum allowable in 32-bit signed
-integers, take special care that integer arithmatic doesn't overlow,
+integers, take special care that integer arithmetic doesn't overflow,
 and make it as clear as possible exactly what the code is doing,
 especially in the edge cases.
 
@@ -440,7 +440,7 @@ To clarify the intention, prefer to cast between types using
     x = (size_t) y;
     x = size_t (y);
 
-Prefer to use ``std::numeric_limits<>`` instead of preprocesser
+Prefer to use ``std::numeric_limits<>`` instead of preprocessor
 define's such as ``INT_MAX``:
 
     // good:

--- a/Contrib/DtexToExr/PxDeepUtils.h
+++ b/Contrib/DtexToExr/PxDeepUtils.h
@@ -281,7 +281,7 @@ IsInfinity (T i_f)
 }
 
 //-*****************************************************************************
-// A zero-nan functon, which actually zeros inf as well.
+// A zero-nan function, which actually zeros inf as well.
 template <typename T>
 inline T
 ZeroNAN (T i_f)

--- a/Contrib/DtexToExr/m4/compilelinkrun.m4
+++ b/Contrib/DtexToExr/m4/compilelinkrun.m4
@@ -26,10 +26,10 @@ dnl $6: body section of sourcecode for a c++ test program
 dnl The test program should make use of a library that is supposed to 
 dnl be tested.
 dnl
-dnl $7: the action to be perfomed if the test succeeds 
+dnl $7: the action to be performed if the test succeeds 
 dnl     (e.g. AC_MSG_RESULT("OpenEXR test program succeeded"))
 dnl
-dnl $8   the action to be perfomed if the test fails
+dnl $8   the action to be performed if the test fails
 dnl     (e.g. AC_MSG_ERROR("OpenEXR test program failed"))
 dnl
 

--- a/Contrib/DtexToExr/m4/path.pkgconfig.m4
+++ b/Contrib/DtexToExr/m4/path.pkgconfig.m4
@@ -7,7 +7,7 @@ AC_DEFUN([AM_PATH_PKGCONFIG],
 [
 
 dnl sets cflags and ldflags
-dnl TEST_CXXFLAGS and TEST_LDFLAGS, by trying thes following
+dnl TEST_CXXFLAGS and TEST_LDFLAGS, by trying the following
 dnl until something works:
 dnl
 dnl 1 -  try the test_prefix
@@ -21,14 +21,14 @@ dnl $1: arg_cxxflags - CXXFLAGS variable to set
 dnl
 dnl $2: arg-ldflags - LDFLAGS variable to set
 dnl
-dnl $3: package name (the package being checked), as requried by pkg-config
+dnl $3: package name (the package being checked), as required by pkg-config
 dnl 
 dnl $4: arg_include_subdir 
 dnl     the name of the subdirectory name that is tacked on to 
 dnl     the end of the include path e.g. "OpenEXR" in 
 dnl     /usr/local/include/OpenEXR
 dnl 
-dnl $5: arg_default_libs - default libraries, used if pkgconfig doesnt work
+dnl $5: arg_default_libs - default libraries, used if pkgconfig doesn't work
 dnl
 dnl $6: arg_test_prefix
 dnl     the argument passed to configure specifying a directory to

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,7 +64,7 @@ Any existing Committer can nominate an individual making significant
 and valuable contributions to the OpenEXR project to become a new
 Committer.  New committers are approved by vote of the TSC.
 
-If you are interested in becomming a Committer, contact the TSC at
+If you are interested in becoming a Committer, contact the TSC at
 info@openexr.com.
 
 ## Technical Steering Committee

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ The OpenEXR technical documentation at
 [openexr.readthedocs.io](https://openexr.readthedocs.io) is generated
 via [Sphinx](https://www.sphinx-doc.org) with the
 [Breathe](https://breathe.readthedocs.io) extension using information
-extracted from header comments by [Doxgen](https://www.doxygen.nl).
+extracted from header comments by [Doxygen](https://www.doxygen.nl).
 
 To build the documentation locally from the source headers and
 ``.rst`` files, set the CMake option ``DOCS=ON``. This adds

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ report it by emailing security@openexr.org. Only Technical Steering
 Committee members and Academy Software Foundation project management
 have access to these messages. Include detailed steps to reproduce the
 issue, and any other information that could aid an investigation. Our
-policy is to respond to vulernability reports within 14 days.
+policy is to respond to vulnerability reports within 14 days.
 
 Our policy is to address critical security vulnerabilities rapidly and
 post patches as quickly as possible.

--- a/cmake/IexConfig.h.in
+++ b/cmake/IexConfig.h.in
@@ -16,13 +16,13 @@
 // clang-format off
 
 //
-// Current internal library namepace name
+// Current internal library namespace name
 //
 #define IEX_INTERNAL_NAMESPACE_CUSTOM @IEX_NAMESPACE_CUSTOM@
 #define IEX_INTERNAL_NAMESPACE @IEX_INTERNAL_NAMESPACE@
 
 //
-// Current public user namepace name
+// Current public user namespace name
 //
 
 #define IEX_NAMESPACE_CUSTOM @IEX_NAMESPACE_CUSTOM@

--- a/cmake/IlmThreadConfig.h.in
+++ b/cmake/IlmThreadConfig.h.in
@@ -19,13 +19,13 @@
 #cmakedefine01 ILMTHREAD_HAVE_POSIX_SEMAPHORES
 
 //
-// Current internal library namepace name
+// Current internal library namespace name
 //
 #define ILMTHREAD_INTERNAL_NAMESPACE_CUSTOM @ILMTHREAD_NAMESPACE_CUSTOM@
 #define ILMTHREAD_INTERNAL_NAMESPACE @ILMTHREAD_INTERNAL_NAMESPACE@
 
 //
-// Current public user namepace name
+// Current public user namespace name
 //
 
 #define ILMTHREAD_NAMESPACE_CUSTOM @ILMTHREAD_NAMESPACE_CUSTOM@

--- a/cmake/LibraryDefine.cmake
+++ b/cmake/LibraryDefine.cmake
@@ -19,7 +19,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
 
   # Use ${OPENEXR_CXX_STANDARD} to determine the standard we use to compile
   # OpenEXR itself. But the headers only require C++11 features, so that's
-  # all we need to pass on as interface reqirements to downstream projects.
+  # all we need to pass on as interface requirements to downstream projects.
   # For example, it's fine for an OpenEXR built with C++14 to be called from
   # an app that is compiled with C++11; OpenEXR needn't force the app to
   # also use C++14.

--- a/cmake/OpenEXRConfig.h.in
+++ b/cmake/OpenEXRConfig.h.in
@@ -26,13 +26,13 @@
 // C++ namespace configuration / options
 
 //
-// Current internal library namepace name
+// Current internal library namespace name
 //
 #define OPENEXR_IMF_INTERNAL_NAMESPACE_CUSTOM @OPENEXR_NAMESPACE_CUSTOM@
 #define OPENEXR_IMF_INTERNAL_NAMESPACE @OPENEXR_INTERNAL_IMF_NAMESPACE@
 
 //
-// Current public user namepace name
+// Current public user namespace name
 //
 
 #define OPENEXR_IMF_NAMESPACE_CUSTOM @OPENEXR_NAMESPACE_CUSTOM@

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -72,7 +72,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_DEBUG_POSTFIX "_d" CACHE STRING "Suffix for debug builds")
 
 if(NOT OPENEXR_IS_SUBPROJECT)
-  # Usual cmake option to build shared libraries or not, only overriden if OpenEXR is a top level project,
+  # Usual cmake option to build shared libraries or not, only overridden if OpenEXR is a top level project,
   # in general this setting should be explicitly configured by the end user
   option(BUILD_SHARED_LIBS "Build shared library" ON)
 endif()

--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -544,7 +544,7 @@ other three arguments define the memory address of pixel ``(x,y)`` as
 **Note:** ``base`` is of type ``char*``, and that offsets from
 ``base`` are not implicitly multiplied by the size of an individual
 pixel, as in the RGBA-only interface. ``xStride`` and ``yStride`` must
-explictly take the size of the pixels into account.
+explicitly take the size of the pixels into account.
 
 With the values specified in our example, the OpenEXR library computes
 the address of the G channel of pixel ``(x,y)`` like this:
@@ -1897,7 +1897,7 @@ of a three-dimensional scene as seen from a particular 3D location.
 Every pixel in the image corresponds to a 3D direction, and the data
 stored in the pixel represent the amount of light arriving from this
 direction. In 3D rendering applications, environment maps are often
-used for image-based lighting techniques that appoximate how objects
+used for image-based lighting techniques that approximate how objects
 are illuminated by their surroundings. Environment maps with enough
 dynamic range to represent even the brightest light sources in the
 environment are sometimes called "light probe images."

--- a/docs/SymbolVisibility.md
+++ b/docs/SymbolVisibility.md
@@ -40,7 +40,7 @@ differences between platforms, hence this document to add
 clarity. Each compiler / platform describes their own behavior, but
 not how that behaves relative to
 others. [libc++](https://libcxx.llvm.org/docs/DesignDocs/VisibilityMacros.html)
-from the llvm project is the closest to providing comparitive
+from the llvm project is the closest to providing comparative
 information, where by looking at how they define their macros and the
 comments surrounding, one can infer the behavior among at least
 windows DLL mode, then gcc vs. clang for unixen. Other compilers, for

--- a/docs/TechnicalIntroduction.rst
+++ b/docs/TechnicalIntroduction.rst
@@ -1158,7 +1158,7 @@ alpha. After reading an OpenEXR image such an application must undo
 the premultiplication by dividing the color channels by alpha. This
 division fails when alpha is zero. The application software could set
 all color channels to zero wherever the alpha channel is zero, but
-this might alter the image in an irreversable way. For example, the
+this might alter the image in an irreversible way. For example, the
 flame on top of a candle would simply disappear and could not be
 recovered.
 

--- a/docs/TheoryDeepPixels.rst
+++ b/docs/TheoryDeepPixels.rst
@@ -92,7 +92,7 @@ Alpha vs Transparency
 OpenEXR images use alpha :math:`\alpha` instead of transparency.
 :math:`T=1-\alpha`: if :math:`\alpha=1` (so :math:`T=0`) then all light
 is absorbed; if :math:`\alpha=0` (so :math:`T=1`), then all light is
-transmitted and the material is transparent. Subsituting :math:`T` into :eq:`absorb` and :eq:`two` combined alpha of two objects is given by the *screen* compositing operation:
+transmitted and the material is transparent. Substituting :math:`T` into :eq:`absorb` and :eq:`two` combined alpha of two objects is given by the *screen* compositing operation:
 
 .. math::
    \alpha_c = 1-(1-\alpha_1)(1-\alpha_2)

--- a/docs/src/writeDeepScanlineFile.cpp
+++ b/docs/src/writeDeepScanlineFile.cpp
@@ -36,7 +36,7 @@ writeDeepScanlineFile (
         DeepSlice (
             FLOAT,
             (char*) (&dataZ[0][0] - dataWindow.min.x - dataWindow.min.y * width),
-            sizeof (float*) * 1, // xStride for pointe
+            sizeof (float*) * 1, // xStride for pointer
 
             sizeof (float*) * width, // yStride for pointer array
             sizeof (float) * 1));    // stride for Z data sample

--- a/share/ci/scripts/linux/validate_openexr_libs.sh
+++ b/share/ci/scripts/linux/validate_openexr_libs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Validate the libary symlinks:
+# Validate the library symlinks:
 #   * The actual elf binary is, e.g. libIlmThread-3_1.so.29.0.0
 #   * The symlinks are:
 #       libIlmThread.so -> libIlmThread-3_1.so

--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -34,7 +34,7 @@ usageMessage (const char argv0[])
         << "  -t : avoid spending excessive time (some files will not be fully checked)\n";
     cerr << "  -s : use stream API instead of file API\n";
     cerr << "  -c : add core library checks\n";
-    cerr << "  -v : print OpenEXR and Imath software libary version info\n";
+    cerr << "  -v : print OpenEXR and Imath software library version info\n";
 }
 
 bool
@@ -115,7 +115,7 @@ main (int argc, char** argv)
         else if (!strcmp (argv[i], "-m"))
         {
             //
-            // note for further memory reduction, calls to the folowing could be added here
+            // note for further memory reduction, calls to the following could be added here
             // CompositeDeepScanLine::setMaximumSampleCount();
             // Header::setMaxImageSize();
             // Header::setMaxTileSize();

--- a/src/bin/exrenvmap/blurImage.cpp
+++ b/src/bin/exrenvmap/blurImage.cpp
@@ -56,7 +56,7 @@ blurImage (EnvmapImage& image1, bool verbose)
     //   it to no less than half its current size, until the
     //   width of each cube face is MAX_IN_WIDTH pixels.
     //
-    // * Multiply each pixel by a weight that is proportinal
+    // * Multiply each pixel by a weight that is proportional
     //   to the solid angle subtended by the pixel as seen
     //   from the center of the environment cube.
     //
@@ -142,7 +142,7 @@ blurImage (EnvmapImage& image1, bool verbose)
 
     {
         //
-        // Multiply each pixel by a weight that is proportinal
+        // Multiply each pixel by a weight that is proportional
         // to the solid angle subtended by the pixel.
         //
 

--- a/src/bin/exrenvmap/makeLatLongMap.h
+++ b/src/bin/exrenvmap/makeLatLongMap.h
@@ -26,7 +26,7 @@ void makeLatLongMap (
     int                    tileHeight,
     IMF::LevelMode         levelMode,
     IMF::LevelRoundingMode roundingMode,
-    IMF::Compression       compresssion,
+    IMF::Compression       compression,
     int                    mapWidth,
     float                  filterRadius,
     int                    numSamples,

--- a/src/bin/exrenvmap/readInputImage.cpp
+++ b/src/bin/exrenvmap/readInputImage.cpp
@@ -115,7 +115,7 @@ readSixImages (
     //
     // Generate six file names by replacing the first '%' character in
     // inFileName with +X, -X, ... -Z.  Interpreting the corresponding
-    // image files as the six sides of a cube, assembe a single cube-
+    // image files as the six sides of a cube, assemble a single cube-
     // face map image.
     //
 

--- a/src/bin/exrmakepreview/main.cpp
+++ b/src/bin/exrmakepreview/main.cpp
@@ -134,7 +134,7 @@ main (int argc, char** argv)
 
     if (previewWidth <= 0)
     {
-        cerr << "Preview image width must be greather than zero." << endl;
+        cerr << "Preview image width must be greater than zero." << endl;
         return 1;
     }
 

--- a/src/bin/exrmaketiled/main.cpp
+++ b/src/bin/exrmaketiled/main.cpp
@@ -50,7 +50,7 @@ usageMessage (const char argv0[], bool verbose = false)
                 "          is produced, image channel c will be resampled\n"
                 "          without low-pass filtering.  This option can\n"
                 "          be specified multiple times to disable low-pass\n"
-                "          filtering for mutiple channels.\n"
+                "          filtering for multiple channels.\n"
                 "\n"
                 "-e x y    when a MIPMAP_LEVELS or RIPMAP_LEVELS image\n"
                 "          is produced, low-pass filtering takes samples\n"

--- a/src/bin/exrmultipart/exrmultipart.cpp
+++ b/src/bin/exrmultipart/exrmultipart.cpp
@@ -601,7 +601,7 @@ separate (vector<const char*> in, const char* out, bool override)
     int                 numOutputs;
     vector<string>      fornamecheck;
 
-    // add check for existance of the file
+    // add check for existence of the file
     try
     {
         MultiPartInputFile temp (filename.c_str ());
@@ -670,7 +670,7 @@ separate (vector<const char*> in, const char* out, bool override)
 
     delete inputimage;
     cout << "\n"
-         << "Seperate Success" << endl;
+         << "Separate Success" << endl;
 }
 
 void

--- a/src/lib/Iex/IexBaseExc.h
+++ b/src/lib/Iex/IexBaseExc.h
@@ -188,7 +188,7 @@ DEFINE_EXC_EXP (
 //	BaseExc is thrown.  The stack-tracing routine should return a
 //	string that contains a printable representation of the program's
 //	current call stack.  This string will be stored in the BaseExc
-//	object; the string is accesible via the BaseExc::stackTrace()
+//	object; the string is accessible via the BaseExc::stackTrace()
 //	method.
 //
 // setStackTracer(0)

--- a/src/lib/Iex/IexMathExc.h
+++ b/src/lib/Iex/IexMathExc.h
@@ -10,10 +10,10 @@
 
 IEX_INTERNAL_NAMESPACE_HEADER_ENTER
 
-//---------------------------------------------------------
-// Exception classess which correspond to specific floating
+//--------------------------------------------------------
+// Exception classes which correspond to specific floating
 // point exceptions.
-//---------------------------------------------------------
+//--------------------------------------------------------
 
 DEFINE_EXC_EXP (IEX_EXPORT, OverflowExc, MathExc)    // Overflow
 DEFINE_EXC_EXP (IEX_EXPORT, UnderflowExc, MathExc)   // Underflow

--- a/src/lib/Iex/IexMathFloatExc.h
+++ b/src/lib/Iex/IexMathFloatExc.h
@@ -30,7 +30,7 @@ IEX_EXPORT
 int getMathExcOn ();
 
 //------------------------------------------------------------------------
-// A classs that temporarily sets floating point exception trapping
+// A class that temporarily sets floating point exception trapping
 // and conversion, and later restores the previous settings.
 //
 // Example:

--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -1160,7 +1160,7 @@ DwaCompressor::LossyDctDecoderBase::unRleAc (
     // high byte is 0xff, then insert the number of 0's
     // as indicated by the low byte.
     //
-    // Otherwise, just copy the number verbaitm.
+    // Otherwise, just copy the number verbatim.
     //
 
     int lastNonZero = 0;
@@ -1843,7 +1843,7 @@ DwaCompressor::compress (
 
     //
     // We might not be dealing with any color data, in which
-    // case the AC buffer size will be 0, and deferencing
+    // case the AC buffer size will be 0, and dereferencing
     // a vector will not be a good thing to do.
     //
 

--- a/src/lib/OpenEXR/ImfDwaCompressorSimd.h
+++ b/src/lib/OpenEXR/ImfDwaCompressorSimd.h
@@ -403,7 +403,7 @@ void
 convertFloatToHalf64_f16c (unsigned short* dst, float* src)
 {
     //
-    // Ordinarly, I'd avoid using inline asm and prefer intrinsics.
+    // Ordinarily, I'd avoid using inline asm and prefer intrinsics.
     // However, in order to get the intrinsics, we need to tell
     // the compiler to generate VEX instructions.
     //

--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -264,7 +264,7 @@ FastHufDecoder::~FastHufDecoder ()
 // properly on BE.
 //
 // If you happen to have more obscure hardware, check that the
-// byte swapping in refill() is happening sensable, add an endian
+// byte swapping in refill() is happening sensible, add an endian
 // check if needed, and fix the preprocessor magic here.
 //
 
@@ -439,7 +439,7 @@ FastHufDecoder::buildTables (uint64_t* base, uint64_t* offset)
 // shift in 0's to bufferBack.
 //
 // The refill act takes numBits from the top of bufferBack and sticks
-// them in the bottom of buffer. If there arn't enough bits in bufferBack,
+// them in the bottom of buffer. If there aren't enough bits in bufferBack,
 // it gets refilled (to 64-bits) from the input bitstream.
 //
 

--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -55,7 +55,7 @@ namespace
 // map of strings to index of string in table
 typedef std::map<std::string, int> indexedStringSet;
 
-// when handling vectors/sets of strings, the string is got by deferencing the pointer/iterator
+// when handling vectors/sets of strings, the string is got by dereferencing the pointer/iterator
 template <class T>
 size_t
 stringSize (const T& i)

--- a/src/lib/OpenEXR/ImfRle.cpp
+++ b/src/lib/OpenEXR/ImfRle.cpp
@@ -41,7 +41,7 @@ rleCompress (int inLength, const char in[], signed char out[])
         if (runEnd - runStart >= MIN_RUN_LENGTH)
         {
             //
-            // Compressable run
+            // Compressible run
             //
 
             *outWrite++ = (runEnd - runStart) - 1;
@@ -51,7 +51,7 @@ rleCompress (int inLength, const char in[], signed char out[])
         else
         {
             //
-            // Uncompressable run
+            // Uncompressible run
             //
 
             while (runEnd < inEnd &&

--- a/src/lib/OpenEXR/ImfRle.cpp
+++ b/src/lib/OpenEXR/ImfRle.cpp
@@ -51,7 +51,7 @@ rleCompress (int inLength, const char in[], signed char out[])
         else
         {
             //
-            // Uncompressible run
+            // Incompressible run
             //
 
             while (runEnd < inEnd &&

--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -1169,7 +1169,7 @@ FastHufDecoder_refill (
     //
     // We can have cases where the previous shift of bufferBack is << 64 -
     // this is an undefined operation but tends to create just zeroes.
-    // so if we won't have any bits left, zero out bufferBack insetad of computing the shift
+    // so if we won't have any bits left, zero out bufferBack instead of computing the shift
     //
 
     if (*bufferBackNumBits <= numBits) { *bufferBack = 0; }
@@ -1215,7 +1215,7 @@ fasthuf_initialize (
 
     //
     // The 'offset' table is the position (in sorted order) of the first id
-    // of a given code lenght. Array is indexed by code length, like base.
+    // of a given code length. Array is indexed by code length, like base.
     //
 
     uint64_t offset[MAX_CODE_LEN + 1];
@@ -1555,7 +1555,7 @@ fasthuf_decode (
         bufferNumBits -= codeLen;
 
         //
-        // If we recieved a RLE symbol (_rleSymbol), then we need
+        // If we received a RLE symbol (_rleSymbol), then we need
         // to read ahead 8 bits to know how many times to repeat
         // the previous symbol. Need to ensure we at least have
         // 8 bits of data in the buffer

--- a/src/lib/OpenEXRCore/internal_rle.c
+++ b/src/lib/OpenEXRCore/internal_rle.c
@@ -42,7 +42,7 @@ internal_rle_compress (
         }
         else
         {
-            /* uncompressable */
+            /* uncompressible */
             ++curcount;
             while (rune < end &&
                    ((rune + 1 >= end || *rune != *(rune + 1)) ||

--- a/src/lib/OpenEXRCore/internal_rle.c
+++ b/src/lib/OpenEXRCore/internal_rle.c
@@ -42,7 +42,7 @@ internal_rle_compress (
         }
         else
         {
-            /* uncompressible */
+            /* incompressible */
             ++curcount;
             while (rune < end &&
                    ((rune + 1 >= end || *rune != *(rune + 1)) ||

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -56,7 +56,7 @@ const int gMaxScanlinesToRead = 1 << 20;
 
 //
 // compute row stride appropriate to process files quickly
-// only used for the 'Rgba' interfaces, which read potentially non-existant channels
+// only used for the 'Rgba' interfaces, which read potentially non-existent channels
 //
 //
 

--- a/src/test/OpenEXRTest/testAttributes.cpp
+++ b/src/test/OpenEXRTest/testAttributes.cpp
@@ -444,7 +444,7 @@ longNames (
     const Array2D<float>& pf1, const char fileName[], int width, int height)
 {
     //
-    // Verify that long attibute or channel names in the header
+    // Verify that long attribute or channel names in the header
     // set the LONG_NAMES_FLAG in the file version number.
     //
 

--- a/src/test/OpenEXRTest/testCopyDeepTiled.cpp
+++ b/src/test/OpenEXRTest/testCopyDeepTiled.cpp
@@ -462,7 +462,7 @@ copyFile (const std::string& srcFn, const std::string& cpyFn)
         DeepTiledOutputFile out_file (cpyFn.c_str (), in_file.header ());
         out_file.copyPixels (in_file);
     }
-    // prevent accidentally reading souce instead of copy
+    // prevent accidentally reading source instead of copy
     remove (srcFn.c_str ());
 }
 

--- a/src/test/OpenEXRTest/testDeepScanLineHuge.cpp
+++ b/src/test/OpenEXRTest/testDeepScanLineHuge.cpp
@@ -175,8 +175,8 @@ generateRandomFile (
 
     //
     // storage layout scheme:
-    // [Pixel1: [Channel1: [Sample1 Sample2 Sample...] ] [Channel2: [Sample1 Sample2...] ] [Channnel...] ]
-    // [Pixel2: [Channel1: [Sample1 Sample2 Sample...] ] [Channel2: [Sample1 Sample2...] ] [Channnel...] ]
+    // [Pixel1: [Channel1: [Sample1 Sample2 Sample...] ] [Channel2: [Sample1 Sample2...] ] [Channel...] ]
+    // [Pixel2: [Channel1: [Sample1 Sample2 Sample...] ] [Channel2: [Sample1 Sample2...] ] [Channel...] ]
     // [Pixel...]
     //
     storage.resize (total_number_of_samples * bytes_per_sample);

--- a/src/test/OpenEXRTest/testDeepScanLineMultipleRead.cpp
+++ b/src/test/OpenEXRTest/testDeepScanLineMultipleRead.cpp
@@ -147,7 +147,7 @@ read_file (const char* filename)
 
             if (samplecounts[i] != static_cast<unsigned int> (row))
             {
-                cout << i << ", " << row << " error, sample counts hould be "
+                cout << i << ", " << row << " error, sample counts should be "
                      << row << ", is " << samplecounts[i] << endl
                      << flush;
             }

--- a/src/test/OpenEXRTest/testDwaLookups.cpp
+++ b/src/test/OpenEXRTest/testDwaLookups.cpp
@@ -404,7 +404,7 @@ cpuCount ()
 //
 // This gives us num_bits(input)-1 values per input. If we alloc
 // space for everything, that's like a 2MB table. We can do better
-// by compressing all the values to be contigious and using offset
+// by compressing all the values to be contiguous and using offset
 // pointers.
 //
 // After we've found the candidates with fewer bits set, sort them

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -279,7 +279,7 @@ writeReadMultiPart (
     // MMIFStream (see above).
     //
 
-    cout << "scan-line based mulitpart file:" << endl;
+    cout << "scan-line based multipart file:" << endl;
 
     {
         cout << "writing";
@@ -649,7 +649,7 @@ writeReadMultiPart (int width, int height, const Array2D<Rgba>& p1)
     // with the original data.
     //
 
-    cout << "scan-line based mulitpart stringstream:" << endl;
+    cout << "scan-line based multipart stringstream:" << endl;
 
     std::string strEXRFile;
 

--- a/src/test/OpenEXRTest/testFutureProofing.cpp
+++ b/src/test/OpenEXRTest/testFutureProofing.cpp
@@ -378,7 +378,7 @@ generateRandomHeaders (int partCount, vector<Header>& headers)
                  << " levelMode = " << levelModes[i] << endl
                  << flush;
         }
-        // future types MUST have a chunkCount attribute - ommitting causes the library
+        // future types MUST have a chunkCount attribute - omitting causes the library
         // to raise an exception (can't compute chunkOffsetTable) and prevents us from reading
         // the rest of the image
         header.setChunkCount (getChunkOffsetTableSize (header));
@@ -1517,7 +1517,7 @@ testWriteRead (int partNumber)
             }
             catch (std::exception& e)
             {
-                cout << "recieved exception (" << e.what ()
+                cout << "received exception (" << e.what ()
                      << ") as expected\n";
                 caught = true;
                 // that's what we thought would happen
@@ -1537,7 +1537,7 @@ testWriteRead (int partNumber)
         }
         catch (std::exception& e)
         {
-            cout << "recieved exception (" << e.what () << ") as expected\n";
+            cout << "received exception (" << e.what () << ") as expected\n";
             caught = true;
             // that's what we thought would happen
         }

--- a/src/test/OpenEXRTest/testMultiPartSharedAttributes.cpp
+++ b/src/test/OpenEXRTest/testMultiPartSharedAttributes.cpp
@@ -279,7 +279,7 @@ testSharedAttributes (const std::string& fn)
         MultiPartOutputFile file (fn.c_str (), &headers[0], headers.size ());
     }
 
-    // Adding a header a that has non-complient standard attributes will throw
+    // Adding a header a that has non-compliant standard attributes will throw
     // an exception.
 
     // Run the tests

--- a/src/test/OpenEXRTest/testMultiView.cpp
+++ b/src/test/OpenEXRTest/testMultiView.cpp
@@ -208,7 +208,7 @@ testMultiViewFunctions ()
             "wensleydale.rough.fell", "wensleydale.left.fell", multiView) ==
         false);
 
-    // four sectons
+    // four sections
 
     assert (
         areCounterparts (

--- a/src/test/OpenEXRTest/testNativeFormat.cpp
+++ b/src/test/OpenEXRTest/testNativeFormat.cpp
@@ -271,7 +271,7 @@ testNativeFormat (const std::string& tempDir)
 {
     try
     {
-        cout << "Testing if uncompressible pixel data are written "
+        cout << "Testing if incompressible pixel data are written "
                 "in Xdr, not native format"
              << endl;
 

--- a/src/test/OpenEXRTest/testRgba.cpp
+++ b/src/test/OpenEXRTest/testRgba.cpp
@@ -91,7 +91,7 @@ writeReadRGBA (
     //
     // Save the selected channels of RGBA image p1; save the
     // scan lines in the specified order.  Read the image back
-    // from the file, and compare the data with the orignal.
+    // from the file, and compare the data with the original.
     //
 
     cout << "channels " << ((channels & WRITE_R) ? "R" : "")

--- a/src/test/OpenEXRTest/testRgbaThreading.cpp
+++ b/src/test/OpenEXRTest/testRgbaThreading.cpp
@@ -58,7 +58,7 @@ writeReadRGBA (
     //
     // Save the selected channels of RGBA image p1; save the
     // scan lines in the specified order.  Read the image back
-    // from the file, and compare the data with the orignal.
+    // from the file, and compare the data with the original.
     //
 
     cout << "channels " << ((channels & WRITE_R) ? "R" : "")

--- a/src/test/OpenEXRTest/testSharedFrameBuffer.cpp
+++ b/src/test/OpenEXRTest/testSharedFrameBuffer.cpp
@@ -151,7 +151,7 @@ writeReadRGBA (
     //
     // Save the selected channels of RGBA image p1; save the
     // scan lines in the specified order.  Read the image back
-    // from the file, and compare the data with the orignal.
+    // from the file, and compare the data with the original.
     //
 
     cout << "channels " << ((channels & WRITE_R) ? "R" : "")


### PR DESCRIPTION
Found via `codespell -q 3 -S CHANGES.md,./ASWF/tsc-meetings -L ba,dout,halfs,iif,leapyear,lits,nnumber,offsetp`

Signed-off-by: luz paz <luzpaz@github.com>
