### PR TITLE
Add header files for IDEs

### DIFF
--- a/src/bin/exrenvmap/CMakeLists.txt
+++ b/src/bin/exrenvmap/CMakeLists.txt
@@ -3,12 +3,19 @@
 
 add_executable( exrenvmap
   blurImage.cpp
+  blurImage.h
   EnvmapImage.cpp
+  EnvmapImage.h
   main.cpp
   makeCubeMap.cpp
+  makeCubeMap.h
   makeLatLongMap.cpp
+  makeLatLongMap.h
+  namespaceAlias.h
   readInputImage.cpp
+  readInputImage.h
   resizeImage.cpp
+  resizeImage.h
 )
 
 target_link_libraries(exrenvmap OpenEXR::OpenEXR)

--- a/src/bin/exrmakepreview/CMakeLists.txt
+++ b/src/bin/exrmakepreview/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_executable(exrmakepreview
   main.cpp
   makePreview.cpp
+  makePreview.h
 )
 target_link_libraries(exrmakepreview OpenEXR::OpenEXR)
 set_target_properties(exrmakepreview PROPERTIES

--- a/src/bin/exrmaketiled/CMakeLists.txt
+++ b/src/bin/exrmaketiled/CMakeLists.txt
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) Contributors (c) to the OpenEXR Project.
 
-add_executable(exrmaketiled 
+add_executable(exrmaketiled
   Image.cpp
+  Image.h
   main.cpp
   makeTiled.cpp
+  makeTiled.h
+  namespaceAlias.h
 )
 target_link_libraries(exrmaketiled OpenEXR::OpenEXR)
 set_target_properties(exrmaketiled PROPERTIES

--- a/src/bin/exrmultiview/CMakeLists.txt
+++ b/src/bin/exrmultiview/CMakeLists.txt
@@ -3,8 +3,11 @@
 
 add_executable(exrmultiview
   Image.cpp
+  Image.h
   main.cpp
   makeMultiView.cpp
+  makeMultiView.h
+  namespaceAlias.h
 )
 target_link_libraries(exrmultiview OpenEXR::OpenEXR)
 set_target_properties(exrmultiview PROPERTIES

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -14,13 +14,21 @@ endif()
 
 add_executable(OpenEXRExamples
   drawImage.cpp
+  drawImage.h
   generalInterfaceExamples.cpp
+  generalInterfaceExamples.h
   generalInterfaceTiledExamples.cpp
+  generalInterfaceTiledExamples.h
   lowLevelIoExamples.cpp
+  lowLevelIoExamples.h
   main.cpp
+  namespaceAlias.h
   previewImageExamples.cpp
+  previewImageExamples.h
   rgbaInterfaceExamples.cpp
+  rgbaInterfaceExamples.h
   rgbaInterfaceTiledExamples.cpp
+  rgbaInterfaceTiledExamples.h
 )
 target_link_libraries(OpenEXRExamples OpenEXR::OpenEXR)
 

--- a/src/lib/OpenEXRCore/CMakeLists.txt
+++ b/src/lib/OpenEXRCore/CMakeLists.txt
@@ -17,6 +17,7 @@ openexr_define_library(OpenEXRCore
     internal_decompress.h
     internal_file.h
     internal_float_vector.h
+    internal_huf.h
     internal_memory.h
     internal_opaque.h
     internal_posix_file_impl.h
@@ -25,6 +26,7 @@ openexr_define_library(OpenEXRCore
     internal_string.h
     internal_string_vector.h
     internal_structs.h
+    internal_util.h
     internal_xdr.h
 
     internal_rle.c

--- a/src/test/IexTest/CMakeLists.txt
+++ b/src/test/IexTest/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_executable(IexTest
   main.cpp
   testBaseExc.cpp
+  testBaseExc.h
 )
 
 target_link_libraries(IexTest OpenEXR::Iex)

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -3,12 +3,19 @@
 
 add_executable(OpenEXRCoreTest
   base_units.cpp
+  base_units.h
   compression.cpp
+  compression.h
+  deep.cpp
+  deep.h
   general_attr.cpp
+  general_attr.h
   main.cpp
   read.cpp
+  read.h
+  test_value.h
   write.cpp
-  deep.cpp
+  write.h
   )
 target_compile_definitions(OpenEXRCoreTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/../OpenEXRTest/")
 # TODO: remove exr once we are happy everything is identical

--- a/src/test/OpenEXRFuzzTest/CMakeLists.txt
+++ b/src/test/OpenEXRFuzzTest/CMakeLists.txt
@@ -5,11 +5,17 @@ option(OPENEXR_RUN_FUZZ_TESTS  "Controls whether to include the fuzz tests (slow
 if(OPENEXR_RUN_FUZZ_TESTS)
   add_executable( OpenEXRFuzzTest
     fuzzFile.cpp
+    fuzzFile.h
     main.cpp
-    testFuzzDeepTiles.cpp
+    tmpDir.h
     testFuzzDeepScanLines.cpp
+    testFuzzDeepScanLines.h
+    testFuzzDeepTiles.cpp
+    testFuzzDeepTiles.h
     testFuzzScanLines.cpp
+    testFuzzScanLines.h
     testFuzzTiles.cpp
+    testFuzzTiles.h
   )
   target_link_libraries(OpenEXRFuzzTest OpenEXR::OpenEXR)
   set_target_properties(OpenEXRFuzzTest PROPERTIES

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -2,69 +2,134 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 add_executable(OpenEXRTest
+  TestUtilFStream.h
+  bswap_32.h
   compareB44.cpp
+  compareB44.h
   compareDwa.cpp
+  compareDwa.h
   compareFloat.cpp
+  compareFloat.h
   main.cpp
   random.cpp
+  random.h
   testAttributes.cpp
+  testAttributes.h
   testB44ExpLogTable.cpp
+  testB44ExpLogTable.h
   testBackwardCompatibility.cpp
+  testBackwardCompatibility.h
   testBadTypeAttributes.cpp
+  testBadTypeAttributes.h
   testChannels.cpp
+  testChannels.h
   testCompositeDeepScanLine.cpp
+  testCompositeDeepScanLine.h
   testCompression.cpp
+  testCompression.h
   testConversion.cpp
+  testConversion.h
   testCopyDeepScanLine.cpp
+  testCopyDeepScanLine.h
   testCopyDeepTiled.cpp
+  testCopyDeepTiled.h
   testCopyMultiPartFile.cpp
+  testCopyMultiPartFile.h
   testCopyPixels.cpp
+  testCopyPixels.h
   testCpuId.cpp
+  testCpuId.h
   testCustomAttributes.cpp
+  testCustomAttributes.h
   testDeepScanLineBasic.cpp
+  testDeepScanLineBasic.h
   testDeepScanLineHuge.cpp
+  testDeepScanLineHuge.h
   testDeepScanLineMultipleRead.cpp
+  testDeepScanLineMultipleRead.h
   testDeepTiledBasic.cpp
+  testDeepTiledBasic.h
   testDwaCompressorSimd.cpp
+  testDwaCompressorSimd.h
   testDwaLookups.cpp
+  testDwaLookups.h
   testExistingStreams.cpp
+  testExistingStreams.h
   testFutureProofing.cpp
+  testFutureProofing.h
   testHuf.cpp
+  testHuf.h
   testIDManifest.cpp
+  testIDManifest.h
   testInputPart.cpp
+  testInputPart.h
   testIsComplete.cpp
+  testIsComplete.h
   testLargeDataWindowOffsets.cpp
+  testLargeDataWindowOffsets.h
   testLineOrder.cpp
+  testLineOrder.h
   testLut.cpp
+  testLut.h
   testMagic.cpp
+  testMagic.h
   testMalformedImages.cpp
+  testMalformedImages.h
   testMultiPartApi.cpp
+  testMultiPartApi.h
   testMultiPartFileMixingBasic.cpp
+  testMultiPartFileMixingBasic.h
   testMultiPartSharedAttributes.cpp
+  testMultiPartSharedAttributes.h
   testMultiPartThreading.cpp
+  testMultiPartThreading.h
   testMultiScanlinePartThreading.cpp
+  testMultiScanlinePartThreading.h
   testMultiTiledPartThreading.cpp
+  testMultiTiledPartThreading.h
   testMultiView.cpp
+  testMultiView.h
   testNativeFormat.cpp
+  testNativeFormat.h
   testOptimized.cpp
+  testOptimized.h
   testOptimizedInterleavePatterns.cpp
+  testOptimizedInterleavePatterns.h
   testPartHelper.cpp
+  testPartHelper.h
   testPreviewImage.cpp
+  testPreviewImage.h
   testRgba.cpp
+  testRgba.h
   testRgbaThreading.cpp
+  testRgbaThreading.h
   testRle.cpp
+  testRle.h
   testSampleImages.cpp
+  testSampleImages.h
   testScanLineApi.cpp
+  testScanLineApi.h
   testSharedFrameBuffer.cpp
+  testSharedFrameBuffer.h
   testStandardAttributes.cpp
+  testStandardAttributes.h
   testTiledCompression.cpp
+  testTiledCompression.h
   testTiledCopyPixels.cpp
+  testTiledCopyPixels.h
   testTiledLineOrder.cpp
+  testTiledLineOrder.h
   testTiledRgba.cpp
+  testTiledRgba.h
   testTiledYa.cpp
+  testTiledYa.h
   testWav.cpp
+  testWav.h
   testXdr.cpp
+  testXdr.h
   testYca.cpp
+  testYca.h
+  tmpDir.h
 )
 target_compile_definitions(OpenEXRTest PRIVATE ILM_IMF_TEST_IMAGEDIR="${CMAKE_CURRENT_SOURCE_DIR}/")
 target_link_libraries(OpenEXRTest OpenEXR::OpenEXR)

--- a/src/test/OpenEXRUtilTest/CMakeLists.txt
+++ b/src/test/OpenEXRUtilTest/CMakeLists.txt
@@ -4,8 +4,12 @@
 add_executable(OpenEXRUtilTest
   main.cpp
   testFlatImage.cpp
+  testFlatImage.h
   testDeepImage.cpp
+  testDeepImage.h
   testIO.cpp
+  testIO.h
+  tmpDir.h
  )
 target_link_libraries(OpenEXRUtilTest OpenEXR::OpenEXRUtil)
 set_target_properties(OpenEXRUtilTest PROPERTIES


### PR DESCRIPTION
Hi, as a follow up to https://github.com/AcademySoftwareFoundation/openexr/pull/1279, I found a couple more places where header files were missing from the CMakeLists.txt files. Adding the header files to the CMakeLists.txt files allows them to show up in IDEs.

Totally unrelated, but while I was making the changes I noticed there were three copies of the file "tmpDir.h" in the tests directories? Maybe that functionality could be refactored into "ImfMisc.h"?
