### PR TITLE
Fix macOS arm64 build

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -47,6 +47,10 @@
 #define _SSE_ALIGNMENT_MASK 0x0F
 #define _AVX_ALIGNMENT_MASK 0x1F
 
+#ifdef __ARM_NEON // Needed to support macOS with arm64 processor (e.g. M1)
+#include <arm_neon.h>
+#endif
+
 //
 // Color space conversion, Inverse 709 CSC, Y'CbCr -> R'G'B'
 //


### PR DESCRIPTION
Commit 7c40603e introduced with PR https://github.com/AcademySoftwareFoundation/openexr/pull/1402 a break of `bazel build //...` on macOS with arm64:

```
ERROR: /Users/vertexwahn/dev/openexr/BUILD.bazel:147:11: Compiling src/lib/OpenEXRCore/internal_dwa.c failed: (Exit 1): wrapped_clang failed: error executing command (from target //:OpenEXRCore) external/local_config_cc/wrapped_clang '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -O0 -DDEBUG 'DEBUG_PREFIX_MAP_PWD=.' ... (remaining 55 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from src/lib/OpenEXRCore/internal_dwa.c:121:
In file included from src/lib/OpenEXRCore/internal_dwa_helpers.h:61:
src/lib/OpenEXRCore/internal_dwa_simd.h:338:9: error: use of undeclared identifier 'float32x4x2_t'
        float32x4x2_t vec_fp32 = vld1q_f32_x2 (src + i);
        ^
src/lib/OpenEXRCore/internal_dwa_simd.h:339:9: error: implicit declaration of function 'vst1q_u16' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        vst1q_u16 (
        ^
src/lib/OpenEXRCore/internal_dwa_simd.h:341:13: error: implicit declaration of function 'vcombine_u16' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            vcombine_u16 (
            ^
src/lib/OpenEXRCore/internal_dwa_simd.h:342:17: error: implicit declaration of function 'vreinterpret_u16_f16' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                vreinterpret_u16_f16 (vcvt_f16_f32 (vec_fp32.val[0])),
                ^
src/lib/OpenEXRCore/internal_dwa_simd.h:342:39: error: implicit declaration of function 'vcvt_f16_f32' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                vreinterpret_u16_f16 (vcvt_f16_f32 (vec_fp32.val[0])),
                                      ^
src/lib/OpenEXRCore/internal_dwa_simd.h:342:53: error: use of undeclared identifier 'vec_fp32'
                vreinterpret_u16_f16 (vcvt_f16_f32 (vec_fp32.val[0])),
                                                    ^
src/lib/OpenEXRCore/internal_dwa_simd.h:343:53: error: use of undeclared identifier 'vec_fp32'
                vreinterpret_u16_f16 (vcvt_f16_f32 (vec_fp32.val[1]))));
                                                    ^
src/lib/OpenEXRCore/internal_dwa_simd.h:766:5: error: unknown type name 'uint8x16_t'; did you mean 'uint16_t'?
    uint8x16_t res_tbl[4] = {
    ^~~~~~~~~~
```

This PR fixes the issue (I assume similar behavior with CMake build)