### PR TITLE
Fix a typo breaking the link to Imath repository in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Platform](https://vfxplatform.com).
 
 With the release of OpenEXR 3, the Imath library formerly distributed
 via the IlmBase component of OpenEXR is now an independent library
-dependency, available for download from https:://github.com/AcademySoftwareFoundation/Imath.
+dependency, available for download from https://github.com/AcademySoftwareFoundation/Imath.
 You can choose to build OpenEXR against an external installation of
 Imath, or the default CMake configuration will download and build it
 automatically during the OpenEXR build process.  Note that the half


### PR DESCRIPTION
Fix a typo breaking the link to lmath repository in readme