### PR TITLE
ensure we are passing through valid function pointers

### DIFF
--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -5,6 +5,7 @@
 
 #include "openexr_compression.h"
 #include "openexr_base.h"
+#include "internal_memory.h"
 
 #include <libdeflate.h>
 
@@ -63,6 +64,7 @@ exr_result_t exr_compress_buffer (
             level = EXR_DEFAULT_ZLIB_COMPRESS_LEVEL;
     }
 
+    libdeflate_set_memory_allocator (internal_exr_alloc, internal_exr_free);
     comp = libdeflate_alloc_compressor (level);
     if (comp)
     {
@@ -100,6 +102,7 @@ exr_result_t exr_uncompress_buffer (
     enum libdeflate_result res;
     size_t actual_in_bytes;
 
+    libdeflate_set_memory_allocator (internal_exr_alloc, internal_exr_free);
     decomp = libdeflate_alloc_decompressor ();
     if (decomp)
     {

--- a/src/lib/OpenEXRCore/memory.c
+++ b/src/lib/OpenEXRCore/memory.c
@@ -10,7 +10,6 @@
 #else
 #    include <stdlib.h>
 #endif
-#include <libdeflate.h>
 
 /**************************************/
 
@@ -25,7 +24,6 @@ exr_set_default_memory_routines (
 {
     _glob_alloc_func = alloc_func;
     _glob_free_func  = free_func;
-    libdeflate_set_memory_allocator (alloc_func, free_func);
 }
 
 /**************************************/


### PR DESCRIPTION
libdeflate doesn't have the same fallback handling such that if someone resets the pointers, allocations later will crash