### PR TITLE
Detect missing vst1q_f32_x2 and provide replacement if necessary

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,6 +72,7 @@ expand_template(
         "#cmakedefine OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX 1": "/* #undef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX */",
         "#cmakedefine OPENEXR_IMF_HAVE_LINUX_PROCFS 1": "/* #undef OPENEXR_IMF_HAVE_LINUX_PROCFS */",
         "#cmakedefine OPENEXR_IMF_HAVE_SYSCONF_NPROCESSORS_ONLN 1": "/* #undef OPENEXR_IMF_HAVE_SYSCONF_NPROCESSORS_ONLN */",
+        "#cmakedefine OPENEXR_MISSING_ARM_VLD1 0": "/* #undef OPENEXR_MISSING_ARM_VLD1 */",
     },
     template = "cmake/OpenEXRConfigInternal.h.in",
 )

--- a/cmake/OpenEXRConfigInternal.h.in
+++ b/cmake/OpenEXRConfigInternal.h.in
@@ -47,6 +47,13 @@
 
 #cmakedefine OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX 1
 
+//
+// Define if we need to shim in our own implementation of vld1q_f32_x2 for
+// older compilers that are missing x2 Neon intrinsics on aarch64
+//
+
+#cmakedefine OPENEXR_MISSING_ARM_VLD1 0
+
 // clang-format on
 
 #endif // INCLUDED_OPENEXR_INTERNAL_CONFIG_H

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -312,3 +312,21 @@ else()
     message(STATUS "Imath interface dirs ${IMATH_HEADER_ONLY_INCLUDE_DIRS}")
   endif()
 endif()
+
+###########################################
+# Check if we need to emulate vld1q_f32_x2
+###########################################
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  include(CheckCSourceCompiles)
+  check_c_source_compiles("#include <arm_neon.h>
+int main() {
+  float a[] = {1.0, 1.0};
+  vld1q_f32_x2(a);
+  return 0;
+}" HAS_VLD1)
+
+  if(NOT HAS_VLD1)
+    set(OPENEXR_MISSING_ARM_VLD1 TRUE)
+  endif()
+endif()

--- a/src/lib/OpenEXR/ImfSimd.h
+++ b/src/lib/OpenEXR/ImfSimd.h
@@ -62,4 +62,18 @@ extern "C" {
 
 }
 
+#include "OpenEXRConfigInternal.h"
+#ifdef OPENEXR_MISSING_ARM_VLD1
+/* Workaround for missing vld1q_f32_x2 in older gcc versions.  */
+
+__extension__ extern __inline float32x4x2_t
+    __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
+    vld1q_f32_x2 (const float32_t* __a)
+{
+    float32x4x2_t ret;
+    asm ("ld1 {%S0.4s - %T0.4s}, [%1]" : "=w"(ret) : "r"(__a) :);
+    return ret;
+}
+#endif
+
 #endif


### PR DESCRIPTION
In ImfDwaCompressorSimd.h, convertFloatToHalf64_neon() uses the vst1q_f32_x2 intrinsic on aarch64. However, older versions of GCC (< 9) do not provide the vst1q_f32_x2 intrinsic on aarch64, so we must detect when vst1q_f32_x2 is not available and provide our own implementation instead.

Specific examples of platforms where this fix is needed are CentOS 8 on aarch64, and NVIDIA's Linux For Tegra 32.x on Jetson Nano.