### PR TITLE
adds deep examples, fixes the deep examples in docs

### DIFF
--- a/docs/src/readDeepTiledFile.cpp
+++ b/docs/src/readDeepTiledFile.cpp
@@ -56,17 +56,18 @@ readDeepTiledFile (
             dataZ[i][j] = new float[sampleCount[i][j]];
             dataA[i][j] = new half[sampleCount[i][j]];
         }
+    }
 
-        file.readTiles (0, numXTiles - 1, 0, numYTiles - 1);
+    file.readTiles (0, numXTiles - 1, 0, numYTiles - 1);
 
-        // (after read data is processed, data must be freed:)
+    // (after read data is processed, data must be freed:)
 
-        for (int i = 0; i < height; i++)
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
         {
-            for (int j = 0; j < width; j++)
-            {
-                delete[] dataZ[i][j];
-                delete[] dataA[i][j];
-            }
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
         }
     }
+}

--- a/docs/src/writeDeepScanlineFile.cpp
+++ b/docs/src/writeDeepScanlineFile.cpp
@@ -7,7 +7,7 @@ writeDeepScanlineFile (
 
     Array2D<half*>& dataA,
 
-    Array2D<unsigned int> sampleCount)
+    Array2D<unsigned int>& sampleCount)
 
 {
     int height = dataWindow.max.y - dataWindow.min.y + 1;
@@ -18,7 +18,7 @@ writeDeepScanlineFile (
     header.channels ().insert ("Z", Channel (FLOAT));
     header.channels ().insert ("A", Channel (HALF));
     header.setType (DEEPSCANLINE);
-    header.compression () = ZIP_COMPRESSION;
+    header.compression () = ZIPS_COMPRESSION;
 
     DeepScanLineOutputFile file (filename, header);
 
@@ -52,8 +52,6 @@ writeDeepScanlineFile (
 
     file.setFrameBuffer (frameBuffer);
 
-    file.readPixelSampleCounts (height);
-
     for (int i = 0; i < height; i++)
     {
         for (int j = 0; j < width; j++)
@@ -62,6 +60,7 @@ writeDeepScanlineFile (
             dataZ[i][j]       = new float[sampleCount[i][j]];
             dataA[i][j]       = new half[sampleCount[i][j]];
             // Generate data for dataZ and dataA.
+            getPixelSampleData(i, j, dataZ, dataA);
         }
 
         file.writePixels (1);

--- a/docs/src/writeDeepTiledFile.cpp
+++ b/docs/src/writeDeepTiledFile.cpp
@@ -13,14 +13,15 @@ writeDeepTiledFile (
     header.channels ().insert ("Z", Channel (FLOAT));
     header.channels ().insert ("A", Channel (HALF));
     header.setType (DEEPTILE);
+    header.compression () = ZIPS_COMPRESSION;
 
     header.setTileDescription (
-        TileDescription (tileSizeX, tileSizeY, MIPMAP_LEVELS));
+        TileDescription (tileSizeX, tileSizeY, ONE_LEVEL));
 
-    Array2D<unsigned int*> dataZ;
+    Array2D<float*> dataZ;
     dataZ.resizeErase (height, width);
 
-    Array2D<unsigned int*> dataA;
+    Array2D<half*> dataA;
     dataA.resizeErase (height, width);
 
     Array2D<unsigned int> sampleCount;
@@ -56,16 +57,22 @@ writeDeepTiledFile (
 
     file.setFrameBuffer (frameBuffer);
 
-    for (int l = 0; l < file.numLevels (); l++)
+    for (int j = 0; j < file.numYTiles (0); j++)
     {
-        for (int j = 0; j < file.numYTiles (l); j++)
+        for (int i = 0; i < file.numXTiles (0); i++)
         {
-            for (int i = 0; i < file.numXTiles (l); i++)
-            {
-                getSampleCountForTile (i, j, sampleCount);
-                getSampleDataForTile (i, j, dataZ, dataA);
-                file.writeTile (i, j, l);
-            }
+            // Generate data for sampleCount, dataZ and dataA.
+            getSampleDataForTile (i, j, tileSizeX, tileSizeY, sampleCount, dataZ, dataA);
+            file.writeTile (i, j, 0);
+        }
+    }
+    
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
         }
     }
 }

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -29,6 +29,10 @@ add_executable(OpenEXRExamples
   rgbaInterfaceExamples.h
   rgbaInterfaceTiledExamples.cpp
   rgbaInterfaceTiledExamples.h
+  deepExamples.cpp
+  deepExamples.h
+  deepTiledExamples.cpp
+  deepTiledExamples.h
 )
 
 target_link_libraries(OpenEXRExamples OpenEXR::OpenEXR)
@@ -58,6 +62,10 @@ install(
     rgbaInterfaceExamples.h
     rgbaInterfaceTiledExamples.cpp
     rgbaInterfaceTiledExamples.h
+    deepExamples.cpp
+    deepExamples.h
+    deepTiledExamples.cpp
+    deepTiledExamples.h
   DESTINATION
     ${CMAKE_INSTALL_DOCDIR}/examples
   )

--- a/src/examples/deepExamples.cpp
+++ b/src/examples/deepExamples.cpp
@@ -1,0 +1,228 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+//-----------------------------------------------------------------------------
+//
+//    Code examples that show how class DeepScanLineInputFile and
+//    class DeepScanLineOutputFile can be used to read and write
+//    OpenEXR image files with 16-bit floating-point green,
+//    and 32-bit floating point depth channels.
+//
+//-----------------------------------------------------------------------------
+
+#include <ImfArray.h>
+
+#include <ImfHeader.h>
+#include <ImfPartType.h>
+#include <ImfChannelList.h>
+#include <ImfDeepFrameBuffer.h>
+#include <ImfDeepScanLineInputFile.h>
+#include <ImfDeepScanLineOutputFile.h>
+
+#include "drawImage.h"
+
+#include "namespaceAlias.h"
+using namespace IMF;
+using namespace std;
+using namespace IMATH_NAMESPACE;
+
+void
+readDeepScanlineFile (
+    const char             filename[],
+    Box2i&                 displayWindow,
+    Box2i&                 dataWindow,
+    Array2D<float*>&       dataZ,
+    Array2D<half*>&        dataA,
+    Array2D<unsigned int>& sampleCount)
+{
+    DeepScanLineInputFile file (filename);
+
+    const Header& header = file.header ();
+    dataWindow           = header.dataWindow ();
+    displayWindow        = header.displayWindow ();
+
+    int width  = dataWindow.max.x - dataWindow.min.x + 1;
+    int height = dataWindow.max.y - dataWindow.min.y + 1;
+
+    sampleCount.resizeErase (height, width);
+
+    dataZ.resizeErase (height, width);
+    dataA.resizeErase (height, width);
+
+    DeepFrameBuffer frameBuffer;
+
+    frameBuffer.insertSampleCountSlice (Slice (
+        UINT,
+        (char*) (&sampleCount[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+        sizeof (unsigned int) * 1,       // xStride
+        sizeof (unsigned int) * width)); // yStride
+
+    frameBuffer.insert (
+        "dataZ",
+        DeepSlice (
+            FLOAT,
+            (char*) (&dataZ[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+
+            sizeof (float*) * 1,     // xStride for pointer array
+            sizeof (float*) * width, // yStride for pointer array
+            sizeof (float) * 1));    // stride for Z data sample
+
+    frameBuffer.insert (
+        "dataA",
+        DeepSlice (
+            HALF,
+            (char*) (&dataA[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (half*) * 1,     // xStride for pointer array
+            sizeof (half*) * width, // yStride for pointer array
+            sizeof (half) * 1));    // stride for O data sample
+
+    file.setFrameBuffer (frameBuffer);
+
+    file.readPixelSampleCounts (dataWindow.min.y, dataWindow.max.y);
+
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+
+            dataZ[i][j] = new float[sampleCount[i][j]];
+            dataA[i][j] = new half[sampleCount[i][j]];
+        }
+    }
+
+    file.readPixels (dataWindow.min.y, dataWindow.max.y);
+
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
+        }
+    }
+}
+
+unsigned int getPixelSampleCount (int i, int j)
+{
+    return 1;
+}
+
+Array2D<float> testDataZ;
+Array2D<half> testDataA;
+
+void getPixelSampleData(
+    int i,
+    int j,
+    Array2D<float*>& dataZ,
+    Array2D<half*>& dataA)
+{
+    dataZ[i][j][0] = testDataZ[i][j];
+    dataA[i][j][0] = testDataA[i][j];
+}
+
+void
+writeDeepScanlineFile (
+    const char       filename[],
+    Box2i            displayWindow,
+    Box2i            dataWindow,
+    Array2D<float*>& dataZ,
+
+    Array2D<half*>& dataA,
+
+    Array2D<unsigned int>& sampleCount)
+
+{
+    int height = dataWindow.max.y - dataWindow.min.y + 1;
+    int width  = dataWindow.max.x - dataWindow.min.x + 1;
+
+    Header header (displayWindow, dataWindow);
+
+    header.channels ().insert ("Z", Channel (FLOAT));
+    header.channels ().insert ("A", Channel (HALF));
+    header.setType (DEEPSCANLINE);
+    header.compression () = ZIPS_COMPRESSION;
+
+    DeepScanLineOutputFile file (filename, header);
+
+    DeepFrameBuffer frameBuffer;
+
+    frameBuffer.insertSampleCountSlice (Slice (
+        UINT,
+        (char*) (&sampleCount[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+        sizeof (unsigned int) * 1, // xS
+
+        sizeof (unsigned int) * width)); // yStride
+
+    frameBuffer.insert (
+        "Z",
+        DeepSlice (
+            FLOAT,
+            (char*) (&dataZ[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (float*) * 1, // xStride for pointer
+
+            sizeof (float*) * width, // yStride for pointer array
+            sizeof (float) * 1));    // stride for Z data sample
+
+    frameBuffer.insert (
+        "A",
+        DeepSlice (
+            HALF,
+            (char*) (&dataA[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (half*) * 1,     // xStride for pointer array
+            sizeof (half*) * width, // yStride for pointer array
+            sizeof (half) * 1));    // stride for A data sample
+
+    file.setFrameBuffer (frameBuffer);
+
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            sampleCount[i][j] = getPixelSampleCount (i, j);
+            dataZ[i][j]       = new float[sampleCount[i][j]];
+            dataA[i][j]       = new half[sampleCount[i][j]];
+            // Generate data for dataZ and dataA.
+            getPixelSampleData(i, j, dataZ, dataA);
+        }
+
+        file.writePixels (1);
+    }
+
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
+        }
+    }
+}
+
+
+void deepExamples()
+{
+    int w = 800;
+    int h = 600;
+    
+    Box2i window;
+    window.min.setValue(1, 1);
+    window.max.setValue(w, h);
+    
+    Array2D<float *> dataZ;
+    dataZ.resizeErase(h, w);
+    
+    Array2D<half *> dataA;
+    dataA.resizeErase(h, w);
+    
+    Array2D<unsigned int> sampleCount;
+    sampleCount.resizeErase(h, w);
+    
+    testDataA.resizeErase(h, w);
+    testDataZ.resizeErase(h, w);
+    drawImage2(testDataA, testDataZ, w, h);
+    
+    writeDeepScanlineFile("test.deep.exr", window, window, dataZ, dataA, sampleCount);
+    readDeepScanlineFile ("test.deep.exr", window, window, dataZ, dataA, sampleCount);
+}

--- a/src/examples/deepExamples.h
+++ b/src/examples/deepExamples.h
@@ -1,0 +1,6 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+void deepExamples ();

--- a/src/examples/deepTiledExamples.cpp
+++ b/src/examples/deepTiledExamples.cpp
@@ -1,0 +1,252 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+//-----------------------------------------------------------------------------
+//
+//    Code examples that show how class DeepTiledInputFile and
+//    class DeepTiledOutputFile can be used to read and write
+//    OpenEXR image files with 16-bit floating-point green,
+//    and 32-bit floating point depth channels.
+//
+//-----------------------------------------------------------------------------
+
+#include <ImfArray.h>
+
+#include <ImfHeader.h>
+#include <ImfPartType.h>
+#include <ImfChannelList.h>
+#include <ImfDeepFrameBuffer.h>
+#include <ImfDeepTiledInputFile.h>
+#include <ImfDeepTiledOutputFile.h>
+
+#include "drawImage.h"
+
+#include "namespaceAlias.h"
+using namespace IMF;
+using namespace std;
+using namespace IMATH_NAMESPACE;
+
+
+// defined in deepExamples.cpp
+extern Array2D<float> testDataZ;
+extern Array2D<half> testDataA;
+extern unsigned int getPixelSampleCount (int i, int j);
+extern void getPixelSampleData(
+    int i,
+    int j,
+    Array2D<float*>& dataZ,
+    Array2D<half*>& dataA);
+
+
+void
+readDeepTiledFile (
+    const char             filename[],
+    Box2i&                 displayWindow,
+    Box2i&                 dataWindow,
+    Array2D<float*>&       dataZ,
+    Array2D<half*>&        dataA,
+    Array2D<unsigned int>& sampleCount)
+{
+    DeepTiledInputFile file (filename);
+    
+    int width  = dataWindow.max.x - dataWindow.min.x + 1;
+    int height = dataWindow.max.y - dataWindow.min.y + 1;
+    
+    sampleCount.resizeErase (height, width);
+    dataZ.resizeErase (height, width);
+    dataA.resizeErase (height, width);
+    
+    DeepFrameBuffer frameBuffer;
+    
+    frameBuffer.insertSampleCountSlice (Slice (
+        UINT,
+        (char*) (&sampleCount[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+        sizeof (unsigned int) * 1,       // xStride
+        sizeof (unsigned int) * width)); // yStride
+    
+    frameBuffer.insert (
+        "Z",
+        DeepSlice (
+            FLOAT,
+            (char*) (&dataZ[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (float*) * 1,     // xStride for pointer array
+            sizeof (float*) * width, // yStride for pointer array
+            sizeof (float) * 1));    // stride for samples
+    
+    frameBuffer.insert (
+        "A",
+        DeepSlice (
+            HALF,
+            (char*) (&dataA[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (half*) * 1,     // xStride for pointer array
+            sizeof (half*) * width, // yStride for pointer array
+            sizeof (half) * 1));    // stride for samples
+    
+    file.setFrameBuffer (frameBuffer);
+    
+    int numXTiles = file.numXTiles (0);
+    int numYTiles = file.numYTiles (0);
+    
+    file.readPixelSampleCounts (0, numXTiles - 1, 0, numYTiles - 1);
+    
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            dataZ[i][j] = new float[sampleCount[i][j]];
+            dataA[i][j] = new half[sampleCount[i][j]];
+        }
+    }
+        
+    file.readTiles (0, numXTiles - 1, 0, numYTiles - 1);
+    
+    // (after read data is processed, data must be freed:)
+    
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
+        }
+    }
+}
+
+void getSampleDataForTile (
+   int i,
+   int j,
+   int tileSizeX,
+   int tileSizeY,
+   Array2D<unsigned int>& sampleCount,
+   Array2D<float*>& dataZ,
+   Array2D<half*>& dataA)
+{
+    for (int k = 0; k < tileSizeY; k++)
+    {
+        int y = j * tileSizeY + k;
+        if (y >= sampleCount.height()) break;
+        
+        for (int l = 0; l < tileSizeX; l++)
+        {
+            int x = i * tileSizeX + l;
+            if (x >= sampleCount.width()) break;
+            
+            sampleCount[y][x] = getPixelSampleCount(y, x);
+            
+            dataZ[y][x] = new float[sampleCount[y][x]];
+            dataA[y][x] = new half [sampleCount[y][x]];
+            
+            getPixelSampleData(y, x, dataZ, dataA);
+        }
+    }
+}
+
+void
+writeDeepTiledFile (
+    const char filename[],
+    Box2i      displayWindow,
+    Box2i      dataWindow,
+    int        tileSizeX,
+    int        tileSizeY)
+{
+    int height = dataWindow.max.y - dataWindow.min.y + 1;
+    int width  = dataWindow.max.x - dataWindow.min.x + 1;
+
+    Header header (displayWindow, dataWindow);
+    header.channels ().insert ("Z", Channel (FLOAT));
+    header.channels ().insert ("A", Channel (HALF));
+    header.setType (DEEPTILE);
+    header.compression () = ZIPS_COMPRESSION;
+
+    header.setTileDescription (
+        TileDescription (tileSizeX, tileSizeY, ONE_LEVEL));
+
+    Array2D<float*> dataZ;
+    dataZ.resizeErase (height, width);
+
+    Array2D<half*> dataA;
+    dataA.resizeErase (height, width);
+
+    Array2D<unsigned int> sampleCount;
+    sampleCount.resizeErase (height, width);
+
+    DeepTiledOutputFile file (filename, header);
+
+    DeepFrameBuffer frameBuffer;
+
+    frameBuffer.insertSampleCountSlice (Slice (
+        UINT,
+        (char*) (&sampleCount[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+        sizeof (unsigned int) * 1,       // xStride
+        sizeof (unsigned int) * width)); // yStride
+
+    frameBuffer.insert (
+        "Z",
+        DeepSlice (
+            FLOAT,
+            (char*) (&dataZ[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (float*) * 1,     // xStride for pointer array
+            sizeof (float*) * width, // yStride for pointer array
+            sizeof (float) * 1));    // stride for samples
+
+    frameBuffer.insert (
+        "A",
+        DeepSlice (
+            HALF,
+            (char*) (&dataA[0][0] - dataWindow.min.x - dataWindow.min.y * width),
+            sizeof (half*) * 1,     // xStride for pointer array
+            sizeof (half*) * width, // yStride for pointer array
+            sizeof (half) * 1));    // stride for samples
+
+    file.setFrameBuffer (frameBuffer);
+
+    for (int j = 0; j < file.numYTiles (0); j++)
+    {
+        for (int i = 0; i < file.numXTiles (0); i++)
+        {
+            // Generate data for sampleCount, dataZ and dataA.
+            getSampleDataForTile (i, j, tileSizeX, tileSizeY, sampleCount, dataZ, dataA);
+            file.writeTile (i, j, 0);
+        }
+    }
+    
+    for (int i = 0; i < height; i++)
+    {
+        for (int j = 0; j < width; j++)
+        {
+            delete[] dataZ[i][j];
+            delete[] dataA[i][j];
+        }
+    }
+}
+
+void deepTiledExamples()
+{
+    int w = 800;
+    int h = 600;
+    
+    int tileSizeX = 64;
+    int tileSizeY = 64;
+    
+    Box2i window;
+    window.min.setValue(1, 1);
+    window.max.setValue(w, h);
+    
+    Array2D<float *> dataZ;
+    dataZ.resizeErase(h, w);
+    
+    Array2D<half *> dataA;
+    dataA.resizeErase(h, w);
+    
+    Array2D<unsigned int> sampleCount;
+    sampleCount.resizeErase(h, w);
+    
+    testDataA.resizeErase(h, w);
+    testDataZ.resizeErase(h, w);
+    drawImage2(testDataA, testDataZ, w, h);
+    
+    writeDeepTiledFile("testTiled.deep.exr", window, window, tileSizeX, tileSizeY);
+    readDeepTiledFile ("testTiled.deep.exr", window, window, dataZ, dataA, sampleCount);
+}

--- a/src/examples/deepTiledExamples.h
+++ b/src/examples/deepTiledExamples.h
@@ -1,0 +1,6 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+void deepTiledExamples ();

--- a/src/examples/main.cpp
+++ b/src/examples/main.cpp
@@ -9,6 +9,8 @@
 #include "previewImageExamples.h"
 #include "rgbaInterfaceExamples.h"
 #include "rgbaInterfaceTiledExamples.h"
+#include "deepExamples.h"
+#include "deepTiledExamples.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -23,6 +25,9 @@ main (int argc, char* argv[])
 
         rgbaInterfaceTiledExamples ();
         generalInterfaceTiledExamples ();
+        
+        deepExamples();
+        deepTiledExamples();
 
         lowLevelIoExamples ();
 


### PR DESCRIPTION
The deep examples under doc/src are broken. I've fixed those and also added the same code in src/examples.

It would be nice if the examples displayed on the website were fetched from a place where they get built periodically, I'm not certain how to do that.