### PR TITLE
fix build of 2.5 branch with GCC 13

### DIFF
--- a/OpenEXR/IlmImf/ImfDwaCompressor.cpp
+++ b/OpenEXR/IlmImf/ImfDwaCompressor.cpp
@@ -159,6 +159,7 @@
 #include <limits>
 
 #include <cstddef>
+#include <cstdint>
 
 
 // Windows specific addition to prevent the indirect import of the redefined min/max macros

--- a/OpenEXR/IlmImf/ImfHuf.cpp
+++ b/OpenEXR/IlmImf/ImfHuf.cpp
@@ -53,6 +53,7 @@
 #include <cstring>
 #include <cassert>
 #include <algorithm>
+#include <cstdint>
 
 
 using namespace std;

--- a/OpenEXR/IlmImf/ImfMisc.cpp
+++ b/OpenEXR/IlmImf/ImfMisc.cpp
@@ -54,6 +54,8 @@
 #include <ImfTileDescription.h>
 #include "ImfNamespace.h"
 
+#include <cstdint>
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 using IMATH_NAMESPACE::Box2i;


### PR DESCRIPTION
explicitly including `<cstdint>` at three locations is sufficient