### PR TITLE
Argument to isValidCompression should be int rather than Compression

### DIFF
--- a/src/lib/OpenEXR/ImfCompression.cpp
+++ b/src/lib/OpenEXR/ImfCompression.cpp
@@ -153,7 +153,7 @@ getCompressionIdFromName (const std::string& name, Compression& id)
 
 /// Return true if a compression id exists.
 bool
-isValidCompression (Compression id)
+isValidCompression (int id)
 {
     return id >= NO_COMPRESSION && id < NUM_COMPRESSION_METHODS;
 }

--- a/src/lib/OpenEXR/ImfCompression.h
+++ b/src/lib/OpenEXR/ImfCompression.h
@@ -66,7 +66,7 @@ IMF_EXPORT void
 getCompressionIdFromName (const std::string& name, Compression& id);
 
 /// Return true if a compression id exists.
-IMF_EXPORT bool isValidCompression (Compression id);
+IMF_EXPORT bool isValidCompression (int id);
 
 /// Return a string enumerating all compression names, with a custom separator.
 IMF_EXPORT void

--- a/src/lib/OpenEXR/ImfCompressionAttribute.cpp
+++ b/src/lib/OpenEXR/ImfCompressionAttribute.cpp
@@ -53,7 +53,7 @@ CompressionAttribute::readValueFrom (
     // (Header::sanityCheck will throw an exception when files with invalid Compression types are read)
     //
 
-    if (!isValidCompression(static_cast<Compression>(tmp)))
+    if (!isValidCompression(tmp))
     {
         tmp = NUM_COMPRESSION_METHODS;
     }

--- a/src/test/OpenEXRTest/testCompressionApi.cpp
+++ b/src/test/OpenEXRTest/testCompressionApi.cpp
@@ -36,6 +36,8 @@ testCompressionApi (const string& tempDir)
 
         for (int i = 0; i < numMethods; i++)
         {
+            assert (isValidCompression (i) == true);
+
             Compression c = static_cast<Compression> (i);
             Compression id;
             string      name, desc;
@@ -50,7 +52,6 @@ testCompressionApi (const string& tempDir)
             getCompressionDescriptionFromId (c, desc);
             assert (!desc.empty ());
 
-            assert (isValidCompression (c) == true);
             assert (isValidCompression (id) == true);
 
             assert (getCompressionNumScanlines (c) > 0);


### PR DESCRIPTION
The sanitizer flags invalid enum values. By definition, the argument might not be a valid enum value.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67239