### PR TITLE
Update conf.py to use favicon_url and logo_url

### DIFF
--- a/website/conf.py
+++ b/website/conf.py
@@ -170,11 +170,13 @@ html_short_title = "OpenEXR"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
+logo_url = "images/openexr-horizontal-color.png"
 html_logo = "images/openexr-horizontal-color.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
+favicon_url = "images/openexr-fav.ico"
 html_favicon = "images/openexr-fav.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Sphinx 6 deprecates html_favicon and html_logo. Keep the old settings so that older versions of sphinx still work.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1670.org.readthedocs.build/en/1670/
<!-- readthedocs-preview openexr end -->