### PR TITLE
python-wheels.yml - bumps cibuildwheel version

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -63,7 +63,7 @@ jobs:
             python-version: '3.x'
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.8.1
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Create setup.py
         run: |


### PR DESCRIPTION
The version number of the cibuildwheel package is the thing that controls which version(s) of python are used to build the wheels.

I'm bumping the version number to the latest currently available so we get builds for Python versions 3.6 - 3.12

Here's an example run on my fork:

https://github.com/barnabyrobson/openexr/actions/runs/6501912851