### PR TITLE
Fix macOS and Windows build failures when threading is disabled

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -331,6 +331,7 @@ jobs:
           - build: 1
             build-type: Release
             build-shared: 'ON'
+            threads-enabled: 'ON'
             compiler-desc: AppleClang11.0
             cxx-standard: 17
             osver: 11.0
@@ -352,6 +353,7 @@ jobs:
           - build: 3
             build-type: Release
             build-shared: 'OFF'
+            threads-enabled: 'ON'
             compiler-desc: AppleClang11.0
             cxx-standard: 17
             osver: 11.0
@@ -362,6 +364,7 @@ jobs:
           - build: 4
             build-type: Debug
             build-shared: 'ON'
+            threads-enabled: 'ON'
             compiler-desc: AppleClang11.0
             cxx-standard: 17
             osver: 11.0
@@ -375,6 +378,7 @@ jobs:
           - build: 5
             build-type: Release
             build-shared: 'ON'
+            threads-enabled: 'ON'
             compiler-desc: AppleClang11.0
             cxx-standard: 17
             osver: 12.0
@@ -454,6 +458,7 @@ jobs:
           - build: 1
             build-type: Release
             build-shared: 'ON'
+            threads-enabled: 'ON'
             compiler-desc: msvc17.5
             cxx-standard: 17
             vfx-cy: 2023
@@ -475,6 +480,7 @@ jobs:
           - build: 3
             build-type: Release
             build-shared: 'OFF'
+            threads-enabled: 'ON'
             compiler-desc: msvc17.5
             cxx-standard: 17
             vfx-cy: 2023
@@ -488,6 +494,7 @@ jobs:
           - build: 4
             build-type: Release
             build-shared: 'ON'
+            threads-enabled: 'ON'
             compiler-desc: msvc16.11
             cxx-standard: 17
             vfx-cy: 2022
@@ -498,6 +505,7 @@ jobs:
           - build: 5
             build-type: Release
             build-shared: 'OFF'
+            threads-enabled: 'ON'
             compiler-desc: msvc16.11
             cxx-standard: 17
             vfx-cy: 2022

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -317,11 +317,12 @@ jobs:
        C++${{ matrix.cxx-standard }},
        config=${{ matrix.build-type }},
        shared=${{ matrix.build-shared }},
-       cxx=${{ matrix.cxx-standard }}>'
+       cxx=${{ matrix.cxx-standard }},
+       threads=${{ matrix.threads-enabled }}>'
     runs-on: macos-${{ matrix.osver }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4]
+        build: [1, 2, 3, 4, 5]
         include:
           # -------------------------------------------------------------------
           # VFX CY2023 - C++17 - MacOS 11.0 
@@ -336,8 +337,19 @@ jobs:
             exclude-tests:
             vfx-cy: 23
 
-          # Static, Release
+          # Shared, Release, Threads OFF
           - build: 2
+            build-type: Release
+            build-shared: 'ON'
+            threads-enabled: 'OFF'
+            compiler-desc: AppleClang11.0
+            cxx-standard: 17
+            osver: 11.0
+            exclude-tests:
+            vfx-cy: 23
+
+          # Static, Release
+          - build: 3
             build-type: Release
             build-shared: 'OFF'
             compiler-desc: AppleClang11.0
@@ -347,7 +359,7 @@ jobs:
             vfx-cy: 23
 
           # Shared, Debug
-          - build: 3
+          - build: 4
             build-type: Debug
             build-shared: 'ON'
             compiler-desc: AppleClang11.0
@@ -360,7 +372,7 @@ jobs:
           # VFX CY2023 - C++17 - MacOS 12
           # -------------------------------------------------------------------
           # Shared, Release
-          - build: 4
+          - build: 5
             build-type: Release
             build-shared: 'ON'
             compiler-desc: AppleClang11.0
@@ -428,11 +440,12 @@ jobs:
       <${{ matrix.compiler-desc }},
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
-       cxx=${{ matrix.cxx-standard }}>'
+       cxx=${{ matrix.cxx-standard }},
+       threads=${{ matrix.threads-enabled }}>'
     runs-on: windows-${{ matrix.osver }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4]
+        build: [1, 2, 3, 4, 5]
         include:
           # -------------------------------------------------------------------
           # VFX CY2023 - C++17 - Windows 2022 runner - MSVC 2022 (17.5)
@@ -447,8 +460,19 @@ jobs:
             exclude-tests: ''
             osver: 2022
 
-          # Static, Release
+          # Shared, Release, Threads OFF
           - build: 2
+            build-type: Release
+            build-shared: 'ON'
+            threads-enabled: 'OFF'
+            compiler-desc: msvc17.5
+            cxx-standard: 17
+            vfx-cy: 2023
+            exclude-tests: ''
+            osver: 2022
+
+          # Static, Release
+          - build: 3
             build-type: Release
             build-shared: 'OFF'
             compiler-desc: msvc17.5
@@ -461,7 +485,7 @@ jobs:
           # VFX CY2022 - C++17 - Windows 2019 runner - MSVC 2019 (16.11) 
           # -------------------------------------------------------------------
           # Shared, Release
-          - build: 3
+          - build: 4
             build-type: Release
             build-shared: 'ON'
             compiler-desc: msvc16.11
@@ -471,7 +495,7 @@ jobs:
             osver: 2019
 
           # Static, Release
-          - build: 4
+          - build: 5
             build-type: Release
             build-shared: 'OFF'
             compiler-desc: msvc16.11

--- a/src/lib/IlmThread/IlmThreadSemaphore.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphore.cpp
@@ -10,11 +10,9 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "IlmThreadConfig.h"
+#include "IlmThreadSemaphore.h"
 
-#if !(ILMTHREAD_THREADING_ENABLED)
-
-#    include "IlmThreadSemaphore.h"
+#if ILMTHREAD_SEMAPHORE_DISABLED
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -41,4 +39,4 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#endif
+#endif // ILMTHREAD_SEMAPHORE_DISABLED

--- a/src/lib/IlmThread/IlmThreadSemaphore.h
+++ b/src/lib/IlmThread/IlmThreadSemaphore.h
@@ -18,6 +18,13 @@
 #include "IlmThreadConfig.h"
 #include "IlmThreadNamespace.h"
 
+//
+// Decipher the platform-specific threading support.
+// Set the ILMTHREAD_SEMAPHORE_* defines to indicate the corresponding
+// implementation of the Semaphore class. Only one of these should be
+// defined.
+//
+
 #if ILMTHREAD_THREADING_ENABLED
 #    if ILMTHREAD_HAVE_POSIX_SEMAPHORES
 #        include <semaphore.h>
@@ -28,6 +35,8 @@
 #            include <dispatch/dispatch.h>
 #            define ILMTHREAD_SEMAPHORE_OSX 1
 #        else
+#            include <condition_variable>
+#            include <mutex>
 #            define ILMTHREAD_SEMAPHORE_OTHER 1
 #        endif
 #    elif (defined(_WIN32) || defined(_WIN64))
@@ -73,7 +82,7 @@ private:
 
     mutable HANDLE _semaphore;
 
-#elif ILMTHREAD_THREADING_OTHER
+#elif ILMTHREAD_SEMAPHORE_OTHER
     
     //
     // If the platform has threads but no semaphores,

--- a/src/lib/IlmThread/IlmThreadSemaphore.h
+++ b/src/lib/IlmThread/IlmThreadSemaphore.h
@@ -18,25 +18,32 @@
 #include "IlmThreadConfig.h"
 #include "IlmThreadNamespace.h"
 
-#if defined(__APPLE__)
-#   include <AvailabilityMacros.h>
-#endif
-
 #if ILMTHREAD_THREADING_ENABLED
 #    if ILMTHREAD_HAVE_POSIX_SEMAPHORES
 #        include <semaphore.h>
-#    elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
-#        include <dispatch/dispatch.h>
+#        define ILMTHREAD_SEMAPHORE_POSIX 1
+#    elif defined(__APPLE__)
+#        include <AvailabilityMacros.h>
+#        if MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#            include <dispatch/dispatch.h>
+#            define ILMTHREAD_SEMAPHORE_OSX 1
+#        else
+#            define ILMTHREAD_SEMAPHORE_OTHER 1
+#        endif
 #    elif (defined(_WIN32) || defined(_WIN64))
 #        ifdef NOMINMAX
 #            undef NOMINMAX
 #        endif
 #        define NOMINMAX
 #        include <windows.h>
+#        define ILMTHREAD_SEMAPHORE_WINDOWS 1
 #    else
 #        include <condition_variable>
 #        include <mutex>
+#        define ILMTHREAD_SEMAPHORE_OTHER 1
 #    endif
+#else
+#    define ILMTHREAD_SEMAPHORE_DISABLED 1
 #endif
 
 ILMTHREAD_INTERNAL_NAMESPACE_HEADER_ENTER
@@ -53,18 +60,21 @@ public:
     ILMTHREAD_EXPORT int  value () const;
 
 private:
-#if ILMTHREAD_HAVE_POSIX_SEMAPHORES
+
+#if ILMTHREAD_SEMAPHORE_POSIX
 
     mutable sem_t _semaphore;
 
-#elif defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#elif ILMTHREAD_SEMAPHORE_OSX
+    
     mutable dispatch_semaphore_t _semaphore;
 
-#elif (defined(_WIN32) || defined(_WIN64))
+#elif ILMTHREAD_SEMAPHORE_WINDOWS
 
     mutable HANDLE _semaphore;
 
-#elif ILMTHREAD_THREADING_ENABLED
+#elif ILMTHREAD_THREADING_OTHER
+    
     //
     // If the platform has threads but no semaphores,
     // then we implement them ourselves using condition variables

--- a/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
@@ -10,14 +10,11 @@
 //
 //-----------------------------------------------------------------------------
 
-#if defined(__APPLE__) && !ILMTHREAD_HAVE_POSIX_SEMAPHORES
-#    include <AvailabilityMacros.h>
+#include "IlmThreadSemaphore.h"
 
-// No libdispatch prior to 10.6, and no support for it on any ppc.
-#if MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+#if ILMTHREAD_SEMAPHORE_OSX
 
-#    include "Iex.h"
-#    include "IlmThreadSemaphore.h"
+#include "Iex.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -63,5 +60,4 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#    endif
-#endif
+#endif // ILMTHREAD_SEMAPHORE_OSX

--- a/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphoreOSX.cpp
@@ -5,7 +5,9 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class Semaphore -- implementation for OSX platform(it don't support unnamed Posix semaphores)
+//	class Semaphore -- implementation for OSX platform (it doesn't
+//	support unnamed Posix semaphores)
+//
 //	std::condition_variable + std::mutex emulation show poor performance
 //
 //-----------------------------------------------------------------------------

--- a/src/lib/IlmThread/IlmThreadSemaphorePosix.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphorePosix.cpp
@@ -10,14 +10,13 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "IlmThreadConfig.h"
+#include "IlmThreadSemaphore.h"
 
-#if ILMTHREAD_HAVE_POSIX_SEMAPHORES
+#if ILMTHREAD_SEMAPHORE_POSIX
 
-#    include "Iex.h"
-#    include "IlmThreadSemaphore.h"
-#    include <assert.h>
-#    include <errno.h>
+#include "Iex.h"
+#include <assert.h>
+#include <errno.h>
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -70,4 +69,4 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#endif
+#endif // ILMTHREAD_SEMAPHORE_POSIX

--- a/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphorePosixCompat.cpp
@@ -10,19 +10,11 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "IlmThreadConfig.h"
+#include "IlmThreadSemaphore.h"
 
-#if defined(__APPLE__)
-#    include <AvailabilityMacros.h>
-#endif
+#if ILMTHREAD_SEMAPHORE_OTHER
 
 // Use this code as a fallback for macOS versions without libdispatch.
-#if ILMTHREAD_THREADING_ENABLED
-#    if (!(ILMTHREAD_HAVE_POSIX_SEMAPHORES) && !defined(_WIN32) && !defined(_WIN64) && \
-        (!defined(__APPLE__) || (defined(__APPLE__) && \
-        (MAC_OS_X_VERSION_MIN_REQUIRED < 1060 || defined(__ppc__)))))
-
-#    include "IlmThreadSemaphore.h"
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -84,5 +76,4 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#    endif // posix semaphore compat
-#endif     // enable threading
+#endif // ILMTHREAD_SEMAPHORE_OTHER

--- a/src/lib/IlmThread/IlmThreadSemaphoreWin32.cpp
+++ b/src/lib/IlmThread/IlmThreadSemaphoreWin32.cpp
@@ -9,15 +9,14 @@
 //
 //-----------------------------------------------------------------------------
 
-#include "IlmThreadConfig.h"
+#include "IlmThreadSemaphore.h"
 
-#if (defined(_WIN32) || defined(_WIN64)) && !ILMTHREAD_HAVE_POSIX_SEMAPHORES
+#if ILMTHREAD_SEMAPHORE_WINDOWS
 
-#    include "Iex.h"
-#    include "IlmThreadSemaphore.h"
-#    include <assert.h>
-#    include <iostream>
-#    include <string>
+#include "Iex.h"
+#include <assert.h>
+#include <iostream>
+#include <string>
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -126,4 +125,5 @@ Semaphore::value () const
 
 ILMTHREAD_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#endif // _WIN32
+#endif // ILMTHREAD_SEMAPHORE_WINDOWS
+


### PR DESCRIPTION
Addresses #1455

The logic around which implementation of the ``IlmThread::Semaphore`` class to use is now consolidated into the block of code that deciphers the platform and specifies the #includes, rather than spread across multiple files.

This also adds macOS and Windows CI jobs with threading disabled.

The previous logic was completely broken for the macOS case, where it would produce duplicate implementations in ``IlmThreadSemaphore.cpp`` _and_ in ``IlmThreadSemaphoreOSX.cpp`` when threading is disabled. 

Please do what you can to confirm that this logic looks correct for all platforms, since it's not completely clear to me that the test suite will reliably fail if the logic is off.

