### PR TITLE
Add tests for the Header class.

### DIFF
--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -57,6 +57,8 @@ add_executable(OpenEXRTest
   testExistingStreams.h
   testFutureProofing.cpp
   testFutureProofing.h
+  testHeader.cpp
+  testHeader.h
   testHuf.cpp
   testHuf.h
   testIDManifest.cpp
@@ -169,6 +171,7 @@ define_openexr_tests(
  testDwaLookups
  testExistingStreams
  testFutureProofing
+ testHeader
  testHuf
  testInputPart
  testIsComplete

--- a/src/test/OpenEXRTest/main.cpp
+++ b/src/test/OpenEXRTest/main.cpp
@@ -32,6 +32,7 @@
 #include "testDwaLookups.h"
 #include "testExistingStreams.h"
 #include "testFutureProofing.h"
+#include "testHeader.h"
 #include "testHuf.h"
 #include "testIDManifest.h"
 #include "testInputPart.h"
@@ -232,6 +233,7 @@ main (int argc, char* argv[])
     TEST (testDwaLookups, "core");
     TEST (testIDManifest, "core");
     TEST (testCpuId, "core");
+    TEST (testHeader, "basic");
 
     // NB: If you add a test here, make sure to enumerate it in the
     // CMakeLists.txt so it runs as part of the test suite

--- a/src/test/OpenEXRTest/testHeader.cpp
+++ b/src/test/OpenEXRTest/testHeader.cpp
@@ -1,0 +1,109 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
+#include <ImfBoxAttribute.h>
+#include <ImfHeader.h>
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+#include <assert.h>
+
+using namespace IEX_NAMESPACE;
+using namespace IMATH_NAMESPACE;
+using namespace OPENEXR_IMF_NAMESPACE;
+using namespace std;
+
+template<typename Header>
+struct Test
+{
+    void testFind(const string& name)
+    {
+        Header header;
+        auto iterator = header.find(name);
+        assert(iterator != header.end());
+    }
+
+    void testSubscript(const string& name)
+    {
+        Header header;
+        auto& comparand = header.find("displayWindow").attribute();
+        auto& attribute = header[name];
+        assert(&attribute == &comparand);
+    }
+
+    void testIterators(const string& name)
+    {
+        Header header;
+
+        auto& comparand = header.find("displayWindow").attribute();
+
+        for (auto iterator = header.begin(); iterator != header.end(); ++iterator)
+        {
+            if (iterator.name() == name)
+            {
+                assert(&iterator.attribute() == &comparand);
+                return;
+            }
+        }
+
+        assert (false);
+    }
+};
+
+void testEraseAttribute(const string& name)
+{
+    Header header;
+    assert(header.find(name) != header.end());
+    header.erase(name);
+    assert(header.find(name) == header.end());
+}
+
+void testEraseAttributeThrowsWithEmptyString()
+{
+    Header header;
+
+    try
+    {
+        header.erase("");
+        assert (false);
+    }
+    catch (const ArgExc&)
+    {
+        assert (true);
+    }
+}
+
+void testHeader (const string& tempDir)
+{
+    try
+    {
+        {
+            Test<Header> headerTest;
+            headerTest.testFind("displayWindow");
+            headerTest.testSubscript("displayWindow");
+            headerTest.testIterators("displayWindow");
+        }
+        {
+            Test<const Header> headerTest;
+            headerTest.testFind("displayWindow");
+            headerTest.testSubscript("displayWindow");
+            headerTest.testIterators("displayWindow");
+        }
+        testEraseAttribute("displayWindow");
+        testEraseAttributeThrowsWithEmptyString();
+        cout << "ok\n" << endl;
+    }
+    catch (const exception& e)
+    {
+        cerr << "ERROR -- caught exception: " << e.what () << endl;
+        assert (false);
+    }
+}

--- a/src/test/OpenEXRTest/testHeader.h
+++ b/src/test/OpenEXRTest/testHeader.h
@@ -1,0 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#include <string>
+
+void testHeader (const std::string& tempDir);


### PR DESCRIPTION
These are intended to exercise methods that are currently not covered by other tests according to the coverage report.