### PR TITLE
Fix for reading memory mapped files with DWA compression

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -121,6 +121,7 @@
 #include "half.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cctype>
 #include <limits>
@@ -2250,10 +2251,12 @@ DwaCompressor::uncompress (
     // Flip the counters from XDR to NATIVE
     //
 
+    std::array<uint64_t, NUM_SIZES_SINGLE> counterBuf;
+    memcpy (counterBuf.data (), inPtr, counterBuf.size() * sizeof (uint64_t));
     for (int i = 0; i < NUM_SIZES_SINGLE; ++i)
     {
-        uint64_t*   dst = (((uint64_t*) inPtr) + i);
-        const char* src = (char*) (((uint64_t*) inPtr) + i);
+        uint64_t*   dst = counterBuf.data() + i;
+        const char* src = (char*) (counterBuf.data() + i);
 
         Xdr::read<CharPtrIO> (src, *dst);
     }
@@ -2262,7 +2265,7 @@ DwaCompressor::uncompress (
     // Unwind all the counter info
     //
 
-    const uint64_t* inPtr64 = (const uint64_t*) inPtr;
+    const uint64_t* inPtr64 = counterBuf.data();
 
     uint64_t version                 = *(inPtr64 + VERSION);
     uint64_t unknownUncompressedSize = *(inPtr64 + UNKNOWN_UNCOMPRESSED_SIZE);

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -23,6 +23,9 @@
 #include <ImfTileDescription.h>
 #include <ImfXdr.h>
 
+#include <codecvt>
+#include <locale>
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 using IMATH_NAMESPACE::Box2i;
@@ -1979,6 +1982,13 @@ getChunkOffsetTableSize (const Header& header)
         return getScanlineChunkOffsetTableSize (header);
     else
         return getTiledChunkOffsetTableSize (header);
+}
+
+std::wstring
+WidenFilename (const char* filename)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+    return converter.from_bytes (filename);
 }
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -434,6 +434,14 @@ bool usesLongNames (const Header& header);
 IMF_EXPORT
 int getChunkOffsetTableSize (const Header& header);
 
+//
+// Convert a filename to a wide string.  This is useful for working with
+// filenames on Windows.
+//
+
+IMF_EXPORT
+std::wstring WidenFilename (const char* filename);
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 #endif

--- a/src/lib/OpenEXR/ImfStdIO.cpp
+++ b/src/lib/OpenEXR/ImfStdIO.cpp
@@ -11,6 +11,7 @@
 //-----------------------------------------------------------------------------
 
 #include "Iex.h"
+#include <ImfMisc.h>
 #include <ImfStdIO.h>
 #include <errno.h>
 #ifdef _WIN32
@@ -35,20 +36,6 @@ namespace
 {
 
 #ifdef _WIN32
-wstring
-WidenFilename (const char* filename)
-{
-    wstring ret;
-    int     fnlen = static_cast<int> (strlen (filename));
-    int     len   = MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, NULL, 0);
-    if (len > 0)
-    {
-        ret.resize (len);
-        MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, &ret[0], len);
-    }
-    return ret;
-}
-
 #    if defined(__GLIBCXX__) &&                                                \
         !(defined(_GLIBCXX_HAVE_WFOPEN) && defined(_GLIBCXX_USE_WCHAR_T))
 #        define USE_CUSTOM_WIDE_OPEN 1

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -6,6 +6,8 @@
 #ifndef INCLUDE_TestUtilFStream_h_
 #    define INCLUDE_TestUtilFStream_h_ 1
 
+#    include <ImfMisc.h>
+
 #    include <fstream>
 #    include <string>
 
@@ -26,20 +28,6 @@
 namespace testutil
 {
 #    ifdef _WIN32
-inline std::wstring
-WidenFilename (const char* filename)
-{
-    std::wstring ret;
-    int          fnlen = static_cast<int> (strlen (filename));
-    int len = MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, NULL, 0);
-    if (len > 0)
-    {
-        ret.resize (len);
-        MultiByteToWideChar (CP_UTF8, 0, filename, fnlen, &ret[0], len);
-    }
-    return ret;
-}
-
 // This is a big work around mechanism for compiling using mingw / gcc under windows
 // until mingw 9 where they add the wide filename version of open
 #        if (                                                                  \


### PR DESCRIPTION
Hi, I mentioned this issue at a TSC meeting a couple of months ago, sorry for the delay in creating a PR.

I use a custom class derived from `Imf::IStream` for reading .exr files that supports memory mapping on Windows and Linux/macOS. I noticed I was getting crashes when reading DWA compressed files, and after looking into it discovered that the DWA code was writing into read only data by casting away the `const`. I guess for regular I/O this didn't cause an issue since it is buffered, but it does cause a crash with memory mapped data. For example in Visual Studio:

```
Exception thrown: write access violation.

>	OpenEXR-3_2_d.dll!Imf_3_2::Xdr::read<Imf_3_2::CharPtrIO,char const *>(const char * & in, unsigned __int64 & v) Line 522	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::DwaCompressor::uncompress(const char * inPtr, int inSize, Imath_3_1::Box<Imath_3_1::Vec2<int>> range, const char * & outPtr) Line 2260	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::DwaCompressor::uncompress(const char * inPtr, int inSize, int minY, const char * & outPtr) Line 2218	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::`anonymous namespace'::LineBufferTaskIIF::execute() Line 844	C++
 	IlmThread-3_2_d.dll!IlmThread_3_2::`anonymous namespace'::NullThreadPoolProvider::addTask(IlmThread_3_2::Task * t) Line 372	C++
 	IlmThread-3_2_d.dll!IlmThread_3_2::ThreadPool::addTask(IlmThread_3_2::Task * task) Line 700	C++
 	IlmThread-3_2_d.dll!IlmThread_3_2::ThreadPool::addGlobalTask(IlmThread_3_2::Task * task) Line 723	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::ScanLineInputFile::readPixels(int scanLine1, int scanLine2) Line 1704	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::InputFile::readPixels(int scanLine1, int scanLine2) Line 900	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::InputPart::readPixels(int scanLine1, int scanLine2) Line 65	C++
 	OpenEXR-3_2_d.dll!Imf_3_2::RgbaInputFile::readPixels(int scanLine1, int scanLine2) Line 1356	C++
 	OpenEXRTest.exe!`anonymous namespace'::writeReadScanLines(const char * fileName, int width, int height, Imf_3_2::Compression compression, const Imf_3_2::Array2D<Imf_3_2::Rgba> & p1) Line 353	C++
 	OpenEXRTest.exe!testExistingStreams(const std::string & tempDir) Line 1007	C++
 	OpenEXRTest.exe!main(int argc, char * * argv) Line 245	C++
 	[External Code]	
```

This PR includes both a fix for the DWA code and adds support for memory mapped I/O to the tests. Specifically:
* Fix the DWA code by using a small temporary buffer
* Add memory map support to `testExistingStreams`
* Modify `testExistingStreams` to run the tests with all compression types
* Move the utility function `WidenFilename()` to `ImfMisc.h/.cpp` for use with Windows filenames
* Change `WidenFilename()` to use `std::wstring_convert()`

It would also be nice to change `char* IStream::readMemoryMapped()` to `const char* IStream::readMemoryMapped()` since the memory should be read only, or that could be a separate PR.