### PR TITLE
Bump version on main to 3.3.0

### DIFF
--- a/src/lib/OpenEXRCore/openexr_version.h
+++ b/src/lib/OpenEXRCore/openexr_version.h
@@ -9,7 +9,7 @@
 #    define INCLUDED_OPENEXR_VERSION_H
 
 #    define OPENEXR_VERSION_MAJOR 3
-#    define OPENEXR_VERSION_MINOR 2
+#    define OPENEXR_VERSION_MINOR 3
 #    define OPENEXR_VERSION_PATCH 0
 
 #endif


### PR DESCRIPTION
The version on main stays a minor release ahead of the latest release, currently 3.2.1. This should have gotten bump right after the 3.2.0 release.