### PR TITLE
Fix Visual Studio on ARM Compilation

### DIFF
--- a/src/lib/OpenEXR/ImfSystemSpecific.cpp
+++ b/src/lib/OpenEXR/ImfSystemSpecific.cpp
@@ -29,7 +29,7 @@ cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
         : /* Clobber */);
 }
 
-#elif defined(_MSC_VER) && ( defined(_M_IX86) || ( defined(_M_AMD64) && !defined(_M_ARM64RC) ) )
+#elif defined(_MSC_VER) && ( defined(_M_IX86) || ( defined(_M_AMD64) && !defined(_M_ARM64EC) ) )
 
 // Helper functions for MSVC
 void

--- a/src/lib/OpenEXR/ImfSystemSpecific.cpp
+++ b/src/lib/OpenEXR/ImfSystemSpecific.cpp
@@ -29,7 +29,7 @@ cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
         : /* Clobber */);
 }
 
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && ( defined(_M_IX86) || ( defined(_M_AMD64) && !defined(_M_ARM64RC) ) )
 
 // Helper functions for MSVC
 void


### PR DESCRIPTION
This fixes Windows on ARM native Visual Studio compilation. The current #ifdef
logic assumes that Visual Studio always targets x86/x64, which is no longer the case.

Unfortunately based on:

https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170

there doesn't seem to be a single macro to test Intel vs ARM compilation, hence the ugly logic.

With this change, OpenEXR compiles native to ARM on Windows and passes its test suite.