### PR TITLE
don't use NaNs/infs in testOptimizedInterleavePatterns

### DIFF
--- a/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
+++ b/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
@@ -312,8 +312,8 @@ setupBuffer (
                 case IMF::HALF: bytes_per_pixel += 2; break;
                 case IMF::FLOAT:
                 case IMF::UINT:
-                    // some architectures (e.g arm7 cannot write 32 bit values
-                    // to addresses which aren't aligned to 32 bit addresses)
+                    // some architectures (e.g arm7) cannot write 32 bit values
+                    // to addresses which aren't aligned to 32 bit addresses
                     // so bump to next multiple of four
                     bytes_per_pixel = alignToFour (bytes_per_pixel);
                     bytes_per_pixel += 4;
@@ -370,10 +370,15 @@ setupBuffer (
     int chan = 0;
     for (int i = 0; i < samples; i++)
     {
-        unsigned short int values =
-            random_int (std::numeric_limits<unsigned short>::max ());
         half v;
-        v.setBits (values);
+        // generate a random finite half (ignore bit patterns that are NaNs or infinity)
+        do
+        {
+            unsigned short int values =
+                random_int (std::numeric_limits<unsigned short>::max ());
+            v.setBits (values);
+        } while( (v-v)!=0  );
+
         if (pt == NULL || pt[chan] == IMF::HALF)
         {
             *(half*) write_ptr = half (v);

--- a/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
+++ b/src/test/OpenEXRTest/testOptimizedInterleavePatterns.cpp
@@ -371,13 +371,16 @@ setupBuffer (
     for (int i = 0; i < samples; i++)
     {
         half v;
-        // generate a random finite half (ignore bit patterns that are NaNs or infinity)
+        // generate a random finite half
+        // if the value is to be cast to a float, ensure the value is not infinity
+        // or NaN, since the value is not guaranteed to round trip from half to float
+        // and back again with bit-identical precision
         do
         {
             unsigned short int values =
                 random_int (std::numeric_limits<unsigned short>::max ());
             v.setBits (values);
-        } while( (v-v)!=0  );
+        } while(!( (v-v)==0 || pt==NULL || pt[chan]==IMF::HALF) );
 
         if (pt == NULL || pt[chan] == IMF::HALF)
         {


### PR DESCRIPTION
Work around issue #1456 : with F16C intrinsics enabled, converting a half->float->half isn't guaranteed to be bit perfect for NaN values, which this test assumes. This change prevents NaN and infinity values being used for float channels.
This is only an issue when writing float values (all half float values read from file should be bitwise identical to the written half value) so NaNs and infinities are still permitted when writing halfs.

Also fix a typo in a comment