### PR TITLE
Fix for IDE headers

### DIFF
--- a/src/lib/Iex/CMakeLists.txt
+++ b/src/lib/Iex/CMakeLists.txt
@@ -5,6 +5,7 @@ openexr_define_library(Iex
   PRIV_EXPORT IEX_EXPORTS
   CURDIR ${CMAKE_CURRENT_SOURCE_DIR}
   SOURCES
+    IexMathFpu.h
     IexBaseExc.cpp
     IexMathFloatExc.cpp
     IexMathFpu.cpp
@@ -18,7 +19,6 @@ openexr_define_library(Iex
     IexMacros.h
     IexMathExc.h
     IexMathFloatExc.h
-    IexMathFpu.h
     IexMathIeeeExc.h
     IexNamespace.h
     IexThrowErrnoExc.h

--- a/src/lib/Iex/CMakeLists.txt
+++ b/src/lib/Iex/CMakeLists.txt
@@ -18,6 +18,7 @@ openexr_define_library(Iex
     IexMacros.h
     IexMathExc.h
     IexMathFloatExc.h
+    IexMathFpu.h
     IexMathIeeeExc.h
     IexNamespace.h
     IexThrowErrnoExc.h

--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -5,6 +5,30 @@ openexr_define_library(OpenEXR
   PRIV_EXPORT OPENEXR_EXPORTS
   CURDIR ${CMAKE_CURRENT_SOURCE_DIR}
   SOURCES
+    ImfAutoArray.h
+    ImfB44Compressor.h
+    ImfCheckedArithmetic.h
+    ImfCompressor.h
+    ImfDwaCompressor.h
+    ImfDwaCompressorSimd.h
+    ImfFastHuf.h
+    ImfInputPartData.h
+    ImfInputStreamMutex.h
+    ImfMisc.h
+    ImfOptimizedPixelReading.h
+    ImfOutputPartData.h
+    ImfOutputStreamMutex.h
+    ImfPizCompressor.h
+    ImfPxr24Compressor.h
+    ImfRle.h
+    ImfRleCompressor.h
+    ImfScanLineInputFile.h
+    ImfSimd.h
+    ImfSystemSpecific.h
+    ImfTileOffsets.h
+    ImfTiledMisc.h
+    ImfZip.h
+    ImfZipCompressor.h
     b44ExpLogTable.h
     dwaLookups.h
     ImfAcesFile.cpp


### PR DESCRIPTION
Hi, while I was working on the SSE PR I noticed that not all of the header files were showing up in the Visual Studio IDE. This PR adds the missing header files in the "OpenEXR" library to the CMakeLists.txt file so that they can be browsed in the IDE. I added these to the SOURCES variable assuming they are private and should not be installed.

I also noticed in the "Iex" library that IexMathFpu.h was missing from the CMakeLists.txt file. This actually looks like a public header so I added it to the HEADERS variable to be installed with the others.