### PR TITLE
NEON optimizations for ZIP reading (reconstruct and interleave)

### DIFF
--- a/src/lib/OpenEXR/ImfZip.cpp
+++ b/src/lib/OpenEXR/ImfZip.cpp
@@ -160,6 +160,56 @@ reconstruct_sse41 (char* buf, size_t outSize)
 
 #endif
 
+#ifdef IMF_HAVE_NEON
+
+void
+reconstruct_neon (char* buf, size_t outSize)
+{
+    static const size_t bytesPerChunk = sizeof (uint8x16_t);
+    const size_t        vOutSize      = outSize / bytesPerChunk;
+
+    const uint8x16_t c           = vdupq_n_u8 (-128);
+    const uint8x16_t shuffleMask = vdupq_n_u8 (15);
+
+    // The first element doesn't have its high bit flipped during compression,
+    // so it must not be flipped here.  To make the SIMD loop nice and
+    // uniform, we pre-flip the bit so that the loop will unflip it again.
+    buf[0] += -128;
+
+    unsigned char* vBuf  = reinterpret_cast<unsigned char*> (buf);
+    uint8x16_t  vZero = vdupq_n_u8 (0);
+    uint8x16_t  vPrev = vdupq_n_u8 (0);
+    for (size_t i = 0; i < vOutSize; ++i)
+    {
+        uint8x16_t d = vaddq_u8 (vld1q_u8 (vBuf), c);
+
+        // Compute the prefix sum of elements.
+        d = vaddq_u8 (d, vextq_u8 (vZero, d, 16 - 1));
+        d = vaddq_u8 (d, vextq_u8 (vZero, d, 16 - 2));
+        d = vaddq_u8 (d, vextq_u8 (vZero, d, 16 - 4));
+        d = vaddq_u8 (d, vextq_u8 (vZero, d, 16 - 8));
+        d = vaddq_u8 (d, vPrev);
+
+        vst1q_u8 (vBuf, d);
+        vBuf += sizeof (uint8x16_t);
+
+        // Broadcast the high byte in our result to all lanes of the prev
+        // value for the next iteration.
+        vPrev = vqtbl1q_u8 (d, shuffleMask);
+    }
+
+    unsigned char prev = vgetq_lane_u8 (vPrev, 15);
+    for (size_t i = vOutSize * bytesPerChunk; i < outSize; ++i)
+    {
+        unsigned char d = prev + buf[i] - 128;
+        buf[i]          = d;
+        prev            = d;
+    }
+}
+
+#endif
+
+
 void
 reconstruct_scalar (char* buf, size_t outSize)
 {
@@ -198,6 +248,44 @@ interleave_sse2 (const char* source, size_t outSize, char* out)
 
         _mm_storeu_si128 (vOut++, lo);
         _mm_storeu_si128 (vOut++, hi);
+    }
+
+    const char* t1   = reinterpret_cast<const char*> (v1);
+    const char* t2   = reinterpret_cast<const char*> (v2);
+    char*       sOut = reinterpret_cast<char*> (vOut);
+
+    for (size_t i = vOutSize * bytesPerChunk; i < outSize; ++i)
+    {
+        *(sOut++) = (i % 2 == 0) ? *(t1++) : *(t2++);
+    }
+}
+
+#endif
+
+#ifdef IMF_HAVE_NEON
+
+void
+interleave_neon (const char* source, size_t outSize, char* out)
+{
+    static const size_t bytesPerChunk = 2 * sizeof (uint8x16_t);
+
+    const size_t vOutSize = outSize / bytesPerChunk;
+
+    const unsigned char* v1 = reinterpret_cast<const unsigned char*> (source);
+    const unsigned char* v2 =
+        reinterpret_cast<const unsigned char*> (source + (outSize + 1) / 2);
+    unsigned char* vOut = reinterpret_cast<unsigned char*> (out);
+
+    for (size_t i = 0; i < vOutSize; ++i)
+    {
+        uint8x16_t a = vld1q_u8 (v1); v1 += sizeof (uint8x16_t);
+        uint8x16_t b = vld1q_u8 (v2); v2 += sizeof (uint8x16_t);
+
+        uint8x16_t lo = vzip1q_u8 (a, b);
+        uint8x16_t hi = vzip2q_u8 (a, b);
+
+        vst1q_u8 (vOut, lo); vOut += sizeof (uint8x16_t);
+        vst1q_u8 (vOut, hi); vOut += sizeof (uint8x16_t);
     }
 
     const char* t1   = reinterpret_cast<const char*> (v1);
@@ -290,6 +378,11 @@ Zip::initializeFuncs ()
     {
         interleave = interleave_sse2;
     }
+#endif
+
+#ifdef IMF_HAVE_NEON
+    reconstruct = reconstruct_neon;
+    interleave = interleave_neon;
 #endif
 }
 


### PR DESCRIPTION
Pretty much straight copies from the SSE2/SSE4 SIMD code, just changed for NEON.

Reading 310Mpix worth of ZIP compressed EXR files into memory, on Apple M1 Max (Clang 14, RelWithDebInfo build config): 7.50s -> 5.52s.

"reconstruct" part goes 1.55s -> 0.35s, "interleave" 0.80s -> 0.04s.