### PR TITLE
Remove check for _MSC_VER in internal_cpuid.h

### DIFF
--- a/src/lib/OpenEXRCore/internal_cpuid.h
+++ b/src/lib/OpenEXRCore/internal_cpuid.h
@@ -15,7 +15,7 @@
 #endif
 
 #if OPENEXR_ENABLE_X86_SIMD_CHECK
-#    if defined(_MSC_VER) && defined(_WIN32)
+#    if defined(_WIN32)
 #        include <intrin.h>
 #    else
 #        include <cpuid.h>
@@ -51,7 +51,7 @@ check_for_x86_simd (int* f16c, int* avx, int* sse2)
 
 #elif OPENEXR_ENABLE_X86_SIMD_CHECK
 
-#   if defined(_MSC_VER) && defined(_WIN32)
+#   if defined(_WIN32)
     int regs[4]={0}, osxsave;
 
     __cpuid (regs, 0);


### PR DESCRIPTION
As noted in #1445, _MSC_VER should only be used to detect msvc, not for Windows. The _WIN32 check should be sufficient. The extra check for _MSC_VER fails when cross-compiling from Linux to Windows.