### PR TITLE
Support relative and absolute libdir/incluedir in pkg-config generation

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -180,12 +180,23 @@ add_library(${PROJECT_NAME}::Config ALIAS IlmThreadConfig)
 ####### Install pkg-config files if requested
 
 if(OPENEXR_INSTALL_PKG_CONFIG)
+
+  # Prepend prefix for includedir only if CMAKE_INSTALL_INCLUDEDIR is relative
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+      set(PKG_CONFIG_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+  else()
+      set(PKG_CONFIG_INSTALL_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+  endif()
+
+  # Prepend exec_prefix for libdir only if CMAKE_INSTALL_LIBDIR is relative
+  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+      set(PKG_CONFIG_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+  else()
+      set(PKG_CONFIG_INSTALL_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+
   # use a helper function to avoid variable pollution, but pretty simple
   function(openexr_pkg_config_help pcinfile)
-    set(prefix ${CMAKE_INSTALL_PREFIX})
-    set(exec_prefix "\${prefix}")
-    set(libdir ${CMAKE_INSTALL_FULL_LIBDIR})
-    set(includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
     string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
     set(LIB_SUFFIX_DASH ${OPENEXR_LIB_SUFFIX}${CMAKE_${uppercase_CMAKE_BUILD_TYPE}_POSTFIX})
     if(OPENEXR_ENABLE_THREADING AND TARGET Threads::Threads)

--- a/cmake/OpenEXR.pc.in
+++ b/cmake/OpenEXR.pc.in
@@ -3,11 +3,11 @@
 ## Copyright (c) Contributors to the OpenEXR Project.
 ##
 
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-libdir=@libdir@
-includedir=@includedir@
-OpenEXR_includedir=@includedir@/OpenEXR
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@PKG_CONFIG_INSTALL_LIBDIR@
+includedir=@PKG_CONFIG_INSTALL_INCLUDEDIR@
+OpenEXR_includedir=${includedir}/OpenEXR
 libsuffix=@LIB_SUFFIX_DASH@
 
 Name: OpenEXR


### PR DESCRIPTION
During pkg-config generation, CMake now uses
`CMAKE_INSTALL_LIBDIR`/`CMAKE_INSTALL_INCLUDEDIR` instead of the `_FULL_` variables, and does not prepend the prefix if they are absolute paths, which makes it possible to support relative installation paths.

See https://github.com/AcademySoftwareFoundation/Imath/issues/281 and https://github.com/AcademySoftwareFoundation/Imath/pull/291

Signed-off-by: Cary Phillips <cary@ilm.com>