### PR TITLE
Only install exrinfo when OPENEXR_INSTALL_TOOLS is on

### DIFF
--- a/src/bin/exrinfo/CMakeLists.txt
+++ b/src/bin/exrinfo/CMakeLists.txt
@@ -6,7 +6,9 @@ target_link_libraries(exrinfo OpenEXR::OpenEXRCore)
 set_target_properties(exrinfo PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-install(TARGETS exrinfo DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(OPENEXR_INSTALL_TOOLS)
+  install(TARGETS exrinfo DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 if(WIN32 AND (BUILD_SHARED_LIBS OR OPENEXR_BUILD_BOTH_STATIC_SHARED))
   target_compile_definitions(exrinfo PRIVATE OPENEXR_DLL)
 endif()


### PR DESCRIPTION
The CMake variable ```OPENEXR_INSTALL_TOOLS``` determines whether the OpenEXR binaries are installed, but it is missing for ```exrinfo```, possibly an oversight?
