### PR TITLE
Reduce memory in testDeepScanLineBasic

### DIFF
--- a/src/test/OpenEXRTest/testDeepScanLineBasic.cpp
+++ b/src/test/OpenEXRTest/testDeepScanLineBasic.cpp
@@ -648,8 +648,8 @@ const int minY   = 11;
 
 namespace large
 {
-const int width  = 10000;
-const int height = 5000;
+const int width  = 5000;
+const int height = 2500;
 const int minX   = -22;
 const int minY   = -12;
 } // namespace large


### PR DESCRIPTION
The valgrind analysis test is failing due to excessive memory requirements on large deep images. Reducing the image size should get the test through, so will do for now, though this is less effective at testing for issues caused with large images.

Maybe there should be macro that could be defined to limit memory consumption of the tests for such situations.