### PR TITLE
Fix ARMv7 build for DwaCompressor, too.

### DIFF
--- a/src/lib/OpenEXR/ImfDwaCompressor.cpp
+++ b/src/lib/OpenEXR/ImfDwaCompressor.cpp
@@ -2789,7 +2789,7 @@ DwaCompressor::initializeFuncs ()
         fromHalfZigZag       = fromHalfZigZag_f16c;
     }
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
     {
         convertFloatToHalf64 = convertFloatToHalf64_neon;
         fromHalfZigZag       = fromHalfZigZag_neon;

--- a/src/lib/OpenEXR/ImfDwaCompressorSimd.h
+++ b/src/lib/OpenEXR/ImfDwaCompressorSimd.h
@@ -395,7 +395,7 @@ convertFloatToHalf64_scalar (unsigned short* dst, float* src)
         dst[i] = ((half) src[i]).bits ();
 }
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
 
 void
 convertFloatToHalf64_neon (unsigned short* dst, float* src)
@@ -821,7 +821,7 @@ fromHalfZigZag_f16c (unsigned short* src, float* dst)
 #endif /* defined IMF_HAVE_GCC_INLINEASM_X86_64 */
 }
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
 
 
 void
@@ -856,7 +856,7 @@ fromHalfZigZag_neon(unsigned short* __restrict__ src, float* __restrict__ dst)
     }
 }
 
-#endif // IMF_HAVE_NEON
+#endif // IMF_HAVE_NEON_AARCH64
 
 //
 // Inverse 8x8 DCT, only inverting the DC. This assumes that

--- a/src/test/OpenEXRTest/testDwaCompressorSimd.cpp
+++ b/src/test/OpenEXRTest/testDwaCompressorSimd.cpp
@@ -408,7 +408,7 @@ testFloatToHalf ()
         }
     }
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
     {
         cout << "      convertFloatToHalf64_neon()" << endl;
         for (int iter = 0; iter < numIter; ++iter)
@@ -437,7 +437,7 @@ testFloatToHalf ()
             }
         }
     }
-    #endif // IMF_HAVE_NEON
+    #endif // IMF_HAVE_NEON_AARCH64
 }
 
 //
@@ -520,7 +520,7 @@ testFromHalfZigZag ()
         } // iter
     }     // f16c
 
-#ifdef IMF_HAVE_NEON
+#ifdef IMF_HAVE_NEON_AARCH64
      {
         const int            numIter = 1000000;
         Rand48               rand48 (0);
@@ -557,7 +557,7 @@ testFromHalfZigZag ()
         } // iter
     }     // neon
 
-#endif // IMF_HAVE_NEON
+#endif // IMF_HAVE_NEON_AARCH64
 }
 
 } // namespace


### PR DESCRIPTION
To fix #1367. Reuse code from #1366 and change the `ImfDwaCompressor*` code's `#ifdef` from `IMF_HAVE_NEON` to `IMF_HAVE_NEON_AARCH64`, too.