### PR TITLE
Check for null pointer passed to memcpy

### DIFF
--- a/src/lib/OpenEXRCore/opaque.c
+++ b/src/lib/OpenEXRCore/opaque.c
@@ -56,7 +56,7 @@ exr_attr_opaquedata_create (
     exr_result_t rv = exr_attr_opaquedata_init (ctxt, u, b);
     if (rv == EXR_ERR_SUCCESS)
     {
-        if (d) memcpy ((void*) u->packed_data, d, b);
+        if (d && u->packed_data) memcpy ((void*) u->packed_data, d, b);
     }
 
     return rv;


### PR DESCRIPTION
This only happens when the size parameter is 0, in which memcpy will not fail, but SonarCloud flags this as a problem:

https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=AcademySoftwareFoundation_openexr&open=AYPeU0_LmU8C9mUeoOgr

Signed-off-by: Cary Phillips <cary@ilm.com>