### PR TITLE
Install website requirements in venv

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,14 +25,14 @@ on:
       - RB-*
     paths:
       - 'website/**'
-      - '.github/workflows/website_workflow.yml'
+      - '.github/workflows/website.yml'
       
   pull_request:
     branches-ignore:
       - RB-*
     paths:
       - 'website/**'
-      - '.github/workflows/website_workflow.yml'
+      - '.github/workflows/website.yml'
 
 permissions:
   contents: read
@@ -61,12 +61,17 @@ jobs:
         run: ./website/scripts/install_doxygen.sh ${DOXYGEN_VERSION} 
         shell: bash
       - name: Install sphinx requirements
-        run: pip3 install -r website/requirements.txt
-      - name: Configure
-        run: cmake .. -DBUILD_WEBSITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+        run: |
+          python3 -m venv _venv
+          source _venv/*/activate
+          pip3 install -r ../website/requirements.txt
+          cmake .. -DBUILD_WEBSITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON
         working-directory: _build
+        shell: bash
       - name: Build
-        run: cmake --build . --target website --config Release
+        run: |
+          cmake --build . --target website --config Release
         working-directory: _build
+        shell: bash
     
     


### PR DESCRIPTION
Apparently, macOS doesn't like to pip install into the system-wide location, it prefers a venv.

And, the filter was wrong.