### PR TITLE
Initialize _ySampling to 0

### DIFF
--- a/src/lib/OpenEXR/ImfOptimizedPixelReading.h
+++ b/src/lib/OpenEXR/ImfOptimizedPixelReading.h
@@ -24,7 +24,7 @@ class OptimizationMode
 public:
     bool _optimizable;
     int  _ySampling;
-    OptimizationMode () : _optimizable (false) {}
+    OptimizationMode () : _optimizable (false), _ySampling (0) {}
 };
 
 #    ifdef IMF_HAVE_SSE2


### PR DESCRIPTION
Caught by the santizer as potential use-before-initialization