### PR TITLE
Add table of linux distro openexr versions to website install page

### DIFF
--- a/.github/workflows/website_workflow.yml
+++ b/.github/workflows/website_workflow.yml
@@ -10,6 +10,8 @@ name: Website
 # Skip the release branches, since the website is built from main.
 
 on:
+  workflow_dispatch:
+
   push:
     branches:-ignore:
       - RB-2.*

--- a/website/install.rst
+++ b/website/install.rst
@@ -36,6 +36,12 @@ Beware that some distributions are out of date and only provide
 distributions of outdated releases OpenEXR. We recommend against using
 OpenEXR v2, and we *strongly* recommend against using OpenEXR v1.
 
+Refer to the current version of OpenEXR on various major Linux distros at
+`repology.org <https://repology.org/project/openexr/versions>`_:
+
+.. image:: https://repology.org/badge/vertical-allrepos/openexr.svg?exclude_unsupported=1&columns=4
+   :target: https://repology.org/project/openexr/versions
+
 macOS
 -----
 


### PR DESCRIPTION
https://repology.org provides autogenerated tables of package versions for many linux distros

Also, add workflow_dispatch trigger, because it's handy during debugging.