### PR TITLE
fix out of bounds check with a full channel name vs. byte count (#1429)

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_classifier.h
+++ b/src/lib/OpenEXRCore/internal_dwa_classifier.h
@@ -93,8 +93,9 @@ Classifier_read (Classifier* out, const uint8_t** ptr, size_t* size)
             if (curin[len] == '\0') break;
             suffix[len] = (char)curin[len];
         }
-        len += 1;
         if (len == 128 + 1) return EXR_ERR_CORRUPT_CHUNK;
+        // account for extra byte for nil terminator
+        len += 1;
 
         mem = internal_exr_alloc (len);
         if (!mem) return EXR_ERR_OUT_OF_MEMORY;


### PR DESCRIPTION
Propagates fix for OSS ClusterFuzz 59070 to 3.1.8