### PR TITLE
Fix issue with decompressing fp32 dwa files

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -1047,6 +1047,7 @@ DwaCompressor_uncompress (
                 me->alloc_fn, me->free_fn, &(cd->_dctData), outBufferEnd);
             if (rv != EXR_ERR_SUCCESS) return rv;
 
+            cd->_dctData._type = chan->data_type;
             outBufferEnd += chan->width * chan->bytes_per_element;
         }
     }


### PR DESCRIPTION
There was an issue with the data type not passed to the DCT decompressor in the DWA decoder. That caused 32 bit DWA images to look squashed, as the decompressed 16 bit values were not getting expanded back to 32 bit.