### PR TITLE
Fix build with i386 and musl libc

### DIFF
--- a/src/lib/Iex/IexMathFpu.cpp
+++ b/src/lib/Iex/IexMathFpu.cpp
@@ -243,14 +243,14 @@ restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 inline void
 restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 {
-#        if (defined(__GLIBC__) && defined(__i386__)) || defined(__ANDROID_API__)
+#        if (defined(__linux__) && defined(__i386__)) || defined(__ANDROID_API__)
     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
 #        else
     setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
 #        endif
 
     _fpstate* kfp = reinterpret_cast<_fpstate*> (ucon.uc_mcontext.fpregs);
-#        if defined(__GLIBC__) && defined(__i386__)
+#        if defined(__linux__) && defined(__i386__)
     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
 #        else
     setMxcsr (kfp->mxcsr, clearExceptions);


### PR DESCRIPTION
The current code asumes glibc == linux. This patch extends support to all non-glibc Linux systems.

Signed-off-by: Cristian Othón Martínez Vera <cfuga@cfuga.mx>
