### PR TITLE
Add ImfMisc.h and ImfCompressor.h as installed headers

### DIFF
--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -134,6 +134,7 @@ openexr_define_library(OpenEXR
     ImfCompositeDeepScanLine.h
     ImfCompression.h
     ImfCompressionAttribute.h
+    ImfCompressor.h
     ImfConvert.h
     ImfCRgbaFile.h
     ImfDeepCompositing.h
@@ -174,6 +175,7 @@ openexr_define_library(OpenEXR
     ImfLineOrderAttribute.h
     ImfLut.h
     ImfMatrixAttribute.h
+    ImfMisc.h
     ImfMultiPartInputFile.h
     ImfMultiPartOutputFile.h
     ImfMultiView.h


### PR DESCRIPTION
I tried compiling the source to ``exrheader`` against an installation of OpenEXR and it failed because it includes ``ImfMisc.h`` and ``ImfCompressor.h``, which were not included in the list of installed headers.

It seems that code should be buildable by the public API, so those headers should, in fact, be distributed.