### PR TITLE
adds a shortcut to avoid reconstructing every call

### DIFF
--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -174,7 +174,7 @@ internal_exr_destroy_part (
     ctable = (uint64_t*) atomic_load (&(cur->chunk_table));
     atomic_store (&(cur->chunk_table), (uintptr_t) (0));
 #endif
-    if (ctable) dofree (ctable);
+    if (ctable && ((uintptr_t)ctable) != UINTPTR_MAX) dofree (ctable);
 }
 
 /**************************************/


### PR DESCRIPTION
When there is a loop trying to get scan / tile info that is ignoring return values, add a shortcut to avoid trying to reconstruct the chunk table every time. This will still respect the strict header flag, either returning an error immediately (strict), or (non-strict) enabling a multi-part file with only partially corrupt parts to work.