### PR TITLE
Fix memory leaks in exrstdattr and example code

### DIFF
--- a/src/bin/exrstdattr/main.cpp
+++ b/src/bin/exrstdattr/main.cpp
@@ -848,6 +848,9 @@ main (int argc, char** argv)
                 outPart.copyPixels (inPart);
             }
         }
+
+        for (int i=0; i<attrs.size(); i++)
+            delete attrs[i].attr;
     }
     catch (const exception& e)
     {

--- a/src/examples/multipartExamples.cpp
+++ b/src/examples/multipartExamples.cpp
@@ -315,6 +315,18 @@ void resizeDeepBuffers (
 }
 
 template <typename T>
+void freeDeepBuffers (list<Array2D<T *>> & channels)
+{
+    for (auto i = channels.begin (); i != channels.end (); i++)
+    {
+        Array2D<T*> & channel = *i;
+        for (int y = 0; y < channel.height (); y++)
+            for (int x = 0; x < channel.width (); x++)
+                delete[] channel[y][x];
+    }
+}
+
+template <typename T>
 void modifyChannels(list<Array2D<T>> & channels, T delta)
 {
     //
@@ -474,6 +486,10 @@ void modifyMultipart ()
                 outputPart.setFrameBuffer (frameBuffer);
                 outputPart.writeTiles (0, outputPart.numXTiles () - 1, 0, outputPart.numYTiles () - 1);
             }
+
+            freeDeepBuffers(intChannels);
+            freeDeepBuffers(halfChannels);
+            freeDeepBuffers(floatChannels);
         }
     }
 }


### PR DESCRIPTION
Caught by the address sanitizer, worth addressing in the example code as good programming practice. And so the test suite passed the sanitizer.