### PR TITLE
Set build-shared:OFF for static CI build

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -120,7 +120,7 @@ jobs:
           # Static, Release
           - build: 4
             build-type: Release
-            build-shared: 'ON'
+            build-shared: 'OFF'
             cxx-standard: 17
             cxx-compiler: g++
             cc-compiler: gcc


### PR DESCRIPTION
Looks like this somehow we've been building shared when we meant to be building static.