### PR TITLE
Correct OpenEXR/ImfHeader.h headers

### DIFF
--- a/src/lib/OpenEXR/ImfHeader.h
+++ b/src/lib/OpenEXR/ImfHeader.h
@@ -15,8 +15,6 @@
 #include "ImfForward.h"
 
 #include "IexBaseExc.h"
-#include "ImathBox.h"
-#include "ImathVec.h"
 #include "ImfCompression.h"
 #include "ImfLineOrder.h"
 #include "ImfName.h"
@@ -28,6 +26,9 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+
+#include <Imath/ImathBox.h>
+#include <Imath/ImathVec.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 


### PR DESCRIPTION
Fix #1043. The program compiles without any change to CMakeLists.txt.  
I did not however try to link a program to this updated version of OpenEXR