### PR TITLE
Fix CPUID detection with -march=x86-64-v3

### DIFF
--- a/src/lib/OpenEXRCore/internal_cpuid.h
+++ b/src/lib/OpenEXRCore/internal_cpuid.h
@@ -40,14 +40,15 @@ check_for_x86_simd (int* f16c, int* avx, int* sse2)
     *f16c = 0;
 #    endif
 
-#elif OPENEXR_ENABLE_X86_SIMD_CHECK
-
+#elif defined(__AVX__) && defined(__F16C__)
     // shortcut if everything is turned on / compiled in
-#    if defined(__AVX__) && defined(__F16C__)
     *f16c = 1;
     *avx  = 1;
     *sse2 = 1;
-#    elif defined(_MSC_VER) && defined(_WIN32)
+
+#elif OPENEXR_ENABLE_X86_SIMD_CHECK
+
+#   if defined(_MSC_VER) && defined(_WIN32)
     int regs[4], osxsave;
 
     __cpuid (regs, 0);


### PR DESCRIPTION
When compiling for x86-64-v3 (or with -mavx -mf16c), bypass the CPUID detection entirely, as osxsave is not (nor need be) defined in that case.

Fixes: #1459, #1467
