### PR TITLE
Bump required cmake to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 # We require this to get object library link library support
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.14)
 
 if(POLICY CMP0074)
   # enable find_package(<Package>) to use <Package>_ROOT as a hint

--- a/website/install.rst
+++ b/website/install.rst
@@ -81,7 +81,7 @@ Prerequisites
 
 Make sure these are installed on your system before building OpenEXR:
 
-* OpenEXR requires CMake version 3.12 or newer
+* OpenEXR requires CMake version 3.14 or newer
 * C++ compiler that supports C++11
 * Imath (auto fetched by CMake if not found) (https://github.com/AcademySoftwareFoundation/openexr)
 * libdeflate source code (auto fetched by CMake if not found) (https://github.com/ebiggers/libdeflate)


### PR DESCRIPTION
This should have gone in to #1624 since `file(CREATE_LINK)` requires CMake 3.14.