### PR TITLE
Build website on windows/macOS, and remote unnecessary installs

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,6 +8,15 @@ name: Website
 
 # Run only on changes in the "website" directory or workflow file.
 # Skip the release branches, since the website is built from main.
+#
+# Readthedocs builds the website on ubuntu-20.04, so technically
+# that's the only system that requires the website to build properly,
+# but developers contributing to the website may work on Windows or
+# macOS, so this confirms that it builds properly there, too.
+#
+# Note that this does not build the OpenEXR libraries, it only runs
+# doxygen and sphinx to generate the website html.
+#
 
 on:
 
@@ -32,34 +41,32 @@ jobs:
 
   Website:
 
-    # Build the website, using a process that mimics the readthedoc build.
-    #
-    # Note that this job does not actually build OpenEXR libraries or
-    # programs, it just runs doxygen, sphinx, and the
-    # website/script/test_images.py script to generate the "Test Images"
-    # page.
-    
-    name: 'Website'
-    runs-on: ubuntu-latest
-    
+    name: "Website"
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+          
+    env:
+      # doxygen 1.10 causes sphinx to fail, so pin to 1.9 for now.
+      DOXYGEN_VERSION: 1.9.1
+      
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Create build directory
         run: mkdir _build
-      - name: Install doxygen & imagemagick
-        # Need imagemagick for convert, to convert "Test Image" exrs to jpgs
-        # Need openexr for exrheader
-        run: sudo apt-get install -y doxygen imagemagick openexr 
+      - name: Install doxygen
+        run: ./website/scripts/install_doxygen.sh ${DOXYGEN_VERSION} 
+        shell: bash
       - name: Install sphinx requirements
         run: pip3 install -r website/requirements.txt
       - name: Configure
-        run: cmake .. -DBUILD_WEBSITE='ON'
+        run: cmake .. -DBUILD_WEBSITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON
         working-directory: _build
       - name: Build
-        run: |
-          cmake --build . \
-                --target website \
-                --config Release
+        run: cmake --build . --target website --config Release
         working-directory: _build
+    
     

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,13 +12,6 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.9"
-  apt_packages:
-    - wget        # for test images
-    - imagemagick # for convert, for test images
-    - openexr     # for exrheader, for test images
-  jobs:
-    pre_build:
-       - python website/scripts/test_images.py 
        
 sphinx:
   configuration: website/conf.py

--- a/website/CMakeLists.txt
+++ b/website/CMakeLists.txt
@@ -6,9 +6,6 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 find_package(Doxygen REQUIRED)
 find_package(Sphinx REQUIRED)
 
-include(FindPythonPackage)
-find_python_package(sphinx-press-theme REQUIRED)
-
 set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR}/src/lib/OpenEXRCore)
 set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
 set(DOXYGEN_INDEX_FILE ${DOXYGEN_OUTPUT_DIR}/html/index.html)

--- a/website/scripts/install_doxygen.sh
+++ b/website/scripts/install_doxygen.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+#
+# Used by the website.yml workflow
+#
+
+set -x
+
+DOXYGEN_VERSION=$1
+
+if [[ $OSTYPE == *linux* ]]; then
+    sudo apt-get install -y doxygen
+elif [[ $OSTYPE == *darwin* ]]; then
+    wget https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/Doxygen-${DOXYGEN_VERSION}.dmg
+    sudo hdiutil attach Doxygen-${DOXYGEN_VERSION}.dmg
+    sudo cp /Volumes/Doxygen/Doxygen.app/Contents/MacOS/Doxywizard /usr/local/bin
+    sudo cp /Volumes/Doxygen/Doxygen.app/Contents/Resources/doxygen /usr/local/bin
+    sudo cp /Volumes/Doxygen/Doxygen.app/Contents/Resources/doxyindexer /usr/local/bin
+    sudo hdiutil detach /Volumes/Doxygen
+elif [[ $OSTYPE == *msys* ]]; then
+    mkdir doxygen
+    cd doxygen
+    curl -kLSs https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.windows.x64.bin.zip -o doxygen.zip
+    unzip doxygen.zip
+    cp * c:\\Windows
+fi


### PR DESCRIPTION
Readthedocs builds the website on ubuntu-20.04, so technically that's the only system that requires the website to build properly, but developers contributing to the website may work on Windows or macOS, so this confirms that it builds properly there, too.

Now that the test image files are no longer generated at build time, no need to install imagemagic and openexr or run the test_image.py script.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1701.org.readthedocs.build/en/1701/
<!-- readthedocs-preview openexr end -->