### PR TITLE
Change setNumThreads to wait for thread start

### DIFF
--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -542,8 +542,11 @@ ThreadPool::setNumThreads (int count)
     // a default provider to a null one or vice-versa
     if (count == 0)
         _data->setProvider (nullptr);
+#ifdef HACKHACK_DO_NOT_KEEP_THIS_IFDEF
     else
         _data->resetToDefaultProvider (count);
+#endif
+
 #else
     // just blindly ignore
     (void) count;

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -301,8 +301,7 @@ DefaultThreadPoolProvider::finish ()
         // kill the thread, double check that it is still active prior
         // to joining.
         DWORD tstatus;
-        if (GetExitCodeThread (
-                _data.threads[i]->_thread.native_handle (), &tstatus))
+        if (GetExitCodeThread (_threads[i].native_handle (), &tstatus))
         {
             if (tstatus != STILL_ACTIVE) { continue; }
         }

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -526,6 +526,7 @@ ThreadPool::setNumThreads (int count)
         Data::ProviderPtr sp = _data->getProvider ();
         if (sp)
         {
+#ifdef HACKHACK_DO_NOT_KEEP_THIS_IFDEF
             bool doReset = false;
             int  curT    = sp->numThreads ();
             if (curT == count) return;
@@ -535,6 +536,9 @@ ThreadPool::setNumThreads (int count)
                 sp->setNumThreads (count);
                 return;
             }
+#else
+            return;
+#endif
         }
     }
 
@@ -542,8 +546,13 @@ ThreadPool::setNumThreads (int count)
     // a default provider to a null one or vice-versa
     if (count == 0)
         _data->setProvider (nullptr);
-#ifdef HACKHACK_DO_NOT_KEEP_THIS_IFDEF
     else
+#ifdef HACKHACK_DO_NOT_KEEP_THIS_IFDEF
+    {
+        count = 3;
+        _data->resetToDefaultProvider (count);
+    }
+#else
         _data->resetToDefaultProvider (count);
 #endif
 

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -185,11 +185,17 @@ DefaultThreadPoolProvider::setNumThreads (int count)
     // This isn't great, perhaps, but the likely scenario of this
     // changing frequently is people ping-ponging between 0 and N
     // which would result in a full clear anyway
-    if (count < numThreads ()) { finish (); }
+    if (count < numThreads ())
+    {
+#ifdef RESTORE_THIS_AFTER_TESTING
+        finish ();
+#else
+        return;
+#endif
+    }
 
     // now take the lock and build any threads needed
     std::lock_guard<std::mutex> lock (_data->_threadMutex);
-
     size_t nToAdd = static_cast<size_t> (count) - _data->_threads.size ();
     for (size_t i = 0; i < nToAdd; ++i)
         _data->_threads.emplace_back (

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -31,6 +31,26 @@ ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 #    define ENABLE_SEM_DTOR_WORKAROUND
 #endif
 
+namespace
+{
+
+static inline void
+handleProcessTask (Task* task)
+{
+    if (task)
+    {
+        TaskGroup* taskGroup = task->group ();
+
+        task->execute ();
+
+        if (taskGroup) taskGroup->finishOneTask ();
+
+        delete task;
+    }
+}
+
+} // empty namespace
+
 #ifdef ENABLE_THREADING
 
 struct TaskGroup::Data
@@ -81,21 +101,6 @@ struct ThreadPool::Data
 
 namespace
 {
-
-static inline void
-handleProcessTask (Task* task)
-{
-    if (task)
-    {
-        TaskGroup* taskGroup = task->group ();
-
-        task->execute ();
-
-        if (taskGroup) taskGroup->finishOneTask ();
-
-        delete task;
-    }
-}
 
 //
 // class DefaultThreadPoolProvider
@@ -605,6 +610,7 @@ ThreadPool::estimateThreadCountForFileIO ()
 #endif
 }
 
+#ifdef ENABLE_THREADING
 void
 ThreadPool::Data::resetToDefaultProvider (int count)
 {
@@ -617,5 +623,6 @@ ThreadPool::Data::resetToDefaultProvider (int count)
     }
     setProvider (dp);
 }
+#endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -185,13 +185,10 @@ DefaultThreadPoolProvider::setNumThreads (int count)
     // This isn't great, perhaps, but the likely scenario of this
     // changing frequently is people ping-ponging between 0 and N
     // which would result in a full clear anyway
-#ifdef ENABLE_DYNAMIC_THREAD_GROWTH
     if (count < numThreads ()) { finish (); }
 
     // now take the lock and build any threads needed
     std::lock_guard<std::mutex> lock (_threadMutex);
-
-    reset ();
 
     size_t nToAdd = static_cast<size_t> (count) - _threads.size ();
     for (size_t i = 0; i < nToAdd; ++i)
@@ -205,22 +202,6 @@ DefaultThreadPoolProvider::setNumThreads (int count)
         _threadSemaphore.wait ();
 
     _threadCount = static_cast<int> (_threads.size ());
-#else
-    finish ();
-
-    reset ();
-
-    size_t nToAdd = static_cast<size_t> (count);
-    _threads.resize (nToAdd);
-    for (size_t i = 0; i < nToAdd; ++i)
-        _threads[i] = std::thread (&DefaultThreadPoolProvider::threadLoop, this);
-
-    // wait for all the threads to start..
-    for (size_t i = 0; i < nToAdd; ++i)
-        _threadSemaphore.wait ();
-
-    _threadCount = count;
-#endif
 }
 
 void
@@ -299,11 +280,7 @@ DefaultThreadPoolProvider::finish ()
 
     _threads.clear ();
 
-#ifdef ENABLE_DYNAMIC_THREAD_GROWTH
     reset ();
-#else
-    _threadCount = 0;
-#endif
 }
 
 void

--- a/src/lib/IlmThread/IlmThreadPool.cpp
+++ b/src/lib/IlmThread/IlmThreadPool.cpp
@@ -684,12 +684,15 @@ ThreadPool::setThreadProvider (ThreadPoolProvider* provider)
 void
 ThreadPool::addTask (Task* task)
 {
+    if (task)
+    {
 #ifdef ENABLE_THREADING
-    _data->getProvider ()->addTask (task);
+        _data->getProvider ()->addTask (task);
 #else
-    task->execute ();
-    delete task;
+        task->execute ();
+        delete task;
 #endif
+    }
 }
 
 ThreadPool&

--- a/src/lib/IlmThread/IlmThreadSemaphore.h
+++ b/src/lib/IlmThread/IlmThreadSemaphore.h
@@ -62,7 +62,7 @@ private:
 
 #elif ILMTHREAD_THREADING_ENABLED
     //
-    // If the platform has threads but no semapohores,
+    // If the platform has threads but no semaphores,
     // then we implement them ourselves using condition variables
     //
 

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -144,6 +144,7 @@ function(DEFINE_OPENEXR_TESTS)
   foreach(curtest IN LISTS ARGN)
     # CMAKE_CROSSCOMPILING_EMULATOR is necessary to support cross-compiling (ex: to win32 from mingw and running tests with wine)
     add_test(NAME OpenEXR.${curtest} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:OpenEXRTest> ${curtest})
+    set_property(TEST OpenEXR.${curtest} PROPERTY ENVIRONMENT LD_PRELOAD=/lib/libSegFault.so)
   endforeach()
 endfunction()
 

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -144,7 +144,6 @@ function(DEFINE_OPENEXR_TESTS)
   foreach(curtest IN LISTS ARGN)
     # CMAKE_CROSSCOMPILING_EMULATOR is necessary to support cross-compiling (ex: to win32 from mingw and running tests with wine)
     add_test(NAME OpenEXR.${curtest} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:OpenEXRTest> ${curtest})
-    set_property(TEST OpenEXR.${curtest} PROPERTY ENVIRONMENT LD_PRELOAD=/lib/libSegFault.so)
   endforeach()
 endfunction()
 


### PR DESCRIPTION
Fix Issue 890, issue with windows shutdown when exiting quickly prior to threads actually starting. This section of setNumThreads will only run when actually changing the count, which limits the impact

Based on a proposed patch by Dieter De Baets @debaetsd

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>