### PR TITLE
Fix Imf/Iex/IlmThread namespaces in python bindings and website code

### DIFF
--- a/src/test/OpenEXRCoreTest/base_units.cpp
+++ b/src/test/OpenEXRCoreTest/base_units.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include <ImfSystemSpecific.h>
+#include <ImfNamespace.h>
 #include "../../lib/OpenEXRCore/internal_cpuid.h"
 #include "../../lib/OpenEXRCore/internal_coding.h"
 
@@ -364,7 +365,7 @@ testBaseDebug (const std::string& tempdir)
 void testCPUIdent (const std::string& tempdir)
 {
     int hf16c, havx, hsse2;
-    Imf::CpuId id;
+    OPENEXR_IMF_NAMESPACE::CpuId id;
     check_for_x86_simd (&hf16c, &havx, &hsse2);
 
     if (hf16c != (int)id.f16c)

--- a/src/test/OpenEXRTest/testCpuId.cpp
+++ b/src/test/OpenEXRTest/testCpuId.cpp
@@ -28,7 +28,7 @@ testCpuId (const string&)
     std::cout << "IMF_HAVE_AVX: " << false << "\n";
 #endif
 
-    Imf::CpuId cpuId;
+    OPENEXR_IMF_NAMESPACE::CpuId cpuId;
     std::cout << "cpuId.sse2: " << cpuId.sse2 << "\n";
     std::cout << "cpuId.sse3: " << cpuId.sse3 << "\n";
     std::cout << "cpuId.ssse3: " << cpuId.ssse3 << "\n";

--- a/src/wrappers/python/OpenEXR.cpp
+++ b/src/wrappers/python/OpenEXR.cpp
@@ -92,8 +92,8 @@ typedef int Py_ssize_t;
 #endif
 
 using namespace std;
-using namespace Imf;
-using namespace Imath;
+using namespace OPENEXR_IMF_NAMESPACE;
+using namespace IMATH_NAMESPACE;
 
 static PyObject *OpenEXR_error = NULL;
 static PyObject *pModuleImath;
@@ -155,7 +155,7 @@ C_IStream::read (char c[], int n)
       memcpy(c, PyString_AsString(data), PyString_Size(data));
       Py_DECREF(data);
     } else {
-      throw Iex::InputExc("file read failed");
+      throw IEX_NAMESPACE::InputExc("file read failed");
     }
     return 0;
 }
@@ -177,7 +177,7 @@ C_IStream::tellg ()
       Py_DECREF(rv);
       return (Int64)t;
     } else {
-      throw Iex::InputExc("tell failed");
+      throw IEX_NAMESPACE::InputExc("tell failed");
     }
 }
 
@@ -188,7 +188,7 @@ C_IStream::seekg (Int64 pos)
     if (data != NULL) {
         Py_DECREF(data);
     } else {
-      throw Iex::InputExc("seek failed");
+      throw IEX_NAMESPACE::InputExc("seek failed");
     }
 }
 
@@ -220,7 +220,7 @@ C_OStream::write (const char*c, int n)
     if (data != NULL) {
       Py_DECREF(data);
     } else {
-      throw Iex::InputExc("file write failed");
+      throw IEX_NAMESPACE::InputExc("file write failed");
     }
 }
 
@@ -241,7 +241,7 @@ C_OStream::tellp ()
       Py_DECREF(rv);
       return (Int64)t;
     } else {
-      throw Iex::InputExc("tell failed");
+      throw IEX_NAMESPACE::InputExc("tell failed");
     }
 }
 
@@ -252,7 +252,7 @@ C_OStream::seekp (Int64 pos)
     if (data != NULL) {
         Py_DECREF(data);
     } else {
-      throw Iex::InputExc("seek failed");
+      throw IEX_NAMESPACE::InputExc("seek failed");
     }
 }
 

--- a/website/src/C_IStream_read.cpp
+++ b/website/src/C_IStream_read.cpp
@@ -8,9 +8,9 @@ C_IStream::read (char c[], int n)
         // determine what happened.
     
         if (ferror (_file))
-            Iex::throwErrnoExc();
+            throwErrnoExc();
         else
-            throw Iex::InputExc ("Unexpected end of file.");
+            throw InputExc ("Unexpected end of file.");
     }
     
     return !feof (_file);

--- a/website/src/C_IStream_read.cpp
+++ b/website/src/C_IStream_read.cpp
@@ -8,9 +8,9 @@ C_IStream::read (char c[], int n)
         // determine what happened.
     
         if (ferror (_file))
-            Iex::throwErrnoExc();
+            IEX_NAMESPACE::throwErrnoExc();
         else
-            throw Iex::InputExc ("Unexpected end of file.");
+            throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
     }
     
     return !feof (_file);

--- a/website/src/C_IStream_read.cpp
+++ b/website/src/C_IStream_read.cpp
@@ -8,9 +8,9 @@ C_IStream::read (char c[], int n)
         // determine what happened.
     
         if (ferror (_file))
-            IEX_NAMESPACE::throwErrnoExc();
+            Iex::throwErrnoExc();
         else
-            throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
+            throw Iex::InputExc ("Unexpected end of file.");
     }
     
     return !feof (_file);

--- a/website/src/MemoryMappedIStream_read.cpp
+++ b/website/src/MemoryMappedIStream_read.cpp
@@ -2,10 +2,10 @@ bool
 MemoryMappedIStream::read (char c[], int n)
 {
     if (_readPosition >= _fileLength)
-        throw Iex::InputExc ("Unexpected end of file.");
+        throw InputExc ("Unexpected end of file.");
     
     if (_readPosition + n > _fileLength)
-        throw Iex::InputExc ("Reading past end of file.");
+        throw InputExc ("Reading past end of file.");
 
     memcpy (c, _buffer + _readPosition, n);
 

--- a/website/src/MemoryMappedIStream_read.cpp
+++ b/website/src/MemoryMappedIStream_read.cpp
@@ -2,10 +2,10 @@ bool
 MemoryMappedIStream::read (char c[], int n)
 {
     if (_readPosition >= _fileLength)
-        throw Iex::InputExc ("Unexpected end of file.");
+        throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
     
     if (_readPosition + n > _fileLength)
-        throw Iex::InputExc ("Reading past end of file.");
+        throw IEX_NAMESPACE::InputExc ("Reading past end of file.");
 
     memcpy (c, _buffer + _readPosition, n);
 

--- a/website/src/MemoryMappedIStream_read.cpp
+++ b/website/src/MemoryMappedIStream_read.cpp
@@ -2,10 +2,10 @@ bool
 MemoryMappedIStream::read (char c[], int n)
 {
     if (_readPosition >= _fileLength)
-        throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
+        throw Iex::InputExc ("Unexpected end of file.");
     
     if (_readPosition + n > _fileLength)
-        throw IEX_NAMESPACE::InputExc ("Reading past end of file.");
+        throw Iex::InputExc ("Reading past end of file.");
 
     memcpy (c, _buffer + _readPosition, n);
 

--- a/website/src/MemoryMappedIStream_readMemoryMapped.cpp
+++ b/website/src/MemoryMappedIStream_readMemoryMapped.cpp
@@ -2,10 +2,10 @@ char *
 MemoryMappedIStream::readMemoryMapped (int n)
 {
     if (_readPosition >= _fileLength)
-        throw Iex::InputExc ("Unexpected end of file.");
+        throw InputExc ("Unexpected end of file.");
 
     if (_readPosition + n > _fileLength)
-        throw Iex::InputExc ("Reading past end of file.");
+        throw InputExc ("Reading past end of file.");
 
     char *data = _buffer + _readPosition;
 

--- a/website/src/MemoryMappedIStream_readMemoryMapped.cpp
+++ b/website/src/MemoryMappedIStream_readMemoryMapped.cpp
@@ -2,10 +2,10 @@ char *
 MemoryMappedIStream::readMemoryMapped (int n)
 {
     if (_readPosition >= _fileLength)
-        throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
+        throw Iex::InputExc ("Unexpected end of file.");
 
     if (_readPosition + n > _fileLength)
-        throw IEX_NAMESPACE::InputExc ("Reading past end of file.");
+        throw Iex::InputExc ("Reading past end of file.");
 
     char *data = _buffer + _readPosition;
 

--- a/website/src/MemoryMappedIStream_readMemoryMapped.cpp
+++ b/website/src/MemoryMappedIStream_readMemoryMapped.cpp
@@ -2,10 +2,10 @@ char *
 MemoryMappedIStream::readMemoryMapped (int n)
 {
     if (_readPosition >= _fileLength)
-        throw Iex::InputExc ("Unexpected end of file.");
+        throw IEX_NAMESPACE::InputExc ("Unexpected end of file.");
 
     if (_readPosition + n > _fileLength)
-        throw Iex::InputExc ("Reading past end of file.");
+        throw IEX_NAMESPACE::InputExc ("Reading past end of file.");
 
     char *data = _buffer + _readPosition;
 

--- a/website/src/all.cpp
+++ b/website/src/all.cpp
@@ -38,6 +38,8 @@
 using namespace IMATH_NAMESPACE;
 using namespace OPENEXR_IMF_NAMESPACE;
 
+namespace Iex = IEX_NAMESPACE;
+
 using std::max;
 
 struct GZ

--- a/website/src/all.cpp
+++ b/website/src/all.cpp
@@ -35,8 +35,8 @@
 #include <unistd.h>
 #endif
 
-using namespace Imath;
-using namespace Imf;
+using namespace IMATH_NAMESPACE;
+using namespace OPENEXR_IMF_NAMESPACE;
 
 using std::max;
 

--- a/website/src/all.cpp
+++ b/website/src/all.cpp
@@ -38,7 +38,12 @@
 using namespace IMATH_NAMESPACE;
 using namespace OPENEXR_IMF_NAMESPACE;
 
-namespace Iex = IEX_NAMESPACE;
+// Example code references the Iex:: namespace explicitly, but when
+// building with a custom namespace, the "Iex" namespace not defined.
+// This #define allows the example code to compile even in builds
+// with a custom namespace.
+
+#define Iex IEX_NAMESPACE
 
 using std::max;
 

--- a/website/src/all.cpp
+++ b/website/src/all.cpp
@@ -37,13 +37,7 @@
 
 using namespace IMATH_NAMESPACE;
 using namespace OPENEXR_IMF_NAMESPACE;
-
-// Example code references the Iex:: namespace explicitly, but when
-// building with a custom namespace, the "Iex" namespace not defined.
-// This #define allows the example code to compile even in builds
-// with a custom namespace.
-
-#define Iex IEX_NAMESPACE
+using namespace IEX_NAMESPACE;
 
 using std::max;
 


### PR DESCRIPTION
Use OPENEXR_NAMESPACE, IEX_NAMESPACE, ILMTHREAD_NAMESPACE instead of Imf, Iex, IlmThread, to support custom settings.

Address #1567.