### PR TITLE
Fix typo causing prefix len to be wrong

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -1600,7 +1600,7 @@ DwaCompressor_classifyChannels (DwaCompressor* me)
             prefixMap,
             me->_numChannels,
             curc->channel_name,
-            (size_t) (curc->channel_name - suffix));
+            (size_t) (suffix - curc->channel_name));
 
         for (size_t i = 0; i < me->_channelRuleCount; ++i)
         {


### PR DESCRIPTION
When constructing the decompress side of dwaa/b compression support, simple typo when computing the prefix length as distance between pointers causing the length to be wrong, triggering csc decompression values to be wrong when decompressed.

Fixes #1682 