### PR TITLE
Default value for chromaticities attribute constructor in exrstdattr

### DIFF
--- a/src/bin/exrstdattr/main.cpp
+++ b/src/bin/exrstdattr/main.cpp
@@ -485,7 +485,7 @@ getChromaticities (
     if (i > argc - 9)
         throw invalid_argument("Expected 8 chromaticity values");
 
-    ChromaticitiesAttribute* a = new ChromaticitiesAttribute;
+    ChromaticitiesAttribute* a = new ChromaticitiesAttribute(Chromaticities());
     attrs.push_back (SetAttr (attrName, part, a));
 
     a->value ().red.x   = static_cast<float> (strtod (argv[i + 1], 0));


### PR DESCRIPTION
This is not a legit fix for #1538, but it might make the problem go away by referencing a different symbol. Obviously, we still need to sort out the symbol visibility.

@kmilos, can you see if this builds with clang64?