### PR TITLE
Fix dupe word typos

### DIFF
--- a/Contrib/DtexToExr/PxDeepUtils.h
+++ b/Contrib/DtexToExr/PxDeepUtils.h
@@ -51,7 +51,7 @@ namespace PxDeep
 //-*****************************************************************************
 // DENSITY
 //-*****************************************************************************
-// "Density" refers to the the optical density which, when integrated
+// "Density" refers to the optical density which, when integrated
 // through a line, produces an alpha. The relationship between alpha, density,
 // and line segment of a given length "dz" is as follows:
 //

--- a/docs/scripts/test_images.py
+++ b/docs/scripts/test_images.py
@@ -38,7 +38,7 @@ def exr_header(exr_path):
        The index of the dict is the part number as a string, i.e. "0", "1", etc.
        The value of each entry is a dict of attribute/value pairs.
 
-       Also return in rows the the list of all attributes across all
+       Also return in rows the list of all attributes across all
        parts, which equates to the complete list of rows in the table,
        since not all parts will necessarily have the same attributes.
     '''

--- a/src/lib/OpenEXR/ImfCRgbaFile.h
+++ b/src/lib/OpenEXR/ImfCRgbaFile.h
@@ -59,7 +59,7 @@ typedef struct ImfRgba ImfRgba;
 #define IMF_VERSION_NUMBER 2
 
 /*
-** Line order; values must the the same as in Imf::LineOrder.
+** Line order; values must the same as in Imf::LineOrder.
 */
 
 #define IMF_INCREASING_Y 0

--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -959,7 +959,7 @@ Header::sanityCheck (bool isTiled, bool isMultipartFile) const
 
     //
     // The pixel aspect ratio must be greater than 0.
-    // In applications, numbers like the the display or
+    // In applications, numbers like the display or
     // data window dimensions are likely to be multiplied
     // or divided by the pixel aspect ratio; to avoid
     // arithmetic exceptions, we limit the pixel aspect

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -331,7 +331,7 @@ copyIntoFrameBuffer (
     else if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
         // Convert the pixels from the file's machine-
         // independent representation, and store the
@@ -470,7 +470,7 @@ copyIntoFrameBuffer (
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         // Copy the results into the frame buffer.
         //
 
@@ -765,7 +765,7 @@ copyIntoDeepFrameBuffer (
     else if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
         // Convert the pixels from the file's machine-
         // independent representation, and store the
@@ -1095,7 +1095,7 @@ copyIntoDeepFrameBuffer (
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         // Copy the results into the frame buffer.
         //
 
@@ -1542,7 +1542,7 @@ copyFromFrameBuffer (
     if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
 
         switch (type)
@@ -1583,7 +1583,7 @@ copyFromFrameBuffer (
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         //
 
         switch (type)
@@ -1656,7 +1656,7 @@ copyFromDeepFrameBuffer (
     if (format == Compressor::XDR)
     {
         //
-        // The the line or tile buffer is in XDR format.
+        // The line or tile buffer is in XDR format.
         //
 
         switch (type)
@@ -1737,7 +1737,7 @@ copyFromDeepFrameBuffer (
     else
     {
         //
-        // The the line or tile buffer is in NATIVE format.
+        // The line or tile buffer is in NATIVE format.
         //
 
         switch (type)

--- a/src/lib/OpenEXR/ImfRgbaFile.h
+++ b/src/lib/OpenEXR/ImfRgbaFile.h
@@ -223,7 +223,7 @@ public:
     // Rounding control for luminance/chroma images:
     //
     // If the output file contains luminance and chroma channels (WRITE_YC
-    // or WRITE_YCA), then the the significands of the luminance and
+    // or WRITE_YCA), then the significands of the luminance and
     // chroma values are rounded to roundY and roundC bits respectively (see
     // function half::round()).  Rounding improves compression with minimal
     // image degradation, usually much less than the degradation caused by

--- a/src/lib/OpenEXRUtil/ImfSampleCountChannel.cpp
+++ b/src/lib/OpenEXRUtil/ImfSampleCountChannel.cpp
@@ -108,7 +108,7 @@ SampleCountChannel::set (int x, int y, unsigned int newNumSamples)
 {
     //
     // Set the number of samples for pixel (x,y) to newNumSamples.
-    // Compute the position of the pixel in the the various
+    // Compute the position of the pixel in the various
     // arrays that describe it.
     //
 

--- a/src/lib/OpenEXRUtil/README
+++ b/src/lib/OpenEXRUtil/README
@@ -142,7 +142,7 @@ loadImage() functions that work only on flat images or only on deep images:
     saveDeepScanLineImage()
     saveDeepTiledImage()
 
-For details the the ImfFlatImageIO.h and ImfDeepImageIO.h header files.
+For details, refer to the ImfFlatImageIO.h and ImfDeepImageIO.h header files.
 
 
 Manipulating Images in Memory

--- a/src/test/OpenEXRTest/testDwaLookups.cpp
+++ b/src/test/OpenEXRTest/testDwaLookups.cpp
@@ -31,7 +31,7 @@
 
 //
 // This test uses the code that generates the dwaLookups.h header to
-// validate the the values in the tables are correct.
+// validate that the values in the tables are correct.
 //
 
 using namespace OPENEXR_IMF_NAMESPACE;


### PR DESCRIPTION
Fix comment typos where the same word was duplicated. I first searched with regex and only included ones that are highly likely to be a mistake.