### PR TITLE
Fix range check in dwa compressor

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -845,13 +845,13 @@ DwaCompressor_uncompress (
     compressedDcBuf  = compressedAcBuf + (ptrdiff_t) (acCompressedSize);
     compressedRleBuf = compressedDcBuf + (ptrdiff_t) (dcCompressedSize);
 
-    if (compressedUnknownBuf >= dataPtrEnd ||
+    if (compressedUnknownBuf > dataPtrEnd ||
         dataPtr > compressedAcBuf ||
-        compressedAcBuf >= dataPtrEnd ||
+        compressedAcBuf > dataPtrEnd ||
         dataPtr > compressedDcBuf ||
-        compressedDcBuf >= dataPtrEnd ||
+        compressedDcBuf > dataPtrEnd ||
         dataPtr > compressedRleBuf ||
-        compressedRleBuf >= dataPtrEnd ||
+        compressedRleBuf > dataPtrEnd ||
         (compressedRleBuf + rleCompressedSize) > dataPtrEnd)
     {
         return EXR_ERR_CORRUPT_CHUNK;


### PR DESCRIPTION
[out-dwaa.zip](https://github.com/AcademySoftwareFoundation/openexr/files/11911980/out-dwaa.zip)

I've attached out-dwaa.exr ~ note that I simply renamed it to .zip because github doesn't allow uploading of exr files into an issue. So just rename it back to exr.

anyway :)

The attached file fails to load in OpenEXRCore, because it's got some buffers that exactly line up at their ends, which causes the sanity checks to fail. Changing the comparisons to `<` instead of `<=` allows the file to load, and I believe preserves the intent of the checks.

Note that I pre-emptively switched all of the checks to `<` even though changing only the first one is sufficient to load this particular test file. I'm wondering if someone could sanity check all the checks?