### PR TITLE
Remove tmpDir.h from OpenEXRUtilTest/OpenEXRFuzzTest CMakeLists.txt

### DIFF
--- a/src/test/OpenEXRFuzzTest/CMakeLists.txt
+++ b/src/test/OpenEXRFuzzTest/CMakeLists.txt
@@ -7,7 +7,6 @@ if(OPENEXR_RUN_FUZZ_TESTS)
     fuzzFile.cpp
     fuzzFile.h
     main.cpp
-    tmpDir.h
     testFuzzDeepScanLines.cpp
     testFuzzDeepScanLines.h
     testFuzzDeepTiles.cpp

--- a/src/test/OpenEXRUtilTest/CMakeLists.txt
+++ b/src/test/OpenEXRUtilTest/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(OpenEXRUtilTest
   testDeepImage.h
   testIO.cpp
   testIO.h
-  tmpDir.h
  )
 target_include_directories(OpenEXRUtilTest PRIVATE ../OpenEXRTest)
 target_link_libraries(OpenEXRUtilTest OpenEXR::OpenEXRUtil)


### PR DESCRIPTION
The local files have been replaced by ../OpenEXRTest/tmpDir.h