### PR TITLE
Fix version tag for python wheel sdist

### DIFF
--- a/.github/workflows/python-wheels-publish-test.yml
+++ b/.github/workflows/python-wheels-publish-test.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Create sdist
         # Only create it once.
         if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          OPENEXR_RELEASE_CANDIDATE_TAG: ${{ github.ref_name }}
         run: pipx run build --sdist . --outdir wheelhouse
 
       - name: Build wheel

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Create sdist
         # Only create it once.
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        env:
-          OPENEXR_RELEASE_CANDIDATE_TAG: ${{ github.ref_name }}
         run: pipx run build --sdist . --outdir wheelhouse
 
       - name: Build wheel

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Create sdist
         # Only create it once.
         if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          OPENEXR_RELEASE_CANDIDATE_TAG: ${{ github.ref_name }}
         run: pipx run build --sdist . --outdir wheelhouse
 
       - name: Build wheel


### PR DESCRIPTION
The sdist wasn't picking up the dynamically-generated version from the tag name, so wasn't getting published.