### PR TITLE
adding better error reporting for bin tests

### DIFF
--- a/src/test/bin/test_exr2aces.py
+++ b/src/test/bin/test_exr2aces.py
@@ -16,31 +16,31 @@ version = sys.argv[4]
 # no args = usage message, error
 result = run ([exr2aces], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exr2aces, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exr2aces, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exr2aces, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exr2aces"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exr2aces")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 # invalid arguments
 result = run ([exr2aces, "foo.exr", "bar.exr"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
+assert(result.returncode != 0), "\n"+result.stderr
 
 def find_line(keyword, lines):
     for line in lines:
@@ -58,14 +58,14 @@ atexit.register(cleanup)
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
 result = run ([exr2aces, "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 # confirm the output has the proper chromaticities
-assert("chromaticities: chromaticities r[0.7347, 0.2653] g[0, 1] b[0.0001, -0.077] w[0.32168, 0.33767]" in result.stdout)
+assert("chromaticities: chromaticities r[0.7347, 0.2653] g[0, 1] b[0.0001, -0.077] w[0.32168, 0.33767]" in result.stdout), "\n"+result.stdout
 
 print("success")
 

--- a/src/test/bin/test_exrcheck.py
+++ b/src/test/bin/test_exrcheck.py
@@ -7,7 +7,7 @@ import sys, os
 from subprocess import PIPE, run
 
 print(f"testing exrcheck: {' '.join(sys.argv)}")
-      
+
 exrcheck = sys.argv[1]
 image_dir = sys.argv[2]
 
@@ -17,28 +17,23 @@ for exr_file in sys.argv[3:]:
 
     result = run ([exrcheck, exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    print(result.stderr)
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     result = run ([exrcheck, "-m", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    print(result.stderr)
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     result = run ([exrcheck, "-t", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    print(result.stderr)
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     result = run ([exrcheck, "-s", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    print(result.stderr)
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     result = run ([exrcheck, "-c", exr_path], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    print(result.stderr)
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
 
 print("success.")

--- a/src/test/bin/test_exrenvmap.py
+++ b/src/test/bin/test_exrenvmap.py
@@ -16,10 +16,10 @@ version = sys.argv[4]
 latlong_image = f"{image_dir}/MultiResolution/WavyLinesLatLong.exr"
 cube_image = f"{image_dir}/MultiResolution/WavyLinesCube.exr"
 
-assert(os.path.isfile(exrenvmap))
-assert(os.path.isfile(exrinfo))
-assert(os.path.isdir(image_dir))
-assert(os.path.isfile(latlong_image))
+assert(os.path.isfile(exrenvmap)), "\nMissing " + exrenvmap
+assert(os.path.isfile(exrinfo)), "\nMissing " + exrinfo
+assert(os.path.isdir(image_dir)), "\nMissing " + image_dir
+assert(os.path.isfile(latlong_image)), "\nMissing " + latlong_image
 
 fd, outimage = tempfile.mkstemp(".exr")
 os.close(fd)
@@ -31,221 +31,221 @@ atexit.register(cleanup)
 # no args = usage message
 result = run ([exrenvmap], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrenvmap, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --help = usage message
 result = run ([exrenvmap, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrenvmap, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrenvmap"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrenvmap")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 # default
 result = run ([exrenvmap, latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 default_file_size = os.path.getsize(outimage)
 
 result = run ([exrenvmap, "-li", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-ci", cube_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 # -o 
 result = run ([exrenvmap, "-o", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -m 
 result = run ([exrenvmap, "-m", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('tiles: tiledesc size 64 x 64 level 1 (mipmap) round 0 (down)' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('tiles: tiledesc size 64 x 64 level 1 (mipmap) round 0 (down)' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -c 
 result = run ([exrenvmap, "-c", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('envmap: envmap cube' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('envmap: envmap cube' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -l 
 result = run ([exrenvmap, "-l", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('envmap: envmap latlong' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('envmap: envmap latlong' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -w 
 
 result = run ([exrenvmap, "-w", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-w", "-64", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-w", "64", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('x tile count: 1 (sz 64)' in result.stdout)
-assert('y tile count: 6 (sz 384)' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('x tile count: 1 (sz 64)' in result.stdout), "\n"+result.stdout
+assert('y tile count: 6 (sz 384)' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -f (filter)
 result = run ([exrenvmap, "-f", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-f", "1.1", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-f", "-1.1", "6", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-f", "1.1", "-6", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrenvmap, "-f", "1.1", "6", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 file_size = os.path.getsize(outimage)
-assert(file_size != default_file_size)
+assert(file_size != default_file_size), "\n{} is the wrong size".format(outimage)
 os.unlink(outimage)
 
 # -b (blur)
 result = run ([exrenvmap, "-b", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 file_size = os.path.getsize(outimage)
-assert(file_size != default_file_size)
+assert(file_size != default_file_size), "\n{} is the wrong size".format(outimage)
 os.unlink(outimage)
 
 # -t 
 result = run ([exrenvmap, "-t", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 result = run ([exrenvmap, "-t", "32", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 result = run ([exrenvmap, "-t", "-32", "48", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 result = run ([exrenvmap, "-t", "32", "-48", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 result = run ([exrenvmap, "-t", "32", "48", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('x tile count: 8 (sz 256)' in result.stdout)
-assert('y tile count: 32 (sz 1536)' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('x tile count: 8 (sz 256)' in result.stdout), "\n"+result.stdout
+assert('y tile count: 32 (sz 1536)' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -u 
 result = run ([exrenvmap, "-u", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 1 (up)' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 1 (up)' in result.stdout), "\n"+result.stdout
 os.unlink(outimage)
 
 # -z 
 result = run ([exrenvmap, "-z", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 result = run ([exrenvmap, "-z", "xxx", latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(not os.path.isfile(outimage))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(not os.path.isfile(outimage)), "\n{} still exists".format(outimage)
 
 for z in ["none", "rle", "zip", "piz", "pxr24", "b44", "b44a", "dwaa", "dwab"]:
     result = run ([exrenvmap, "-z", z, latlong_image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
-    assert(os.path.isfile(outimage))
+    assert(result.returncode == 0), "\n"+result.stderr
+    assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
     result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
-    assert(f'compression: compression \'{z}\'' in result.stdout)
+    assert(result.returncode == 0), "\n"+result.stderr
+    assert(f'compression: compression \'{z}\'' in result.stdout), "\n"+result.stdout
     os.unlink(outimage)
 
 with tempfile.TemporaryDirectory() as tempdir:
@@ -253,7 +253,7 @@ with tempfile.TemporaryDirectory() as tempdir:
     cube_face_image_t = f"{tempdir}/out.%.exr"
     result = run ([exrenvmap, latlong_image, cube_face_image_t], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     for o in ["+X", "-X", "+Y", "-Y", "+Z", "-Z"]:
         
@@ -261,16 +261,16 @@ with tempfile.TemporaryDirectory() as tempdir:
         result = run ([exrinfo, "-v", cube_face_image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(" ".join(result.args))
         assert(result.returncode == 0)
-        assert('x tile count: 4 (sz 256)' in result.stdout)
-        assert('y tile count: 4 (sz 256)' in result.stdout)
+        assert('x tile count: 4 (sz 256)' in result.stdout), "\n"+result.stdout
+        assert('y tile count: 4 (sz 256)' in result.stdout), "\n"+result.stdout
 
     result = run ([exrenvmap, cube_face_image_t, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
-    assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout)
+    assert(result.returncode == 0), "\n"+result.stderr
+    assert('tiles: tiledesc size 64 x 64 level 0 (single image) round 0 (down)' in result.stdout), "\n"+result.stdout
 
 print("success")

--- a/src/test/bin/test_exrheader.py
+++ b/src/test/bin/test_exrheader.py
@@ -15,33 +15,32 @@ version = sys.argv[3]
 # no args = usage message
 result = run ([exrheader], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrheader, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-print(result.stdout)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --help = usage message
 result = run ([exrheader, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrheader, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrheader"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrheader")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 # nonexistent.exr, error
 result = run ([exrheader, "nonexistent.exr"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
+assert(result.returncode != 0), "\n"+result.stderr
 
 def find_line(keyword, lines):
     for line in lines:
@@ -53,19 +52,22 @@ def find_line(keyword, lines):
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
 result = run ([exrheader, image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 output = result.stdout.split('\n')
-assert ("2, flags 0x0" in find_line("file format version:", output))
-assert ("pxr24" in find_line ("compression", output))
-assert ("(0 0) - (799 799)" in find_line ("dataWindow", output))
-assert ("(0 0) - (799 799)" in find_line ("displayWindow", output))
-assert ("increasing y" in find_line ("lineOrder", output))
-assert ("1" in find_line ("pixelAspectRatio", output))
-assert ("(0 0)" in find_line ("screenWindowCenter", output))
-assert ("1" in find_line ("screenWindowWidth", output))
-assert ("scanlineimage" in find_line ("type (type string)", output))
-
+try:
+    assert ("2, flags 0x0" in find_line("file format version:", output))
+    assert ("pxr24" in find_line ("compression", output))
+    assert ("(0 0) - (799 799)" in find_line ("dataWindow", output))
+    assert ("(0 0) - (799 799)" in find_line ("displayWindow", output))
+    assert ("increasing y" in find_line ("lineOrder", output))
+    assert ("1" in find_line ("pixelAspectRatio", output))
+    assert ("(0 0)" in find_line ("screenWindowCenter", output))
+    assert ("1" in find_line ("screenWindowWidth", output))
+    assert ("scanlineimage" in find_line ("type (type string)", output))
+except AssertionError:
+    print(result.stdout)
+    raise
 print("success")
 
 

--- a/src/test/bin/test_exrinfo.py
+++ b/src/test/bin/test_exrinfo.py
@@ -14,43 +14,51 @@ version = sys.argv[3]
 
 result = run ([exrinfo, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exrinfo, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrinfo, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 print(result.stdout)
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrinfo"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrinfo")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
 result = run ([exrinfo, image, "-a", "-v"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 output = result.stdout.split('\n')
-assert ('pxr24' in output[1])
-assert ('800 x 800' in output[2])
-assert ('800 x 800' in output[3])
-assert ('1 channels' in output[4])
+try:
+    assert ('pxr24' in output[1])
+    assert ('800 x 800' in output[2])
+    assert ('800 x 800' in output[3])
+    assert ('1 channels' in output[4])
+except AssertionError:
+    print(result.stdout)
+    raise
 
 # test image as stdio
 with open(image, 'rb') as f:
     data = f.read()
 result = run ([exrinfo, '-', "-a", "-v"], input=data, stdout=PIPE, stderr=PIPE)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 output = result.stdout.decode().split('\n')
-assert ('pxr24' in output[1])
-assert ('800 x 800' in output[2])
-assert ('800 x 800' in output[3])
-assert ('1 channels' in output[4])
+try:
+    assert ('pxr24' in output[1])
+    assert ('800 x 800' in output[2])
+    assert ('800 x 800' in output[3])
+    assert ('1 channels' in output[4])
+except AssertionError:
+    print(result.stdout)
+    raise
 
 print("success")
 

--- a/src/test/bin/test_exrmakepreview.py
+++ b/src/test/bin/test_exrmakepreview.py
@@ -13,33 +13,33 @@ exrinfo = sys.argv[2]
 image_dir = sys.argv[3]
 version = sys.argv[4]
 
-assert(os.path.isfile(exrmakepreview))
-assert(os.path.isfile(exrinfo))
-assert(os.path.isdir(image_dir))
+assert(os.path.isfile(exrmakepreview)), "\nMissing " + exrmakepreview
+assert(os.path.isfile(exrinfo)), "\nMissing " + exrinfo
+assert(os.path.isdir(image_dir)), "\nMissing " + image_dir
 
 # no args = usage message
 result = run ([exrmakepreview], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrmakepreview, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 assert(result.stdout.startswith ("Usage: "))
 
 result = run ([exrmakepreview, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrmakepreview, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrmakepreview"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrmakepreview")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 
 def find_line(keyword, lines):
@@ -58,13 +58,13 @@ atexit.register(cleanup)
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
 result = run ([exrmakepreview, "-w", "50", "-e", "1", "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 output = result.stdout.split('\n')
-assert("preview 50 x 50" in find_line("  preview", output))
+assert("preview 50 x 50" in find_line("  preview", output)), "\n"+result.stdout
 
 print("success")
 

--- a/src/test/bin/test_exrmaketiled.py
+++ b/src/test/bin/test_exrmaketiled.py
@@ -15,10 +15,10 @@ version = sys.argv[4]
 
 image = f"{image_dir}/TestImages/GammaChart.exr"
 
-assert(os.path.isfile(exrmaketiled))
-assert(os.path.isfile(exrinfo))
-assert(os.path.isdir(image_dir))
-assert(os.path.isfile(image))
+assert(os.path.isfile(exrmaketiled)), "\nMissing " + exrmaketiled
+assert(os.path.isfile(exrinfo)), "\nMissing " + exrinfo
+assert(os.path.isdir(image_dir)), "\nMissing " + image_dir
+assert(os.path.isfile(image)), "\nMissing " + image
 
 fd, outimage = tempfile.mkstemp(".exr")
 os.close(fd)
@@ -30,36 +30,35 @@ atexit.register(cleanup)
 # no args = usage message
 result = run ([exrmaketiled], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrmaketiled, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exrmaketiled, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrmaketiled, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-print(result.stdout)
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrmaketiled"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrmaketiled")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 result = run ([exrmaketiled, image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('tiled image has levels: x 1 y 1' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert('tiled image has levels: x 1 y 1' in result.stdout), "\n"+result.stdout
 
 print("success")

--- a/src/test/bin/test_exrmultipart.py
+++ b/src/test/bin/test_exrmultipart.py
@@ -15,26 +15,26 @@ version = sys.argv[4]
 
 result = run ([exrmultipart], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert("Usage:" in result.stderr)
+assert(result.returncode != 0), "\n"+result.stderr
+assert("Usage:" in result.stderr), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrmultipart, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exrmultipart, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrmultipart, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrmultipart"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrmultipart")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 image = f"{image_dir}/Beachball/multipart.0001.exr"
 
@@ -50,11 +50,11 @@ atexit.register(cleanup)
 command = [exrmultipart, "-combine", "-i", f"{image}:0", f"{image}:1", "-o", outimage]
 result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 # error: can't convert multipart images
 command = [exrmultipart, "-convert", "-i", image, "-o", outimage]
@@ -66,19 +66,18 @@ assert (result.returncode != 0)
 singlepart_image = f"{image_dir}/Beachball/singlepart.0001.exr"
 command = [exrmultipart, "-convert", "-i", singlepart_image, "-o", outimage]
 result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 
 # separate
 
 # get part names from the multipart image
 result = run ([exrinfo, image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
+assert(result.returncode == 0), "\n"+result.stderr
 part_names = {}
 for p in result.stdout.split('\n part ')[1:]:
     output = p.split('\n')
@@ -90,19 +89,19 @@ with tempfile.TemporaryDirectory() as tempdir:
     command = [exrmultipart, "-separate", "-i", image, "-o", f"{tempdir}/separate"]
     result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
-    assert(result.returncode == 0)
+    assert(result.returncode == 0), "\n"+result.stderr
 
     for i in range(1, 10):
         s = f"{tempdir}/separate.{i}.exr"
         result = run ([exrinfo, "-v", s], stdout=PIPE, stderr=PIPE, universal_newlines=True)
         print(" ".join(result.args))
-        assert(result.returncode == 0)
+        assert(result.returncode == 0), "\n"+result.stderr
         output = result.stdout.split('\n')
-        assert(output[1].startswith(' parts: 1'))
+        assert(output[1].startswith(' parts: 1')), "\n"+result.stdout
         output[2].startswith(' part 1:')
         part_name = output[2][9:]
         part_number = str(i)
-        assert(part_names[part_number] == part_name)
-        
+        assert(part_names[part_number] == part_name), "\n"+result.stdout
+
 print("success")
 

--- a/src/test/bin/test_exrmultiview.py
+++ b/src/test/bin/test_exrmultiview.py
@@ -15,26 +15,26 @@ version = sys.argv[4]
 
 result = run ([exrmultiview], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert("Usage:" in result.stderr)
+assert(result.returncode != 0), "\n"+result.stderr
+assert("Usage:" in result.stderr), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrmultiview, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exrmultiview, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrmultiview, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrmultiview"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrmultiview")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 left_image = f"{image_dir}/TestImages/GammaChart.exr"
 right_image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
@@ -54,11 +54,15 @@ assert(result.returncode == 0)
 
 result = run ([exrinfo, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('\'B\': half samp 1 1' in result.stdout)
-assert('\'G\': half samp 1 1' in result.stdout)
-assert('\'R\': half samp 1 1' in result.stdout)
-assert('\'right.Y\': half samp 1 1' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+try:
+    assert('\'B\': half samp 1 1' in result.stdout)
+    assert('\'G\': half samp 1 1' in result.stdout)
+    assert('\'R\': half samp 1 1' in result.stdout)
+    assert('\'right.Y\': half samp 1 1' in result.stdout)
+except AssertionError:
+    print(result.stdout)
+    raise
 
 print("success")
 

--- a/src/test/bin/test_exrstdattr.py
+++ b/src/test/bin/test_exrstdattr.py
@@ -13,9 +13,9 @@ exrinfo = sys.argv[2]
 image_dir = sys.argv[3]
 version = sys.argv[4]
 
-assert(os.path.isfile(exrstdattr))
-assert(os.path.isfile(exrinfo))
-assert(os.path.isdir(image_dir))
+assert(os.path.isfile(exrstdattr)), "\nMissing " + exrstdattr
+assert(os.path.isfile(exrinfo)), "\nMissing " + exrinfo
+assert(os.path.isdir(image_dir)), "\nMissing " + image_dir
 
 fd, outimage = tempfile.mkstemp(".exr")
 os.close(fd)
@@ -27,26 +27,26 @@ atexit.register(cleanup)
 # no args = usage message
 result = run ([exrstdattr], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode != 0)
-assert(result.stderr.startswith ("Usage: "))
+assert(result.returncode != 0), "\n"+result.stderr
+assert(result.stderr.startswith ("Usage: ")), "\n"+result.stderr
 
 # -h = usage message
 result = run ([exrstdattr, "-h"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 result = run ([exrstdattr, "--help"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("Usage: "))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("Usage: ")), "\n"+result.stdout
 
 # --version
 result = run ([exrstdattr, "--version"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(result.stdout.startswith ("exrstdattr"))
-assert(version in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+assert(result.stdout.startswith ("exrstdattr")), "\n"+result.stdout
+assert(version in result.stdout), "\n"+result.stdout
 
 attrs = [
     ["-part", "0"],
@@ -84,7 +84,7 @@ for a in attrs:
     result = run ([exrstdattr, a[0]], stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print(" ".join(result.args))
     print(result.stderr)
-    assert(result.returncode != 0)
+    assert(result.returncode != 0), "\n"+result.stderr
 
 command = [exrstdattr]
 for a in attrs:
@@ -94,44 +94,48 @@ command += [image, outimage]
 
 result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert(os.path.isfile(outimage))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage)), "\nMissing " + outimage
 
 result = run ([exrinfo, "-v", outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
-assert(result.returncode == 0)
-assert('adoptedNeutral: v2f [ 1.1, 2.2 ]' in result.stdout)
-assert('altitude: float 6.5' in result.stdout)
-assert('aperture: float 3.2' in result.stdout)
-assert('capDate: string \'1999:12:31 23:59:59\'' in result.stdout)
-assert('channels: chlist 1 channels' in result.stdout)
-assert('\'Y\': half samp 1 1' in result.stdout)
-assert('chromaticities: chromaticities r[1, 2] g[3, 4] b[5, 6] w[7, 8]' in result.stdout)
-assert('comments: string \'blah blah blah\'' in result.stdout)
-assert('compression: compression \'pxr24\' (0x05)' in result.stdout)
-assert('dataWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
-assert('displayWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
-assert('envmap: envmap latlong' in result.stdout)
-assert('expTime: float 4.3' in result.stdout)
-assert('focus: float 5.4' in result.stdout)
-assert('framesPerSecond: rational 48 / 1 (48)' in result.stdout)
-assert('isoSpeed: float 2.1' in result.stdout)
-assert('keyCode: keycode mfgc 1 film 2 prefix 3 count 4 perf_off 5 ppf 6 ppc 20' in result.stdout)
-assert('latitude: float 7.6' in result.stdout)
-assert('lineOrder: lineOrder 0 (increasing)' in result.stdout)
-assert('longitude: float 8.7' in result.stdout)
-assert('owner: string \'florian\'' in result.stdout)
-assert('pixelAspectRatio: float 1.7' in result.stdout)
-assert('screenWindowCenter: v2f [ 42, 43 ]' in result.stdout)
-assert('screenWindowWidth: float 4.4' in result.stdout)
-assert('test_float: float 4.2' in result.stdout)
-assert('test_int: int 42' in result.stdout)
-assert('test_string: string \'forty two\'' in result.stdout)
-assert('timeCode: timecode time 305419896 user 878082192' in result.stdout)
-assert('type: string \'scanlineimage\'' in result.stdout)
-assert('utcOffset: float 9' in result.stdout)
-assert('whiteLuminance: float 17.1' in result.stdout)
-assert('wrapmodes: string \'clamp\'' in result.stdout)
-assert('xDensity: float 10' in result.stdout)
+assert(result.returncode == 0), "\n"+result.stderr
+try:
+    assert('adoptedNeutral: v2f [ 1.1, 2.2 ]' in result.stdout)
+    assert('altitude: float 6.5' in result.stdout)
+    assert('aperture: float 3.2' in result.stdout)
+    assert('capDate: string \'1999:12:31 23:59:59\'' in result.stdout)
+    assert('channels: chlist 1 channels' in result.stdout)
+    assert('\'Y\': half samp 1 1' in result.stdout)
+    assert('chromaticities: chromaticities r[1, 2] g[3, 4] b[5, 6] w[7, 8]' in result.stdout)
+    assert('comments: string \'blah blah blah\'' in result.stdout)
+    assert('compression: compression \'pxr24\' (0x05)' in result.stdout)
+    assert('dataWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
+    assert('displayWindow: box2i [ 0, 0 - 799 799 ] 800 x 800' in result.stdout)
+    assert('envmap: envmap latlong' in result.stdout)
+    assert('expTime: float 4.3' in result.stdout)
+    assert('focus: float 5.4' in result.stdout)
+    assert('framesPerSecond: rational 48 / 1 (48)' in result.stdout)
+    assert('isoSpeed: float 2.1' in result.stdout)
+    assert('keyCode: keycode mfgc 1 film 2 prefix 3 count 4 perf_off 5 ppf 6 ppc 20' in result.stdout)
+    assert('latitude: float 7.6' in result.stdout)
+    assert('lineOrder: lineOrder 0 (increasing)' in result.stdout)
+    assert('longitude: float 8.7' in result.stdout)
+    assert('owner: string \'florian\'' in result.stdout)
+    assert('pixelAspectRatio: float 1.7' in result.stdout)
+    assert('screenWindowCenter: v2f [ 42, 43 ]' in result.stdout)
+    assert('screenWindowWidth: float 4.4' in result.stdout)
+    assert('test_float: float 4.2' in result.stdout)
+    assert('test_int: int 42' in result.stdout)
+    assert('test_string: string \'forty two\'' in result.stdout)
+    assert('timeCode: timecode time 305419896 user 878082192' in result.stdout)
+    assert('type: string \'scanlineimage\'' in result.stdout)
+    assert('utcOffset: float 9' in result.stdout)
+    assert('whiteLuminance: float 17.1' in result.stdout)
+    assert('wrapmodes: string \'clamp\'' in result.stdout)
+    assert('xDensity: float 10' in result.stdout)
+except AssertionError:
+    print(result.stdout)
+    raise
 
 print("success")


### PR DESCRIPTION
Adding the stdout or stderr to the AssertionErrors in our tests.

I imagine there are a couple of ways to accomplish this. This seemed like the least intrusive, but it still is a large amount of lines changed, oh well. Happy to take a different approach if others think it would look better, this is my first PR here

Issue:
https://github.com/AcademySoftwareFoundation/openexr/issues/1558

Testing:
If you want to test this out yourself it's a bit tricky because you need the tests to fail (which I obviously don't want to do in my commit).
I found changing something like `latlong_image` value in test_exrenvmap.py was enough to get the test to fail and see what the output looks like. 
You can run a single test like:
`make test ARGS="-R 'exrenvmap' --output-on-failure"`
you need to be in your _build dir to run that