### PR TITLE
Sphinx warnings by default now cause doc build to fail

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
 set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
 set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 
+set(SPHINX_OPTS "-W" CACHE STRING "Sphinx build options")
+
 configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
 file(MAKE_DIRECTORY ${DOXYGEN_OUTPUT_DIR})
@@ -31,7 +33,7 @@ add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
 
 add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
                    COMMAND 
-                     ${SPHINX_EXECUTABLE} -b html
+                     ${SPHINX_EXECUTABLE} -b html ${SPHINX_OPTS}
                      # Tell Breathe where to find the Doxygen output
                      -Dbreathe_projects.OpenEXR=${DOXYGEN_OUTPUT_DIR}/xml
                    ${SPHINX_SOURCE} ${SPHINX_BUILD}

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -82,6 +82,8 @@ typedef void (*exr_error_handler_cb_t) (
  *
  *  @param failed Indicates the write operation failed, the
  *                implementor may wish to cleanup temporary files
+ *  @param ctxt The context
+ *  @param userdata The userdata
  */
 typedef void (*exr_destroy_stream_func_ptr_t) (
     exr_const_context_t ctxt, void* userdata, int failed);


### PR DESCRIPTION
* sphinx-build -W treats warnings as errors
* Together with building the docs in the CI (#1339) this means that issues with the documentation will cause the CI checks to fail
* All doxygen-annotated class/function comments must now be warning-free. This PR fixes a warning in openexr_context.h by adding missing parameter descriptions.