### PR TITLE
Fix compiler warnings from gcc-12

### DIFF
--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
@@ -507,7 +507,7 @@ CompositeDeepScanLine::readPixels (int start, int end)
     vector<unsigned int> num_sources (
         total_pixels); //number of parts with non-zero sample count
 
-    size_t overall_sample_count =
+    int64_t overall_sample_count =
         0; // sum of all samples in all images between start and end
 
     //
@@ -561,7 +561,7 @@ CompositeDeepScanLine::readPixels (int start, int end)
             // allocate pointers for channel data
             //
 
-            size_t offset = 0;
+            int64_t offset = 0;
 
             for (size_t pixel = 0; pixel < total_pixels; pixel++)
             {

--- a/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.cpp
@@ -197,7 +197,7 @@ MultiPartInputFile::getPart (int partNumber)
 const Header&
 MultiPartInputFile::header (int n) const
 {
-    if (n < 0 || n >= _data->_headers.size ())
+    if (n < 0 || static_cast<size_t>(n) >= _data->_headers.size ())
     {
         THROW (
             IEX_NAMESPACE::ArgExc,
@@ -857,7 +857,7 @@ bool
 MultiPartInputFile::partComplete (int part) const
 {
 
-    if (part < 0 || part >= _data->_headers.size ())
+    if (part < 0 || static_cast<size_t>(part) >= _data->_headers.size ())
     {
         THROW (
             IEX_NAMESPACE::ArgExc,

--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -1300,7 +1300,7 @@ fasthuf_initialize (
     for (int i = 0; i < MAX_CODE_LEN; ++i)
         fhd->_numSymbols += codeCount[i];
 
-    if (fhd->_numSymbols > sizeof (fhd->_idToSymbol) / sizeof (int))
+    if ((size_t) fhd->_numSymbols > sizeof (fhd->_idToSymbol) / sizeof (int))
     {
         if (pctxt)
             pctxt->print_error (
@@ -1809,7 +1809,6 @@ internal_huf_decompress (
         uint64_t* freq     = (uint64_t*) spare;
         HufDec*   hdec     = (HufDec*) (freq + HUF_ENCSIZE);
         uint64_t  nLeft    = nCompressed - 20;
-        uint64_t  nTableSz = 0;
 
         hufClearDecTable (hdec);
         hufUnpackEncTable (&ptr, &nLeft, im, iM, freq);

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -126,10 +126,10 @@ interleave (uint8_t* out, const uint8_t* source, uint64_t outSize)
 static void
 interleave (uint8_t* out, const uint8_t* source, uint64_t outSize)
 {
-    const char* t1   = source;
-    const char* t2   = source + (outSize + 1) / 2;
-    char*       s    = out;
-    char* const stop = s + outSize;
+    const uint8_t* t1   = source;
+    const uint8_t* t2   = source + (outSize + 1) / 2;
+    uint8_t*       s    = out;
+    uint8_t* const stop = s + outSize;
 
     while (true)
     {

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -479,7 +479,7 @@ readDeepScanLine (T& in, bool reduceMemory, bool reduceTime)
             //
             size_t bufferSize = 0;
             size_t fileBufferSize = 0;
-            for (int j = 0; j < w; j++)
+            for (uint64_t j = 0; j < w; j++)
             {
                 for (int k = 0; k < channelCount; k++)
                 {
@@ -507,7 +507,7 @@ readDeepScanLine (T& in, bool reduceMemory, bool reduceTime)
                 pixelBuffer.resize (bufferSize);
 
                 size_t bufferIndex = 0;
-                for (int j = 0; j < w; j++)
+                for (uint64_t j = 0; j < w; j++)
                 {
                     for (int k = 0; k < channelCount; k++)
                     {
@@ -562,8 +562,6 @@ readDeepTile (T& in, bool reduceMemory, bool reduceTime)
         const Header& fileHeader = in.header ();
 
         Array2D<unsigned int> localSampleCount;
-
-        Box2i dataWindow = fileHeader.dataWindow ();
 
         int      bytesPerSample = calculateBytesPerPixel (in.header ());
 
@@ -1074,7 +1072,6 @@ runChecks (T& source, bool reduceMemory, bool reduceTime)
         try
         {
             MultiPartInputFile multi (source);
-            Box2i              b          = multi.header (0).dataWindow ();
 
             //
             // significant memory is also required to read a tiled file
@@ -1221,7 +1218,6 @@ readCoreScanlinePart (
 
     std::vector<uint8_t>  imgdata;
     bool                  doread = false;
-    exr_chunk_info_t      cinfo;
     exr_decode_pipeline_t decoder = EXR_DECODE_PIPELINE_INITIALIZER;
 
     int32_t lines_per_chunk;

--- a/src/test/OpenEXRTest/testAttributes.cpp
+++ b/src/test/OpenEXRTest/testAttributes.cpp
@@ -583,7 +583,7 @@ static int move_assignment_operator;
 
 struct TestType
 {
-    TestType () { default_constructor++; }
+    TestType () : _f(0) { default_constructor++; }
 
     ~TestType () { destructor++; }
 

--- a/src/test/OpenEXRTest/testPreviewImage.cpp
+++ b/src/test/OpenEXRTest/testPreviewImage.cpp
@@ -110,8 +110,8 @@ readWriteFiles (
 
         assert (dw == file2.dataWindow ());
 
-        size_t w  = dw.max.x - dw.min.x + 1;
-        size_t h  = dw.max.y - dw.min.y + 1;
+        int w  = dw.max.x - dw.min.x + 1;
+        int h  = dw.max.y - dw.min.y + 1;
         int dx = dw.min.x;
         int dy = dw.min.y;
 
@@ -119,7 +119,7 @@ readWriteFiles (
         file2.setFrameBuffer (pixels2 - dx - dy * w, 1, w);
         file2.readPixels (dw.min.y, dw.max.y);
 
-        for (size_t i = 0; i < w * h; ++i)
+        for (int i = 0; i < w * h; ++i)
         {
             assert (pixels1[i].r == pixels2[i].r);
             assert (pixels1[i].g == pixels2[i].g);

--- a/src/test/OpenEXRTest/testPreviewImage.cpp
+++ b/src/test/OpenEXRTest/testPreviewImage.cpp
@@ -110,8 +110,8 @@ readWriteFiles (
 
         assert (dw == file2.dataWindow ());
 
-        int w  = dw.max.x - dw.min.x + 1;
-        int h  = dw.max.y - dw.min.y + 1;
+        size_t w  = dw.max.x - dw.min.x + 1;
+        size_t h  = dw.max.y - dw.min.y + 1;
         int dx = dw.min.x;
         int dy = dw.min.y;
 


### PR DESCRIPTION
* use size_t/int64_t where appropriate
* explicit cast to size_t where necessary
* initialize fields
* remove unused variables

Signed-off-by: Cary Phillips <cary@ilm.com>