### PR TITLE
internal_structs.h: __STDC_FORMAT_MACROS should be defined prior to inttypes.h

### DIFF
--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -19,6 +19,10 @@
 #    endif
 #endif
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
A number of systems require `__STDC_FORMAT_MACROS` to be defined prior to including `inttypes.h`/`cinttypes`, otherwise build fails with undefined `PRI*` types.