### PR TITLE
Improve filters for ossfuzz and bazel

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -12,29 +12,23 @@ name: Bazel
 
 on:
   push:
-    branches-ignore:
-      - RB-2.*
-    tags-ignore:
-      - v1.*
-      - v2.*
     paths:
       - '**'
       - '!**.md'
       - '!website/**'
       - 'website/src/**'
       - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/bazel_build.yml'
   pull_request:
-    branches-ignore:
-      - RB-2.*
-    tags-ignore:
-      - v1.*
-      - v2.*
     paths:
       - '**'
       - '!**.md'
       - '!website/**'
       - 'website/src/**'
       - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/bazel_build.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/ossfuzz_workflow.yml
+++ b/.github/workflows/ossfuzz_workflow.yml
@@ -8,29 +8,23 @@ name: OSS-Fuzz
 
 on:
   push:
-    branches-ignore:
-      - RB-2.*
-    tags-ignore:
-      - v1.*
-      - v2.*
     paths:
       - '**'
       - '!**.md'
       - '!website/**'
       - '!bazel/**'
       - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ossfuzz_workflow.yml'
   pull_request:
-    branches-ignore:
-      - RB-2.*
-    tags-ignore:
-      - v1.*
-      - v2.*
     paths:
       - '**'
       - '!**.md'
       - '!website/**'
       - '!bazel/**'
       - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ossfuzz_workflow.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Ignore changes to workflow files other than the one in question.

Also, no point in filtering out old release branches and tags, since the workflow files don't exist there anyway.