### PR TITLE
Fix MSVC Debug build with internal zlib

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -220,11 +220,18 @@ if(OPENEXR_FORCE_INTERNAL_ZLIB OR NOT TARGET ZLIB::ZLIB)
     set(zlibstaticlibname "z")
   endif()
 
+  if(MSVC)
+    set(zlibpostfix "d")
+  endif()
+
   if(NOT (APPLE OR WIN32) AND BUILD_SHARED_LIBS AND NOT OPENEXR_FORCE_INTERNAL_ZLIB)
     add_library(zlib_shared SHARED IMPORTED GLOBAL)
     add_dependencies(zlib_shared zlib_external)
     set_property(TARGET zlib_shared PROPERTY
       IMPORTED_LOCATION "${zlib_INTERNAL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${zliblibname}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      )
+    set_property(TARGET zlib_static PROPERTY
+      IMPORTED_LOCATION_DEBUG "${zlib_INTERNAL_DIR}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}${zliblibname}${zlibpostfix}${CMAKE_SHARED_LIBRARY_SUFFIX}"
       )
     target_include_directories(zlib_shared INTERFACE "${zlib_INTERNAL_DIR}/include")
   endif()
@@ -233,6 +240,9 @@ if(OPENEXR_FORCE_INTERNAL_ZLIB OR NOT TARGET ZLIB::ZLIB)
   add_dependencies(zlib_static zlib_external)
   set_property(TARGET zlib_static PROPERTY
     IMPORTED_LOCATION "${zlib_INTERNAL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${zlibstaticlibname}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    )
+  set_property(TARGET zlib_static PROPERTY
+    IMPORTED_LOCATION_DEBUG "${zlib_INTERNAL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}${zlibstaticlibname}${zlibpostfix}${CMAKE_STATIC_LIBRARY_SUFFIX}"
     )
   target_include_directories(zlib_static INTERFACE "${zlib_INTERNAL_DIR}/include")
 


### PR DESCRIPTION
I found this issue when trying to build in debug mode with msvc and it not being able to link to the internal zlib.

To replicate in a MSVC Developer command prompt and a clean build dir run

```
cmake .. -DOPENEXR_FORCE_INTERNAL_ZLIB=ON
cmake --build .
```
I get this error
```
LINK : fatal error LNK1104: cannot open file '..\..\..\zlib-install\lib\zlibstatic.lib' [D:\Dev\openexr\build\src\lib\OpenEXR\OpenEXR.vcxproj]
```

zlib's cmake script is setting `CMAKE_DEBUG_POSTFIX` to "d" with msvc. The lib name should be `zlibstaticd.lib` in debug. The current scripts don't take the "d" into account.

There might be a better way fix this. I couldn't figure out a way in cmake to override this behavior without modifying zlib. I ended up going with setting the additional `IMPORTED_LOCATION_DEBUG`  property instead. I also tried those fancy generator expressions but they didn't appear to work with the `IMPORTED_LOCATION` property. 
