### PR TITLE
Silence warning C4201: nonstandard extension used: nameless struct/union.

### DIFF
--- a/src/lib/OpenEXRCore/openexr_attr.h
+++ b/src/lib/OpenEXRCore/openexr_attr.h
@@ -186,79 +186,37 @@ typedef struct
 /** @brief Struct to hold a 2-element integer vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            int32_t x, y;
-        };
-        int32_t arr[2];
-    };
+  int32_t x, y;
 } exr_attr_v2i_t;
 
 /** @brief Struct to hold a 2-element 32-bit float vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            float x, y;
-        };
-        float arr[2];
-    };
+  float x, y;
 } exr_attr_v2f_t;
 
 /** @brief Struct to hold a 2-element 64-bit float vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            double x, y;
-        };
-        double arr[2];
-    };
+  double x, y;
 } exr_attr_v2d_t;
 
 /** @brief Struct to hold a 3-element integer vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            int32_t x, y, z;
-        };
-        int32_t arr[3];
-    };
+  int32_t x, y, z;
 } exr_attr_v3i_t;
 
 /** @brief Struct to hold a 3-element 32-bit float vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            float x, y, z;
-        };
-        float arr[3];
-    };
+  float x, y, z;
 } exr_attr_v3f_t;
 
 /** @brief Struct to hold a 3-element 64-bit float vector. */
 typedef struct
 {
-    union
-    {
-        struct
-        {
-            double x, y, z;
-        };
-        double arr[3];
-    };
+  double x, y, z;
 } exr_attr_v3d_t;
 
 /** @brief Struct to hold an integer box/region definition. */

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2046,27 +2046,27 @@ pull_attr (
             break;
         case EXR_ATTR_V2I:
             rv = extract_attr_32bit (
-                ctxt, scratch, nattr->v2i->arr, name, type, attrsz, 2);
+                ctxt, scratch, nattr->v2i, name, type, attrsz, 2);
             break;
         case EXR_ATTR_V2F:
             rv = extract_attr_32bit (
-                ctxt, scratch, nattr->v2f->arr, name, type, attrsz, 2);
+                ctxt, scratch, nattr->v2f, name, type, attrsz, 2);
             break;
         case EXR_ATTR_V2D:
             rv = extract_attr_64bit (
-                ctxt, scratch, nattr->v2d->arr, name, type, attrsz, 2);
+                ctxt, scratch, nattr->v2d, name, type, attrsz, 2);
             break;
         case EXR_ATTR_V3I:
             rv = extract_attr_32bit (
-                ctxt, scratch, nattr->v3i->arr, name, type, attrsz, 3);
+                ctxt, scratch, nattr->v3i, name, type, attrsz, 3);
             break;
         case EXR_ATTR_V3F:
             rv = extract_attr_32bit (
-                ctxt, scratch, nattr->v3f->arr, name, type, attrsz, 3);
+                ctxt, scratch, nattr->v3f, name, type, attrsz, 3);
             break;
         case EXR_ATTR_V3D:
             rv = extract_attr_64bit (
-                ctxt, scratch, nattr->v3d->arr, name, type, attrsz, 3);
+                ctxt, scratch, nattr->v3d, name, type, attrsz, 3);
             break;
         case EXR_ATTR_DEEP_IMAGE_STATE:
             rv = extract_attr_uint8 (


### PR DESCRIPTION
I am checking if we could switch to the "new" OpenEXRCore api in the @ImageMagick project and I we are getting a build warning when including `openexr.h` in our Visual Studio project:

> Silence warning C4201: nonstandard extension used: nameless struct/union.

An anonymous struct, is not part of the standard ANSI C (C89/C90) or ISO C90. It was introduced in C11 as an optional feature and might not be supported by all compilers, especially in strict ANSI C modes. This PR simplifies the structs to silence this warning.