### PR TITLE
IlmThread: fix defines for older macOS: do not prefix with __

### DIFF
--- a/src/lib/IlmThread/IlmThreadSemaphore.h
+++ b/src/lib/IlmThread/IlmThreadSemaphore.h
@@ -25,7 +25,7 @@
 #if ILMTHREAD_THREADING_ENABLED
 #    if ILMTHREAD_HAVE_POSIX_SEMAPHORES
 #        include <semaphore.h>
-#    elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#    elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
 #        include <dispatch/dispatch.h>
 #    elif (defined(_WIN32) || defined(_WIN64))
 #        ifdef NOMINMAX
@@ -57,7 +57,7 @@ private:
 
     mutable sem_t _semaphore;
 
-#elif defined(__APPLE__) && __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
     mutable dispatch_semaphore_t _semaphore;
 
 #elif (defined(_WIN32) || defined(_WIN64))

--- a/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
@@ -14,7 +14,7 @@
 #    include <AvailabilityMacros.h>
 
 // No libdispatch prior to 10.6, and no support for it on any ppc.
-#if __MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#if MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
 
 #    include "Iex.h"
 #    include "IlmThreadSemaphore.h"

--- a/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
@@ -20,7 +20,7 @@
 #if ILMTHREAD_THREADING_ENABLED
 #    if (!(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined(_WIN32) && !defined(_WIN64) && \
         (!defined(__APPLE__) || (defined(__APPLE__) && \
-        (__MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
+        (MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
 
 #    include "IlmThreadSemaphore.h"
 


### PR DESCRIPTION
See: https://github.com/macports/macports-ports/pull/18711

A small fix: turned out that macOS prior to 10.9 does not understand prefixed macros for `MAC_OS_X_VERSION_MIN_REQUIRED`. (I did not notice that initially, since was building for `ppc`, so other condition worked.)
This version is tested on 10.6–10.8 Intel, now macros work correctly.