### PR TITLE
Fix coverage analysis for .c files

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -51,6 +51,8 @@ jobs:
                 -DCMAKE_CXX_STANDARD=14 \
                 -DCMAKE_CXX_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
                 -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON \
+                -DCMAKE_C_FLAGS="-g -O0 -fprofile-arcs -ftest-coverage" \
+                -DCMAKE_C_OUTPUT_EXTENSION_REPLACE=ON \
                 -DCMAKE_EXE_LINKER_FLAGS="-lgcov" \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS='OFF' \

--- a/share/ci/scripts/linux/run_gcov.sh
+++ b/share/ci/scripts/linux/run_gcov.sh
@@ -1,17 +1,39 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
 
 set -ex
 
-mkdir _coverage
-cd _coverage
+if [ $# -gt 0 ]
+then
+   build=$1  # use explicity-provided build directory
+else
+   build=`pwd`/'_build'  # from with CI, use the _build subdirectory
+fi
+   
+coverage="$build/_coverage"
 
-# The sed command below converts from:
-#   ../_build/src/OpenEXR/CMakeFiles/OpenColorIO.dir/ops/Exponent.gcno
-# to:
-#   ../src/OpenEXR/ops/Exponent.cpp
+mkdir -p $coverage
+cd $coverage
 
-for g in $(find ../_build -name "*.gcno" -type f); do
-    gcov -l -p -o $(dirname "$g") $(echo "$g" | sed -e 's/\/_build\//\//' -e 's/\.gcno/\.cpp/' -e 's/\/CMakeFiles.*\.dir\//\//')
+for gcno in $(find $build -name "*.gcno" -type f); do
+
+    # Identify the original source file (.cpp or .c) from the .gcno
+    # file by examining the .o.d make dependency file. The source
+    # file should be the second line in the .o.d file.
+    
+    # gcno = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.gcno
+    # object_directory = $build/src/bin/exrheader/CMakeFiles/exrheader.dir
+    # source_base = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main
+    # dependenty_file = $build/src/bin/exrheader/CMakeFiles/exrheader.dir/main.o.d
+
+    object_directory=$(dirname "$gcno") 
+    source_base=$(basename "$gcno" ".gcno") 
+    dependency_file=$object_directory/$source_base.o.d 
+    source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
+    gcov -l -p -o $object_directory $source_file 
 done
 
-cd ..
+
+

--- a/share/ci/scripts/linux/run_gcov.sh
+++ b/share/ci/scripts/linux/run_gcov.sh
@@ -31,8 +31,12 @@ for gcno in $(find $build -name "*.gcno" -type f); do
     object_directory=$(dirname "$gcno") 
     source_base=$(basename "$gcno" ".gcno") 
     dependency_file=$object_directory/$source_base.o.d 
-    source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
-    gcov -l -p -o $object_directory $source_file 
+
+    if [ -f "$dependency_file" ]; then
+
+        source_file=$(head -2 $dependency_file | tail -1 | sed -e 's/ //' -e 's/ \\//') 
+        gcov -l -p -o $object_directory $source_file 
+    fi
 done
 
 

--- a/src/test/bin/test_exrcheck.py
+++ b/src/test/bin/test_exrcheck.py
@@ -18,5 +18,18 @@ for exr_file in sys.argv[3:]:
     result = run ([exrcheck, exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     assert(result.returncode == 0)
 
+    result = run ([exrcheck, "-m", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert(result.returncode == 0)
+
+    result = run ([exrcheck, "-t", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert(result.returncode == 0)
+
+    result = run ([exrcheck, "-s", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert(result.returncode == 0)
+
+    result = run ([exrcheck, "-c", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    assert(result.returncode == 0)
+
+
 print("success.")
 


### PR DESCRIPTION
Looks like the coverage analysis has been completely missing .c files.

- Set  CMAKE_C_FLAGS/CMAKE_C_OUTPUT_EXTENSION_REPLACE just like CXX  
- Fix run_gcov.sh to deduce the source file by examining the .o.d file rather than simply replacing .gcno with .cpp, which misses .c files
- Add exrcheck test runs with -m, -t, -s, and -c for better coverage