### PR TITLE
CI/CD - Added Snyk C/C++ Scanning Job

### DIFF
--- a/.github/workflows/snyk-scan-pr.yml
+++ b/.github/workflows/snyk-scan-pr.yml
@@ -1,0 +1,45 @@
+---
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+name: Snyk Scan Code
+
+on:
+  # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.h'
+      - '**.c'
+      - '**.cpp'
+
+jobs:
+  snyk-scan-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: snyk/actions/setup@master
+        id: snyk
+
+      - name: Snyk version
+        run: echo "${{ steps.snyk.outputs.version }}"
+
+      - name: Snyk Auth
+        run: snyk auth ${{ secrets.SNYK_TOKEN }}
+
+      - name: Snyk Scan Code
+        # Scan the C/C++ code for vulnerabilities using the Snyk CLI with the unmanaged flag
+        # https://docs.snyk.io/scan-using-snyk/supported-languages-and-frameworks/c-c++ for options
+        run: snyk test --unmanaged --print-dep-paths --org=${{ secrets.SNYK_ORG }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        continue-on-error: true # optional
+
+      - name: Monitor for Vulnerabilities
+        # To import the test results (issues and dependencies) in the Snyk CLI, run the snyk monitor --unmanaged command:
+        run: snyk monitor --unmanaged --org=${{ secrets.SNYK_ORG }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        continue-on-error: true # optional


### PR DESCRIPTION
- added example C/C++ Code scanner using the Snyk GitHub Action.
  The `--unmanaged` flag indicates this is for a C/C++ codebase. In this
  example, it currently scans on a new pull request to the 'main'
  branch. The repository administrator should set both the `SNYK_ORG` and
  `SNYK_TOKEN` environment variables before merging this PR. The
  environment variables can be obtained from the LFX Security team.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206294838276359