### PR TITLE
Pin RTD to sphinx 5.3

### DIFF
--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,3 +1,3 @@
-sphinx >= 5.0
+sphinx == 5.3
 breathe
 sphinx-press-theme


### PR DESCRIPTION
Sphinx handling of `html_logo` and `html_favicon` changed in version 6, but changing to the documented logo_url and favicon_url still doesn't work for some reason. But Sphinx 5.3 works, so let's pin to that. This will need to get sorted out at some point, when there's a need to move to a newer sphinx.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1673.org.readthedocs.build/en/1673/
<!-- readthedocs-preview openexr end -->