### PR TITLE
Extend exrstdattr to add -erase option

### DIFF
--- a/src/bin/exrstdattr/main.cpp
+++ b/src/bin/exrstdattr/main.cpp
@@ -800,33 +800,23 @@ main (int argc, char** argv)
         int                numParts = in.parts ();
         vector<Header>     headers;
 
+        //
+        // Treat attributes added to a header in its constructor
+        // as critical and don't allow them to be deleted.
+        // 'name' and 'type' are only required in multipart
+        // file and errors will be reported if they
+        // are erased
+        //
+        Header stdHdr;
+
         for (int part = 0; part < numParts; ++part)
         {
             Header h = in.header (part);
 
-            for (size_t i = 0; i < attrs.size (); ++i)
-            {
-                const SetAttr& attr = attrs[i];
-
-                if (attr.part == -1 || attr.part == part)
-                {
-                    h.insert (attr.name, *attr.attr);
-                }
-                else if (attr.part < 0 || attr.part >= numParts)
-                {
-                    cerr << "Invalid part number " << attr.part
-                         << ". "
-                            "Part numbers in file "
-                         << inFileName
-                         << " "
-                            "go from 0 to "
-                         << numParts - 1 << "." << endl;
-
-                    return 1;
-                }
-            }
-
-            Header stdHdr;
+            //
+            // process attributes to erase first, so they can be reinserted
+            // with a different type
+            //
             for (size_t i = 0 ; i < eraseattrs.size() ; ++i)
             {
                 const EraseAttr& attr = eraseattrs[i];
@@ -855,11 +845,34 @@ main (int argc, char** argv)
                 }
             }
 
+
+            for (size_t i = 0; i < attrs.size (); ++i)
+            {
+                const SetAttr& attr = attrs[i];
+
+                if (attr.part == -1 || attr.part == part)
+                {
+                    h.insert (attr.name, *attr.attr);
+                }
+                else if (attr.part < 0 || attr.part >= numParts)
+                {
+                    cerr << "Invalid part number " << attr.part
+                         << ". "
+                            "Part numbers in file "
+                         << inFileName
+                         << " "
+                            "go from 0 to "
+                         << numParts - 1 << "." << endl;
+
+                    return 1;
+                }
+            }
+
             headers.push_back (h);
         }
 
         //
-        // Crete an output file with the modified headers,
+        // Create an output file with the modified headers,
         // and copy the pixels from the input file to the
         // output file.
         //

--- a/src/test/bin/test_exrstdattr.py
+++ b/src/test/bin/test_exrstdattr.py
@@ -20,6 +20,10 @@ assert(os.path.isdir(image_dir)), "\nMissing " + image_dir
 fd, outimage = tempfile.mkstemp(".exr")
 os.close(fd)
 
+fd, outimage2 = tempfile.mkstemp(".exr")
+os.close(fd)
+
+
 def cleanup():
     print(f"deleting {outimage}")
 atexit.register(cleanup)
@@ -137,5 +141,28 @@ try:
 except AssertionError:
     print(result.stdout)
     raise
+
+# test for bad erase argument
+result = run ([exrstdattr, "-erase"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+print(result.stderr)
+assert(result.returncode != 0), "\n"+result.stderr
+
+# test for errors trying to delete a critical attribute
+result = run ([exrstdattr, "-erase","dataWindow",outimage,outimage2], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+print(result.stderr)
+assert(result.returncode != 0), "\n"+result.stderr
+
+# test deleting 'comments'
+result = run ([exrstdattr, "-erase","comments",outimage,outimage2], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert(result.returncode == 0), "\n"+result.stderr
+assert(os.path.isfile(outimage2)), "\nMissing " + outimage2
+
+result = run ([exrinfo, "-v", outimage2], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+print(" ".join(result.args))
+assert("comments" not in result.stdout)
+
 
 print("success")


### PR DESCRIPTION
Add a flag to permit attributes to be removed using exrstdattr, as well as modified or removed. It's also possible to change the type of an attribute, by erasing it and re-inserting it. Some attributes are essential to OpenEXR to write the file correctly. Those are specifically detected and cannot be removed.
test_exrstdattr.py is also extended to check `-erase` does what it should. I notice that this didn't actually clean up the temporary file it made. Perhaps that should be added too?