### PR TITLE
Fix Huffman performance regression on Linux/clang

### DIFF
--- a/src/lib/OpenEXR/ImfFastHuf.cpp
+++ b/src/lib/OpenEXR/ImfFastHuf.cpp
@@ -14,14 +14,11 @@
 // Static enabling/disabling the fast huffman decode
 
 
-#if defined(__clang__)
+#if defined(__APPLE__) && defined(__clang__)
 //
 // Enabled for clang on Apple platforms (tested):
 //
-
-#    if defined(__APPLE__)
-#        define OPENEXR_IMF_ENABLE_FAST_HUF_DECODER
-#    endif
+#    define OPENEXR_IMF_ENABLE_FAST_HUF_DECODER
 
 #elif defined(__INTEL_COMPILER) || defined(__GNUC__)
 //


### PR DESCRIPTION
PR #1323 introduces a nested `#ifdef` check that results in a performance regression on Linux systems that use the clang compiler. This is because the check for `__clang__` succeeds, but the nested check for `__APPLE__` fails. As a result, the `#elif` case is not taken on Linux.

Fixes issue #1479