### PR TITLE
Removed unused sliceOptimizationData::type

### DIFF
--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -160,7 +160,6 @@ struct sliceOptimizationData
     half fillValue; ///< if filling, the value to use
     size_t
         offset; ///< position this channel will be in the read buffer, accounting for previous channels, as well as their type
-    PixelType type; ///< type of channel
     size_t
         xStride; ///< x-stride of channel in buffer (must be set to cause channels to interleave)
     size_t


### PR DESCRIPTION
Removed unused `sliceOptimizationData::type` (which is always equal to `OPENEXR_IMF_INTERNAL_NAMESPACE::HALF`).