### PR TITLE
Add DEPENDENCIES Imath::Imath for OpenEXRCore

### DIFF
--- a/src/bin/exrinfo/CMakeLists.txt
+++ b/src/bin/exrinfo/CMakeLists.txt
@@ -7,12 +7,6 @@ set_target_properties(exrinfo PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-# when building with an internal imath, this isn't generated until
-# install time, so use the private header only include path
-if (NOT TARGET Imath::ImathConfig)
-  target_include_directories(exrinfo PRIVATE ${IMATH_HEADER_ONLY_INCLUDE_DIRS})
-endif()
-
 if(OPENEXR_INSTALL_TOOLS)
   install(TARGETS exrinfo DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/src/lib/OpenEXRCore/CMakeLists.txt
+++ b/src/lib/OpenEXRCore/CMakeLists.txt
@@ -99,18 +99,10 @@ openexr_define_library(OpenEXRCore
 
   PRIVATE_DEPS
     ${OPENEXR_EXTRA_MATH_LIB}
+
+  DEPENDENCIES
+    Imath::Imath
   )
-
-target_link_libraries(OpenEXRCore PUBLIC Imath::Imath)
-
-# when building with an internal imath, this isn't generated until
-# install time, so need to use private header only include path (we
-# aren't linking to imath or anything c++)
-if (TARGET Imath::ImathConfig)
-  target_link_libraries(OpenEXRCore PRIVATE Imath::ImathConfig)
-else()
-  target_include_directories(OpenEXRCore PRIVATE ${IMATH_HEADER_ONLY_INCLUDE_DIRS})
-endif()
 
 if (DEFINED EXR_DEFLATE_LIB)
   if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
This frees `exrinfo` and any other external application from needing any special settings to pick up the necessary Imath #includes.
