### PR TITLE
Update SonarCloud job to install latest sonar-scanner and build-wrapper using a github action

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,10 +7,14 @@
 name: Analysis
 
 on:
-  schedule:
+  # schedule:
     # Weekly Sunday build
-    - cron: "0 0 * * 0"
-  workflow_dispatch:
+    #   - cron: "0 0 * * 0"
+    # workflow_dispatch:
+    #
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -33,6 +37,7 @@ jobs:
     env:
       CXX: g++
       CC: gcc
+      BW_OUTPUT: bw_output
     steps:
       # TODO: Remove this workaround following resolution of:
       #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
@@ -41,7 +46,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 50
+          # Disabling shallow clone is recommended for improving the
+          # relevancy of reporting
+          fetch-depth: 0
+      - name:  Install sonar-scanner and build-wrapper
+        uses: sonarsource/sonarcloud-github-c-cpp@v1
       - name: Create build directories
         run: |
           mkdir _install
@@ -66,7 +75,7 @@ jobs:
       - name: Build OpenEXR with build-wrapper
         shell: bash
         run: |
-          build-wrapper-linux-x86-64 --out-dir bw_output \
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BW_OUTPUT }} \
                 cmake --build . \
                       --target install \
                       --config Release
@@ -86,139 +95,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN
-
-  # ------------------------------------------------------------------------------
-  #  Valgrind memcheck test
-  # ------------------------------------------------------------------------------
-  linux_valgrind:
-    name: 'Valgrind Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
-    if: github.repository == 'AcademySoftwareFoundation/openexr'
-    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
-    runs-on: ubuntu-latest
-    container:
-      # DockerHub: https://hub.docker.com/u/aswf
-      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2022
-    env:
-      CXX: g++
-      CC: gcc
-    steps:
-      # TODO: Remove this workaround following resolution of:
-      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
-      - name: Setup container
-        run: sudo rm -rf /usr/local/lib64/cmake/glew
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 50
-      - name: Create build directories
-        run: |
-          mkdir _install
-          mkdir _build
-        shell: bash
-      - name: Install Dependencies
-        run: |
-          share/ci/scripts/linux/install_valgrind.sh 
-        shell: bash
-      - name: Configure
-        run: |
-          cmake .. \
-                -DCMAKE_INSTALL_PREFIX=../_install \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_CXX_STANDARD=14 \
-                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
-                -DBUILD_SHARED_LIBS='OFF' \
-                -DOPENEXR_BUILD_TOOLS='ON' \
-                -DOPENEXR_RUN_FUZZ_TESTS='OFF' \
-                -DOPENEXR_ENABLE_THREADING='ON'
-        working-directory: _build
-      - name: Build
-        run: |
-          cmake --build . \
-                --target install \
-                --config Release
-        working-directory: _build
-      - name: Valgrind memcheck tests
-        run: |
-          ctest -C Release \
-                --timeout 50000 \
-                --force-new-ctest-process \
-                --test-action memcheck \
-                --output-on-failure \
-                -VV
-        working-directory: _build
-      - name: Valgrind memcheck test results
-        run: |
-          share/ci/scripts/linux/log_valgrind.sh _build
-        shell: bash
-
-  # ------------------------------------------------------------------------------
-  #  Fuzz test
-  # ------------------------------------------------------------------------------
-  linux_fuzz:
-    name: 'Fuzz Test ${{ matrix.build-descrip }} Linux CentOS 7 VFX CY2022 <GCC 9.3.1>'
-    if: github.repository == 'AcademySoftwareFoundation/openexr'
-    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
-    runs-on: ubuntu-latest
-    container:
-      # DockerHub: https://hub.docker.com/u/aswf
-      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-openexr:2022
-    strategy:
-      matrix:
-        build: [1, 2]
-        include:
-          # Fuzz test
-          - build: 1
-            build-descrip: 
-            cflags: 
-            cxxflags: 
-          # Fuzz with sanitizer
-          - build: 2
-            build-descrip: With Sanitizer 
-            cflags: -DCFLAGS='-fsanitize=address'
-            cxxflags: -DCXXFLAGS='-fsanitize=address'
-    env:
-      CXX: g++
-      CC: gcc
-    steps:
-      # TODO: Remove this workaround following resolution of:
-      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
-      - name: Setup container
-        run: sudo rm -rf /usr/local/lib64/cmake/glew
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 50
-      - name: Create build directories
-        run: |
-          mkdir _install
-          mkdir _build
-        shell: bash
-      - name: Configure
-        run: |
-          cmake .. \
-                -DCMAKE_INSTALL_PREFIX=../_install \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_CXX_STANDARD=14 \
-                -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
-                -DBUILD_SHARED_LIBS='OFF' \
-                -DOPENEXR_BUILD_TOOLS='ON' \
-                -DOPENEXR_RUN_FUZZ_TESTS='ON' \
-                -DOPENEXR_ENABLE_THREADING='ON' \
-                ${{ matrix.cxxflags }} \
-                ${{ matrix.cflags }} 
-        working-directory: _build
-      - name: Build
-        run: |
-          cmake --build . \
-                --target install \
-                --config Release
-        working-directory: _build
-      - name: Fuzz test
-        run: |
-          bin/OpenEXRFuzzTest
-        working-directory: _build
+        run: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN -Dsonar.cfamily.build-wrapper-output="${{ env.BW_OUTPUT }}" 
 
 


### PR DESCRIPTION
NOTE: Not ready for review - still testing this PR! I submitted this to test my changes since the Sonar scan has to be run on the ASWF repo to work properly.

Updating the SonarCloud job to get the latest sonar-scanner and build-wrapper by using a github action instead of using the versions in the docker image. @cary-ilm noticed that the SonarCloud analysis is generating a warning that the build wrapper version does not match the analyzer version.