### PR TITLE
Extend Iex test coverage

### DIFF
--- a/src/lib/Iex/IexThrowErrnoExc.cpp
+++ b/src/lib/Iex/IexThrowErrnoExc.cpp
@@ -209,7 +209,7 @@ throwErrnoExc (const std::string& text, int errnum)
         case EUNATCH: throw EunatchExc (tmp);
 #endif
 
-#if defined(ENOSCI)
+#if defined(ENOCSI)
         case ENOCSI: throw EnocsiExc (tmp);
 #endif
 

--- a/src/test/IexTest/CMakeLists.txt
+++ b/src/test/IexTest/CMakeLists.txt
@@ -5,6 +5,10 @@ add_executable(IexTest
   main.cpp
   testBaseExc.cpp
   testBaseExc.h
+  testMathExc.cpp
+  testMathExc.h
+  mathFuncs.cpp
+  mathFuncs.h
 )
 
 target_link_libraries(IexTest OpenEXR::Iex)

--- a/src/test/IexTest/main.cpp
+++ b/src/test/IexTest/main.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include <testBaseExc.h>
+#include <testMathExc.h>
 
 #include <string.h>
 
@@ -18,5 +19,6 @@ int
 main (int argc, char* argv[])
 {
     TEST (testBaseExc);
+    TEST (testMathExc);
     return 0;
 }

--- a/src/test/IexTest/mathFuncs.cpp
+++ b/src/test/IexTest/mathFuncs.cpp
@@ -1,0 +1,28 @@
+#undef __THROW
+#include <math.h>
+#include <iostream>
+
+float
+divide (float x, float y)
+{
+    std::cout << x << " / " << y << std::endl;
+    return x / y;
+}
+
+float
+root (float x)
+{
+    std::cout << "sqrt (" << x << ")" << std::endl;
+    return sqrt (x);
+}
+
+float
+grow (float x, int y)
+{
+    std::cout << "grow (" << x << ", " << y << ")" << std::endl;
+
+    for (int i = 0; i < y; i++)
+	x = x * x;
+
+    return x;
+}

--- a/src/test/IexTest/mathFuncs.h
+++ b/src/test/IexTest/mathFuncs.h
@@ -1,0 +1,5 @@
+
+float divide (float x, float y);
+float root (float x);
+float grow (float x, int y);
+

--- a/src/test/IexTest/testBaseExc.cpp
+++ b/src/test/IexTest/testBaseExc.cpp
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <iostream>
 #include <stdexcept>
+#include <typeinfo>
 #include <errno.h>
 #include <testBaseExc.h>
 

--- a/src/test/IexTest/testBaseExc.cpp
+++ b/src/test/IexTest/testBaseExc.cpp
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <iostream>
 #include <stdexcept>
+#include <errno.h>
 #include <testBaseExc.h>
 
 namespace
@@ -191,14 +192,16 @@ test6 ()
     // and the += and assign functions.
     //
 
+    T e0;
+    
     T e1 ("arg");
 
     e1 += "X";
-    std::stringstream s;
-    s << "Y";
-    e1 += s;
+    std::stringstream ss;
+    ss << "Y";
+    e1 += ss;
 
-    T e2 (e1);
+    T e2 (e1); 
 
     assert (e1.message () == "argXY");
     assert (e1.stackTrace () == getStackTrace ());
@@ -208,12 +211,31 @@ test6 ()
 
     e2.assign ("Z");
     assert (e2.message () == "Z");
-    e2.assign (s);
+    e2.assign (ss);
     assert (e2.message () == "Y");
 
-    T e3 (s);
-    assert (e3.message () == s.str ());
+    T e3 (ss);
+    assert (e3.message () == ss.str ());
 
+    std::string str4 ("e4");
+    T e4(str4);
+    assert (e4.message() == str4);
+
+    const std::string str5 ("e5");
+    T e5(str5);
+    assert (e5.message() == str5);
+    
+    {
+        const T e6("e6");
+        T e7(e6);
+        assert (e7.message() == e6.message());
+    }
+
+    {
+        e5 = e4;
+        assert (e5.message() == e4.message());
+    }
+    
     //
     // Confirm the throw/catch
     //
@@ -235,6 +257,508 @@ test6 ()
     }
 
     assert (caught);
+}
+
+template <class T>
+void
+testThrowErrnoExc(int err)
+{
+    bool caught = false;
+    
+    try
+    {
+        IEX_INTERNAL_NAMESPACE::throwErrnoExc("err", err);
+    }
+    catch (const T& e)
+    {
+        caught = true;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "testThrowErrnoExc: caught " << typeid(e).name()
+                  << ", expected " << typeid(T).name()
+                  << std::endl;
+    }
+    
+    assert (caught);
+}
+    
+void
+test7()
+{
+#if defined(EPERM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EpermExc>(EPERM);
+#endif
+#if defined(ENOENT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoentExc>(ENOENT);
+#endif
+#if defined(ESRCH)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EsrchExc>(ESRCH);
+#endif
+#if defined(EINTR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EintrExc>(EINTR);
+#endif
+#if defined(EIO)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EioExc>(EIO);
+#endif
+#if defined(ENXIO)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnxioExc>(ENXIO);
+#endif
+#if defined(E2BIG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::E2bigExc>(E2BIG);
+#endif
+#if defined(ENOEXEC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoexecExc>(ENOEXEC);
+#endif
+#if defined(EBADF)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadfExc>(EBADF);
+#endif
+#if defined(ECHILD)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EchildExc>(ECHILD);
+#endif
+#if defined(EAGAIN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EagainExc>(EAGAIN);
+#endif
+#if defined(ENOMEM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnomemExc>(ENOMEM);
+#endif
+#if defined(EACCES)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EaccesExc>(EACCES);
+#endif
+#if defined(EFAULT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EfaultExc>(EFAULT);
+#endif
+#if defined(ENOTBLK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotblkExc>(ENOTBLK);
+#endif
+#if defined(EBUSY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbusyExc>(EBUSY);
+#endif
+#if defined(EEXIST)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EexistExc>(EEXIST);
+#endif
+#if defined(EXDEV)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ExdevExc>(EXDEV);
+#endif
+#if defined(ENODEV)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnodevExc>(ENODEV);
+#endif
+#if defined(ENOTDIR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotdirExc>(ENOTDIR);
+#endif
+#if defined(EISDIR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EisdirExc>(EISDIR);
+#endif
+#if defined(EINVAL)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinvalExc>(EINVAL);
+#endif
+#if defined(ENFILE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnfileExc>(ENFILE);
+#endif
+#if defined(EMFILE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EmfileExc>(EMFILE);
+#endif
+#if defined(ENOTTY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnottyExc>(ENOTTY);
+#endif
+#if defined(ETXTBSY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EtxtbsyExc>(ETXTBSY);
+#endif
+#if defined(EFBIG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EfbigExc>(EFBIG);
+#endif
+#if defined(ENOSPC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnospcExc>(ENOSPC);
+#endif
+#if defined(ESPIPE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EspipeExc>(ESPIPE);
+#endif
+#if defined(EROFS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ErofsExc>(EROFS);
+#endif
+#if defined(EMLINK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EmlinkExc>(EMLINK);
+#endif
+#if defined(EPIPE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EpipeExc>(EPIPE);
+#endif
+#if defined(EDOM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdomExc>(EDOM);
+#endif
+#if defined(ERANGE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ErangeExc>(ERANGE);
+#endif
+#if defined(ENOMSG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnomsgExc>(ENOMSG);
+#endif
+#if defined(EIDRM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EidrmExc>(EIDRM);
+#endif
+#if defined(ECHRNG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EchrngExc>(ECHRNG);
+#endif
+#if defined(EL2NSYNC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::El2nsyncExc>(EL2NSYNC);
+#endif
+#if defined(EL3HLT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::El3hltExc>(EL3HLT);
+#endif
+#if defined(EL3RST)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::El3rstExc>(EL3RST);
+#endif
+#if defined(ELNRNG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElnrngExc>(ELNRNG);
+#endif
+#if defined(EUNATCH)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EunatchExc>(EUNATCH);
+#endif
+#if defined(ENOCSI)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnocsiExc>(ENOCSI);
+#endif
+#if defined(EL2HLT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::El2hltExc>(EL2HLT);
+#endif
+#if defined(EDEADLK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdeadlkExc>(EDEADLK);
+#endif
+#if defined(ENOLCK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnolckExc>(ENOLCK);
+#endif
+#if defined(EBADE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadeExc>(EBADE);
+#endif
+#if defined(EBADR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadrExc>(EBADR);
+#endif
+#if defined(EXFULL)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ExfullExc>(EXFULL);
+#endif
+#if defined(ENOANO)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoanoExc>(ENOANO);
+#endif
+#if defined(EBADRQC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadrqcExc>(EBADRQC);
+#endif
+#if defined(EBADSLT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadsltExc>(EBADSLT);
+#endif
+#if defined(EDEADLOCK) && defined(EDEADLK)
+#    if EDEADLOCK != EDEADLK
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdeadlockExc>(EDEADLOCK);
+#    endif
+#elif defined(EDEADLOCK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdeadlockExc>(EDEADLOCK);
+#endif
+#if defined(EBFONT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbfontExc>(EBFONT);
+#endif
+#if defined(ENOSTR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnostrExc>(ENOSTR);
+#endif
+#if defined(ENODATA)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnodataExc>(ENODATA);
+#endif
+#if defined(ETIME)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EtimeExc>(ETIME);
+#endif
+#if defined(ENOSR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnosrExc>(ENOSR);
+#endif
+#if defined(ENONET)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnonetExc>(ENONET);
+#endif
+#if defined(ENOPKG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnopkgExc>(ENOPKG);
+#endif
+#if defined(EREMOTE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EremoteExc>(EREMOTE);
+#endif
+#if defined(ENOLINK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnolinkExc>(ENOLINK);
+#endif
+#if defined(EADV)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EadvExc>(EADV);
+#endif
+#if defined(ESRMNT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EsrmntExc>(ESRMNT);
+#endif
+#if defined(ECOMM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EcommExc>(ECOMM);
+#endif
+#if defined(EPROTO)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EprotoExc>(EPROTO);
+#endif
+#if defined(EMULTIHOP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EmultihopExc>(EMULTIHOP);
+#endif
+#if defined(EBADMSG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadmsgExc>(EBADMSG);
+#endif
+#if defined(ENAMETOOLONG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnametoolongExc>(ENAMETOOLONG);
+#endif
+#if defined(EOVERFLOW)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EoverflowExc>(EOVERFLOW);
+#endif
+#if defined(ENOTUNIQ)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotuniqExc>(ENOTUNIQ);
+#endif
+#if defined(EBADFD)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbadfdExc>(EBADFD);
+#endif
+#if defined(EREMCHG)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EremchgExc>(EREMCHG);
+#endif
+#if defined(ELIBACC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElibaccExc>(ELIBACC);
+#endif
+#if defined(ELIBBAD)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElibbadExc>(ELIBBAD);
+#endif
+#if defined(ELIBSCN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElibscnExc>(ELIBSCN);
+#endif
+#if defined(ELIBMAX)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElibmaxExc>(ELIBMAX);
+#endif
+#if defined(ELIBEXEC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ElibexecExc>(ELIBEXEC);
+#endif
+#if defined(EILSEQ)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EilseqExc>(EILSEQ);
+#endif
+#if defined(ENOSYS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnosysExc>(ENOSYS);
+#endif
+#if defined(ELOOP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EloopExc>(ELOOP);
+#endif
+#if defined(ERESTART)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::ErestartExc>(ERESTART);
+#endif
+#if defined(ESTRPIPE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EstrpipeExc>(ESTRPIPE);
+#endif
+#if defined(ENOTEMPTY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotemptyExc>(ENOTEMPTY);
+#endif
+#if defined(EUSERS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EusersExc>(EUSERS);
+#endif
+#if defined(ENOTSOCK)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotsockExc>(ENOTSOCK);
+#endif
+#if defined(EDESTADDRREQ)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdestaddrreqExc>(EDESTADDRREQ);
+#endif
+#if defined(EMSGSIZE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EmsgsizeExc>(EMSGSIZE);
+#endif
+#if defined(EPROTOTYPE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EprototypeExc>(EPROTOTYPE);
+#endif
+#if defined(ENOPROTOOPT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoprotooptExc>(ENOPROTOOPT);
+#endif
+#if defined(EPROTONOSUPPORT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EprotonosupportExc>(EPROTONOSUPPORT);
+#endif
+#if defined(ESOCKTNOSUPPORT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EsocktnosupportExc>(ESOCKTNOSUPPORT);
+#endif
+#if defined(EOPNOTSUPP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EopnotsuppExc>(EOPNOTSUPP);
+#endif
+#if defined(EPFNOSUPPORT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EpfnosupportExc>(EPFNOSUPPORT);
+#endif
+#if defined(EAFNOSUPPORT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EafnosupportExc>(EAFNOSUPPORT);
+#endif
+#if defined(EADDRINUSE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EaddrinuseExc>(EADDRINUSE);
+#endif
+#if defined(EADDRNOTAVAIL)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EaddrnotavailExc>(EADDRNOTAVAIL);
+#endif
+#if defined(ENETDOWN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnetdownExc>(ENETDOWN);
+#endif
+#if defined(ENETUNREACH)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnetunreachExc>(ENETUNREACH);
+#endif
+#if defined(ENETRESET)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnetresetExc>(ENETRESET);
+#endif
+#if defined(ECONNABORTED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EconnabortedExc>(ECONNABORTED);
+#endif
+#if defined(ECONNRESET)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EconnresetExc>(ECONNRESET);
+#endif
+#if defined(ENOBUFS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnobufsExc>(ENOBUFS);
+#endif
+#if defined(EISCONN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EisconnExc>(EISCONN);
+#endif
+#if defined(ENOTCONN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotconnExc>(ENOTCONN);
+#endif
+#if defined(ESHUTDOWN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EshutdownExc>(ESHUTDOWN);
+#endif
+#if defined(ETOOMANYREFS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EtoomanyrefsExc>(ETOOMANYREFS);
+#endif
+#if defined(ETIMEDOUT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EtimedoutExc>(ETIMEDOUT);
+#endif
+#if defined(ECONNREFUSED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EconnrefusedExc>(ECONNREFUSED);
+#endif
+#if defined(EHOSTDOWN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EhostdownExc>(EHOSTDOWN);
+#endif
+#if defined(EHOSTUNREACH)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EhostunreachExc>(EHOSTUNREACH);
+#endif
+#if defined(EALREADY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EalreadyExc>(EALREADY);
+#endif
+#if defined(EINPROGRESS)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinprogressExc>(EINPROGRESS);
+#endif
+#if defined(ESTALE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EstaleExc>(ESTALE);
+#endif
+#if defined(EIORESID)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EioresidExc>(EIORESID);
+#endif
+#if defined(EUCLEAN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EucleanExc>(EUCLEAN);
+#endif
+#if defined(ENOTNAM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotnamExc>(ENOTNAM);
+#endif
+#if defined(ENAVAIL)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnavailExc>(ENAVAIL);
+#endif
+#if defined(EISNAM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EisnamExc>(EISNAM);
+#endif
+#if defined(EREMOTEIO)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EremoteioExc>(EREMOTEIO);
+#endif
+#if defined(EINIT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinitExc>(EINIT);
+#endif
+#if defined(EREMDEV)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EremdevExc>(EREMDEV);
+#endif
+#if defined(ECANCELED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EcanceledExc>(ECANCELED);
+#endif
+#if defined(ENOLIMFILE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnolimfileExc>(ENOLIMFILE);
+#endif
+#if defined(EPROCLIM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EproclimExc>(EPROCLIM);
+#endif
+#if defined(EDISJOINT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdisjointExc>(EDISJOINT);
+#endif
+#if defined(ENOLOGIN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnologinExc>(ENOLOGIN);
+#endif
+#if defined(ELOGINLIM)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EloginlimExc>(ELOGINLIM);
+#endif
+#if defined(EGROUPLOOP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EgrouploopExc>(EGROUPLOOP);
+#endif
+#if defined(ENOATTACH)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoattachExc>(ENOATTACH);
+#endif
+#if defined(ENOTSUP) && defined(EOPNOTSUPP)
+#    if ENOTSUP != EOPNOTSUPP
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotsupExc>(ENOTSUP);
+#    endif
+#elif defined(ENOTSUP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotsupExc>(ENOTSUP);
+#endif
+#if defined(ENOATTR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoattrExc>(ENOATTR);
+#endif
+#if defined(EDIRCORRUPTED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdircorruptedExc>(EDIRCORRUPTED);
+#endif
+#if defined(EDQUOT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdquotExc>(EDQUOT);
+#endif
+#if defined(ENFSREMOTE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnfsremoteExc>(ENFSREMOTE);
+#endif
+#if defined(ECONTROLLER)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EcontrollerExc>(ECONTROLLER);
+#endif
+#if defined(ENOTCONTROLLER)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotcontrollerExc>(ENOTCONTROLLER);
+#endif
+#if defined(EENQUEUED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EenqueuedExc>(EENQUEUED);
+#endif
+#if defined(ENOTENQUEUED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotenqueuedExc>(ENOTENQUEUED);
+#endif
+#if defined(EJOINED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EjoinedExc>(EJOINED);
+#endif
+#if defined(ENOTJOINED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotjoinedExc>(ENOTJOINED);
+#endif
+#if defined(ENOPROC)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoprocExc>(ENOPROC);
+#endif
+#if defined(EMUSTRUN)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EmustrunExc>(EMUSTRUN);
+#endif
+#if defined(ENOTSTOPPED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnotstoppedExc>(ENOTSTOPPED);
+#endif
+#if defined(ECLOCKCPU)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EclockcpuExc>(ECLOCKCPU);
+#endif
+#if defined(EINVALSTATE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinvalstateExc>(EINVALSTATE);
+#endif
+#if defined(ENOEXIST)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnoexistExc>(ENOEXIST);
+#endif
+#if defined(EENDOFMINOR)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EendofminorExc>(EENDOFMINOR);
+#endif
+#if defined(EBUFSIZE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EbufsizeExc>(EBUFSIZE);
+#endif
+#if defined(EEMPTY)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EemptyExc>(EEMPTY);
+#endif
+#if defined(ENOINTRGROUP)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EnointrgroupExc>(ENOINTRGROUP);
+#endif
+#if defined(EINVALMODE)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinvalmodeExc>(EINVALMODE);
+#endif
+#if defined(ECANTEXTENT)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EcantextentExc>(ECANTEXTENT);
+#endif
+#if defined(EINVALTIME)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EinvaltimeExc>(EINVALTIME);
+#endif
+#if defined(EDESTROYED)
+    testThrowErrnoExc<IEX_INTERNAL_NAMESPACE::EdestroyedExc>(EDESTROYED);
+#endif
 }
 
 } // namespace
@@ -420,5 +944,7 @@ testBaseExc ()
     test6<IEX_INTERNAL_NAMESPACE::InexactExc> ();
     test6<IEX_INTERNAL_NAMESPACE::InvalidFpOpExc> ();
 
+    test7();
+    
     std::cout << "ok\n" << std::endl;
 }

--- a/src/test/IexTest/testMathExc.cpp
+++ b/src/test/IexTest/testMathExc.cpp
@@ -1,6 +1,12 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
 #include <testMathExc.h>
 #include <mathFuncs.h>
 #include <IexMathFloatExc.h>
+#include <IexMathExc.h>
 #include <iostream>
 #include <assert.h>
 #include <string.h>
@@ -25,7 +31,7 @@ test1 ()
 
     std::cout << "invalid operations / exception handling off" << std::endl;
 
-    Iex::mathExcOn (0);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (0);
 
     for (int i = 0; i < 3; ++i)
     {
@@ -51,7 +57,7 @@ test2a ()
 	print (divide (1, 0));		// division by zero
 	assert (false); // note, this happens when running under valgrind
     }
-    catch (const Iex::DivzeroExc &e)
+    catch (const IEX_INTERNAL_NAMESPACE::DivzeroExc &e)
     {
 	std::cout << "caught exception: " << e.what() << std::endl;
     }
@@ -66,7 +72,7 @@ test2b ()
 	print (root (-1));		// invalid operation
 	assert (false); // note, this happens when running under valgrind
     }
-    catch (const Iex::InvalidFpOpExc &e)
+    catch (const IEX_INTERNAL_NAMESPACE::InvalidFpOpExc &e)
     {
 	std::cout << "caught exception: " << e.what() << std::endl;
     }
@@ -81,7 +87,7 @@ test2c ()
 	print (grow (1000, 100));	// overflow
 	assert (false); // note, this happens when running under valgrind
     }
-    catch (const Iex::OverflowExc &e)
+    catch (const IEX_INTERNAL_NAMESPACE::OverflowExc &e)
     {
 	std::cout << "caught exception: " << e.what() << std::endl;
     }
@@ -99,7 +105,7 @@ test2 ()
 
     std::cout << "invalid operations / exception handling on" << std::endl;
 
-    Iex::mathExcOn (Iex::IEEE_OVERFLOW | Iex::IEEE_DIVZERO | Iex::IEEE_INVALID);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (IEX_INTERNAL_NAMESPACE::IEEE_OVERFLOW | IEX_INTERNAL_NAMESPACE::IEEE_DIVZERO | IEX_INTERNAL_NAMESPACE::IEEE_INVALID);
 
     for (int i = 0; i < 3; ++i)
     {
@@ -137,28 +143,28 @@ test3 ()
 
     int when = 0;
 
-    Iex::mathExcOn (when);
-    assert (Iex::getMathExcOn() == when);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (when);
+    assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
 
-    when = Iex::IEEE_OVERFLOW;
+    when = IEX_INTERNAL_NAMESPACE::IEEE_OVERFLOW;
 
-    Iex::mathExcOn (when);
-    assert (Iex::getMathExcOn() == when);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (when);
+    assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
 
-    when = Iex::IEEE_DIVZERO;
+    when = IEX_INTERNAL_NAMESPACE::IEEE_DIVZERO;
 
-    Iex::mathExcOn (when);
-    assert (Iex::getMathExcOn() == when);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (when);
+    assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
 
-    when = Iex::IEEE_INVALID;
+    when = IEX_INTERNAL_NAMESPACE::IEEE_INVALID;
 
-    Iex::mathExcOn (when);
-    assert (Iex::getMathExcOn() == when);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (when);
+    assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
 
-    when = Iex::IEEE_OVERFLOW | Iex::IEEE_DIVZERO | Iex::IEEE_INVALID;
+    when = IEX_INTERNAL_NAMESPACE::IEEE_OVERFLOW | IEX_INTERNAL_NAMESPACE::IEEE_DIVZERO | IEX_INTERNAL_NAMESPACE::IEEE_INVALID;
 
-    Iex::mathExcOn (when);
-    assert (Iex::getMathExcOn() == when);
+    IEX_INTERNAL_NAMESPACE::mathExcOn (when);
+    assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
 }
 
 } // namespace

--- a/src/test/IexTest/testMathExc.cpp
+++ b/src/test/IexTest/testMathExc.cpp
@@ -121,6 +121,11 @@ test3 ()
     // was most recently set with setMathExcOn().
     //
 
+
+#if defined(HAVE_UCONTEXT_H) &&                                                \
+    (defined(IEX_HAVE_SIGCONTEXT_CONTROL_REGISTER_SUPPORT) ||                  \
+     defined(IEX_HAVE_CONTROL_REGISTER_SUPPORT))
+
     std::cout << "getMathExc()" << std::endl;
 
     int when = 0;
@@ -147,6 +152,7 @@ test3 ()
 
     IEX_INTERNAL_NAMESPACE::mathExcOn (when);
     assert (IEX_INTERNAL_NAMESPACE::getMathExcOn() == when);
+#endif
 }
 
 } // namespace

--- a/src/test/IexTest/testMathExc.cpp
+++ b/src/test/IexTest/testMathExc.cpp
@@ -1,0 +1,185 @@
+#include <testMathExc.h>
+#include <mathFuncs.h>
+#include <IexMathFloatExc.h>
+#include <iostream>
+#include <assert.h>
+#include <string.h>
+
+namespace {
+
+void
+print (float f)
+{
+    std::cout << f << std::endl;
+}
+
+
+void
+test1 ()
+{
+    //
+    // Turn math exception handling off, and verify that no C++ exceptions
+    // are thrown even though "exceptional" floating-point operations are
+    // performed.
+    //
+
+    std::cout << "invalid operations / exception handling off" << std::endl;
+
+    Iex::mathExcOn (0);
+
+    for (int i = 0; i < 3; ++i)
+    {
+	try
+	{
+	    print (divide (1, 0));	// division by zero
+	    print (root (-1));		// invalid operation
+	    print (grow (1000, 100));	// overflow
+	}
+	catch (...)
+	{
+	    assert (false);
+	}
+    }
+}
+
+
+void
+test2a ()
+{
+    try
+    {
+	print (divide (1, 0));		// division by zero
+	assert (false); // note, this happens when running under valgrind
+    }
+    catch (const Iex::DivzeroExc &e)
+    {
+	std::cout << "caught exception: " << e.what() << std::endl;
+    }
+}
+
+
+void
+test2b ()
+{
+    try
+    {
+	print (root (-1));		// invalid operation
+	assert (false); // note, this happens when running under valgrind
+    }
+    catch (const Iex::InvalidFpOpExc &e)
+    {
+	std::cout << "caught exception: " << e.what() << std::endl;
+    }
+}
+
+
+void
+test2c ()
+{
+    try
+    {
+	print (grow (1000, 100));	// overflow
+	assert (false); // note, this happens when running under valgrind
+    }
+    catch (const Iex::OverflowExc &e)
+    {
+	std::cout << "caught exception: " << e.what() << std::endl;
+    }
+}
+
+
+void
+test2 ()
+{
+    //
+    // Turn math exception handling on, and verify that C++ exceptions
+    // are thrown when "exceptional" floating-point operations are
+    // performed.
+    //
+
+    std::cout << "invalid operations / exception handling on" << std::endl;
+
+    Iex::mathExcOn (Iex::IEEE_OVERFLOW | Iex::IEEE_DIVZERO | Iex::IEEE_INVALID);
+
+    for (int i = 0; i < 3; ++i)
+    {
+#if defined(BUILD) && defined(__VERSION__)
+    // magic voodoo so that QUOTE(BUILD)
+    // turns into quoted "LINUX_AMD64_OPT_DEBUG"
+    #define QUOTE0(x) #x
+    #define QUOTE(x) QUOTE0(x)
+        if (strcmp(QUOTE(BUILD), "LINUX_AMD64_OPT_DEBUG") == 0
+         && strcmp(__VERSION__, "4.1.2 20080704 (Red Hat 4.1.2-44)") == 0)
+            std::cout << "WARNING: skipping 1/0 test since it's known to fail"
+                      << " in optimized builds using compiler version"
+                      << " \""<<__VERSION__<<"\""
+                      << " (see SQ42578)"
+                      << std::endl;
+        else
+#endif
+            test2a();
+
+	test2b();
+	test2c();
+    }
+}
+
+
+void
+test3 ()
+{
+    //
+    // Verify that getMathExcOn() returns the value that
+    // was most recently set with setMathExcOn().
+    //
+
+    std::cout << "getMathExc()" << std::endl;
+
+    int when = 0;
+
+    Iex::mathExcOn (when);
+    assert (Iex::getMathExcOn() == when);
+
+    when = Iex::IEEE_OVERFLOW;
+
+    Iex::mathExcOn (when);
+    assert (Iex::getMathExcOn() == when);
+
+    when = Iex::IEEE_DIVZERO;
+
+    Iex::mathExcOn (when);
+    assert (Iex::getMathExcOn() == when);
+
+    when = Iex::IEEE_INVALID;
+
+    Iex::mathExcOn (when);
+    assert (Iex::getMathExcOn() == when);
+
+    when = Iex::IEEE_OVERFLOW | Iex::IEEE_DIVZERO | Iex::IEEE_INVALID;
+
+    Iex::mathExcOn (when);
+    assert (Iex::getMathExcOn() == when);
+}
+
+} // namespace
+
+
+void
+testMathExc()
+{
+    std::cout << "See if floating-point exceptions work:" << std::endl;
+
+#if defined (GCC_VERSION_295) || defined (GCC_VERSION_296) || defined (ICC_VERSION_71)
+
+         std::cout << "\nWARNING: test skipped for GCC295/296/ICC Linux / IA32.\n"
+                      "Floating-point exceptions do not work yet." << std::endl;
+
+#else
+    test1();
+    test2();
+    test3();
+
+    std::cout << " ok" << std::endl;
+#endif
+
+}

--- a/src/test/IexTest/testMathExc.cpp
+++ b/src/test/IexTest/testMathExc.cpp
@@ -55,7 +55,6 @@ test2a ()
     try
     {
 	print (divide (1, 0));		// division by zero
-	assert (false); // note, this happens when running under valgrind
     }
     catch (const IEX_INTERNAL_NAMESPACE::DivzeroExc &e)
     {
@@ -70,7 +69,6 @@ test2b ()
     try
     {
 	print (root (-1));		// invalid operation
-	assert (false); // note, this happens when running under valgrind
     }
     catch (const IEX_INTERNAL_NAMESPACE::InvalidFpOpExc &e)
     {
@@ -85,7 +83,6 @@ test2c ()
     try
     {
 	print (grow (1000, 100));	// overflow
-	assert (false); // note, this happens when running under valgrind
     }
     catch (const IEX_INTERNAL_NAMESPACE::OverflowExc &e)
     {
@@ -109,22 +106,7 @@ test2 ()
 
     for (int i = 0; i < 3; ++i)
     {
-#if defined(BUILD) && defined(__VERSION__)
-    // magic voodoo so that QUOTE(BUILD)
-    // turns into quoted "LINUX_AMD64_OPT_DEBUG"
-    #define QUOTE0(x) #x
-    #define QUOTE(x) QUOTE0(x)
-        if (strcmp(QUOTE(BUILD), "LINUX_AMD64_OPT_DEBUG") == 0
-         && strcmp(__VERSION__, "4.1.2 20080704 (Red Hat 4.1.2-44)") == 0)
-            std::cout << "WARNING: skipping 1/0 test since it's known to fail"
-                      << " in optimized builds using compiler version"
-                      << " \""<<__VERSION__<<"\""
-                      << " (see SQ42578)"
-                      << std::endl;
-        else
-#endif
-            test2a();
-
+        test2a();
 	test2b();
 	test2c();
     }
@@ -175,17 +157,9 @@ testMathExc()
 {
     std::cout << "See if floating-point exceptions work:" << std::endl;
 
-#if defined (GCC_VERSION_295) || defined (GCC_VERSION_296) || defined (ICC_VERSION_71)
-
-         std::cout << "\nWARNING: test skipped for GCC295/296/ICC Linux / IA32.\n"
-                      "Floating-point exceptions do not work yet." << std::endl;
-
-#else
     test1();
     test2();
     test3();
 
     std::cout << " ok" << std::endl;
-#endif
-
 }

--- a/src/test/IexTest/testMathExc.h
+++ b/src/test/IexTest/testMathExc.h
@@ -1,0 +1,3 @@
+
+void testMathExc();
+


### PR DESCRIPTION
- better tests for exception class constructors
- tests for math exceptions
- tests for errno exceptions
- fixed a 22-year old bug in `throwErrnoExc(ENOCSI)`