### PR TITLE
Fix NDK compile error

### DIFF
--- a/src/lib/Iex/IexMathFpu.cpp
+++ b/src/lib/Iex/IexMathFpu.cpp
@@ -243,7 +243,7 @@ restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 inline void
 restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 {
-#        if defined(__GLIBC__) && defined(__i386__)
+#        if (defined(__GLIBC__) && defined(__i386__)) || defined(__ANDROID_API__)
     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
 #        else
     setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);


### PR DESCRIPTION
Without the fix when compiling under NDK, the following error will be observed:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:buildCMakeRelWithDebInfo[x86]'.
> Build command failed.
  Error while executing process /Users/cristi/Library/Android/sdk/cmake/3.22.1/bin/ninja with arguments {-C /Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86 Iex IlmThread Imath OpenEXR OpenEXRCore OpenEXRExamples OpenEXRUtil blocksdesign cjpeg cjpeg-static djpeg djpeg-static exr2aces exrcheck exrenvmap exrheader exrinfo exrmakepreview exrmaketiled exrmultipart exrmultiview exrstdattr jcstest jpeg jpegtran jpegtran-static md5cmp png png-fix-itxt pngfix pngimage pngstest pngtest pngunknown pngvalid rdjpgcom strtest tjbench tjbench-static tjexample tjunittest tjunittest-static turbojpeg wrjpgcom}
  ninja: Entering directory `/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86'
  [1/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadSemaphore.cpp.o
  [2/587] Building CXX object _deps/imath-build/src/Imath/CMakeFiles/Imath.dir/ImathRandom.cpp.o
  [3/587] Building CXX object _deps/imath-build/src/Imath/CMakeFiles/Imath.dir/ImathFun.cpp.o
  [4/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadSemaphoreOSX.cpp.o
  [5/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadSemaphorePosix.cpp.o
  [6/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadSemaphoreWin32.cpp.o
  [7/587] Building C object _deps/openexrgit-build/src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_rle.c.o
  [8/587] Building C object _deps/openexrgit-build/src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_zip.c.o
  [9/587] Building CXX object _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFloatExc.cpp.o
  [10/587] Building CXX object _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFpu.cpp.o
  FAILED: _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFpu.cpp.o 
  /Users/cristi/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=i686-none-linux-android29 --sysroot=/Users/cristi/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -DIEX_EXPORTS -DIex_EXPORTS -I/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/_deps/openexrgit-build/src/lib/Iex -I/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/_deps/openexrgit-src/src/lib/Iex -I/Users/cristi/Desktop/work/BlocksDesign/common/libjpeg-turbo -I/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/libjpeg-turbo -I/Users/cristi/Desktop/work/BlocksDesign/common/libpng -I/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/libpng -I/Users/cristi/Desktop/work/BlocksDesign/common/. -I/Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/_deps/openexrgit-build/cmake -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security   -O2 -g -DNDEBUG -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFpu.cpp.o -MF _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFpu.cpp.o.d -o _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexMathFpu.cpp.o -c /Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/_deps/openexrgit-src/src/lib/Iex/IexMathFpu.cpp
  /Users/cristi/Desktop/work/BlocksDesign/android/app/.cxx/RelWithDebInfo/453r2463/x86/_deps/openexrgit-src/src/lib/Iex/IexMathFpu.cpp:249:38: error: no member named 'cwd' in '_libc_fpstate'; did you mean 'cw'?
      setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
                                       ^~~
                                       cw
  /Users/cristi/Library/Android/sdk/ndk/25.1.8937393/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/sys/ucontext.h:180:17: note: 'cw' declared here
    unsigned long cw;
                  ^
  1 error generated.
  [11/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThread.cpp.o
  [12/587] Building CXX object _deps/imath-build/src/Imath/CMakeFiles/Imath.dir/ImathColorAlgo.cpp.o
  [13/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadSemaphorePosixCompat.cpp.o
  [14/587] Building C object _deps/openexrgit-build/src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_pxr24.c.o
  [15/587] Building CXX object _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexThrowErrnoExc.cpp.o
  [16/587] Building C object _deps/openexrgit-build/src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_b44.c.o
  [17/587] Building C object _deps/openexrgit-build/src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_b44_table.c.o
  [18/587] Building CXX object _deps/openexrgit-build/src/lib/IlmThread/CMakeFiles/IlmThread.dir/IlmThreadPool.cpp.o
  [19/587] Building CXX object _deps/imath-build/src/Imath/CMakeFiles/Imath.dir/half.cpp.o
  [20/587] Building CXX object _deps/imath-build/src/Imath/CMakeFiles/Imath.dir/ImathMatrixAlgo.cpp.o
  [21/587] Building CXX object _deps/openexrgit-build/src/lib/Iex/CMakeFiles/Iex.dir/IexBaseExc.cpp.o
  ninja: build stopped: subcommand failed.



* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 23s

```