### PR TITLE
Add tests for bin programs

### DIFF
--- a/src/bin/exr2aces/main.cpp
+++ b/src/bin/exr2aces/main.cpp
@@ -30,7 +30,7 @@ namespace
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0 << " [options] infile outfile" << endl;
+    cerr << "Usage: " << argv0 << " [options] infile outfile" << endl;
 
     if (verbose)
     {

--- a/src/bin/exrcheck/main.cpp
+++ b/src/bin/exrcheck/main.cpp
@@ -26,7 +26,7 @@ using std::vector;
 void
 usageMessage (const char argv0[])
 {
-    cerr << "usage: " << argv0 << " [options] imagefile [imagefile ...]\n";
+    cerr << "Usage: " << argv0 << " [options] imagefile [imagefile ...]\n";
     cerr << "options: \n";
     cerr
         << "  -m : avoid excessive memory allocation (some files will not be fully checked)\n";

--- a/src/bin/exrenvmap/main.cpp
+++ b/src/bin/exrenvmap/main.cpp
@@ -32,7 +32,7 @@ namespace
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0 << " [options] infile outfile" << endl;
+    cerr << "Usage: " << argv0 << " [options] infile outfile" << endl;
 
     if (verbose)
     {

--- a/src/bin/exrheader/main.cpp
+++ b/src/bin/exrheader/main.cpp
@@ -458,7 +458,7 @@ printInfo (const char fileName[])
 void
 usageMessage (const char argv0[])
 {
-    std::cerr << "usage: " << argv0 << " imagefile [imagefile ...]\n";
+    std::cerr << "Usage: " << argv0 << " imagefile [imagefile ...]\n";
 }
 
 int

--- a/src/bin/exrinfo/main.c
+++ b/src/bin/exrinfo/main.c
@@ -104,7 +104,7 @@ process_stdin (int verbose, int allmeta, int strict)
 static int
 process_file (const char* filename, int verbose, int allmeta, int strict)
 {
-    int                       failcount;
+    int                       failcount = 0;
     exr_result_t              rv;
     exr_context_t             e     = NULL;
     exr_context_initializer_t cinit = EXR_DEFAULT_CONTEXT_INITIALIZER;

--- a/src/bin/exrmakepreview/main.cpp
+++ b/src/bin/exrmakepreview/main.cpp
@@ -22,7 +22,7 @@ using namespace std;
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0 << " [options] infile outfile" << endl;
+    cerr << "Usage: " << argv0 << " [options] infile outfile" << endl;
 
     if (verbose)
     {

--- a/src/bin/exrmaketiled/main.cpp
+++ b/src/bin/exrmaketiled/main.cpp
@@ -30,7 +30,7 @@ namespace
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0 << " [options] infile outfile" << endl;
+    cerr << "Usage: " << argv0 << " [options] infile outfile" << endl;
 
     if (verbose)
     {

--- a/src/bin/exrmultipart/exrmultipart.cpp
+++ b/src/bin/exrmultipart/exrmultipart.cpp
@@ -676,19 +676,18 @@ separate (vector<const char*> in, const char* out, bool override)
 void
 usageMessage (const char argv[])
 {
-    cout << argv << " handles the combining and splitting of multipart data\n";
-    cout
-        << "\n"
-        << "Usage: "
+    cerr << "Usage: "
            "exrmultipart -combine -i input.exr[:partnum][::partname] "
            "[input2.exr[:partnum]][::partname] [...] -o outfile.exr [options]\n";
-    cout << "   or: exrmultipart -separate -i infile.exr -o outfileBaseName "
+    cerr << "   or: exrmultipart -separate -i infile.exr -o outfileBaseName "
             "[options]\n";
-    cout << "   or: exrmultipart -convert -i infile.exr -o outfile.exr "
+    cerr << "   or: exrmultipart -convert -i infile.exr -o outfile.exr "
             "[options]\n";
-    cout << "\n"
-         << "Options:\n";
-    cout << "-override [0/1]      0-do not override conflicting shared "
+    cerr << "\n";
+    cerr << argv << " handles the combining and splitting of multipart data\n";
+    cerr << "\n";
+    cerr << "Options:\n";
+    cerr << "-override [0/1]      0-do not override conflicting shared "
             "attributes [default]\n"
             "                     1-override conflicting shared attributes\n";
 

--- a/src/bin/exrmultiview/main.cpp
+++ b/src/bin/exrmultiview/main.cpp
@@ -29,7 +29,7 @@ namespace
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0
+    cerr << "Usage: " << argv0
          << " "
             "[options] viewname1 infile1 viewname2 infile2 ... outfile"
          << endl;

--- a/src/bin/exrstdattr/main.cpp
+++ b/src/bin/exrstdattr/main.cpp
@@ -44,7 +44,7 @@ using namespace IMATH_NAMESPACE;
 void
 usageMessage (const char argv0[], bool verbose = false)
 {
-    cerr << "usage: " << argv0 << " [commands] infile outfile" << endl;
+    cerr << "Usage: " << argv0 << " [commands] infile outfile" << endl;
 
     if (verbose)
     {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -9,3 +9,5 @@ add_subdirectory(OpenEXRCoreTest)
 add_subdirectory(OpenEXRTest)
 add_subdirectory(OpenEXRUtilTest)
 add_subdirectory(OpenEXRFuzzTest)
+add_subdirectory(bin)
+

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -11,7 +11,7 @@ if(BUILD_TESTING)
     
   message(STATUS "adding bin tests")
 
-  set(OPENEXR_IMAGES_REPO "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main" CACHE STRING
+  set(OPENEXR_IMAGES_REPO "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images" CACHE STRING
     "Bin test Image repo")
 
   set(OPENEXR_IMAGES_TAG "v1.0" CACHE STRING "Bin test image repo tag")

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -16,8 +16,7 @@ if(BUILD_TESTING)
       TestImages/GrayRampsHorizontal.exr
       LuminanceChroma/Garden.exr
       MultiResolution/ColorCodedLevels.exr
-      MultiResolution/StageEnvCube.exr
-      MultiResolution/StageEnvLatLong.exr
+      MultiResolution/WavyLinesLatLong.exr
       LuminanceChroma/Flowers.exr
       MultiView/Adjuster.exr
       Chromaticities/Rec709_YC.exr

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -11,7 +11,13 @@ if(BUILD_TESTING)
     
   message(STATUS "adding bin tests")
 
-  set(images_url "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main")
+  set(OPENEXR_IMAGES_REPO "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main" CACHE STRING
+    "Bin test Image repo")
+
+  set(OPENEXR_IMAGES_TAG "v1.0" CACHE STRING "Bin test image repo tag")
+
+  set(images_url ${OPENEXR_IMAGES_REPO}/${OPENEXR_IMAGES_TAG})
+
   set(images 
       TestImages/GrayRampsHorizontal.exr
       LuminanceChroma/Garden.exr

--- a/src/test/bin/CMakeLists.txt
+++ b/src/test/bin/CMakeLists.txt
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+if(BUILD_TESTING)
+
+  find_package(Python3 COMPONENTS Interpreter)
+  if (NOT Python3_FOUND)
+    message(STATUS "Python3 not found: skipping bin tests")
+    return()
+  endif()
+    
+  message(STATUS "adding bin tests")
+
+  set(images_url "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main")
+  set(images 
+      TestImages/GrayRampsHorizontal.exr
+      LuminanceChroma/Garden.exr
+      MultiResolution/ColorCodedLevels.exr
+      MultiResolution/StageEnvCube.exr
+      MultiResolution/StageEnvLatLong.exr
+      LuminanceChroma/Flowers.exr
+      MultiView/Adjuster.exr
+      Chromaticities/Rec709_YC.exr
+      Chromaticities/Rec709.exr
+      Chromaticities/XYZ_YC.exr
+      Chromaticities/XYZ.exr
+      TestImages/GammaChart.exr
+      Beachball/singlepart.0001.exr
+      v2/LeftView/Balls.exr
+      v2/Stereo/Trunks.exr
+      Beachball/multipart.0001.exr
+  )
+
+  foreach(image ${images})
+      message(STATUS "Downloading ${images_url}/${image}")
+      file(DOWNLOAD ${images_url}/${image} ${CMAKE_CURRENT_BINARY_DIR}/${image})
+  endforeach()
+
+  add_test(NAME OpenEXR.bin.exrinfo
+           COMMAND ${Python3_EXECUTABLE}
+           ${CMAKE_CURRENT_SOURCE_DIR}/test_exrinfo.py $<TARGET_FILE:exrinfo> ${CMAKE_CURRENT_BINARY_DIR})
+
+  add_test(NAME OpenEXR.bin.exrheader
+           COMMAND ${Python3_EXECUTABLE}
+           ${CMAKE_CURRENT_SOURCE_DIR}/test_exrheader.py $<TARGET_FILE:exrheader> ${CMAKE_CURRENT_BINARY_DIR})
+
+  set(tests
+      exr2aces
+      exrenvmap
+      exrmakepreview
+      exrmaketiled
+      exrmultiview
+      exrmultipart
+      exrstdattr
+  )
+
+  foreach(test ${tests})
+  
+    add_test(NAME OpenEXR.bin.${test}
+           COMMAND ${Python3_EXECUTABLE}
+           ${CMAKE_CURRENT_SOURCE_DIR}/test_${test}.py $<TARGET_FILE:${test}> $<TARGET_FILE:exrinfo> ${CMAKE_CURRENT_BINARY_DIR})
+  endforeach()
+  
+  # run exrcheck on all images
+  add_test(NAME OpenEXR.bin.exrcheck
+           COMMAND ${Python3_EXECUTABLE}
+           ${CMAKE_CURRENT_SOURCE_DIR}/test_exrcheck.py
+           $<TARGET_FILE:exrcheck>
+           ${CMAKE_CURRENT_BINARY_DIR}
+           ${images})
+
+endif()
+
+

--- a/src/test/bin/test_exr2aces.py
+++ b/src/test/bin/test_exr2aces.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exr2aces: {sys.argv}")
+
+exr2aces = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+# no args = usage message
+result = run ([exr2aces], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exr2aces, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+def find_line(keyword, lines):
+    for line in lines:
+        if line.startswith(keyword):
+            return line
+    return None
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+atexit.register(cleanup)
+
+image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+result = run ([exr2aces, "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+# confirm the output has the proper chromaticities
+assert("chromaticities: chromaticities r[0.7347, 0.2653] g[0, 1] b[0.0001, -0.077] w[0.32168, 0.33767]" in result.stdout)
+
+print("success")
+
+
+
+
+
+
+
+
+

--- a/src/test/bin/test_exrcheck.py
+++ b/src/test/bin/test_exrcheck.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os
+from subprocess import PIPE, run
+
+print(f"testing exrcheck: {sys.argv}")
+      
+exrcheck = sys.argv[1]
+image_dir = sys.argv[2]
+
+for exr_file in sys.argv[3:]:
+
+    exr_path = f"{image_dir}/{exr_file}"
+
+    result = run ([exrcheck, exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert(result.returncode == 0)
+
+print("success.")
+

--- a/src/test/bin/test_exrenvmap.py
+++ b/src/test/bin/test_exrenvmap.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrenvcube: {sys.argv}")
+
+exrenvcube = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+image = f"{image_dir}/MultiResolution/StageEnvLatLong.exr"
+
+assert(os.path.isfile(exrenvcube))
+assert(os.path.isfile(exrinfo))
+assert(os.path.isdir(image_dir))
+assert(os.path.isfile(image))
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+atexit.register(cleanup)
+
+# no args = usage message
+result = run ([exrenvcube], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exrenvcube, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+result = run ([exrenvcube, image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('tiled image has levels: x 1 y 1' in result.stdout)
+
+print("success")

--- a/src/test/bin/test_exrenvmap.py
+++ b/src/test/bin/test_exrenvmap.py
@@ -6,15 +6,15 @@
 import sys, os, tempfile, atexit
 from subprocess import PIPE, run
 
-print(f"testing exrenvcube: {sys.argv}")
+print(f"testing exrenvmap: {sys.argv}")
 
-exrenvcube = sys.argv[1]
+exrenvmap = sys.argv[1]
 exrinfo = sys.argv[2]
 image_dir = sys.argv[3]
 
-image = f"{image_dir}/MultiResolution/StageEnvLatLong.exr"
+image = f"{image_dir}/MultiResolution/WavyLinesLatLong.exr"
 
-assert(os.path.isfile(exrenvcube))
+assert(os.path.isfile(exrenvmap))
 assert(os.path.isfile(exrinfo))
 assert(os.path.isdir(image_dir))
 assert(os.path.isfile(image))
@@ -27,18 +27,28 @@ def cleanup():
 atexit.register(cleanup)
 
 # no args = usage message
-result = run ([exrenvcube], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+result = run ([exrenvmap], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
+#print(f"stdout: {result.stdout}")
+#print(f"stderr: {result.stderr}")
 assert(result.returncode == 1)
 assert(result.stderr.startswith ("Usage: "))
 
 # -h = usage message
-result = run ([exrenvcube, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+result = run ([exrenvmap, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 1)
 assert(result.stderr.startswith ("Usage: "))
 
-result = run ([exrenvcube, image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+# default
+result = run ([exrenvmap, image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+default_file_size = os.path.getsize(outimage)
+
+# -o 
+result = run ([exrenvmap, "-o", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0)
 assert(os.path.isfile(outimage))
@@ -46,6 +56,147 @@ assert(os.path.isfile(outimage))
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0)
-assert('tiled image has levels: x 1 y 1' in result.stdout)
+assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout)
+os.unlink(outimage)
+
+# -m 
+result = run ([exrenvmap, "-m", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('tiles: tiledesc size 64 x 64 level 1 (mipmap) round 0 (down)' in result.stdout)
+os.unlink(outimage)
+
+# -c 
+result = run ([exrenvmap, "-c", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('envmap: envmap cube' in result.stdout)
+os.unlink(outimage)
+
+# -l 
+result = run ([exrenvmap, "-l", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('envmap: envmap latlong' in result.stdout)
+os.unlink(outimage)
+
+# -w 
+result = run ([exrenvmap, "-w", "64", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('x tile count: 1 (sz 64)' in result.stdout)
+assert('y tile count: 6 (sz 384)' in result.stdout)
+os.unlink(outimage)
+
+# -f (filter)
+result = run ([exrenvmap, "-f", "1.1", "6", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+file_size = os.path.getsize(outimage)
+assert(file_size != default_file_size)
+os.unlink(outimage)
+
+# -b (blur)
+result = run ([exrenvmap, "-b", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+file_size = os.path.getsize(outimage)
+assert(file_size != default_file_size)
+
+# -t 
+result = run ([exrenvmap, "-t", "32", "48", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('x tile count: 8 (sz 256)' in result.stdout)
+assert('y tile count: 32 (sz 1536)' in result.stdout)
+os.unlink(outimage)
+
+# -u 
+result = run ([exrenvmap, "-u", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 1 (up)' in result.stdout)
+os.unlink(outimage)
+
+# -z dwaa 
+result = run ([exrenvmap, "-z", "dwaa", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('compression: compression \'dwaa\' (0x08)' in result.stdout)
+os.unlink(outimage)
+
+# -z dwab
+result = run ([exrenvmap, "-z", "dwab", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('compression: compression \'dwab\' (0x09)' in result.stdout)
+os.unlink(outimage)
+
+with tempfile.TemporaryDirectory() as tempdir:
+
+    cube_face_image_t = f"{tempdir}/out.%.exr"
+    result = run ([exrenvmap, image, cube_face_image_t], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print(" ".join(result.args))
+    assert(result.returncode == 0)
+
+    for o in ["+X", "-X", "+Y", "-Y", "+Z", "-Z"]:
+        
+        cube_face_image = f"{tempdir}/out.{o}.exr"
+        result = run ([exrinfo, "-v", cube_face_image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        print(" ".join(result.args))
+        assert(result.returncode == 0)
+        assert('x tile count: 4 (sz 256)' in result.stdout)
+        assert('y tile count: 4 (sz 256)' in result.stdout)
+
+    result = run ([exrenvmap, cube_face_image_t, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print(" ".join(result.args))
+    assert(result.returncode == 0)
+
+    result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print(" ".join(result.args))
+    assert(result.returncode == 0)
+    assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout)
 
 print("success")

--- a/src/test/bin/test_exrheader.py
+++ b/src/test/bin/test_exrheader.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os
+from subprocess import PIPE, run
+
+print(f"testing exrheader: {sys.argv}")
+
+exrheader = sys.argv[1]
+image_dir = sys.argv[2]
+
+# no args = usage message
+result = run ([exrheader], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exrheader, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+def find_line(keyword, lines):
+    for line in lines:
+        if line.startswith(keyword):
+            return line
+    return None
+
+# attributes
+image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+result = run ([exrheader, image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+output = result.stdout.split('\n')
+assert ("2, flags 0x0" in find_line("file format version:", output))
+assert ("pxr24" in find_line ("compression", output))
+assert ("(0 0) - (799 799)" in find_line ("dataWindow", output))
+assert ("(0 0) - (799 799)" in find_line ("displayWindow", output))
+assert ("increasing y" in find_line ("lineOrder", output))
+assert ("1" in find_line ("pixelAspectRatio", output))
+assert ("(0 0)" in find_line ("screenWindowCenter", output))
+assert ("1" in find_line ("screenWindowWidth", output))
+assert ("scanlineimage" in find_line ("type (type string)", output))
+
+print("success")
+
+
+
+
+
+
+
+
+

--- a/src/test/bin/test_exrinfo.py
+++ b/src/test/bin/test_exrinfo.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os
+from subprocess import PIPE, run
+
+print(f"testing exrinfo: {sys.argv}")
+
+exrinfo = sys.argv[1]
+image_dir = sys.argv[2]
+
+result = run ([exrinfo, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(result.stderr.startswith ("Usage: "))
+
+image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+result = run ([exrinfo, image, "-a", "-v"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+output = result.stdout.split('\n')
+assert ('pxr24' in output[1])
+assert ('800 x 800' in output[2])
+assert ('800 x 800' in output[3])
+assert ('1 channels' in output[4])
+
+# test image as stdio
+with  open(image, 'rb') as f:
+    data = f.read()
+result = run ([exrinfo, '-', "-a", "-v"], input=data, stdout=PIPE, stderr=PIPE)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+output = result.stdout.decode().split('\n')
+assert ('pxr24' in output[1])
+assert ('800 x 800' in output[2])
+assert ('800 x 800' in output[3])
+assert ('1 channels' in output[4])
+
+print("success")
+

--- a/src/test/bin/test_exrinfo.py
+++ b/src/test/bin/test_exrinfo.py
@@ -27,7 +27,7 @@ assert ('800 x 800' in output[3])
 assert ('1 channels' in output[4])
 
 # test image as stdio
-with  open(image, 'rb') as f:
+with open(image, 'rb') as f:
     data = f.read()
 result = run ([exrinfo, '-', "-a", "-v"], input=data, stdout=PIPE, stderr=PIPE)
 print(" ".join(result.args))

--- a/src/test/bin/test_exrmakepreview.py
+++ b/src/test/bin/test_exrmakepreview.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrmakepreview: {sys.argv}")
+
+exrmakepreview = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+assert(os.path.isfile(exrmakepreview))
+assert(os.path.isfile(exrinfo))
+assert(os.path.isdir(image_dir))
+
+# no args = usage message
+result = run ([exrmakepreview], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exrmakepreview, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+def find_line(keyword, lines):
+    for line in lines:
+        if line.startswith(keyword):
+            return line
+    return None
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+atexit.register(cleanup)
+
+image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+result = run ([exrmakepreview, "-w", "50", "-e", "1", "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+output = result.stdout.split('\n')
+assert("preview 50 x 50" in find_line("  preview", output))
+
+print("success")
+
+
+
+
+
+
+
+
+

--- a/src/test/bin/test_exrmaketiled.py
+++ b/src/test/bin/test_exrmaketiled.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrmaketiled: {sys.argv}")
+
+exrmaketiled = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+image = f"{image_dir}/TestImages/GammaChart.exr"
+
+assert(os.path.isfile(exrmaketiled))
+assert(os.path.isfile(exrinfo))
+assert(os.path.isdir(image_dir))
+assert(os.path.isfile(image))
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+atexit.register(cleanup)
+
+# no args = usage message
+result = run ([exrmaketiled], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exrmaketiled, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+result = run ([exrmaketiled, image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('tiled image has levels: x 1 y 1' in result.stdout)
+
+print("success")

--- a/src/test/bin/test_exrmultipart.py
+++ b/src/test/bin/test_exrmultipart.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrmultipart: {sys.argv}")
+
+exrmultipart = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+result = run ([exrmultipart], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert("Usage:" in result.stderr)
+
+image = f"{image_dir}/Beachball/multipart.0001.exr"
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+    os.unlink(outimage)
+atexit.register(cleanup)
+
+# combine
+command = [exrmultipart, "-combine", "-i", f"{image}:0", f"{image}:1", "-o", outimage]
+result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+# error: can't convert multipart images
+command = [exrmultipart, "-convert", "-i", image, "-o", outimage]
+result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert (result.returncode != 0)
+
+# convert
+singlepart_image = f"{image_dir}/Beachball/singlepart.0001.exr"
+command = [exrmultipart, "-convert", "-i", singlepart_image, "-o", outimage]
+result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+# separate
+
+# get part names from the multipart image
+result = run ([exrinfo, image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+part_names = {}
+for p in result.stdout.split('\n part ')[1:]:
+    output = p.split('\n')
+    part_number, part_name = output[0].split(': ')
+    part_names[part_number] = part_name
+
+with tempfile.TemporaryDirectory() as tempdir:
+
+    command = [exrmultipart, "-separate", "-i", image, "-o", f"{tempdir}/separate"]
+    result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print(" ".join(result.args))
+    assert(result.returncode == 0)
+
+    for i in range(1, 10):
+        s = f"{tempdir}/separate.{i}.exr"
+        result = run ([exrinfo, "-v", s], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        print(" ".join(result.args))
+        assert(result.returncode == 0)
+        output = result.stdout.split('\n')
+        assert(output[1].startswith(' parts: 1'))
+        output[2].startswith(' part 1:')
+        part_name = output[2][9:]
+        part_number = str(i)
+        assert(part_names[part_number] == part_name)
+        
+print("success")
+

--- a/src/test/bin/test_exrmultiview.py
+++ b/src/test/bin/test_exrmultiview.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrmultiview: {sys.argv}")
+
+exrmultiview = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+result = run ([exrmultiview], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert("Usage:" in result.stderr)
+
+result = run ([exrmultiview, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert("Usage:" in result.stderr)
+
+left_image = f"{image_dir}/TestImages/GammaChart.exr"
+right_image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+    os.unlink(outimage)
+atexit.register(cleanup)
+
+command = [exrmultiview, "left", left_image, "right", right_image, outimage]
+result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+
+result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('\'B\': half samp 1 1' in result.stdout)
+assert('\'G\': half samp 1 1' in result.stdout)
+assert('\'R\': half samp 1 1' in result.stdout)
+assert('\'right.Y\': half samp 1 1' in result.stdout)
+
+print("success")
+

--- a/src/test/bin/test_exrstdattr.py
+++ b/src/test/bin/test_exrstdattr.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+import sys, os, tempfile, atexit
+from subprocess import PIPE, run
+
+print(f"testing exrstdattr: {sys.argv}")
+
+exrstdattr = sys.argv[1]
+exrinfo = sys.argv[2]
+image_dir = sys.argv[3]
+
+assert(os.path.isfile(exrstdattr))
+assert(os.path.isfile(exrinfo))
+assert(os.path.isdir(image_dir))
+
+fd, outimage = tempfile.mkstemp(".exr")
+os.close(fd)
+
+def cleanup():
+    print(f"deleting {outimage}")
+atexit.register(cleanup)
+
+# no args = usage message
+result = run ([exrstdattr], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+# -h = usage message
+result = run ([exrstdattr, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 1)
+assert(result.stderr.startswith ("Usage: "))
+
+command = [exrstdattr]
+command += ["-part", "0"]
+command += ["-screenWindowCenter", "42", "43"]
+command += ["-screenWindowWidth", "4.4"]
+command += ["-pixelAspectRatio", "1.7"]
+command += ["-wrapmodes", "clamp"]
+command += ["-timeCode", "12345678", "34567890"]
+command += ["-keyCode", "1", "2", "3", "4", "5", "6", "20"]
+command += ["-framesPerSecond", "48", "1"]
+command += ["-envmap", "LATLONG"]
+command += ["-isoSpeed", "2.1"]
+command += ["-aperture", "3.2"]
+command += ["-expTime", "4.3"]
+command += ["-focus", "5.4"]
+command += ["-altitude", "6.5"]
+command += ["-latitude", "7.6"]
+command += ["-longitude", "8.7"]
+command += ["-utcOffset", "9"]
+command += ["-owner", "florian"]
+command += ["-xDensity", "10.0"]
+command += ["-lookModTransform", "lmt"]
+command += ["-renderingTransform", "rt"]
+command += ["-adoptedNeutral", "1.1", "2.2"]
+command += ["-whiteLuminance", "17.1"]
+command += ["-chromaticities", "1", "2", "3", "4", "5", "6", "7", "8"]
+command += ["-int", "test_int", "42"]
+command += ["-float", "test_float", "4.2"]
+command += ["-string", "test_string", "forty two"]
+command += ["-capDate", "1999:12:31 23:59:59"]
+command += ["-comments", "blah blah blah"]
+image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+command += [image, outimage]
+
+result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert(os.path.isfile(outimage))
+
+result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0)
+assert('adoptedNeutral: v2f [ 1.1, 2.2 ]' in result.stdout)
+assert('altitude: float 6.5' in result.stdout)
+assert('aperture: float 3.2' in result.stdout)
+assert('capDate: string \'1999:12:31 23:59:59\'' in result.stdout)
+assert('channels: chlist 1 channels' in result.stdout)
+assert('\'Y\': half samp 1 1' in result.stdout)
+assert('chromaticities: chromaticities r[1, 2] g[3, 4] b[5, 6] w[7, 8]' in result.stdout)
+assert('comments: string \'blah blah blah\'' in result.stdout)
+assert('compression: compression \'pxr24\' (0x05)' in result.stdout)
+assert('dataWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
+assert('displayWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
+assert('envmap: envmap latlong' in result.stdout)
+assert('expTime: float 4.3' in result.stdout)
+assert('focus: float 5.4' in result.stdout)
+assert('framesPerSecond: rational 48 / 1 (48)' in result.stdout)
+assert('isoSpeed: float 2.1' in result.stdout)
+assert('keyCode: keycode mfgc 1 film 2 prefix 3 count 4 perf_off 5 ppf 6 ppc 20' in result.stdout)
+assert('latitude: float 7.6' in result.stdout)
+assert('lineOrder: lineOrder 0 (increasing)' in result.stdout)
+assert('longitude: float 8.7' in result.stdout)
+assert('lookModTransform: string \'lmt\'' in result.stdout)
+assert('owner: string \'florian\'' in result.stdout)
+assert('pixelAspectRatio: float 1.7' in result.stdout)
+assert('renderingTransform: string \'rt\'' in result.stdout)
+assert('screenWindowCenter: v2f [ 42, 43 ]' in result.stdout)
+assert('screenWindowWidth: float 4.4' in result.stdout)
+assert('test_float: float 4.2' in result.stdout)
+assert('test_int: int 42' in result.stdout)
+assert('test_string: string \'forty two\'' in result.stdout)
+assert('timeCode: timecode time 305419896 user 878082192' in result.stdout)
+assert('type: string \'scanlineimage\'' in result.stdout)
+assert('utcOffset: float 9' in result.stdout)
+assert('whiteLuminance: float 17.1' in result.stdout)
+assert('wrapmodes: string \'clamp\'' in result.stdout)
+assert('xDensity: float 10' in result.stdout)
+
+print("success")


### PR DESCRIPTION
Python-based tests for:
- exr2aces
- exrcheck
- exrenvmap
- exrheader
- exrinfo
- exrmakepreview
- exrmaketiled
- exrmultipart
- exrmultiview
- exrstdattr

Also:
- The tests require Python3 and are skipped if it's not available
- The tests download test images at build time from https://github.com/AcademySoftwareFoundation/openexr-images
- Tests generally confirm the significant bits of output printed to stdout, so rely on the formatting of exrinfo
- All programs capitialize "Usage" in their usage message
- exrmultipart now prints its usage message to stderr rather than cout
- Fixed an uninitialized variable in exrinfo.c that caused inconsistent return code