### PR TITLE
Update CI with vfx2023 Linux jobs.

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -59,11 +59,11 @@ jobs:
       image: aswf/ci-openexr:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
 
           # -------------------------------------------------------------------
-          # VFX CY2022 - GCC
+          # VFX CY2023 - GCC
           # -------------------------------------------------------------------
           # Shared, Release
           - build: 1
@@ -72,10 +72,10 @@ jobs:
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
-            compiler-desc: gcc9.3.1
+            compiler-desc: gcc11.2.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2022
+            vfx-cy: 2023
             exclude-tests:
 
           # Shared, Release, Threads OFF
@@ -85,10 +85,10 @@ jobs:
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
-            compiler-desc: gcc9.3.1
+            compiler-desc: gcc11.2.1
             label: 
             threads-enabled: 'OFF'
-            vfx-cy: 2022
+            vfx-cy: 2023
             exclude-tests:
 
           # Shared, Debug
@@ -98,10 +98,10 @@ jobs:
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
-            compiler-desc: gcc9.3.1
+            compiler-desc: gcc11.2.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2022
+            vfx-cy: 2023
             exclude-tests:
 
           # Static, Release
@@ -111,16 +111,64 @@ jobs:
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
-            compiler-desc: gcc9.3.1
+            compiler-desc: gcc11.2.1
             label: 
             threads-enabled: 'ON'
-            vfx-cy: 2022
+            vfx-cy: 2023
             exclude-tests:
 
-          # Static, Debug
+          # Shared, Release, C++14
           - build: 5
-            build-type: Debug
-            build-shared: 'OFF'
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 14
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: gcc11.2.1
+            label: 
+            threads-enabled: 'ON'
+            vfx-cy: 2023
+            exclude-tests:
+
+          # -------------------------------------------------------------------
+          # VFX CY2023 - Clang 15.0
+          # -------------------------------------------------------------------
+          # Release
+          - build: 6
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 17
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: clang15.0
+            label: 
+            threads-enabled: 'ON'
+            vfx-cy: 2023
+            exclude-tests:
+
+          # -------------------------------------------------------------------
+          # VFX CY2023 - Clang 14.0
+          # -------------------------------------------------------------------
+          # Release
+          - build: 7
+            build-type: Release
+            build-shared: 'ON'
+            cxx-standard: 17
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: clang14.0
+            label: 
+            threads-enabled: 'ON'
+            vfx-cy: 2023
+            exclude-tests:
+
+          # -------------------------------------------------------------------
+          # VFX CY2022 - GCC, Release
+          # -------------------------------------------------------------------
+          # Shared, Release
+          - build: 8
+            build-type: Release
+            build-shared: 'ON'
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc
@@ -131,65 +179,10 @@ jobs:
             exclude-tests:
 
           # -------------------------------------------------------------------
-          # VFX CY2021 - Clang
-          # -------------------------------------------------------------------
-          # Release
-          - build: 6
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10
-            label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2022
-            exclude-tests:
-
-          # Debug
-          - build: 7
-            build-type: Debug
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10
-            label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2022
-            exclude-tests:
-
-          # Static, Release
-          - build: 8
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10
-            label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2022
-            exclude-tests:
-
-          # Static, Debug
-          - build: 9
-            build-type: Debug
-            build-shared: 'OFF'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: clang10
-            label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2022
-            exclude-tests:
-
-          # -------------------------------------------------------------------
           # VFX CY2021 - GCC, Release
           # -------------------------------------------------------------------
           # Shared, Release
-          - build: 10
+          - build: 9
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 17
@@ -205,7 +198,7 @@ jobs:
           # VFX CY2020 - GCC, Release
           # -------------------------------------------------------------------
           # Shared, Release
-          - build: 11
+          - build: 10
             build-type: Release
             build-shared: 'ON'
             cxx-standard: 14
@@ -215,38 +208,6 @@ jobs:
             label: 
             threads-enabled: 'ON'
             vfx-cy: 2020
-            exclude-tests:
-
-          # -------------------------------------------------------------------
-          # VFX CY2019 - GCC, Release
-          # -------------------------------------------------------------------
-          # Shared, Release
-          - build: 12
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 14
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc6.3.1
-            label: 
-            threads-enabled: 'ON'
-            vfx-cy: 2019
-            exclude-tests: 
-
-          # -------------------------------------------------------------------
-          # Legacy - VFX CY2019 - C++11
-          # -------------------------------------------------------------------
-          # Shared, Release
-          - build: 13
-            build-type: Release
-            build-shared: 'ON'
-            cxx-standard: 11
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: gcc6.3.1
-            label: 'Legacy '
-            threads-enabled: 'ON'
-            vfx-cy: 2019
             exclude-tests:
 
     env:


### PR DESCRIPTION
Below are a list of the CI Linux builds in this PR and relate Imath PR (will add link in comment).

Questions for both Imath and OpenEXR : 

- Do we still need c++14 builds for 2023? Imath had them for 2022, OpenEXR did not.
- Do we need static debug builds for 2023? OpenEXR had them for 2022, Imath did not.
- Do we need clang builds for prior years? Imath had them for 2022, OpenEXR did not.
- Any other builds I should drop or add?
- Should we be using Clang 14.0 or 15.0 for 2023? AFAICT the docker image has both.

Imath
2023 gcc 11.2.1 python 3.10.9 C++17 - Shared Release
2023 gcc 11.2.1 python 3.10.9 C++17 - Shared Debug
2023 gcc 11.2.1 python 3.10.9 C++17 - Static Release
2023 gcc 11.2.1 python 3.10.9 C++14 - Static Release
2023 clang ? python 3.10.9 C++17 - Shared Release
2023 clang ? python 3.10.9 C++17 - Shared Debug
2023 clang ? python 3.10.9 C++17 - Static Release
2023 clang ? python 3.10.9 C++14 - Static Debug
2022 gcc 9.3.1  python 3.9.7 C++17 - Shared Release
2022 clang 10.4 python 3.9.7 C++17 - Shared Release
2021 gcc 9.3.1  python 3.7.9 C++17 - Shared Release
2021 clang 10.4 python 3.7.9 C++17 - Shared Release
2020 gcc 6.3.1  python 3.7.3 C++14 - Shared Release
2020 clang 7.8  python 3.7.3 C++14 - Shared Release
2019 gcc 6.3.1  python 3.7.3 C++11 - Shared Release

OpenEXR
2023 gcc 11.2.1 C++17 - Shared Release
2023 gcc 11.2.1 C++17 - Shared Release, Threads OFF
2023 gcc 11.2.1 C++17 - Shared Debug
2023 gcc 11.2.1 C++17 - Static Release
2023 gcc 11.2.1 C++17 - Static Debug
2023 clang ? C++17 - Shared Release
2023 clang ? C++17 - Shared Debug
2023 clang ? C++17 - Static Release
2023 clang 10.4 C++17 - Static Debug
2022 gcc 9.3.1  C++17 - Shared Release
2021 gcc 9.3.1  C++17 - Shared Release
2020 gcc 6.3.1  C++14 - Shared Release
2019 gcc 6.3.1  C++11 - Shared Release