### PR TITLE
Remove some dead code when writing

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -251,20 +251,11 @@ DwaCompressor_compress (DwaCompressor* me)
     uint8_t*  outDataPtr;
     uint8_t*  inDataPtr;
 
-    // Starting with 2, we write the channel
+    // Starting with fileversion 2, we write the channel
     // classification rules into the file
-    if (fileVersion < 2)
-    {
-        me->_channelRules = sLegacyChannelRules;
-        me->_channelRuleCount =
-            sizeof (sLegacyChannelRules) / sizeof (Classifier);
-    }
-    else
-    {
-        me->_channelRules = sDefaultChannelRules;
-        me->_channelRuleCount =
-            sizeof (sDefaultChannelRules) / sizeof (Classifier);
-    }
+    me->_channelRules = sDefaultChannelRules;
+    me->_channelRuleCount =
+        sizeof (sDefaultChannelRules) / sizeof (Classifier);
 
     rv = DwaCompressor_initializeBuffers (me, &outBufferSize);
 

--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -251,7 +251,7 @@ DwaCompressor_compress (DwaCompressor* me)
     uint8_t*  outDataPtr;
     uint8_t*  inDataPtr;
 
-    // Starting with fileversion 2, we write the channel
+    // Starting with DWA v2, we write the channel
     // classification rules into the file
     me->_channelRules = sDefaultChannelRules;
     me->_channelRuleCount =


### PR DESCRIPTION
The file version is set to 2 above for writing files, so it is impossible to take the first branch and write version 1 style. If people are interested in how older versions wrote they can look in history of ImfDwaCompressor.cpp or look at the read code.