### PR TITLE
internal_xdr.h: fix endian logic for Apple

### DIFF
--- a/src/lib/OpenEXRCore/internal_xdr.h
+++ b/src/lib/OpenEXRCore/internal_xdr.h
@@ -57,7 +57,11 @@
 #    define le32toh(x) OSSwapLittleToHostInt32 (x)
 #    define htole64(x) OSSwapHostToLittleInt64 (x)
 #    define le64toh(x) OSSwapLittleToHostInt64 (x)
-#    define EXR_HOST_IS_NOT_LITTLE_ENDIAN (BYTE_ORDER != LITTLE_ENDIAN)
+#    if defined(__m68k__) || defined(__POWERPC__)
+#        define EXR_HOST_IS_NOT_LITTLE_ENDIAN 1
+#    else
+#        define EXR_HOST_IS_NOT_LITTLE_ENDIAN 0
+#    endif
 
 #elif defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__) ||   \
     defined(__DragonFly__)


### PR DESCRIPTION
See: https://github.com/AcademySoftwareFoundation/openexr/issues/1404

@meshula As you advised, first just fix logic in this header.