### PR TITLE
python-wheels.yml - add arm64 builds for macOS

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -41,9 +41,15 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-latest, macOS-latest]
     env:
-      # Skip 32-bit wheels builds.
+      # On macOS we build both x86 and arm to support Intel and Apple Silicon.
+      CIBW_ARCHS_MACOS: x86_64 arm64 
+      # Skip 32-bit wheels builds on Windows.
       # Also skip the PyPy builds, since they fail the unittests
       CIBW_SKIP: "*-win32 *_i686 pp*"
+      # The CI platform is Intel based so we are doing cross compilation
+      # for arm64. It is not currently possible to test arm64 when cross
+      # compiling. 
+      CIBW_TEST_SKIP: "*_arm64"
       CIBW_BEFORE_BUILD: >
         echo "Installing OpenEXR..." &&
         cd openexr.build &&


### PR DESCRIPTION
The CI platform that builds the wheels is Intel based and by default only builds Intel wheels.

Modern Macs are all based on Apple Silicon so to support them we need to also build arm64. This is done via cross compiling.

It is not possible to test when cross compiling according to:

https://cibuildwheel.readthedocs.io/en/stable/faq/#how-to-cross-compile