### PR TITLE
Add more documentation on building the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for more information.
 # Quick Start
 
 See the [technical documentation](https://openexr.readthedocs.io) for
-complete details, but to get started, the "hello, world" `.exr` writer program is:
+complete details, but to get started, the "hello, world" `.exr` writer program `writer.cpp` is:
 
     #include <ImfRgbaFile.h>
     #include <ImfArray.h>

--- a/website/HelloWorld.rst
+++ b/website/HelloWorld.rst
@@ -12,7 +12,7 @@ Hello, World
    :maxdepth: 1
 
 A simple program to write a simple ``.exr`` file of an image of 10x10
-pixels with values that are a ramp in green and blue:
+pixels with values that are a ramp in green and blue `writer.cpp`:
 
 .. literalinclude:: src/writer/writer.cpp
 

--- a/website/HelloWorld.rst
+++ b/website/HelloWorld.rst
@@ -12,7 +12,7 @@ Hello, World
    :maxdepth: 1
 
 A simple program to write a simple ``.exr`` file of an image of 10x10
-pixels with values that are a ramp in green and blue `writer.cpp`:
+pixels with values that are a ramp in green and blue ``writer.cpp``:
 
 .. literalinclude:: src/writer/writer.cpp
 

--- a/website/tools.rst
+++ b/website/tools.rst
@@ -18,6 +18,7 @@ To build a tool in a git bash window:
 ::
     cd <tool directory>
     cmake -S . -B _build
+    cmake --build _build
 
 .. toctree::
    :caption: Tools

--- a/website/tools.rst
+++ b/website/tools.rst
@@ -14,6 +14,11 @@ operations, consider `oiiotool
 Swiss Army Knife of `OpenImageIO
 <https://sites.google.com/site/openimageio/home>`_
 
+To build a tool in a git bash window:
+::
+    cd <tool directory>
+    cmake -S . -B _build
+
 .. toctree::
    :caption: Tools
    :titlesonly:


### PR DESCRIPTION
The instructions for building the writer app don't include the filename. Adding this makes the following steps which assume the file is named "writer.cpp" work seamlessly.

There are no instructions on building the tools and unless you've used cmake you would be stuck wondering.