### PR TITLE
Set EXR_DEFLATE_LIB to deflate_LINK_LIBRARIES

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -215,7 +215,7 @@ if(NOT TARGET PkgConfig::deflate AND NOT deflate_FOUND)
   set(EXR_DEFLATE_LIB)
 else()
   set(EXR_DEFLATE_INCLUDE_DIR)
-  set(EXR_DEFLATE_LIB ${deflate_LIBRARIES})
+  set(EXR_DEFLATE_LIB ${deflate_LINK_LIBRARIES})
   # set EXR_DEFATE_LDFLAGS for OpenEXR.pc.in for static build
   if (BUILD_SHARED_LIBS)
     set(EXR_DEFLATE_LDFLAGS "")


### PR DESCRIPTION
`deflate_LINK_LIBRARIES` has the necessary `-L` flag needed by pkgconfig, whereas `deflate_LIBRARIES` is the bare library name.

This hopefully resolves #1571 
