### PR TITLE
Remove .bazelrc file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) Contributors to the OpenEXR Project.
-
-build --symlink_prefix=/ # Out of source build
-
-# Uncomment this to treat C++ compile warnings as errors
-#build --cxxopt=-Wall
-#build --cxxopt=-Werror
-#build --cxxopt=-Wextra

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ build-nuget/
 *~
 .vscode
 docs/_test_images/
+
+# Ignore Bazel generated files
+bazel-* 


### PR DESCRIPTION
This PR only affects the Bazel build of OpenEXR - it removes the .bazelrc file, which was just added to keep the source directory of openexr clean when building with Bazel - now .gitignore is used for this