### PR TITLE
Update macOS installation instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,19 +13,35 @@ Install
 The OpenEXR library is available for download and installation in
 binary form via package managers on many Linux distributions. See
 `https://pkgs.org/download/openexr
-<https://pkgs.org/download/openexr>`_ for a complete list. The common
-ones that generally provide current releases include:
+<https://pkgs.org/download/openexr>`_ for a complete list. 
 
-* `Fedora <https://packages.fedoraproject.org/pkgs/openexr/openexr/>`_
-* `Gentoo <https://packages.gentoo.org/packages/media-libs/openexr>`_ 
-* `Ubuntu <https://packages.ubuntu.com/source/kinetic/openexr>`_
+RHEL/CentOS:
+
+.. code-block::
+
+    $ sudo yum makecache
+    $ sudo yum install OpenEXR
+
+Ubuntu:
+
+.. code-block::
+
+    $ sudo apt-get update
+    $ sudo apt-get install openexr
 
 Beware that some distributions are out of date and only provide
 distributions of outdated releases OpenEXR. We recommend against using
 OpenEXR v2, and we *strongly* recommend against using OpenEXR v1.
 
-On macOS, we do not recommend installation via HomeBrew because the
-distribution is outdated.
+On macOS, install via `Homebrew <https://formulae.brew.sh/formula/openexr>`_:
+
+.. code-block::
+
+   $ brew install openexr
+
+We do not recommend installation via
+`Macports <https://ports.macports.org/port/openexr>`_ because the
+distribution is out of date.
 
 Also note that the official OpenEXR project does not provide supported
 python bindings. ``pip install openexr`` installs the `openexrpython


### PR DESCRIPTION
The recommendations for macOS were backwards. Homebrew is the recommended installer. Macports is not recommended, as it's on v2.3.