### PR TITLE
Don't trigger ci/bazel/ossfuzz builds on pushes/PRs to src/wrappers

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -22,6 +22,7 @@ on:
       - '!**.md'
       - '!website/**'
       - 'website/src/**'
+      - '!src/wrappers/**'
   pull_request:
     branches-ignore:
       - RB-2.*
@@ -33,6 +34,7 @@ on:
       - '!**.md'
       - '!website/**'
       - 'website/src/**'
+      - '!src/wrappers/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -24,6 +24,7 @@ on:
       - '!website/**'
       - 'website/src/**'
       - '!bazel/**'
+      - '!src/wrappers/**'
   pull_request:
     branches-ignore:
       - RB-2.*
@@ -36,6 +37,7 @@ on:
       - '!website/**'
       - 'website/src/**'
       - '!bazel/**'
+      - '!src/wrappers/**'
 
 permissions:
   contents: read

--- a/.github/workflows/ossfuzz_workflow.yml
+++ b/.github/workflows/ossfuzz_workflow.yml
@@ -18,6 +18,7 @@ on:
       - '!**.md'
       - '!website/**'
       - '!bazel/**'
+      - '!src/wrappers/**'
   pull_request:
     branches-ignore:
       - RB-2.*
@@ -29,6 +30,7 @@ on:
       - '!**.md'
       - '!website/**'
       - '!bazel/**'
+      - '!src/wrappers/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
No need to rebuild/test OpenEXR on changes to the python wheels.