### PR TITLE
Fix typo in the "Reading and Writing Image Files" example stream class

### DIFF
--- a/docs/ReadingAndWritingImageFiles.rst
+++ b/docs/ReadingAndWritingImageFiles.rst
@@ -1462,7 +1462,7 @@ exception. If ``read(c,n)`` hits the end of the file after reading
                 throw Iex::InputExc ("Unexpected end of file.");
         }
         
-        return feof (_file);
+        return !feof (_file);
     }
 
 ``tellg()`` returns the current reading position, in bytes, from the


### PR DESCRIPTION
The example C_IStream::read() function should return !feof(), not feof()

Addresses #1270.

Signed-off-by: Cary Phillips <cary@ilm.com>