### PR TITLE
Add a reference to building tools from source to the tools webpage.

### DIFF
--- a/website/install.rst
+++ b/website/install.rst
@@ -423,7 +423,12 @@ Component Options
 
 * ``OPENEXR_BUILD_TOOLS``
 
-  Build and install the binary programs (exrheader, exrinfo,
+  Build the binary programs (exrheader, exrinfo,
+  exrmakepreview, etc). Default is ``ON``.
+  
+* ``OPENEXR_INSTALL_TOOLS``
+
+  Install the binary programs (exrheader, exrinfo,
   exrmakepreview, etc). Default is ``ON``.
   
 * ``OPENEXR_INSTALL_EXAMPLES``

--- a/website/tools.rst
+++ b/website/tools.rst
@@ -14,6 +14,15 @@ operations, consider `oiiotool
 Swiss Army Knife of `OpenImageIO
 <https://sites.google.com/site/openimageio/home>`_
 
+The OpenEXR tools are not generally included in most package managers'
+distribution of OpenEXR libraries (e.g. via ``yum install``). To build
+the tools from source, configure the top-level OpenEXR project build
+with the cmake option ``OPENEXR_BUILD_TOOLS=ON``. The tools can only
+be built from source as a component of the overall project build, not
+separately. To further include the tools in the OpenEXR installation
+after build (i.e. ``cmake --target install``), configure with
+``OPENEXR_INSTALL_TOOLS=ON``. Both are on by default.
+
 .. toctree::
    :caption: Tools
    :titlesonly:


### PR DESCRIPTION
Also, add missing reference in the build/install documentation to ``OPENEXR_INSTALL_TOOLS``.

This could stand to be simplified, it's not clear we really need to support the option of building but not installing.

Addresses part of #1584.