### PR TITLE
Propagate OPENEXR_INSTALL_PKG_CONFIG to internal Imath

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -219,8 +219,9 @@ if(OPENEXR_INSTALL_PKG_CONFIG)
     )
   endfunction()
   openexr_pkg_config_help(OpenEXR.pc.in)
+  message(STATUS "OpenEXR pkg-config generation enabled")
 else()
-  message(STATUS "-- pkg-config generation disabled")
+  message(STATUS "OpenEXR pkg-config generation disabled")
 endif()
 
 ###################################################

--- a/cmake/OpenEXR.pc.in
+++ b/cmake/OpenEXR.pc.in
@@ -9,6 +9,7 @@ libdir=@PKG_CONFIG_INSTALL_LIBDIR@
 includedir=@PKG_CONFIG_INSTALL_INCLUDEDIR@
 OpenEXR_includedir=${includedir}/OpenEXR
 libsuffix=@LIB_SUFFIX_DASH@
+version=@OPENEXR_VERSION@
 
 Name: OpenEXR
 Description: OpenEXR image library

--- a/cmake/OpenEXR.pc.in
+++ b/cmake/OpenEXR.pc.in
@@ -9,7 +9,6 @@ libdir=@PKG_CONFIG_INSTALL_LIBDIR@
 includedir=@PKG_CONFIG_INSTALL_INCLUDEDIR@
 OpenEXR_includedir=${includedir}/OpenEXR
 libsuffix=@LIB_SUFFIX_DASH@
-version=@OPENEXR_VERSION@
 
 Name: OpenEXR
 Description: OpenEXR image library

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -253,6 +253,11 @@ if(NOT TARGET Imath::Imath AND NOT Imath_FOUND)
   FetchContent_GetProperties(Imath)
   if(NOT Imath_POPULATED)
     FetchContent_Populate(Imath)
+
+    # Propagate OpenEXR's setting for pkg-config generation to Imath:
+    # If OpenEXR is generating it, the internal Imath should, too.
+    set(IMATH_INSTALL_PKG_CONFIG ${OPENEXR_INSTALL_PKG_CONFIG}) 
+
     # hrm, cmake makes Imath lowercase for the properties (to imath)
     add_subdirectory(${imath_SOURCE_DIR} ${imath_BINARY_DIR})
   endif()


### PR DESCRIPTION
If OpenEXR is installing a pkg-config file, then the internal Imath build (if there is one) should install it, too.

Also, add an explicit release version variable to the .pc file.

This is in preparation for the python wheel build to pick up the version settings from the pkg-config files.