### PR TITLE
Improve workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      day: "monday"
+      interval: "weekly"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      day: "monday"
+      interval: "weekly"

--- a/.github/workflows/release-notice.yml
+++ b/.github/workflows/release-notice.yml
@@ -9,6 +9,9 @@ on:
       - published
       # published should cover both 'released' and 'prereleased'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk-scan-cron.yml
+++ b/.github/workflows/snyk-scan-cron.yml
@@ -9,9 +9,13 @@ on:
   schedule:
     - cron: "0 4 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   snyk-scan-pr:
     runs-on: ubuntu-latest
+    if: github.repository == 'AcademySoftwareFoundation/openexr'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/website_workflow.yml
+++ b/.github/workflows/website_workflow.yml
@@ -12,14 +12,14 @@ name: Website
 on:
 
   push:
-    branches:-ignore:
+    branches-ignore:
       - RB-*
     paths:
       - 'website/**'
       - '.github/workflows/website_workflow.yml'
       
   pull_request:
-    branches:-ignore:
+    branches-ignore:
       - RB-*
     paths:
       - 'website/**'


### PR DESCRIPTION
- Per OpenSSF, permissions should be read at the top level, with additional permissions only for the necessary run.
- Add .github/dependabot.yml
- Fix a typo in the website_workflow's filters.
- Run the snyk-scan only on the main repo, not forks, since it requires secrets.