### PR TITLE
Use security@openexr.com for consistency

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 ## Reporting a Vulnerability
 
 If you think you've found a potential vulnerability in OpenEXR, please
-report it by emailing security@openexr.org. Only Technical Steering
+report it by emailing security@openexr.com. Only Technical Steering
 Committee members and Academy Software Foundation project management
 have access to these messages. Include detailed steps to reproduce the
 issue, and any other information that could aid an investigation. Our


### PR DESCRIPTION
openexr.com forwards to openexr.org, but for consistency, let's refer to all email addresses as @openexr.com, to match the website.