### PR TITLE
Remove unused private member variable _maxScanLineSize (ABI break)

### DIFF
--- a/src/lib/OpenEXR/ImfB44Compressor.cpp
+++ b/src/lib/OpenEXR/ImfB44Compressor.cpp
@@ -427,7 +427,6 @@ B44Compressor::B44Compressor (
     size_t        numScanLines,
     bool          optFlatFields)
     : Compressor (hdr)
-    , _maxScanLineSize (static_cast<int> (maxScanLineSize))
     , _optFlatFields (optFlatFields)
     , _format (XDR)
     , _numScanLines (static_cast<int> (numScanLines))

--- a/src/lib/OpenEXR/ImfB44Compressor.h
+++ b/src/lib/OpenEXR/ImfB44Compressor.h
@@ -71,7 +71,6 @@ private:
         IMATH_NAMESPACE::Box2i range,
         const char*&           outPtr);
 
-    int                _maxScanLineSize;
     bool               _optFlatFields;
     Format             _format;
     int                _numScanLines;


### PR DESCRIPTION
By accident I messed up https://github.com/AcademySoftwareFoundation/openexr/pull/1148 - therefore this new PR

@meshula 