### PR TITLE
add missed #include <cstdint> statement

### DIFF
--- a/src/lib/OpenEXR/ImfTiledMisc.h
+++ b/src/lib/OpenEXR/ImfTiledMisc.h
@@ -19,6 +19,7 @@
 
 #include <stdio.h>
 #include <vector>
+#include <cstdint>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 


### PR DESCRIPTION
While trying to apply the patch from PR #1264, and testing different builds for my Gentoo package, I noticed there's another include statement for cstdint missing.

Eventually this slipped through your checks / CI because currently you're not using gcc-13 for any of your test builds, as far as I can see.

Signed-off-by: Bernd Waibel <waebbl-gentoo@posteo.net>