### PR TITLE
Bazel support: Switch back to VS2019 due to a toolchain issue in Bazel

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -48,8 +48,11 @@ jobs:
         bazelisk build //...
 
   build_and_test_windows:
-    name: Windows Server 2022 build <Visual Studio 2022>
-    runs-on: windows-2022
+    # TODO: switch back to VS 2022 when https://github.com/bazelbuild/bazel/issues/18592 issue is solved
+    #name: Windows Server 2022 build <Visual Studio 2022>
+    #runs-on: windows-2022
+    name: Windows Server 2019 build <Visual Studio 2019>
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This change only affects the Bazel build in the CI and makes the CI green again.

Because of an update of Visual Studio the Bazel Windows Build is failing - more details here: https://github.com/bazelbuild/bazel/issues/18592

One workaround is to use VS 2019 for now, until this is fixed.

Another option would be to modify the directory of VS2022.

Once this is fixed the Bazel Windows CI build will switch back to VS2022.