### PR TITLE
Change reference to IlmBase to Imath in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ OpenEXR is intended solely for 2D data. It is not appropriate for
 storage of volumetric data, cached or lit 3D scenes, or more complex
 3D data such as light fields.
 
-The goals of the IlmBase project are simplicity, ease of use,
-correctness and verifiability, and breadth of adoption. IlmBase is not
+The goals of the Imath project are simplicity, ease of use,
+correctness and verifiability, and breadth of adoption. Imath is not
 intended to be a comprehensive linear algebra or numerical analysis
 package.
 


### PR DESCRIPTION
I really thought we'd eradicated references to IlmBase, but apparently not.

Signed-off-by: Cary Phillips <cary@ilm.com>