### PR TITLE
Fix build error on win_arm64

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -18,7 +18,7 @@
 // aligned. Unaligned pointers may risk seg-faulting.
 //
 
-#if defined __SSE2__ || (_MSC_VER >= 1300 && !_M_CEE_PURE)
+#if defined __SSE2__ || (_MSC_VER >= 1300 && (_M_IX86 || _M_X64) && !_M_CEE_PURE)
 #    define IMF_HAVE_SSE2 1
 #    include <emmintrin.h>
 #    include <mmintrin.h>

--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -18,7 +18,7 @@
 // aligned. Unaligned pointers may risk seg-faulting.
 //
 
-#if defined __SSE2__ || (_MSC_VER >= 1300 && (_M_IX86 || _M_X64) && !_M_CEE_PURE)
+#if defined __SSE2__ || (_MSC_VER && (_M_IX86 || _M_X64))
 #    define IMF_HAVE_SSE2 1
 #    include <emmintrin.h>
 #    include <mmintrin.h>


### PR DESCRIPTION
Fixes the following build failure on win_arm64 (Windows on ARM64) with Visual Studio 2022 17.6.2:

```
[  8%] Building C object src/lib/OpenEXRCore/CMakeFiles/OpenEXRCore.dir/internal_dwa.c.obj
internal_dwa.c
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\include\emmintrin.h(20): fatal error C1189: #error:  This header is specific to X86, X64, ARM64, and ARM64EC targets
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe" -E cmake_cl_compile_depends --dep-file=CMakeFiles\OpenEXRCore.dir\internal_dwa.c.obj.d --working-dir=C:\Build\_build\openexr-v3.1.8\_build-vc17-arm64\src\lib\OpenEXRCore --filter-prefix="Note: including file: " -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1436~1.325\bin\HOSTAR~1\arm64\cl.exe @C:\Users\gohlke\AppData\Local\Temp\nm1EA5.tmp' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\bin\HostARM64\ARM64\nmake.exe" -s -f src\lib\OpenEXRCore\CMakeFiles\OpenEXRCore.dir\build.make /nologo -SL                 src\lib\OpenEXRCore\CMakeFiles\OpenEXRCore.dir\build' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\bin\HostARM64\ARM64\nmake.exe" -s -f CMakeFiles\Makefile2 /nologo -LS                 all' : return code '0x2'
Stop.
Build failed!
```