### PR TITLE
Fix compiler warning

### DIFF
--- a/src/lib/OpenEXR/ImfInputFile.cpp
+++ b/src/lib/OpenEXR/ImfInputFile.cpp
@@ -338,7 +338,7 @@ bufferedReadPixels (InputFile::Data* ifd, int scanLine1, int scanLine2)
                     switch (toSlice.type)
                     {
                         case UINT: {
-                            unsigned int fill = toSlice.fillValue;
+                            unsigned int fill = static_cast<unsigned int>(toSlice.fillValue);
                             for (int x = xStart; x <= levelRange.max.x;
                                  x += toSlice.xSampling)
                             {


### PR DESCRIPTION
* The beef of the PR: fix a compiler warning
* ... but while at it, also `assert` that a value being converted to `unsigned int` is not negative