### PR TITLE
Fix ARMv7 build by making recent ZIP NEON optimizations be ARMv8 (aarch64) only

### DIFF
--- a/src/lib/OpenEXR/ImfSimd.h
+++ b/src/lib/OpenEXR/ImfSimd.h
@@ -46,6 +46,10 @@
 #    define IMF_HAVE_NEON
 #endif
 
+#if defined(__aarch64__)
+#    define IMF_HAVE_NEON_AARCH64 1
+#endif
+
 extern "C" {
 #ifdef IMF_HAVE_SSE2
 #    include <emmintrin.h>

--- a/src/lib/OpenEXR/ImfZip.cpp
+++ b/src/lib/OpenEXR/ImfZip.cpp
@@ -160,7 +160,7 @@ reconstruct_sse41 (char* buf, size_t outSize)
 
 #endif
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
 
 void
 reconstruct_neon (char* buf, size_t outSize)
@@ -262,7 +262,7 @@ interleave_sse2 (const char* source, size_t outSize, char* out)
 
 #endif
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
 
 void
 interleave_neon (const char* source, size_t outSize, char* out)
@@ -380,7 +380,7 @@ Zip::initializeFuncs ()
     }
 #endif
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
     reconstruct = reconstruct_neon;
     interleave = interleave_neon;
 #endif

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -24,8 +24,8 @@
 #    define IMF_HAVE_SSE4_1 1
 #    include <smmintrin.h>
 #endif
-#if defined(__ARM_NEON)
-#    define IMF_HAVE_NEON 1
+#if defined(__aarch64__)
+#    define IMF_HAVE_NEON_AARCH64 1
 #    include <arm_neon.h>
 #endif
 
@@ -78,7 +78,7 @@ reconstruct (uint8_t* buf, uint64_t outSize)
         prev      = d;
     }
 }
-#elif defined(IMF_HAVE_NEON)
+#elif defined(IMF_HAVE_NEON_AARCH64)
 static void
 reconstruct (uint8_t* buf, uint64_t outSize)
 {
@@ -174,7 +174,7 @@ interleave (uint8_t* out, const uint8_t* source, uint64_t outSize)
         *(sOut++) = (i % 2 == 0) ? *(t1++) : *(t2++);
 }
 
-#elif defined(IMF_HAVE_NEON)
+#elif defined(IMF_HAVE_NEON_AARCH64)
 static void
 interleave (uint8_t* out, const uint8_t* source, uint64_t outSize)
 {


### PR DESCRIPTION
Should fix #1365. Recent PR (#1348) added NEON accelerated code paths for ZIP filtering. But that code uses several instructions that are ARMv8 (aarch64) only, and thus fail building on 32-bit ARM (armv7) platforms. Make these optimizations only kick in when building for 64-bit ARM platforms.