### PR TITLE
Support negative stride

### DIFF
--- a/src/lib/OpenEXR/ImfAcesFile.cpp
+++ b/src/lib/OpenEXR/ImfAcesFile.cpp
@@ -190,7 +190,7 @@ AcesOutputFile::~AcesOutputFile ()
 
 void
 AcesOutputFile::setFrameBuffer (
-    const Rgba* base, size_t xStride, size_t yStride)
+    const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     _data->rgbaFile->setFrameBuffer (base, xStride, yStride);
 }
@@ -282,11 +282,11 @@ public:
 
     RgbaInputFile* rgbaFile;
 
-    Rgba*  fbBase;
-    size_t fbXStride;
-    size_t fbYStride;
-    int    minX;
-    int    maxX;
+    Rgba*     fbBase;
+    ptrdiff_t fbXStride;
+    ptrdiff_t fbYStride;
+    int       minX;
+    int       maxX;
 
     bool mustConvertColor;
     M44f fileToAces;
@@ -440,7 +440,7 @@ AcesInputFile::~AcesInputFile ()
 }
 
 void
-AcesInputFile::setFrameBuffer (Rgba* base, size_t xStride, size_t yStride)
+AcesInputFile::setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     _data->rgbaFile->setFrameBuffer (base, xStride, yStride);
     _data->fbBase    = base;

--- a/src/lib/OpenEXR/ImfAcesFile.h
+++ b/src/lib/OpenEXR/ImfAcesFile.h
@@ -54,6 +54,7 @@
 #include "ImfRgba.h"
 #include "ImfThreading.h"
 
+#include <cstddef>
 #include <string>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -150,7 +151,7 @@ public:
     //------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (const Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //-------------------------------------------------
     // Write pixel data (see class Imf::OutputFile)
@@ -247,7 +248,7 @@ public:
     //-----------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //--------------------------------------------
     // Read pixel data (see class Imf::InputFile)

--- a/src/lib/OpenEXR/ImfCRgbaFile.cpp
+++ b/src/lib/OpenEXR/ImfCRgbaFile.cpp
@@ -947,7 +947,7 @@ ImfCloseOutputFile (ImfOutputFile* out)
 
 int
 ImfOutputSetFrameBuffer (
-    ImfOutputFile* out, const ImfRgba* base, size_t xStride, size_t yStride)
+    ImfOutputFile* out, const ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     try
     {
@@ -1043,8 +1043,8 @@ int
 ImfTiledOutputSetFrameBuffer (
     ImfTiledOutputFile* out,
     const ImfRgba*      base,
-    size_t              xStride,
-    size_t              yStride)
+    ptrdiff_t           xStride,
+    ptrdiff_t           yStride)
 {
     try
     {
@@ -1165,7 +1165,7 @@ ImfCloseInputFile (ImfInputFile* in)
 
 int
 ImfInputSetFrameBuffer (
-    ImfInputFile* in, ImfRgba* base, size_t xStride, size_t yStride)
+    ImfInputFile* in, ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     try
     {
@@ -1245,7 +1245,7 @@ ImfCloseTiledInputFile (ImfTiledInputFile* in)
 
 int
 ImfTiledInputSetFrameBuffer (
-    ImfTiledInputFile* in, ImfRgba* base, size_t xStride, size_t yStride)
+    ImfTiledInputFile* in, ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     try
     {

--- a/src/lib/OpenEXR/ImfCRgbaFile.h
+++ b/src/lib/OpenEXR/ImfCRgbaFile.h
@@ -9,6 +9,7 @@
 #include "ImfExport.h"
 
 #include <stdlib.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -297,7 +298,7 @@ int ImfCloseOutputFile (ImfOutputFile* out);
 
 IMF_EXPORT
 int ImfOutputSetFrameBuffer (
-    ImfOutputFile* out, const ImfRgba* base, size_t xStride, size_t yStride);
+    ImfOutputFile* out, const ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
 IMF_EXPORT
 int ImfOutputWritePixels (ImfOutputFile* out, int numScanLines);
@@ -335,8 +336,8 @@ IMF_EXPORT
 int ImfTiledOutputSetFrameBuffer (
     ImfTiledOutputFile* out,
     const ImfRgba*      base,
-    size_t              xStride,
-    size_t              yStride);
+    ptrdiff_t           xStride,
+    ptrdiff_t           yStride);
 
 IMF_EXPORT
 int ImfTiledOutputWriteTile (
@@ -385,7 +386,7 @@ int ImfCloseInputFile (ImfInputFile* in);
 
 IMF_EXPORT
 int ImfInputSetFrameBuffer (
-    ImfInputFile* in, ImfRgba* base, size_t xStride, size_t yStride);
+    ImfInputFile* in, ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
 IMF_EXPORT
 int ImfInputReadPixels (ImfInputFile* in, int scanLine1, int scanLine2);
@@ -414,7 +415,7 @@ int ImfCloseTiledInputFile (ImfTiledInputFile* in);
 
 IMF_EXPORT
 int ImfTiledInputSetFrameBuffer (
-    ImfTiledInputFile* in, ImfRgba* base, size_t xStride, size_t yStride);
+    ImfTiledInputFile* in, ImfRgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
 IMF_EXPORT
 int

--- a/src/lib/OpenEXR/ImfDeepFrameBuffer.cpp
+++ b/src/lib/OpenEXR/ImfDeepFrameBuffer.cpp
@@ -14,8 +14,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 DeepSlice::DeepSlice (
     PixelType t,
     char*     b,
-    size_t    xst,
-    size_t    yst,
+    ptrdiff_t xst,
+    ptrdiff_t yst,
     size_t    spst,
     int       xsm,
     int       ysm,

--- a/src/lib/OpenEXR/ImfDeepFrameBuffer.h
+++ b/src/lib/OpenEXR/ImfDeepFrameBuffer.h
@@ -49,8 +49,8 @@ struct IMF_EXPORT_TYPE DeepSlice : public Slice
     DeepSlice (
         PixelType type         = HALF,
         char*     base         = 0,
-        size_t    xStride      = 0,
-        size_t    yStride      = 0,
+        ptrdiff_t xStride      = 0,
+        ptrdiff_t yStride      = 0,
         size_t    sampleStride = 0,
         int       xSampling    = 1,
         int       ySampling    = 1,

--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -62,8 +62,8 @@ struct InSliceInfo
     PixelType typeInFile;
     char*     base;
     char*     pointerArrayBase;
-    size_t    xPointerStride;
-    size_t    yPointerStride;
+    ptrdiff_t xPointerStride;
+    ptrdiff_t yPointerStride;
     size_t    sampleStride;
     int       xSampling;
     int       ySampling;
@@ -75,8 +75,8 @@ struct InSliceInfo
         PixelType typeInFrameBuffer = HALF,
         char*     base              = NULL,
         PixelType typeInFile        = HALF,
-        size_t    xPointerStride    = 0,
-        size_t    yPointerStride    = 0,
+        ptrdiff_t xPointerStride    = 0,
+        ptrdiff_t yPointerStride    = 0,
         size_t    sampleStride      = 0,
         int       xSampling         = 1,
         int       ySampling         = 1,
@@ -89,8 +89,8 @@ InSliceInfo::InSliceInfo (
     PixelType tifb,
     char*     b,
     PixelType tifl,
-    size_t    xpst,
-    size_t    ypst,
+    ptrdiff_t xpst,
+    ptrdiff_t ypst,
     size_t    spst,
     int       xsm,
     int       ysm,

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -60,8 +60,8 @@ struct TInSliceInfo
     PixelType typeInFrameBuffer;
     PixelType typeInFile;
     char*     pointerArrayBase;
-    size_t    xStride;
-    size_t    yStride;
+    ptrdiff_t xStride;
+    ptrdiff_t yStride;
     ptrdiff_t sampleStride;
     bool      fill;
     bool      skip;
@@ -73,8 +73,8 @@ struct TInSliceInfo
         PixelType typeInFrameBuffer = HALF,
         char*     base              = NULL,
         PixelType typeInFile        = HALF,
-        size_t    xStride           = 0,
-        size_t    yStride           = 0,
+        ptrdiff_t xStride           = 0,
+        ptrdiff_t yStride           = 0,
         ptrdiff_t sampleStride      = 0,
         bool      fill              = false,
         bool      skip              = false,
@@ -87,8 +87,8 @@ TInSliceInfo::TInSliceInfo (
     PixelType tifb,
     char*     b,
     PixelType tifl,
-    size_t    xs,
-    size_t    ys,
+    ptrdiff_t xs,
+    ptrdiff_t ys,
     ptrdiff_t spst,
     bool      f,
     bool      s,

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
@@ -71,8 +71,8 @@ struct TOutSliceInfo
     PixelType   type;
     const char* base;
     size_t      sampleStride;
-    size_t      xStride;
-    size_t      yStride;
+    ptrdiff_t   xStride;
+    ptrdiff_t   yStride;
     bool        zero;
     int         xTileCoords;
     int         yTileCoords;
@@ -80,8 +80,8 @@ struct TOutSliceInfo
     TOutSliceInfo (
         PixelType type         = HALF,
         size_t    sampleStride = 0,
-        size_t    xStride      = 0,
-        size_t    yStride      = 0,
+        ptrdiff_t xStride      = 0,
+        ptrdiff_t yStride      = 0,
         bool      zero         = false,
         int       xTileCoords  = 0,
         int       yTileCoords  = 0);
@@ -90,8 +90,8 @@ struct TOutSliceInfo
 TOutSliceInfo::TOutSliceInfo (
     PixelType t,
     size_t    spst,
-    size_t    xStride,
-    size_t    yStride,
+    ptrdiff_t xStride,
+    ptrdiff_t yStride,
     bool      z,
     int       xtc,
     int       ytc)

--- a/src/lib/OpenEXR/ImfFrameBuffer.cpp
+++ b/src/lib/OpenEXR/ImfFrameBuffer.cpp
@@ -22,8 +22,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 Slice::Slice (
     PixelType t,
     char*     b,
-    size_t    xst,
-    size_t    yst,
+    ptrdiff_t xst,
+    ptrdiff_t yst,
     int       xsm,
     int       ysm,
     double    fv,
@@ -49,8 +49,8 @@ Slice::Make (
     const IMATH_NAMESPACE::V2i& origin,
     int64_t                     w,
     int64_t                     h,
-    size_t                      xStride,
-    size_t                      yStride,
+    ptrdiff_t                   xStride,
+    ptrdiff_t                   yStride,
     int                         xSampling,
     int                         ySampling,
     double                      fillValue,
@@ -69,7 +69,7 @@ Slice::Make (
                 THROW (IEX_NAMESPACE::ArgExc, "Invalid pixel type.");
         }
     }
-    if (yStride == 0) yStride = static_cast<size_t> (w / xSampling) * xStride;
+    if (yStride == 0) yStride = (w / xSampling) * xStride;
 
     // data window is an int, so force promote to higher type to avoid
     // overflow for off y (degenerate size checks should be in
@@ -99,8 +99,8 @@ Slice::Make (
     PixelType                     type,
     const void*                   ptr,
     const IMATH_NAMESPACE::Box2i& dataWindow,
-    size_t                        xStride,
-    size_t                        yStride,
+    ptrdiff_t                     xStride,
+    ptrdiff_t                     yStride,
     int                           xSampling,
     int                           ySampling,
     double                        fillValue,

--- a/src/lib/OpenEXR/ImfFrameBuffer.h
+++ b/src/lib/OpenEXR/ImfFrameBuffer.h
@@ -21,6 +21,7 @@
 #include <ImathBox.h>
 
 #include <cstdint>
+#include <cstddef>
 #include <map>
 #include <string>
 
@@ -62,9 +63,9 @@ struct IMF_EXPORT_TYPE Slice
     //
     //---------------------------------------------------------------------
 
-    char*  base;
-    size_t xStride;
-    size_t yStride;
+    char*     base;
+    ptrdiff_t xStride;
+    ptrdiff_t yStride;
 
     //--------------------------------------------
     // Subsampling: pixel (x, y) is present in the
@@ -107,8 +108,8 @@ struct IMF_EXPORT_TYPE Slice
     Slice (
         PixelType type        = HALF,
         char*     base        = 0,
-        size_t    xStride     = 0,
-        size_t    yStride     = 0,
+        ptrdiff_t xStride     = 0,
+        ptrdiff_t yStride     = 0,
         int       xSampling   = 1,
         int       ySampling   = 1,
         double    fillValue   = 0.0,
@@ -127,8 +128,8 @@ struct IMF_EXPORT_TYPE Slice
         const IMATH_NAMESPACE::V2i& origin,
         int64_t                     w,
         int64_t                     h,
-        size_t                      xStride     = 0,
-        size_t                      yStride     = 0,
+        ptrdiff_t                   xStride     = 0,
+        ptrdiff_t                   yStride     = 0,
         int                         xSampling   = 1,
         int                         ySampling   = 1,
         double                      fillValue   = 0.0,
@@ -141,8 +142,8 @@ struct IMF_EXPORT_TYPE Slice
         PixelType                     type,
         const void*                   ptr,
         const IMATH_NAMESPACE::Box2i& dataWindow,
-        size_t                        xStride     = 0,
-        size_t                        yStride     = 0,
+        ptrdiff_t                     xStride     = 0,
+        ptrdiff_t                     yStride     = 0,
         int                           xSampling   = 1,
         int                           ySampling   = 1,
         double                        fillValue   = 0.0,

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -262,7 +262,7 @@ copyIntoFrameBuffer (
     const char*&       readPtr,
     char*              writePtr,
     char*              endPtr,
-    size_t             xStride,
+    ptrdiff_t          xStride,
     bool               fill,
     double             fillValue,
     Compressor::Format format,
@@ -273,6 +273,7 @@ copyIntoFrameBuffer (
     // Copy a horizontal row of pixels from an input
     // file's line or tile buffer to a frame buffer.
     //
+    endPtr += xStride;
 
     if (fill)
     {
@@ -288,7 +289,7 @@ copyIntoFrameBuffer (
             {
                 unsigned int fillVal = (unsigned int) (fillValue);
 
-                while (writePtr <= endPtr)
+                while (writePtr != endPtr)
                 {
                     *(unsigned int*) writePtr = fillVal;
                     writePtr += xStride;
@@ -301,7 +302,7 @@ copyIntoFrameBuffer (
             {
                 half fillVal = half (fillValue);
 
-                while (writePtr <= endPtr)
+                while (writePtr != endPtr)
                 {
                     *(half*) writePtr = fillVal;
                     writePtr += xStride;
@@ -314,7 +315,7 @@ copyIntoFrameBuffer (
             {
                 float fillVal = float (fillValue);
 
-                while (writePtr <= endPtr)
+                while (writePtr != endPtr)
                 {
                     *(float*) writePtr = fillVal;
                     writePtr += xStride;
@@ -343,7 +344,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             Xdr::read<CharPtrIO> (
                                 readPtr, *(unsigned int*) writePtr);
@@ -353,7 +354,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             half h;
                             Xdr::read<CharPtrIO> (readPtr, h);
@@ -364,7 +365,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             float f;
                             Xdr::read<CharPtrIO> (readPtr, f);
@@ -385,7 +386,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             unsigned int ui;
                             Xdr::read<CharPtrIO> (readPtr, ui);
@@ -396,7 +397,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             Xdr::read<CharPtrIO> (readPtr, *(half*) writePtr);
                             writePtr += xStride;
@@ -405,7 +406,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             float f;
                             Xdr::read<CharPtrIO> (readPtr, f);
@@ -426,7 +427,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             unsigned int ui;
                             Xdr::read<CharPtrIO> (readPtr, ui);
@@ -437,7 +438,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             half h;
                             Xdr::read<CharPtrIO> (readPtr, h);
@@ -448,7 +449,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             Xdr::read<CharPtrIO> (readPtr, *(float*) writePtr);
                             writePtr += xStride;
@@ -479,7 +480,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             for (size_t i = 0; i < sizeof (unsigned int); ++i)
                                 writePtr[i] = readPtr[i];
@@ -491,7 +492,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             half h                    = *(half*) readPtr;
                             *(unsigned int*) writePtr = halfToUint (h);
@@ -502,7 +503,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             float f;
 
@@ -528,7 +529,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             unsigned int ui;
 
@@ -546,14 +547,14 @@ copyIntoFrameBuffer (
                         // If we're tightly packed, just memcpy
                         if (xStride == sizeof (half))
                         {
-                            int numBytes = endPtr - writePtr + sizeof (half);
+                            int numBytes = endPtr - writePtr;
                             memcpy (writePtr, readPtr, numBytes);
                             readPtr += numBytes;
                             writePtr += numBytes;
                         }
                         else
                         {
-                            while (writePtr <= endPtr)
+                            while (writePtr != endPtr)
                             {
                                 *(half*) writePtr = *(half*) readPtr;
                                 readPtr += sizeof (half);
@@ -564,7 +565,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             float f;
 
@@ -589,7 +590,7 @@ copyIntoFrameBuffer (
                 {
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             unsigned int ui;
 
@@ -604,7 +605,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             half h             = *(half*) readPtr;
                             *(float*) writePtr = float (h);
@@ -615,7 +616,7 @@ copyIntoFrameBuffer (
 
                     case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                        while (writePtr <= endPtr)
+                        while (writePtr != endPtr)
                         {
                             for (size_t i = 0; i < sizeof (float); ++i)
                                 writePtr[i] = readPtr[i];
@@ -1525,12 +1526,13 @@ copyFromFrameBuffer (
     char*&             writePtr,
     const char*&       readPtr,
     const char*        endPtr,
-    size_t             xStride,
+    ptrdiff_t          xStride,
     Compressor::Format format,
     PixelType          type)
 {
     char*       localWritePtr = writePtr;
     const char* localReadPtr  = readPtr;
+    endPtr += xStride;
     //
     // Copy a horizontal row of pixels from a frame
     // buffer to an output file's line or tile buffer.
@@ -1546,7 +1548,7 @@ copyFromFrameBuffer (
         {
             case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     Xdr::write<CharPtrIO> (
                         localWritePtr, *(const unsigned int*) localReadPtr);
@@ -1556,7 +1558,7 @@ copyFromFrameBuffer (
 
             case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     Xdr::write<CharPtrIO> (
                         localWritePtr, *(const half*) localReadPtr);
@@ -1566,7 +1568,7 @@ copyFromFrameBuffer (
 
             case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     Xdr::write<CharPtrIO> (
                         localWritePtr, *(const float*) localReadPtr);
@@ -1587,7 +1589,7 @@ copyFromFrameBuffer (
         {
             case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     for (size_t i = 0; i < sizeof (unsigned int); ++i)
                         *localWritePtr++ = localReadPtr[i];
@@ -1598,7 +1600,7 @@ copyFromFrameBuffer (
 
             case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     *(half*) localWritePtr = *(const half*) localReadPtr;
                     localWritePtr += sizeof (half);
@@ -1608,7 +1610,7 @@ copyFromFrameBuffer (
 
             case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
 
-                while (localReadPtr <= endPtr)
+                while (localReadPtr != endPtr)
                 {
                     for (size_t i = 0; i < sizeof (float); ++i)
                         *localWritePtr++ = localReadPtr[i];

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -22,6 +22,7 @@
 #include <ImfStdIO.h>
 #include <ImfTileDescription.h>
 #include <ImfXdr.h>
+#include <cassert>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -274,6 +275,20 @@ copyIntoFrameBuffer (
     // file's line or tile buffer to a frame buffer.
     //
     endPtr += xStride;
+
+    if (xStride == 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Zero stride is invalid.");
+    }
+    if ((endPtr - writePtr) / xStride <= 0)
+    {
+        // Nothing to do, the specified range is empty.
+        return;
+    }
+    if ((endPtr - writePtr) % xStride != 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Stride will not exactly span input data.");
+    }
 
     if (fill)
     {
@@ -1533,6 +1548,21 @@ copyFromFrameBuffer (
     char*       localWritePtr = writePtr;
     const char* localReadPtr  = readPtr;
     endPtr += xStride;
+
+    if (xStride == 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Zero stride is invalid.");
+    }
+    if ((endPtr - localReadPtr) / xStride <= 0)
+    {
+        // Nothing to do, the specified range is empty.
+        return;
+    }
+    if ((endPtr - localReadPtr) % xStride != 0)
+    {
+        throw IEX_NAMESPACE::ArgExc ("Stride will not exactly span input data.");
+    }
+
     //
     // Copy a horizontal row of pixels from a frame
     // buffer to an output file's line or tile buffer.

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -173,7 +173,7 @@ int numLinesInBuffer (Compressor* compressor);
 //			readPtr points just past the end of the
 //			copied data.
 //
-//    writePtr, endPtr	point to the lefmost and rightmost pixels
+//    writePtr, endPtr	point to the first and last pixels
 //			in the frame buffer slice
 //
 //    xStride		the xStride for the frame buffer slice
@@ -191,7 +191,7 @@ void copyIntoFrameBuffer (
     const char*&       readPtr,
     char*              writePtr,
     char*              endPtr,
-    size_t             xStride,
+    ptrdiff_t          xStride,
     bool               fill,
     double             fillValue,
     Compressor::Format format,
@@ -207,7 +207,7 @@ void copyIntoFrameBuffer (
 //    readPtr             initially points to the beginning of the
 //                        data in the line or tile buffer. readPtr
 //                        is advanced as the pixel data are copied;
-//                        when copyIntoFrameBuffer() returns,
+//                        when copyIntoDeepFrameBuffer() returns,
 //                        readPtr points just past the end of the
 //                        copied data.
 //
@@ -307,7 +307,7 @@ void convertInPlace (
 //			writePtr points just past the end of the
 //			copied data.
 //
-//    readPtr, endPtr	point to the lefmost and rightmost pixels
+//    readPtr, endPtr	point to the first and last pixels
 //			in the frame buffer slice
 //
 //    xStride		the xStride for the frame buffer slice
@@ -326,7 +326,7 @@ void copyFromFrameBuffer (
     char*&             writePtr,
     const char*&       readPtr,
     const char*        endPtr,
-    size_t             xStride,
+    ptrdiff_t          xStride,
     Compressor::Format format,
     PixelType          type);
 
@@ -372,7 +372,7 @@ void copyFromFrameBuffer (
 //
 //    type                      the pixel data type in the frame buffer
 //                              and in the output file's channel (function
-//                              copyFromFrameBuffer() doesn't do on-the-fly
+//                              copyFromDeepFrameBuffer() doesn't do on-the-fly
 //                              data type conversion)
 //
 

--- a/src/lib/OpenEXR/ImfOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfOutputFile.cpp
@@ -59,8 +59,8 @@ struct OutSliceInfo
 {
     PixelType   type;
     const char* base;
-    size_t      xStride;
-    size_t      yStride;
+    ptrdiff_t   xStride;
+    ptrdiff_t   yStride;
     int         xSampling;
     int         ySampling;
     bool        zero;
@@ -68,15 +68,15 @@ struct OutSliceInfo
     OutSliceInfo (
         PixelType   type      = HALF,
         const char* base      = 0,
-        size_t      xStride   = 0,
-        size_t      yStride   = 0,
+        ptrdiff_t   xStride   = 0,
+        ptrdiff_t   yStride   = 0,
         int         xSampling = 1,
         int         ySampling = 1,
         bool        zero      = false);
 };
 
 OutSliceInfo::OutSliceInfo (
-    PixelType t, const char* b, size_t xs, size_t ys, int xsm, int ysm, bool z)
+    PixelType t, const char* b, ptrdiff_t xs, ptrdiff_t ys, int xsm, int ysm, bool z)
     : type (t)
     , base (b)
     , xStride (xs)

--- a/src/lib/OpenEXR/ImfRgbaFile.cpp
+++ b/src/lib/OpenEXR/ImfRgbaFile.cpp
@@ -153,7 +153,7 @@ public:
 
     void setYCRounding (unsigned int roundY, unsigned int roundC);
 
-    void setFrameBuffer (const Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     void writePixels (int numScanLines);
     int  currentScanLine () const;
@@ -180,8 +180,8 @@ private:
     Rgba*       _buf[N];
     Rgba*       _tmpBuf;
     const Rgba* _fbBase;
-    size_t      _fbXStride;
-    size_t      _fbYStride;
+    ptrdiff_t   _fbXStride;
+    ptrdiff_t   _fbYStride;
     int         _roundY;
     int         _roundC;
 };
@@ -241,7 +241,7 @@ RgbaOutputFile::ToYca::setYCRounding (unsigned int roundY, unsigned int roundC)
 
 void
 RgbaOutputFile::ToYca::setFrameBuffer (
-    const Rgba* base, size_t xStride, size_t yStride)
+    const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     if (_fbBase == 0)
     {
@@ -603,7 +603,7 @@ RgbaOutputFile::~RgbaOutputFile ()
 
 void
 RgbaOutputFile::setFrameBuffer (
-    const Rgba* base, size_t xStride, size_t yStride)
+    const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     if (_toYca)
     {
@@ -612,8 +612,8 @@ RgbaOutputFile::setFrameBuffer (
     }
     else
     {
-        size_t xs = xStride * sizeof (Rgba);
-        size_t ys = yStride * sizeof (Rgba);
+        ptrdiff_t xs = xStride * sizeof (Rgba);
+        ptrdiff_t ys = yStride * sizeof (Rgba);
 
         FrameBuffer fb;
 
@@ -749,8 +749,8 @@ public:
 
     void setFrameBuffer (
         Rgba*         base,
-        size_t        xStride,
-        size_t        yStride,
+        ptrdiff_t     xStride,
+        ptrdiff_t     yStride,
         const string& channelNamePrefix);
 
     void readPixels (int scanLine1, int scanLine2);
@@ -777,8 +777,8 @@ private:
     Rgba*      _buf2[3];
     Rgba*      _tmpBuf;
     Rgba*      _fbBase;
-    size_t     _fbXStride;
-    size_t     _fbYStride;
+    ptrdiff_t  _fbXStride;
+    ptrdiff_t  _fbYStride;
 };
 
 RgbaInputFile::FromYca::FromYca (
@@ -823,7 +823,7 @@ RgbaInputFile::FromYca::~FromYca ()
 
 void
 RgbaInputFile::FromYca::setFrameBuffer (
-    Rgba* base, size_t xStride, size_t yStride, const string& channelNamePrefix)
+    Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride, const string& channelNamePrefix)
 {
     if (_fbBase == 0)
     {
@@ -1219,7 +1219,7 @@ RgbaInputFile::~RgbaInputFile ()
 }
 
 void
-RgbaInputFile::setFrameBuffer (Rgba* base, size_t xStride, size_t yStride)
+RgbaInputFile::setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     if (_fromYca)
     {
@@ -1228,8 +1228,8 @@ RgbaInputFile::setFrameBuffer (Rgba* base, size_t xStride, size_t yStride)
     }
     else
     {
-        size_t xs = xStride * sizeof (Rgba);
-        size_t ys = yStride * sizeof (Rgba);
+        ptrdiff_t xs = xStride * sizeof (Rgba);
+        ptrdiff_t ys = yStride * sizeof (Rgba);
 
         FrameBuffer fb;
 

--- a/src/lib/OpenEXR/ImfRgbaFile.h
+++ b/src/lib/OpenEXR/ImfRgbaFile.h
@@ -26,6 +26,7 @@
 #include <ImathBox.h>
 #include <ImathVec.h>
 #include <half.h>
+#include <cstddef>
 #include <string>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -43,8 +44,8 @@ ComputeBasePointer (
     const Rgba*                 ptr,
     const IMATH_NAMESPACE::V2i& origin,
     int64_t                     w,
-    size_t                      xStride = 1,
-    size_t                      yStride = 0)
+    ptrdiff_t                   xStride = 1,
+    ptrdiff_t                   yStride = 0)
 {
     if (yStride == 0) yStride = w;
     int64_t offx = static_cast<int64_t> (origin.x);
@@ -69,8 +70,8 @@ ComputeBasePointer (
     Rgba*                       ptr,
     const IMATH_NAMESPACE::V2i& origin,
     int64_t                     w,
-    size_t                      xStride = 1,
-    size_t                      yStride = 0)
+    ptrdiff_t                   xStride = 1,
+    ptrdiff_t                   yStride = 0)
 {
     if (yStride == 0) yStride = w;
     int64_t offx = static_cast<int64_t> (origin.x);
@@ -176,7 +177,7 @@ public:
     //------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (const Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //---------------------------------------------
     // Write pixel data (see class Imf::OutputFile)
@@ -353,7 +354,7 @@ public:
     //-----------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //----------------------------------------------------------------
     // Switch to a different layer within the current part

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -58,8 +58,8 @@ struct InSliceInfo
     PixelType typeInFrameBuffer;
     PixelType typeInFile;
     char*     base;
-    size_t    xStride;
-    size_t    yStride;
+    ptrdiff_t xStride;
+    ptrdiff_t yStride;
     int       xSampling;
     int       ySampling;
     bool      fill;
@@ -70,8 +70,8 @@ struct InSliceInfo
         PixelType typeInFrameBuffer = HALF,
         PixelType typeInFile        = HALF,
         char*     base              = 0,
-        size_t    xStride           = 0,
-        size_t    yStride           = 0,
+        ptrdiff_t xStride           = 0,
+        ptrdiff_t yStride           = 0,
         int       xSampling         = 1,
         int       ySampling         = 1,
         bool      fill              = false,
@@ -83,8 +83,8 @@ InSliceInfo::InSliceInfo (
     PixelType tifb,
     PixelType tifl,
     char*     b,
-    size_t    xs,
-    size_t    ys,
+    ptrdiff_t xs,
+    ptrdiff_t ys,
     int       xsm,
     int       ysm,
     bool      f,

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -59,8 +59,8 @@ struct TInSliceInfo
     PixelType typeInFrameBuffer;
     PixelType typeInFile;
     char*     base;
-    size_t    xStride;
-    size_t    yStride;
+    ptrdiff_t xStride;
+    ptrdiff_t yStride;
     bool      fill;
     bool      skip;
     double    fillValue;
@@ -71,8 +71,8 @@ struct TInSliceInfo
         PixelType typeInFrameBuffer = HALF,
         PixelType typeInFile        = HALF,
         char*     base              = 0,
-        size_t    xStride           = 0,
-        size_t    yStride           = 0,
+        ptrdiff_t xStride           = 0,
+        ptrdiff_t yStride           = 0,
         bool      fill              = false,
         bool      skip              = false,
         double    fillValue         = 0.0,
@@ -84,8 +84,8 @@ TInSliceInfo::TInSliceInfo (
     PixelType tifb,
     PixelType tifl,
     char*     b,
-    size_t    xs,
-    size_t    ys,
+    ptrdiff_t xs,
+    ptrdiff_t ys,
     bool      f,
     bool      s,
     double    fv,

--- a/src/lib/OpenEXR/ImfTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledOutputFile.cpp
@@ -70,8 +70,8 @@ struct TOutSliceInfo
 {
     PixelType   type;
     const char* base;
-    size_t      xStride;
-    size_t      yStride;
+    ptrdiff_t   xStride;
+    ptrdiff_t   yStride;
     bool        zero;
     int         xTileCoords;
     int         yTileCoords;
@@ -79,15 +79,15 @@ struct TOutSliceInfo
     TOutSliceInfo (
         PixelType   type        = HALF,
         const char* base        = 0,
-        size_t      xStride     = 0,
-        size_t      yStride     = 0,
+        ptrdiff_t   xStride     = 0,
+        ptrdiff_t   yStride     = 0,
         bool        zero        = false,
         int         xTileCoords = 0,
         int         yTileCoords = 0);
 };
 
 TOutSliceInfo::TOutSliceInfo (
-    PixelType t, const char* b, size_t xs, size_t ys, bool z, int xtc, int ytc)
+    PixelType t, const char* b, ptrdiff_t xs, ptrdiff_t ys, bool z, int xtc, int ytc)
     : type (t)
     , base (b)
     , xStride (xs)

--- a/src/lib/OpenEXR/ImfTiledRgbaFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledRgbaFile.cpp
@@ -119,7 +119,7 @@ class TiledRgbaOutputFile::ToYa
 public:
     ToYa (TiledOutputFile& outputFile, RgbaChannels rgbaChannels);
 
-    void setFrameBuffer (const Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     void writeTile (int dx, int dy, int lx, int ly);
 
@@ -131,8 +131,8 @@ private:
     V3f              _yw;
     Array2D<Rgba>    _buf;
     const Rgba*      _fbBase;
-    size_t           _fbXStride;
-    size_t           _fbYStride;
+    ptrdiff_t        _fbXStride;
+    ptrdiff_t        _fbYStride;
 };
 
 TiledRgbaOutputFile::ToYa::ToYa (
@@ -154,7 +154,7 @@ TiledRgbaOutputFile::ToYa::ToYa (
 
 void
 TiledRgbaOutputFile::ToYa::setFrameBuffer (
-    const Rgba* base, size_t xStride, size_t yStride)
+    const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     _fbBase    = base;
     _fbXStride = xStride;
@@ -332,7 +332,7 @@ TiledRgbaOutputFile::~TiledRgbaOutputFile ()
 
 void
 TiledRgbaOutputFile::setFrameBuffer (
-    const Rgba* base, size_t xStride, size_t yStride)
+    const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     if (_toYa)
     {
@@ -343,8 +343,8 @@ TiledRgbaOutputFile::setFrameBuffer (
     }
     else
     {
-        size_t xs = xStride * sizeof (Rgba);
-        size_t ys = yStride * sizeof (Rgba);
+        ptrdiff_t xs = xStride * sizeof (Rgba);
+        ptrdiff_t ys = yStride * sizeof (Rgba);
 
         FrameBuffer fb;
 
@@ -581,8 +581,8 @@ public:
 
     void setFrameBuffer (
         Rgba*         base,
-        size_t        xStride,
-        size_t        yStride,
+        ptrdiff_t     xStride,
+        ptrdiff_t     yStride,
         const string& channelNamePrefix);
 
     void readTile (int dx, int dy, int lx, int ly);
@@ -594,8 +594,8 @@ private:
     V3f             _yw;
     Array2D<Rgba>   _buf;
     Rgba*           _fbBase;
-    size_t          _fbXStride;
-    size_t          _fbYStride;
+    ptrdiff_t       _fbXStride;
+    ptrdiff_t       _fbYStride;
 };
 
 TiledRgbaInputFile::FromYa::FromYa (TiledInputFile& inputFile)
@@ -614,7 +614,7 @@ TiledRgbaInputFile::FromYa::FromYa (TiledInputFile& inputFile)
 
 void
 TiledRgbaInputFile::FromYa::setFrameBuffer (
-    Rgba* base, size_t xStride, size_t yStride, const string& channelNamePrefix)
+    Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride, const string& channelNamePrefix)
 {
     if (_fbBase == 0)
     {
@@ -747,7 +747,7 @@ TiledRgbaInputFile::~TiledRgbaInputFile ()
 }
 
 void
-TiledRgbaInputFile::setFrameBuffer (Rgba* base, size_t xStride, size_t yStride)
+TiledRgbaInputFile::setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride)
 {
     if (_fromYa)
     {
@@ -758,8 +758,8 @@ TiledRgbaInputFile::setFrameBuffer (Rgba* base, size_t xStride, size_t yStride)
     }
     else
     {
-        size_t xs = xStride * sizeof (Rgba);
-        size_t ys = yStride * sizeof (Rgba);
+        ptrdiff_t xs = xStride * sizeof (Rgba);
+        ptrdiff_t ys = yStride * sizeof (Rgba);
 
         FrameBuffer fb;
 

--- a/src/lib/OpenEXR/ImfTiledRgbaFile.h
+++ b/src/lib/OpenEXR/ImfTiledRgbaFile.h
@@ -28,6 +28,7 @@
 #include <half.h>
 
 #include <string>
+#include <cstddef>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
@@ -137,7 +138,7 @@ public:
     //------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (const Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (const Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //--------------------------
     // Access to the file header
@@ -352,7 +353,7 @@ public:
     //-----------------------------------------------------
 
     IMF_EXPORT
-    void setFrameBuffer (Rgba* base, size_t xStride, size_t yStride);
+    void setFrameBuffer (Rgba* base, ptrdiff_t xStride, ptrdiff_t yStride);
 
     //-------------------------------------------------------------------
     // Switch to a different layer -- subsequent calls to readTile()

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(OpenEXRTest
   testMultiTiledPartThreading.cpp
   testMultiView.cpp
   testNativeFormat.cpp
+  testNegativeStride.cpp
   testOptimized.cpp
   testOptimizedInterleavePatterns.cpp
   testPartHelper.cpp
@@ -119,6 +120,7 @@ define_openexr_tests(
  testMultiTiledPartThreading
  testMultiView
  testNativeFormat
+ testNegativeStride
  testOptimized
  testOptimizedInterleavePatterns
  testPartHelper

--- a/src/test/OpenEXRTest/main.cpp
+++ b/src/test/OpenEXRTest/main.cpp
@@ -48,6 +48,7 @@
 #include "testMultiTiledPartThreading.h"
 #include "testMultiView.h"
 #include "testNativeFormat.h"
+#include "testNegativeStride.h"
 #include "testOptimized.h"
 #include "testOptimizedInterleavePatterns.h"
 #include "testPartHelper.h"
@@ -206,6 +207,7 @@ main (int argc, char* argv[])
     TEST (testYca, "basic");
     TEST (testTiledYa, "basic");
     TEST (testNativeFormat, "basic");
+    TEST (testNegativeStride, "basic");
     TEST (testMultiView, "basic");
     TEST (testIsComplete, "basic");
     TEST (testDeepScanLineBasic, "deep");

--- a/src/test/OpenEXRTest/testNegativeStride.cpp
+++ b/src/test/OpenEXRTest/testNegativeStride.cpp
@@ -1,0 +1,159 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
+#include <iostream>
+#include <iomanip>
+
+#include <ImfArray.h>
+#include <ImfHeader.h>
+#include <ImfPixelType.h>
+#include <ImfChannelList.h>
+#include <ImfFrameBuffer.h>
+#include <ImfInputFile.h>
+#include <ImfOutputFile.h>
+#include <ImfThreading.h>
+
+#include <assert.h>
+#include <stdio.h>
+
+using namespace OPENEXR_IMF_NAMESPACE;
+using namespace std;
+
+namespace {
+
+enum FLIP_FLAGS
+{
+    FLIP_NONE = 0,
+    FLIP_X    = 1,
+    FLIP_Y    = 2
+};
+
+void
+fillPixels (Array2D<float>& ph, int width, int height)
+{
+    for (int y = 0; y < height; ++y)
+        for (int x = 0; x < width; ++x)
+            ph[y][x] = y * 1000 + x;
+}
+
+Slice filppedSlice (const Array2D<float>& ph, FLIP_FLAGS flip)
+{
+    cout << "flipX " << ((flip & FLIP_X) != 0)
+         << ", flipY " << ((flip & FLIP_Y) != 0)
+         << flush;
+
+    char *base = (char *) &ph[0][0];
+    ptrdiff_t strideX = sizeof (ph[0][0]);
+    ptrdiff_t strideY = sizeof (ph[0][0]) * ph.width ();
+    if (flip & FLIP_X)
+    {
+        base += strideX * (ph.width () - 1);
+        strideX = -strideX;
+    }
+    if (flip & FLIP_Y)
+    {
+        base += strideY * (ph.height () - 1);
+        strideY = -strideY;
+    }
+    return Slice (FLOAT, base, strideX, strideY);
+}
+
+void
+writeRead (
+    const Array2D<float>& ph,
+    const char           fileName[],
+    FLIP_FLAGS           writeFlip,
+    FLIP_FLAGS           readFlip)
+{
+    int width = ph.width ();
+    int height = ph.height ();
+    {
+        Header hdr (width, height);
+        hdr.channels ().insert ("F", Channel (FLOAT));
+
+        FrameBuffer fb;
+        fb.insert ("F", filppedSlice (ph, writeFlip));
+
+        cout << " writing" << flush;
+
+        remove (fileName);
+        OutputFile out (fileName, hdr);
+        out.setFrameBuffer (fb);
+        out.writePixels (height);
+    }
+    {
+        cout << " ";
+        FrameBuffer fb;
+        Array2D<float> ph2 (height, width);
+        for (int y = 0; y < height; ++y)
+            for (int x = 0; x < width; ++x)
+                ph2[y][x] = -1.0f;
+        fb.insert ("F", filppedSlice (ph2, readFlip));
+
+        cout << " reading" << flush;
+
+        InputFile in (fileName);
+        in.setFrameBuffer (fb);
+        in.readPixels (0, height - 1);
+
+        cout << " comparing" << flush;
+
+        FLIP_FLAGS flip = (FLIP_FLAGS) (writeFlip ^ readFlip);
+
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                int x2 = x;
+                int y2 = y;
+
+                if (flip & FLIP_X)
+                    x2 = width - 1 - x;
+
+                if (flip & FLIP_Y)
+                    y2 = height - 1 - y;
+
+                assert (ph[y][x] == ph2[y2][x2]);
+            }   
+        }
+    }
+}
+
+} // namespace
+
+void
+testNegativeStride (const string& tempDir)
+{
+    try
+    {
+        cout << "Testing negative slice stride" << endl;
+
+        const int W = 117;
+        const int H = 97;
+
+        Array2D<float> ph (H, W);
+        fillPixels (ph, W, H);
+
+        string fileName = tempDir + "imf_test_negative_stride.exr";
+        for (int readFlip = 0; readFlip < 4; ++readFlip)
+            for (int writeFlip = 0; writeFlip < 4; ++writeFlip)
+            {
+                writeRead (ph, fileName.c_str (),
+                           (FLIP_FLAGS) writeFlip, (FLIP_FLAGS) readFlip);
+                cout << endl;
+            }
+
+        cout << "ok\n" << endl;
+    }
+    catch (const std::exception& e)
+    {
+        cerr << "ERROR -- caught exception: " << e.what () << endl;
+        assert (false);
+    }
+}

--- a/src/test/OpenEXRTest/testNegativeStride.h
+++ b/src/test/OpenEXRTest/testNegativeStride.h
@@ -1,0 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#include <string>
+
+void testNegativeStride (const std::string& tempDir);


### PR DESCRIPTION
Add support for negative stride to FrameBuffer Slice.

Change data type of stride from size_t to ptrdiff_t.

Add support for negative stride in `copyIntoFrameBuffer` and `copyFromFrameBuffer`.

Add a new `testNegativeStride` test.

Fixes: #614
Signed-off-by: 胡玮文 <huww98@outlook.com>