### PR TITLE
fix issue with unpacking sample counts

### DIFF
--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -289,8 +289,6 @@ default_decompress_chunk (exr_decode_pipeline_t* decode)
             (((uint64_t) decode->chunk.width) *
              ((uint64_t) decode->chunk.height));
 
-        if ((decode->decode_flags & EXR_DECODE_SAMPLE_COUNTS_AS_INDIVIDUAL))
-            sampsize += 1;
         sampsize *= sizeof (int32_t);
 
         rv = decompress_data (


### PR DESCRIPTION
When unpacking sample counts as "individual" counts (no longer monotonic), it writes the total sample count to a value 1 past the individual sample counts, but this is not in the packed data, so do not expect to unpack that many values. The buffer just needs to be allocated one value larger to avoid write past end of buffer which is taken care of in the update_pack_unpack_ptrs function