### PR TITLE
Use posix compat code for old macOS without libdispatch

### DIFF
--- a/src/lib/IlmThread/IlmThreadSemaphore.h
+++ b/src/lib/IlmThread/IlmThreadSemaphore.h
@@ -18,10 +18,14 @@
 #include "IlmThreadConfig.h"
 #include "IlmThreadNamespace.h"
 
+#if defined(__APPLE__)
+#   include <AvailabilityMacros.h>
+#endif
+
 #if ILMTHREAD_THREADING_ENABLED
 #    if ILMTHREAD_HAVE_POSIX_SEMAPHORES
 #        include <semaphore.h>
-#    elif defined(__APPLE__)
+#    elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
 #        include <dispatch/dispatch.h>
 #    elif (defined(_WIN32) || defined(_WIN64))
 #        ifdef NOMINMAX
@@ -53,7 +57,7 @@ private:
 
     mutable sem_t _semaphore;
 
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
     mutable dispatch_semaphore_t _semaphore;
 
 #elif (defined(_WIN32) || defined(_WIN64))

--- a/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
@@ -11,6 +11,10 @@
 //-----------------------------------------------------------------------------
 
 #if defined(__APPLE__) && !ILMTHREAD_HAVE_POSIX_SEMAPHORES
+#    include <AvailabilityMacros.h>
+
+// No libdispatch prior to 10.6, and no support for it on any ppc.
+#if __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
 
 #    include "Iex.h"
 #    include "IlmThreadSemaphore.h"
@@ -59,4 +63,5 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
+#    endif
 #endif

--- a/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
@@ -12,12 +12,17 @@
 
 #include "IlmThreadConfig.h"
 
-#if ILMTHREAD_THREADING_ENABLED
-#    if (                                                                      \
-        !(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined(__APPLE__) &&           \
-        !defined(_WIN32) && !defined(_WIN64))
+#if defined(__APPLE__)
+#    include <AvailabilityMacros.h>
+#endif
 
-#        include "IlmThreadSemaphore.h"
+// Use this code as a fallback for macOS versions without libdispatch.
+#if ILMTHREAD_THREADING_ENABLED
+#    if (!(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined(_WIN32) && !defined(_WIN64) && \
+        (!defined(__APPLE__) || (defined(__APPLE__) && \
+        (__MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
+
+#    include "IlmThreadSemaphore.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 


### PR DESCRIPTION
See: https://github.com/AcademySoftwareFoundation/openexr/issues/1405

@meshula Please take a look.