### PR TITLE
Add OPENEXR_MISSING_ARM_VLD1 workaround to internal_dwa_simd.h

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -51,6 +51,20 @@
 #include <arm_neon.h>
 #endif
 
+#include "OpenEXRConfigInternal.h"
+#ifdef OPENEXR_MISSING_ARM_VLD1
+/* Workaround for missing vld1q_f32_x2 in older gcc versions.  */
+
+__extension__ extern __inline float32x4x2_t
+    __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
+    vld1q_f32_x2 (const float32_t* __a)
+{
+    float32x4x2_t ret;
+    asm ("ld1 {%S0.4s - %T0.4s}, [%1]" : "=w"(ret) : "r"(__a) :);
+    return ret;
+}
+#endif
+
 //
 // Color space conversion, Inverse 709 CSC, Y'CbCr -> R'G'B'
 //


### PR DESCRIPTION
Addresses #1477

This could still use some consolidation between ``ImfSimd.h`` and libOpenEXRCore, but that's a bigger issue for later.