### PR TITLE
Bazel: Bump libdeflate to 1.19

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,4 +6,4 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "imath", version = "3.1.9")
-bazel_dep(name = "libdeflate", version = "1.18")
+bazel_dep(name = "libdeflate", version = "1.19")

--- a/bazel/third_party/openexr_deps.bzl
+++ b/bazel/third_party/openexr_deps.bzl
@@ -13,9 +13,9 @@ def openexr_deps():
         http_archive,
         name = "libdeflate",
         build_file = "@com_openexr//:bazel/third_party/libdeflate.BUILD",
-        sha256 = "225d982bcaf553221c76726358d2ea139bb34913180b20823c782cede060affd",
-        strip_prefix = "libdeflate-1.18",
-        urls = ["https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.18.tar.gz"],
+        sha256 = "27bf62d71cd64728ff43a9feb92f2ac2f2bf748986d856133cc1e51992428c25",
+        strip_prefix = "libdeflate-1.19",
+        urls = ["https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.19.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
This PR affects only the Bazel build: Bump libdeflate to 1.19