### PR TITLE
Switch Deep Tiled Input to use Core

### DIFF
--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -984,12 +984,14 @@ void DeepTiledInputFile::Data::readTiles (
         putChunkProcess (std::move(tp));
     }
 
+#if ILMTHREAD_THREADING_ENABLED
     if (! _failures.empty())
     {
         std::string fail = _failures[0];
         _failures.clear ();
         throw IEX_NAMESPACE::IoExc (fail);
     }
+#endif
 }
 
 ////////////////////////////////////////

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -11,156 +11,70 @@
 
 #include "ImfDeepTiledInputFile.h"
 
-#include "ImfChannelList.h"
-#include "ImfCompressor.h"
+#include "Iex.h"
+
+#include "IlmThreadPool.h"
+#if ILMTHREAD_THREADING_ENABLED
+#    include "IlmThreadSemaphore.h"
+#endif
+
 #include "ImfDeepFrameBuffer.h"
-#include "ImfMisc.h"
-#include "ImfStdIO.h"
-#include "ImfTileDescriptionAttribute.h"
+#include "ImfInputPartData.h"
+
+// TODO: remove once TiledOutput is converted
+#include "ImfTileOffsets.h"
 #include "ImfTiledMisc.h"
 
-#include "Iex.h"
-#include "IlmThreadPool.h"
-#include "IlmThreadSemaphore.h"
-#include "ImathVec.h"
-#include "ImfConvert.h"
-#include "ImfInputPartData.h"
-#include "ImfInputStreamMutex.h"
-#include "ImfMultiPartInputFile.h"
-#include "ImfPartType.h"
-#include "ImfThreading.h"
-#include "ImfTileOffsets.h"
-#include "ImfVersion.h"
-#include "ImfXdr.h"
-
 #include <algorithm>
-#include <assert.h>
-#include <limits>
+#include <mutex>
 #include <string>
 #include <vector>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-using ILMTHREAD_NAMESPACE::Semaphore;
-using ILMTHREAD_NAMESPACE::Task;
-using ILMTHREAD_NAMESPACE::TaskGroup;
-using ILMTHREAD_NAMESPACE::ThreadPool;
-using IMATH_NAMESPACE::Box2i;
-using IMATH_NAMESPACE::V2i;
-using std::max;
-using std::min;
-using std::string;
-using std::vector;
+namespace {
 
-namespace
+// TODO: similarities to tiled input file...
+struct TileProcess
 {
+    ~TileProcess ()
+    {
+        if (!first)
+            exr_decoding_destroy (decoder.context, &decoder);
+    }
 
-struct TInSliceInfo
-{
-    PixelType typeInFrameBuffer;
-    PixelType typeInFile;
-    char*     pointerArrayBase;
-    size_t    xStride;
-    size_t    yStride;
-    ptrdiff_t sampleStride;
-    bool      fill;
-    bool      skip;
-    double    fillValue;
-    int       xTileCoords;
-    int       yTileCoords;
+    void run_decode (
+        exr_const_context_t ctxt,
+        int pn,
+        const DeepFrameBuffer *outfb,
+        const std::vector<DeepSlice> &filllist);
 
-    TInSliceInfo (
-        PixelType typeInFrameBuffer = HALF,
-        char*     base              = NULL,
-        PixelType typeInFile        = HALF,
-        size_t    xStride           = 0,
-        size_t    yStride           = 0,
-        ptrdiff_t sampleStride      = 0,
-        bool      fill              = false,
-        bool      skip              = false,
-        double    fillValue         = 0.0,
-        int       xTileCoords       = 0,
-        int       yTileCoords       = 0);
+    void update_pointers (
+        const DeepFrameBuffer *outfb,
+        int fb_absX, int fb_absY,
+        int t_absX, int t_absY);
+
+    void run_fill (
+        const DeepFrameBuffer *outfb,
+        int fb_absX, int fb_absY,
+        int t_absX, int t_absY,
+        const std::vector<DeepSlice> &filllist);
+
+    void copy_sample_count (
+        const DeepFrameBuffer *outfb,
+        int fb_absX, int fb_absY,
+        int t_absX, int t_absY);
+
+    exr_result_t          last_decode_err = EXR_ERR_UNKNOWN;
+    bool                  first = true;
+    bool                  counts_only = false;
+    exr_chunk_info_t      cinfo;
+    exr_decode_pipeline_t decoder;
+
+    std::shared_ptr<TileProcess> next;
 };
 
-TInSliceInfo::TInSliceInfo (
-    PixelType tifb,
-    char*     b,
-    PixelType tifl,
-    size_t    xs,
-    size_t    ys,
-    ptrdiff_t spst,
-    bool      f,
-    bool      s,
-    double    fv,
-    int       xtc,
-    int       ytc)
-    : typeInFrameBuffer (tifb)
-    , typeInFile (tifl)
-    , pointerArrayBase (b)
-    , xStride (xs)
-    , yStride (ys)
-    , sampleStride (spst)
-    , fill (f)
-    , skip (s)
-    , fillValue (fv)
-    , xTileCoords (xtc)
-    , yTileCoords (ytc)
-{
-    // empty
-}
-
-struct TileBuffer
-{
-    Array2D<unsigned int> sampleCount;
-    const char*           uncompressedData;
-    char*                 buffer;
-    uint64_t              dataSize;
-    uint64_t              uncompressedDataSize;
-    Compressor*           compressor;
-    Compressor::Format    format;
-    int                   dx;
-    int                   dy;
-    int                   lx;
-    int                   ly;
-    bool                  hasException;
-    string                exception;
-
-    TileBuffer ();
-    ~TileBuffer ();
-
-    inline void wait () { _sem.wait (); }
-    inline void post () { _sem.post (); }
-
-protected:
-    Semaphore _sem;
-};
-
-TileBuffer::TileBuffer ()
-    : uncompressedData (0)
-    , buffer (0)
-    , dataSize (0)
-    , compressor (0)
-    , format (defaultFormat (compressor))
-    , dx (-1)
-    , dy (-1)
-    , lx (-1)
-    , ly (-1)
-    , hasException (false)
-    , exception ()
-    , _sem (1)
-{
-    // empty
-}
-
-TileBuffer::~TileBuffer ()
-{
-    delete compressor;
-}
-
-} // namespace
-
-class MultiPartInputFile;
+} // empty namespace
 
 //
 // struct TiledInputFile::Data stores things that will be
@@ -168,1012 +82,221 @@ class MultiPartInputFile;
 //
 
 struct DeepTiledInputFile::Data
+{
+    Data (Context *ctxt, int pN, int nT)
+    : _ctxt (ctxt)
+    , partNumber (pN)
+    , numThreads (nT)
 #if ILMTHREAD_THREADING_ENABLED
-    : public std::mutex
+    , _sem ((unsigned int)nT)
 #endif
-{
-    Header          header;      // the image header
-    TileDescription tileDesc;    // describes the tile layout
-    int             version;     // file's version
-    DeepFrameBuffer frameBuffer; // framebuffer to write into
-    LineOrder       lineOrder;   // the file's lineorder
-    int             minX;        // data window's min x coord
-    int             maxX;        // data window's max x coord
-    int             minY;        // data window's min y coord
-    int             maxY;        // data window's max x coord
+    {}
 
-    int  numXLevels; // number of x levels
-    int  numYLevels; // number of y levels
-    int* numXTiles;  // number of x tiles at a level
-    int* numYTiles;  // number of y tiles at a level
+    void initialize ()
+    {
+        if (_ctxt->storage (partNumber) != EXR_STORAGE_DEEP_TILED)
+            throw IEX_NAMESPACE::ArgExc ("File part is not a tiled part");
 
-    TileOffsets tileOffsets; // stores offsets in file for
-    // each tile
+        if (EXR_ERR_SUCCESS != exr_get_tile_descriptor (
+                *_ctxt,
+                partNumber,
+                &tile_x_size,
+                &tile_y_size,
+                &tile_level_mode,
+                &tile_round_mode))
+            throw IEX_NAMESPACE::ArgExc ("Unable to query tile descriptor");
 
-    bool fileIsComplete; // True if no tiles are missing
-                         // in the file
+        if (EXR_ERR_SUCCESS != exr_get_tile_levels (
+                *_ctxt,
+                partNumber,
+                &num_x_levels,
+                &num_y_levels))
+            throw IEX_NAMESPACE::ArgExc ("Unable to query number of tile levels");
+    }
 
-    vector<TInSliceInfo*> slices; // info about channels in file
+    // TODO: generalize to have async framebuffer path
+    void readTiles (int dx1, int dx2, int dy1, int dy2, int lx, int ly, bool countsOnly);
 
-    // ourselves? or does someone
-    // else do it?
+    Context* _ctxt;
+    int partNumber;
+    int numThreads;
+    Header header;
+    bool header_filled = false;
 
-    int partNumber; // part number
+    uint32_t tile_x_size = 0;
+    uint32_t tile_y_size = 0;
+    exr_tile_level_mode_t tile_level_mode = EXR_TILE_LAST_TYPE;
+    exr_tile_round_mode_t tile_round_mode = EXR_TILE_ROUND_LAST_TYPE;
 
-    bool multiPartBackwardSupport; // if we are reading a multipart file
-                                   // using OpenEXR 1.7 API
+    int32_t num_x_levels = 0;
+    int32_t num_y_levels = 0;
 
-    int numThreads; // number of threads
+    bool frameBufferValid = false;
+    DeepFrameBuffer frameBuffer;
+    std::vector<DeepSlice> fill_list;
 
-    MultiPartInputFile* multiPartFile; // the MultiPartInputFile used to
-                                       // support backward compatibility
+#if ILMTHREAD_THREADING_ENABLED
+    std::vector<std::string> _failures;
 
-    vector<TileBuffer*> tileBuffers; // each holds a single tile
+    std::mutex _mx;
+    ILMTHREAD_NAMESPACE::Semaphore _sem;
+#endif
 
-    bool memoryMapped; // if the stream is memory mapped
+    std::shared_ptr<TileProcess> processStack;
+    std::shared_ptr<TileProcess> getChunkProcess ()
+    {
+        std::shared_ptr<TileProcess> retval;
+#if ILMTHREAD_THREADING_ENABLED
+        std::lock_guard<std::mutex> lk (_mx);
+#endif
+        retval = processStack;
+        if (!retval)
+            retval = std::make_shared<TileProcess> ();
+        processStack = retval->next;
+        retval->next.reset();
+        return retval;
+    }
+    void putChunkProcess (std::shared_ptr<TileProcess> tp)
+    {
+#if ILMTHREAD_THREADING_ENABLED
+        std::lock_guard<std::mutex> lk (_mx);
+#endif
+        tp->next = processStack;
+        processStack = tp;
+    }
 
-    char* sampleCountSliceBase;   // pointer to the start of
-                                  // the sample count array
-    ptrdiff_t sampleCountXStride; // x stride of the sample count array
-    ptrdiff_t sampleCountYStride; // y stride of the sample count array
+#if ILMTHREAD_THREADING_ENABLED
+    class TileBufferTask final : public ILMTHREAD_NAMESPACE::Task
+    {
+    public:
+        TileBufferTask (
+            ILMTHREAD_NAMESPACE::TaskGroup* group,
+            Data*                   ifd,
+            const DeepFrameBuffer*  outfb,
+            const exr_chunk_info_t& cinfo,
+            bool                    countsOnly)
+            : Task (group)
+            , _outfb (outfb)
+            , _ifd (ifd)
+            , _tile (ifd->getChunkProcess ())
+        {
+            _tile->cinfo = cinfo;
+            _tile->counts_only = countsOnly;
+        }
 
-    int sampleCountXTileCoords; // the value of xTileCoords from the
-                                // sample count slice
-    int sampleCountYTileCoords; // the value of yTileCoords from the
-                                // sample count slice
+        ~TileBufferTask () override
+        {
+            if (_tile)
+                _ifd->putChunkProcess (std::move (_tile));
+            _ifd->_sem.post ();
+        }
 
-    Array<char> sampleCountTableBuffer; // the buffer for sample count table
+        void execute () override;
 
-    Compressor* sampleCountTableComp; // the decompressor for sample count table
+    private:
+        void run_decode ();
 
-    uint64_t maxSampleCountTableSize; // the max size in bytes for a pixel
-                                      // sample count table
-    int combinedSampleSize; // total size of all channels combined to check sampletable size
-    static const int gLargeChunkTableSize = 1024 * 1024;
-    void
-    validateStreamSize (); // throw an exception if the file is significantly
-                           // smaller than the data/tile geometry would require
-    InputStreamMutex* _streamData;
-    bool              _deleteStream; // should we delete the stream
-    Data (int numThreads);
-    ~Data ();
+        const DeepFrameBuffer* _outfb;
+        Data*                  _ifd;
 
-    Data (const Data& other)            = delete;
-    Data& operator= (const Data& other) = delete;
-    Data (Data&& other)                 = delete;
-    Data& operator= (Data&& other)      = delete;
-
-    inline TileBuffer* getTileBuffer (int number);
-    // hash function from tile indices
-    // into our vector of tile buffers
-
-    int& getSampleCount (int x, int y);
-    // get the number of samples
-    // in each pixel
+        std::shared_ptr<TileProcess> _tile;
+    };
+#endif
 };
 
-DeepTiledInputFile::Data::Data (int numThreads)
-    : numXTiles (0)
-    , numYTiles (0)
-    , partNumber (-1)
-    , multiPartBackwardSupport (false)
-    , numThreads (numThreads)
-    , memoryMapped (false)
-    , sampleCountTableComp (nullptr)
-    , _streamData (nullptr)
-    , _deleteStream (false)
+DeepTiledInputFile::DeepTiledInputFile (
+    const char*               filename,
+    const ContextInitializer& ctxtinit,
+    int                       numThreads)
+    : _ctxt (filename, ctxtinit, Context::read_mode_t{})
+    , _data (std::make_shared<Data> (&_ctxt, 0, numThreads))
 {
-    //
-    // We need at least one tileBuffer, but if threading is used,
-    // to keep n threads busy we need 2*n tileBuffers
-    //
-
-    tileBuffers.resize (max (1, 2 * numThreads));
+    _data->initialize ();
 }
-
-DeepTiledInputFile::Data::~Data ()
-{
-    delete[] numXTiles;
-    delete[] numYTiles;
-
-    for (size_t i = 0; i < tileBuffers.size (); i++)
-        delete tileBuffers[i];
-
-    if (multiPartBackwardSupport) delete multiPartFile;
-
-    for (size_t i = 0; i < slices.size (); i++)
-        delete slices[i];
-
-    delete sampleCountTableComp;
-}
-
-TileBuffer*
-DeepTiledInputFile::Data::getTileBuffer (int number)
-{
-    return tileBuffers[number % tileBuffers.size ()];
-}
-
-int&
-DeepTiledInputFile::Data::getSampleCount (int x, int y)
-{
-    return sampleCount (
-        sampleCountSliceBase,
-        static_cast<int> (sampleCountXStride),
-        static_cast<int> (sampleCountYStride),
-        x,
-        y);
-}
-
-void
-DeepTiledInputFile::Data::validateStreamSize ()
-{
-    const Box2i& dataWindow = header.dataWindow ();
-    uint64_t     tileWidth  = header.tileDescription ().xSize;
-    uint64_t     tileHeight = header.tileDescription ().ySize;
-
-    uint64_t tilesX =
-        (static_cast<uint64_t> (dataWindow.max.x + 1 - dataWindow.min.x) +
-         tileWidth - 1) /
-        tileWidth;
-
-    uint64_t tilesY =
-        (static_cast<uint64_t> (dataWindow.max.y + 1 - dataWindow.min.y) +
-         tileHeight - 1) /
-        tileHeight;
-
-    uint64_t chunkCount = tilesX * tilesY;
-    if (chunkCount > gLargeChunkTableSize)
-    {
-
-        if (chunkCount > gLargeChunkTableSize)
-        {
-            uint64_t pos = _streamData->is->tellg ();
-            _streamData->is->seekg (pos + (chunkCount - 1) * sizeof (uint64_t));
-            uint64_t temp;
-            OPENEXR_IMF_INTERNAL_NAMESPACE::Xdr::read<
-                OPENEXR_IMF_INTERNAL_NAMESPACE::StreamIO> (
-                *_streamData->is, temp);
-            _streamData->is->seekg (pos);
-        }
-    }
-}
-
-namespace
-{
-
-void
-readTileData (
-    InputStreamMutex*         streamData,
-    DeepTiledInputFile::Data* ifd,
-    int                       dx,
-    int                       dy,
-    int                       lx,
-    int                       ly,
-    char*&                    buffer,
-    uint64_t&                 dataSize,
-    uint64_t&                 unpackedDataSize)
-{
-    //
-    // Read a single tile block from the file and into the array pointed
-    // to by buffer.  If the file is memory-mapped, then we change where
-    // buffer points instead of writing into the array (hence buffer needs
-    // to be a reference to a char *).
-    //
-
-    //
-    // Look up the location for this tile in the Index and
-    // seek to that position if necessary
-    //
-
-    uint64_t tileOffset = ifd->tileOffsets (dx, dy, lx, ly);
-
-    if (tileOffset == 0)
-    {
-        THROW (
-            IEX_NAMESPACE::InputExc,
-            "Tile (" << dx << ", " << dy << ", " << lx << ", " << ly
-                     << ") is missing.");
-    }
-
-    //
-    // In a multi-part file, the next chunk does not need to
-    // belong to the same part, so we have to compare the
-    // offset here.
-    //
-
-    if (!isMultiPart (ifd->version))
-    {
-        if (streamData->currentPosition != tileOffset)
-            streamData->is->seekg (tileOffset);
-    }
-    else
-    {
-        //
-        // In a multi-part file, the file pointer may be moved by other
-        // parts, so we have to ask tellg() where we are.
-        //
-        if (streamData->is->tellg () != tileOffset)
-            streamData->is->seekg (tileOffset);
-    }
-
-    //
-    // Read the first few bytes of the tile (the header).
-    // Verify that the tile coordinates and the level number
-    // are correct.
-    //
-
-    int tileXCoord, tileYCoord, levelX, levelY;
-
-    if (isMultiPart (ifd->version))
-    {
-        int partNumber;
-        Xdr::read<StreamIO> (*streamData->is, partNumber);
-        if (partNumber != ifd->partNumber)
-        {
-            THROW (
-                IEX_NAMESPACE::ArgExc,
-                "Unexpected part number " << partNumber << ", should be "
-                                          << ifd->partNumber << ".");
-        }
-    }
-
-    Xdr::read<StreamIO> (*streamData->is, tileXCoord);
-    Xdr::read<StreamIO> (*streamData->is, tileYCoord);
-    Xdr::read<StreamIO> (*streamData->is, levelX);
-    Xdr::read<StreamIO> (*streamData->is, levelY);
-
-    uint64_t tableSize;
-    Xdr::read<StreamIO> (*streamData->is, tableSize);
-
-    Xdr::read<StreamIO> (*streamData->is, dataSize);
-    Xdr::read<StreamIO> (*streamData->is, unpackedDataSize);
-
-    //
-    // Skip the pixel sample count table because we have read this data.
-    //
-
-    Xdr::skip<StreamIO> (*streamData->is, static_cast<int> (tableSize));
-
-    if (tileXCoord != dx)
-        throw IEX_NAMESPACE::InputExc ("Unexpected tile x coordinate.");
-
-    if (tileYCoord != dy)
-        throw IEX_NAMESPACE::InputExc ("Unexpected tile y coordinate.");
-
-    if (levelX != lx)
-        throw IEX_NAMESPACE::InputExc (
-            "Unexpected tile x level number coordinate.");
-
-    if (levelY != ly)
-        throw IEX_NAMESPACE::InputExc (
-            "Unexpected tile y level number coordinate.");
-
-    //
-    // Read the pixel data.
-    //
-
-    if (streamData->is->isMemoryMapped ())
-        buffer = streamData->is->readMemoryMapped (static_cast<int> (dataSize));
-    else
-    {
-        // (TODO) check if the packed data size is too big?
-        // (TODO) better memory management here. Don't delete buffer everytime.
-        if (buffer != 0) delete[] buffer;
-        buffer = new char[dataSize];
-        streamData->is->read (buffer, static_cast<int> (dataSize));
-    }
-
-    //
-    // Keep track of which tile is the next one in
-    // the file, so that we can avoid redundant seekg()
-    // operations (seekg() can be fairly expensive).
-    //
-
-    streamData->currentPosition = tileOffset + 4 * Xdr::size<int> () +
-                                  3 * Xdr::size<uint64_t> () + tableSize +
-                                  dataSize;
-}
-
-//
-// A TileBufferTask encapsulates the task of uncompressing
-// a single tile and copying it into the frame buffer.
-//
-
-class TileBufferTask : public Task
-{
-public:
-    TileBufferTask (
-        TaskGroup*                group,
-        DeepTiledInputFile::Data* ifd,
-        TileBuffer*               tileBuffer);
-
-    virtual ~TileBufferTask ();
-
-    virtual void execute ();
-
-private:
-    DeepTiledInputFile::Data* _ifd;
-    TileBuffer*               _tileBuffer;
-};
-
-TileBufferTask::TileBufferTask (
-    TaskGroup* group, DeepTiledInputFile::Data* ifd, TileBuffer* tileBuffer)
-    : Task (group), _ifd (ifd), _tileBuffer (tileBuffer)
-{
-    // empty
-}
-
-TileBufferTask::~TileBufferTask ()
-{
-    //
-    // Signal that the tile buffer is now free
-    //
-
-    _tileBuffer->post ();
-}
-
-void
-TileBufferTask::execute ()
-{
-    try
-    {
-        //
-        // Calculate information about the tile
-        //
-
-        Box2i tileRange = OPENEXR_IMF_INTERNAL_NAMESPACE::dataWindowForTile (
-            _ifd->tileDesc,
-            _ifd->minX,
-            _ifd->maxX,
-            _ifd->minY,
-            _ifd->maxY,
-            _tileBuffer->dx,
-            _tileBuffer->dy,
-            _tileBuffer->lx,
-            _tileBuffer->ly);
-
-        //
-        // Get the size of the tile.
-        //
-
-        Array<unsigned int> numPixelsPerScanLine;
-        numPixelsPerScanLine.resizeErase (
-            tileRange.max.y - tileRange.min.y + 1);
-
-        int sizeOfTile          = 0;
-        int maxBytesPerTileLine = 0;
-
-        for (int y = tileRange.min.y; y <= tileRange.max.y; y++)
-        {
-            numPixelsPerScanLine[y - tileRange.min.y] = 0;
-
-            int bytesPerLine = 0;
-
-            for (int x = tileRange.min.x; x <= tileRange.max.x; x++)
-            {
-                int xOffset = _ifd->sampleCountXTileCoords * tileRange.min.x;
-                int yOffset = _ifd->sampleCountYTileCoords * tileRange.min.y;
-
-                int count = _ifd->getSampleCount (x - xOffset, y - yOffset);
-                for (unsigned int c = 0; c < _ifd->slices.size (); ++c)
-                {
-                    // This slice does not exist in the file.
-                    if (!_ifd->slices[c]->fill)
-                    {
-                        sizeOfTile +=
-                            count * pixelTypeSize (_ifd->slices[c]->typeInFile);
-                        bytesPerLine +=
-                            count * pixelTypeSize (_ifd->slices[c]->typeInFile);
-                    }
-                }
-                numPixelsPerScanLine[y - tileRange.min.y] += count;
-            }
-
-            if (bytesPerLine > maxBytesPerTileLine)
-                maxBytesPerTileLine = bytesPerLine;
-        }
-
-        // (TODO) don't do this every time.
-        if (_tileBuffer->compressor != 0) delete _tileBuffer->compressor;
-        _tileBuffer->compressor = newTileCompressor (
-            _ifd->header.compression (),
-            maxBytesPerTileLine,
-            _ifd->tileDesc.ySize,
-            _ifd->header);
-
-        //
-        // Uncompress the data, if necessary
-        //
-
-        if (_tileBuffer->compressor &&
-            _tileBuffer->dataSize < static_cast<uint64_t> (sizeOfTile))
-        {
-            _tileBuffer->format = _tileBuffer->compressor->format ();
-
-            _tileBuffer->compressor->setExpectedSize (sizeOfTile);
-            _tileBuffer->compressor->setTileLevel (
-                _tileBuffer->lx,
-                _tileBuffer->ly);
-            _tileBuffer->dataSize = _tileBuffer->compressor->uncompressTile (
-                _tileBuffer->buffer,
-                static_cast<int> (_tileBuffer->dataSize),
-                tileRange,
-                _tileBuffer->uncompressedData);
-        }
-        else
-        {
-            //
-            // If the line is uncompressed, it's in XDR format,
-            // regardless of the compressor's output format.
-            //
-
-            _tileBuffer->format           = Compressor::XDR;
-            _tileBuffer->uncompressedData = _tileBuffer->buffer;
-        }
-
-        //
-        // sanity check data size: the uncompressed data should be exactly
-        // 'sizeOfTile' (if it's less, the file is corrupt and there'll be a buffer overrun)
-        //
-        if (_tileBuffer->dataSize != static_cast<uint64_t> (sizeOfTile))
-        {
-            THROW (
-                IEX_NAMESPACE::InputExc,
-                "size mismatch when reading deep tile: expected "
-                    << sizeOfTile << "bytes of uncompressed data but got "
-                    << _tileBuffer->dataSize);
-        }
-
-        //
-        // Convert the tile of pixel data back from the machine-independent
-        // representation, and store the result in the frame buffer.
-        //
-
-        const char* readPtr = _tileBuffer->uncompressedData;
-        // points to where we
-        // read from in the
-        // tile block
-
-        //
-        // Iterate over the scan lines in the tile.
-        //
-
-        for (int y = tileRange.min.y; y <= tileRange.max.y; ++y)
-        {
-            //
-            // Iterate over all image channels.
-            //
-
-            for (unsigned int i = 0; i < _ifd->slices.size (); ++i)
-            {
-                TInSliceInfo& slice = *_ifd->slices[i];
-
-                //
-                // These offsets are used to facilitate both
-                // absolute and tile-relative pixel coordinates.
-                //
-
-                int xOffsetForData = (slice.xTileCoords == 0) ? 0
-                                                              : tileRange.min.x;
-                int yOffsetForData = (slice.yTileCoords == 0) ? 0
-                                                              : tileRange.min.y;
-                int xOffsetForSampleCount =
-                    (_ifd->sampleCountXTileCoords == 0) ? 0 : tileRange.min.x;
-                int yOffsetForSampleCount =
-                    (_ifd->sampleCountYTileCoords == 0) ? 0 : tileRange.min.y;
-
-                //
-                // Fill the frame buffer with pixel data.
-                //
-
-                if (slice.skip)
-                {
-                    //
-                    // The file contains data for this channel, but
-                    // the frame buffer contains no slice for this channel.
-                    //
-
-                    skipChannel (
-                        readPtr,
-                        slice.typeInFile,
-                        numPixelsPerScanLine[y - tileRange.min.y]);
-                }
-                else
-                {
-                    //
-                    // The frame buffer contains a slice for this channel.
-                    //
-
-                    copyIntoDeepFrameBuffer (
-                        readPtr,
-                        slice.pointerArrayBase,
-                        _ifd->sampleCountSliceBase,
-                        _ifd->sampleCountXStride,
-                        _ifd->sampleCountYStride,
-                        y,
-                        tileRange.min.x,
-                        tileRange.max.x,
-                        xOffsetForSampleCount,
-                        yOffsetForSampleCount,
-                        xOffsetForData,
-                        yOffsetForData,
-                        slice.sampleStride,
-                        slice.xStride,
-                        slice.yStride,
-                        slice.fill,
-                        slice.fillValue,
-                        _tileBuffer->format,
-                        slice.typeInFrameBuffer,
-                        slice.typeInFile);
-                }
-            }
-        }
-    }
-    catch (std::exception& e)
-    {
-        if (!_tileBuffer->hasException)
-        {
-            _tileBuffer->exception    = e.what ();
-            _tileBuffer->hasException = true;
-        }
-    }
-    catch (...)
-    {
-        if (!_tileBuffer->hasException)
-        {
-            _tileBuffer->exception    = "unrecognized exception";
-            _tileBuffer->hasException = true;
-        }
-    }
-}
-
-TileBufferTask*
-newTileBufferTask (
-    TaskGroup*                group,
-    DeepTiledInputFile::Data* ifd,
-    int                       number,
-    int                       dx,
-    int                       dy,
-    int                       lx,
-    int                       ly)
-{
-    //
-    // Wait for a tile buffer to become available,
-    // fill the buffer with raw data from the file,
-    // and create a new TileBufferTask whose execute()
-    // method will uncompress the tile and copy the
-    // tile's pixels into the frame buffer.
-    //
-
-    TileBuffer* tileBuffer = ifd->getTileBuffer (number);
-
-    try
-    {
-        tileBuffer->wait ();
-
-        tileBuffer->dx = dx;
-        tileBuffer->dy = dy;
-        tileBuffer->lx = lx;
-        tileBuffer->ly = ly;
-
-        tileBuffer->uncompressedData = 0;
-
-        readTileData (
-            ifd->_streamData,
-            ifd,
-            dx,
-            dy,
-            lx,
-            ly,
-            tileBuffer->buffer,
-            tileBuffer->dataSize,
-            tileBuffer->uncompressedDataSize);
-    }
-    catch (...)
-    {
-        //
-        // Reading from the file caused an exception.
-        // Signal that the tile buffer is free, and
-        // re-throw the exception.
-        //
-
-        tileBuffer->post ();
-        throw;
-    }
-
-    return new TileBufferTask (group, ifd, tileBuffer);
-}
-
-} // namespace
 
 DeepTiledInputFile::DeepTiledInputFile (const char fileName[], int numThreads)
-    : _data (new Data (numThreads))
+    : DeepTiledInputFile (
+        fileName,
+        ContextInitializer ()
+        .silentHeaderParse (true)
+        .strictHeaderValidation (false),
+        numThreads)
 {
-    _data->_deleteStream = true;
-    //
-    // This constructor is called when a user
-    // explicitly wants to read a tiled file.
-    //
-
-    IStream* is = 0;
-    try
-    {
-        is = new StdIFStream (fileName);
-        readMagicNumberAndVersionField (*is, _data->version);
-
-        //
-        // Compatibility to read multpart file.
-        //
-        if (isMultiPart (_data->version)) { compatibilityInitialize (*is); }
-        else
-        {
-            _data->_streamData     = new InputStreamMutex ();
-            _data->_streamData->is = is;
-            _data->header.readFrom (*_data->_streamData->is, _data->version);
-            initialize ();
-            _data->tileOffsets.readFrom (
-                *(_data->_streamData->is), _data->fileIsComplete, false, true);
-            _data->_streamData->currentPosition =
-                _data->_streamData->is->tellg ();
-        }
-    }
-    catch (IEX_NAMESPACE::BaseExc& e)
-    {
-        if (is) delete is;
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData)
-            delete _data->_streamData;
-        if (_data) delete _data;
-
-        REPLACE_EXC (
-            e,
-            "Cannot open image file "
-            "\"" << fileName
-                 << "\". " << e.what ());
-        throw;
-    }
-    catch (...)
-    {
-        if (is) delete is;
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData)
-            delete _data->_streamData;
-        if (_data) delete _data;
-
-        throw;
-    }
 }
 
 DeepTiledInputFile::DeepTiledInputFile (
     OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is, int numThreads)
-    : _data (new Data (numThreads))
+    : DeepTiledInputFile (
+        is.fileName (),
+        ContextInitializer ()
+        .silentHeaderParse (true)
+        .strictHeaderValidation (false)
+        .setInputStream (&is),
+        numThreads)
 {
-    _data->_streamData   = 0;
-    _data->_deleteStream = false;
-
-    //
-    // This constructor is called when a user
-    // explicitly wants to read a tiled file.
-    //
-
-    try
-    {
-        readMagicNumberAndVersionField (is, _data->version);
-
-        //
-        // Backward compatibility to read multpart file.
-        //
-        if (isMultiPart (_data->version)) { compatibilityInitialize (is); }
-        else
-        {
-
-            _data->_streamData     = new InputStreamMutex ();
-            _data->_streamData->is = &is;
-            _data->header.readFrom (*_data->_streamData->is, _data->version);
-            initialize ();
-            // file is guaranteed not to be multipart, but is deep
-            _data->tileOffsets.readFrom (
-                *(_data->_streamData->is), _data->fileIsComplete, false, true);
-            _data->memoryMapped = _data->_streamData->is->isMemoryMapped ();
-            _data->_streamData->currentPosition =
-                _data->_streamData->is->tellg ();
-        }
-    }
-    catch (IEX_NAMESPACE::BaseExc& e)
-    {
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData)
-            delete _data->_streamData;
-        if (_data) delete _data;
-
-        REPLACE_EXC (
-            e,
-            "Cannot open image file "
-            "\"" << is.fileName ()
-                 << "\". " << e.what ());
-        throw;
-    }
-    catch (...)
-    {
-        if (_data && !_data->multiPartBackwardSupport && _data->_streamData)
-            delete _data->_streamData;
-        if (_data) delete _data;
-
-        throw;
-    }
-}
-
-DeepTiledInputFile::DeepTiledInputFile (
-    const Header&                            header,
-    OPENEXR_IMF_INTERNAL_NAMESPACE::IStream* is,
-    int                                      version,
-    int                                      numThreads)
-    : _data (new Data (numThreads))
-
-{
-    _data->_streamData->is = is;
-    _data->_deleteStream   = false;
-
-    //
-    // This constructor called by class Imf::InputFile
-    // when a user wants to just read an image file, and
-    // doesn't care or know if the file is tiled.
-    // No need to have backward compatibility here, because
-    // we have the header.
-    //
-
-    _data->header  = header;
-    _data->version = version;
-    initialize ();
-    _data->tileOffsets.readFrom (
-        *(_data->_streamData->is), _data->fileIsComplete, false, true);
-    _data->memoryMapped                 = is->isMemoryMapped ();
-    _data->_streamData->currentPosition = _data->_streamData->is->tellg ();
 }
 
 DeepTiledInputFile::DeepTiledInputFile (InputPartData* part)
-    : _data (new Data (part->numThreads))
+    : _ctxt (part->context),
+      _data (std::make_shared<Data> (&_ctxt, part->partNumber, part->numThreads))
 {
-    _data->_deleteStream = false;
-    try
-    {
-        multiPartInitialize (part);
-    }
-    catch (...)
-    {
-        delete _data;
-        throw;
-    }
-}
-
-void
-DeepTiledInputFile::compatibilityInitialize (
-    OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is)
-{
-    is.seekg (0);
-    //
-    // Construct a MultiPartInputFile, initialize TiledInputFile
-    // with the part 0 data.
-    // (TODO) maybe change the third parameter of the constructor of MultiPartInputFile later.
-    //
-    _data->multiPartFile = new MultiPartInputFile (is, _data->numThreads);
-    _data->multiPartBackwardSupport = true;
-    InputPartData* part             = _data->multiPartFile->getPart (0);
-
-    multiPartInitialize (part);
-}
-
-void
-DeepTiledInputFile::multiPartInitialize (InputPartData* part)
-{
-    if (part->header.type () != DEEPTILE)
-        THROW (
-            IEX_NAMESPACE::ArgExc,
-            "Can't build a DeepTiledInputFile from a part of type "
-                << part->header.type ());
-
-    _data->_streamData  = part->mutex;
-    _data->header       = part->header;
-    _data->version      = part->version;
-    _data->partNumber   = part->partNumber;
-    _data->memoryMapped = _data->_streamData->is->isMemoryMapped ();
-    initialize ();
-    _data->tileOffsets.readFrom (part->chunkOffsets, _data->fileIsComplete);
-    _data->_streamData->currentPosition = _data->_streamData->is->tellg ();
-}
-
-void
-DeepTiledInputFile::initialize ()
-{
-
-    if (_data->header.type () != DEEPTILE)
-    {
-        throw IEX_NAMESPACE::ArgExc (
-            "Expected a deep tiled file but the file is not deep tiled.");
-    }
-
-    if (_data->partNumber == -1)
-    {
-        if (!isNonImage (_data->version))
-            throw IEX_NAMESPACE::ArgExc (
-                "Expected a deep tiled file but the file is not a deep image.");
-    }
-
-    if (_data->header.version () != 1)
-    {
-        THROW (
-            IEX_NAMESPACE::ArgExc,
-            "Version "
-                << _data->header.version ()
-                << " not supported for deeptiled images in this version of the library");
-    }
-
-    _data->header.sanityCheck (true);
-
-    //
-    // before allocating memory for tile offsets, confirm file is large enough
-    // to contain tile offset table
-    // (for multipart files, the chunk offset table has already been read)
-    //
-    if (!isMultiPart (_data->version)) { _data->validateStreamSize (); }
-
-    _data->tileDesc  = _data->header.tileDescription ();
-    _data->lineOrder = _data->header.lineOrder ();
-
-    _data->maxSampleCountTableSize =
-        static_cast<size_t> (_data->tileDesc.ySize) *
-        static_cast<size_t> (_data->tileDesc.xSize) * sizeof (int);
-
-    //
-    // impose limit of 2^32 bytes of storage for maxSampleCountTableSize
-    // (disallow files with very large tile areas that would otherwise cause excessive memory allocation)
-    //
-
-    if (_data->maxSampleCountTableSize >
-        std::numeric_limits<unsigned int>::max ())
-    {
-        THROW (
-            IEX_NAMESPACE::ArgExc,
-            "Deep tile size exceeds maximum permitted area");
-    }
-
-    //
-    // Save the dataWindow information
-    //
-
-    const Box2i& dataWindow = _data->header.dataWindow ();
-    _data->minX             = dataWindow.min.x;
-    _data->maxX             = dataWindow.max.x;
-    _data->minY             = dataWindow.min.y;
-    _data->maxY             = dataWindow.max.y;
-
-    //
-    // Precompute level and tile information to speed up utility functions
-    //
-
-    precalculateTileInfo (
-        _data->tileDesc,
-        _data->minX,
-        _data->maxX,
-        _data->minY,
-        _data->maxY,
-        _data->numXTiles,
-        _data->numYTiles,
-        _data->numXLevels,
-        _data->numYLevels);
-
-    //
-    // Create all the TileBuffers and allocate their internal buffers
-    //
-
-    _data->tileOffsets = TileOffsets (
-        _data->tileDesc.mode,
-        _data->numXLevels,
-        _data->numYLevels,
-        _data->numXTiles,
-        _data->numYTiles);
-
-    for (size_t i = 0; i < _data->tileBuffers.size (); i++)
-        _data->tileBuffers[i] = new TileBuffer ();
-
-    _data->sampleCountTableBuffer.resizeErase (
-        static_cast<int> (_data->maxSampleCountTableSize));
-
-    _data->sampleCountTableComp = newCompressor (
-        _data->header.compression (),
-        _data->maxSampleCountTableSize,
-        _data->header);
-
-    const ChannelList& c      = _data->header.channels ();
-    _data->combinedSampleSize = 0;
-    for (ChannelList::ConstIterator i = c.begin (); i != c.end (); i++)
-    {
-        switch (i.channel ().type)
-        {
-            case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
-                _data->combinedSampleSize += Xdr::size<half> ();
-                break;
-            case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
-                _data->combinedSampleSize += Xdr::size<float> ();
-                break;
-            case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
-                _data->combinedSampleSize += Xdr::size<unsigned int> ();
-                break;
-            default:
-                THROW (
-                    IEX_NAMESPACE::ArgExc,
-                    "Bad type for channel "
-                        << i.name () << " initializing deepscanline reader");
-        }
-    }
-}
-
-DeepTiledInputFile::~DeepTiledInputFile ()
-{
-    if (!_data->memoryMapped)
-        for (size_t i = 0; i < _data->tileBuffers.size (); i++)
-            if (_data->tileBuffers[i]->buffer != 0)
-                delete[] _data->tileBuffers[i]->buffer;
-
-    if (_data->_deleteStream) delete _data->_streamData->is;
-
-    //
-    // (TODO) we should have a way to tell if the stream data is owned by this file or
-    // by a parent multipart file.
-    //
-
-    if (_data->partNumber == -1) delete _data->_streamData;
-
-    delete _data;
+    _data->initialize ();
 }
 
 const char*
 DeepTiledInputFile::fileName () const
 {
-    return _data->_streamData->is->fileName ();
+    return _ctxt.fileName ();
 }
 
 const Header&
 DeepTiledInputFile::header () const
 {
+#if ILMTHREAD_THREADING_ENABLED
+    std::lock_guard<std::mutex> lock (_data->_mx);
+#endif
+    if (!_data->header_filled)
+    {
+        _data->header = _ctxt.header (_data->partNumber);
+        _data->header_filled = true;
+    }
     return _data->header;
 }
 
 int
 DeepTiledInputFile::version () const
 {
-    return _data->version;
+    return _ctxt.version ();
 }
 
 void
 DeepTiledInputFile::setFrameBuffer (const DeepFrameBuffer& frameBuffer)
 {
 #if ILMTHREAD_THREADING_ENABLED
-    std::lock_guard<std::mutex> lock (*_data->_streamData);
+    std::lock_guard<std::mutex> lock (_data->_mx);
 #endif
-    //
-    // Set the frame buffer
-    //
-
-    //
-    // Check if the new frame buffer descriptor is
-    // compatible with the image file header.
-    //
-
-    const ChannelList& channels = _data->header.channels ();
+    _data->fill_list.clear ();
 
     for (DeepFrameBuffer::ConstIterator j = frameBuffer.begin ();
          j != frameBuffer.end ();
          ++j)
     {
-        ChannelList::ConstIterator i = channels.find (j.name ());
+        const exr_attr_chlist_entry_t* curc = _ctxt.findChannel (
+            _data->partNumber, j.name ());
 
-        if (i == channels.end ()) continue;
+        if (!curc)
+        {
+            _data->fill_list.push_back (j.slice ());
+            continue;
+        }
 
-        if (i.channel ().xSampling != j.slice ().xSampling ||
-            i.channel ().ySampling != j.slice ().ySampling)
+        if (curc->x_sampling != j.slice ().xSampling ||
+            curc->y_sampling != j.slice ().ySampling)
             THROW (
                 IEX_NAMESPACE::ArgExc,
                 "X and/or y subsampling factors "
                 "of \""
-                    << i.name ()
+                    << j.name ()
                     << "\" channel "
                        "of input file \""
                     << fileName ()
@@ -1182,126 +305,16 @@ DeepTiledInputFile::setFrameBuffer (const DeepFrameBuffer& frameBuffer)
                        "subsampling factors.");
     }
 
-    //
-    // Store the pixel sample count table.
-    // (TODO) Support for different sampling rates?
-    //
-
-    const Slice& sampleCountSlice = frameBuffer.getSampleCountSlice ();
-    if (sampleCountSlice.base == 0)
-    {
-        throw IEX_NAMESPACE::ArgExc (
-            "Invalid base pointer, please set a proper sample count slice.");
-    }
-    else
-    {
-        _data->sampleCountSliceBase   = sampleCountSlice.base;
-        _data->sampleCountXStride     = sampleCountSlice.xStride;
-        _data->sampleCountYStride     = sampleCountSlice.yStride;
-        _data->sampleCountXTileCoords = sampleCountSlice.xTileCoords;
-        _data->sampleCountYTileCoords = sampleCountSlice.yTileCoords;
-    }
-
-    //
-    // Initialize the slice table for readPixels().
-    //
-
-    vector<TInSliceInfo*>      slices;
-    ChannelList::ConstIterator i = channels.begin ();
-
-    for (DeepFrameBuffer::ConstIterator j = frameBuffer.begin ();
-         j != frameBuffer.end ();
-         ++j)
-    {
-        while (i != channels.end () && strcmp (i.name (), j.name ()) < 0)
-        {
-            //
-            // Channel i is present in the file but not
-            // in the frame buffer; data for channel i
-            // will be skipped during readPixels().
-            //
-
-            slices.push_back (new TInSliceInfo (
-                i.channel ().type,
-                NULL,
-                i.channel ().type,
-                0,     // xStride
-                0,     // yStride
-                0,     // sampleStride
-                false, // fill
-                true,  // skip
-                0.0)); // fillValue
-            ++i;
-        }
-
-        bool fill = false;
-
-        if (i == channels.end () || strcmp (i.name (), j.name ()) > 0)
-        {
-            //
-            // Channel i is present in the frame buffer, but not in the file.
-            // In the frame buffer, slice j will be filled with a default value.
-            //
-
-            fill = true;
-        }
-
-        slices.push_back (new TInSliceInfo (
-            j.slice ().type,
-            j.slice ().base,
-            fill ? j.slice ().type : i.channel ().type,
-            j.slice ().xStride,
-            j.slice ().yStride,
-            j.slice ().sampleStride,
-            fill,
-            false, // skip
-            j.slice ().fillValue,
-            (j.slice ().xTileCoords) ? 1 : 0,
-            (j.slice ().yTileCoords) ? 1 : 0));
-
-        if (i != channels.end () && !fill) ++i;
-    }
-
-    // (TODO) inspect the following code. It's additional to the scanline input file.
-    // Is this needed?
-
-    while (i != channels.end ())
-    {
-        //
-        // Channel i is present in the file but not
-        // in the frame buffer; data for channel i
-        // will be skipped during readPixels().
-        //
-
-        slices.push_back (new TInSliceInfo (
-            i.channel ().type,
-            NULL,
-            i.channel ().type,
-            0,     // xStride
-            0,     // yStride
-            0,     // sampleStride
-            false, // fill
-            true,  // skip
-            0.0)); // fillValue
-        ++i;
-    }
-
-    //
-    // Store the new frame buffer.
-    //
-
     _data->frameBuffer = frameBuffer;
-
-    for (size_t i = 0; i < _data->slices.size (); i++)
-        delete _data->slices[i];
-    _data->slices = slices;
+    _data->frameBufferValid = true;
+    _data->processStack.reset();
 }
 
 const DeepFrameBuffer&
 DeepTiledInputFile::frameBuffer () const
 {
 #if ILMTHREAD_THREADING_ENABLED
-    std::lock_guard<std::mutex> lock (*_data->_streamData);
+    std::lock_guard<std::mutex> lock (_data->_mx);
 #endif
     return _data->frameBuffer;
 }
@@ -1309,7 +322,7 @@ DeepTiledInputFile::frameBuffer () const
 bool
 DeepTiledInputFile::isComplete () const
 {
-    return _data->fileIsComplete;
+    return _ctxt.chunkTableValid (_data->partNumber);
 }
 
 void
@@ -1322,12 +335,11 @@ DeepTiledInputFile::readTiles (
 
     try
     {
-#if ILMTHREAD_THREADING_ENABLED
-        std::lock_guard<std::mutex> lock (*_data->_streamData);
-#endif
-        if (_data->slices.size () == 0)
-            throw IEX_NAMESPACE::ArgExc ("No frame buffer specified "
-                                         "as pixel data destination.");
+        if (!_data->frameBufferValid)
+        {
+            throw IEX_NAMESPACE::ArgExc (
+                "readTiles called with no valid frame buffer");
+        }
 
         if (!isValidLevel (lx, ly))
             THROW (
@@ -1338,91 +350,16 @@ DeepTiledInputFile::readTiles (
                     << ") "
                        "is invalid.");
 
-        //
-        // Determine the first and last tile coordinates in both dimensions.
-        // We always attempt to read the range of tiles in the order that
-        // they are stored in the file.
-        //
-
         if (dx1 > dx2) std::swap (dx1, dx2);
-
         if (dy1 > dy2) std::swap (dy1, dy2);
 
-        int dyStart = dy1;
-        int dyStop  = dy2 + 1;
-        int dY      = 1;
-
-        if (_data->lineOrder == DECREASING_Y)
-        {
-            dyStart = dy2;
-            dyStop  = dy1 - 1;
-            dY      = -1;
-        }
-
-        //
-        // Create a task group for all tile buffer tasks.  When the
-        // task group goes out of scope, the destructor waits until
-        // all tasks are complete.
-        //
-
-        {
-            TaskGroup taskGroup;
-            int       tileNumber = 0;
-
-            for (int dy = dyStart; dy != dyStop; dy += dY)
-            {
-                for (int dx = dx1; dx <= dx2; dx++)
-                {
-                    if (!isValidTile (dx, dy, lx, ly))
-                        THROW (
-                            IEX_NAMESPACE::ArgExc,
-                            "Tile (" << dx << ", " << dy << ", " << lx << ","
-                                     << ly << ") is not a valid tile.");
-
-                    ThreadPool::addGlobalTask (newTileBufferTask (
-                        &taskGroup, _data, tileNumber++, dx, dy, lx, ly));
-                }
-            }
-
-            //
-            // finish all tasks
-            //
-        }
-
-        //
-        // Exception handling:
-        //
-        // TileBufferTask::execute() may have encountered exceptions, but
-        // those exceptions occurred in another thread, not in the thread
-        // that is executing this call to TiledInputFile::readTiles().
-        // TileBufferTask::execute() has caught all exceptions and stored
-        // the exceptions' what() strings in the tile buffers.
-        // Now we check if any tile buffer contains a stored exception; if
-        // this is the case then we re-throw the exception in this thread.
-        // (It is possible that multiple tile buffers contain stored
-        // exceptions.  We re-throw the first exception we find and
-        // ignore all others.)
-        //
-
-        const string* exception = 0;
-
-        for (size_t i = 0; i < _data->tileBuffers.size (); ++i)
-        {
-            TileBuffer* tileBuffer = _data->tileBuffers[i];
-
-            if (tileBuffer->hasException && !exception)
-                exception = &tileBuffer->exception;
-
-            tileBuffer->hasException = false;
-        }
-
-        if (exception) throw IEX_NAMESPACE::IoExc (*exception);
+        _data->readTiles (dx1, dx2, dy1, dy2, lx, ly, false);
     }
     catch (IEX_NAMESPACE::BaseExc& e)
     {
         REPLACE_EXC (
             e,
-            "Error reading pixel data from image "
+            "Error reading deep tiled data from image "
             "file \""
                 << fileName () << "\". " << e.what ());
         throw;
@@ -1447,6 +384,19 @@ DeepTiledInputFile::readTile (int dx, int dy, int l)
     readTile (dx, dy, l, l);
 }
 
+#pragma pack(push, 1)
+struct DeepTileChunkHeader
+{
+    int32_t dx;
+    int32_t dy;
+    int32_t lx;
+    int32_t ly;
+    uint64_t packedCountSize;
+    uint64_t packedDataSize;
+    uint64_t unpackedDataSize;
+};
+#pragma pack(pop)
+
 void
 DeepTiledInputFile::rawTileData (
     int&      dx,
@@ -1456,141 +406,86 @@ DeepTiledInputFile::rawTileData (
     char*     pixelData,
     uint64_t& pixelDataSize) const
 {
-    if (!isValidTile (dx, dy, lx, ly))
-        throw IEX_NAMESPACE::ArgExc ("Tried to read a tile outside "
-                                     "the image file's data window.");
+    exr_chunk_info_t cinfo;
 
-    uint64_t tileOffset = _data->tileOffsets (dx, dy, lx, ly);
+    static_assert (sizeof(DeepTileChunkHeader) == 40, "Expect a 40-byte tiled chunk header");
 
-    if (tileOffset == 0)
+    if (EXR_ERR_SUCCESS == exr_read_tile_chunk_info (
+            _ctxt, _data->partNumber, dx, dy, lx, ly, &cinfo))
     {
-        THROW (
-            IEX_NAMESPACE::InputExc,
-            "Tile (" << dx << ", " << dy << ", " << lx << ", " << ly
-                     << ") is missing.");
-    }
+        uint64_t cbytes;
+        cbytes = sizeof (DeepTileChunkHeader);
+        cbytes += cinfo.sample_count_table_size;
+        cbytes += cinfo.packed_size;
 
-#if ILMTHREAD_THREADING_ENABLED
-    std::lock_guard<std::mutex> lock (*_data->_streamData);
-#endif
-    if (_data->_streamData->is->tellg () != tileOffset)
-        _data->_streamData->is->seekg (tileOffset);
+        if (!pixelData || cbytes > pixelDataSize)
+        {
+            pixelDataSize = cbytes;
+            return;
+        }
 
-    //
-    // Read the first few bytes of the tile (the header).
-    // Verify that the tile coordinates and the level number
-    // are correct.
-    //
+        pixelDataSize = cbytes;
 
-    int tileXCoord, tileYCoord, levelX, levelY;
+        DeepTileChunkHeader* dch = reinterpret_cast<DeepTileChunkHeader*> (pixelData);
+        dch->dx = cinfo.start_x;
+        dch->dy = cinfo.start_y;
+        dch->lx = cinfo.level_x;
+        dch->ly = cinfo.level_y;
+        dch->packedCountSize = cinfo.sample_count_table_size;
+        dch->packedDataSize = cinfo.packed_size;
+        dch->unpackedDataSize = cinfo.unpacked_size;
 
-    if (isMultiPart (_data->version))
-    {
-        int partNumber;
-        Xdr::read<StreamIO> (*_data->_streamData->is, partNumber);
-        if (partNumber != _data->partNumber)
+        pixelData += sizeof(DeepTileChunkHeader);
+
+        if (EXR_ERR_SUCCESS !=
+            exr_read_deep_chunk (
+                _ctxt,
+                _data->partNumber,
+                &cinfo,
+                pixelData + cinfo.sample_count_table_size,
+                pixelData))
         {
             THROW (
                 IEX_NAMESPACE::ArgExc,
-                "Unexpected part number " << partNumber << ", should be "
-                                          << _data->partNumber << ".");
+                "Error reading deep tiled data from image "
+                "file \""
+                << fileName () << "\". Unable to read raw tile data of "
+                << pixelDataSize << " bytes.");
         }
     }
-
-    Xdr::read<StreamIO> (*_data->_streamData->is, tileXCoord);
-    Xdr::read<StreamIO> (*_data->_streamData->is, tileYCoord);
-    Xdr::read<StreamIO> (*_data->_streamData->is, levelX);
-    Xdr::read<StreamIO> (*_data->_streamData->is, levelY);
-
-    uint64_t sampleCountTableSize;
-    uint64_t packedDataSize;
-    Xdr::read<StreamIO> (*_data->_streamData->is, sampleCountTableSize);
-
-    Xdr::read<StreamIO> (*_data->_streamData->is, packedDataSize);
-
-    if (tileXCoord != dx)
-        throw IEX_NAMESPACE::InputExc ("Unexpected tile x coordinate.");
-
-    if (tileYCoord != dy)
-        throw IEX_NAMESPACE::InputExc ("Unexpected tile y coordinate.");
-
-    if (levelX != lx)
-        throw IEX_NAMESPACE::InputExc (
-            "Unexpected tile x level number coordinate.");
-
-    if (levelY != ly)
-        throw IEX_NAMESPACE::InputExc (
-            "Unexpected tile y level number coordinate.");
-
-    // total requirement for reading all the data
-
-    uint64_t totalSizeRequired = 40 + sampleCountTableSize + packedDataSize;
-
-    bool big_enough = totalSizeRequired <= pixelDataSize;
-
-    pixelDataSize = totalSizeRequired;
-
-    // was the block we were given big enough?
-    if (!big_enough || pixelData == NULL)
+    else
     {
-        // special case: seek stream back to start if we are at the beginning (regular reading pixels assumes it doesn't need to seek
-        // in single part files)
-        if (!isMultiPart (_data->version))
-        {
-            _data->_streamData->is->seekg (_data->_streamData->currentPosition);
-        }
-        // leave lock here - bail before reading more data
-        return;
+        THROW (
+            IEX_NAMESPACE::ArgExc,
+            "Error reading deep tile data from image "
+            "file \""
+            << fileName ()
+            << "\". Unable to query data block information.");
     }
-
-    // copy the values we have read into the output block
-    *(int*) (pixelData + 0)       = dx;
-    *(int*) (pixelData + 4)       = dy;
-    *(int*) (pixelData + 8)       = levelX;
-    *(int*) (pixelData + 12)      = levelY;
-    *(uint64_t*) (pixelData + 16) = sampleCountTableSize;
-    *(uint64_t*) (pixelData + 24) = packedDataSize;
-
-    // didn't read the unpackedsize - do that now
-    Xdr::read<StreamIO> (
-        *_data->_streamData->is, *(uint64_t*) (pixelData + 32));
-
-    // read the actual data
-    _data->_streamData->is->read (
-        pixelData + 40,
-        static_cast<int> (sampleCountTableSize + packedDataSize));
-
-    if (!isMultiPart (_data->version))
-    {
-        _data->_streamData->currentPosition +=
-            sampleCountTableSize + packedDataSize + 40;
-    }
-
-    // leave lock here
 }
 
 unsigned int
 DeepTiledInputFile::tileXSize () const
 {
-    return _data->tileDesc.xSize;
+    return _data->tile_x_size;
 }
 
 unsigned int
 DeepTiledInputFile::tileYSize () const
 {
-    return _data->tileDesc.ySize;
+    return _data->tile_y_size;
 }
 
 LevelMode
 DeepTiledInputFile::levelMode () const
 {
-    return _data->tileDesc.mode;
+    return (LevelMode)_data->tile_level_mode;
 }
 
 LevelRoundingMode
 DeepTiledInputFile::levelRoundingMode () const
 {
-    return _data->tileDesc.roundingMode;
+    return (LevelRoundingMode)_data->tile_round_mode;
 }
 
 int
@@ -1606,19 +501,19 @@ DeepTiledInputFile::numLevels () const
                    "(numLevels() is not defined for files "
                    "with RIPMAP level mode).");
 
-    return _data->numXLevels;
+    return _data->num_x_levels;
 }
 
 int
 DeepTiledInputFile::numXLevels () const
 {
-    return _data->numXLevels;
+    return _data->num_x_levels;
 }
 
 int
 DeepTiledInputFile::numYLevels () const
 {
-    return _data->numYLevels;
+    return _data->num_y_levels;
 }
 
 bool
@@ -1636,113 +531,99 @@ DeepTiledInputFile::isValidLevel (int lx, int ly) const
 int
 DeepTiledInputFile::levelWidth (int lx) const
 {
-    try
+    int32_t levw = 0;
+    if (EXR_ERR_SUCCESS != exr_get_level_sizes (
+            _ctxt, _data->partNumber, lx, 0, &levw, nullptr))
     {
-        return levelSize (
-            _data->minX, _data->maxX, lx, _data->tileDesc.roundingMode);
-    }
-    catch (IEX_NAMESPACE::BaseExc& e)
-    {
-        REPLACE_EXC (
-            e,
+        THROW (
+            IEX_NAMESPACE::ArgExc,
             "Error calling levelWidth() on image "
             "file \""
-                << fileName () << "\". " << e.what ());
-        throw;
+                << fileName () << "\".");
     }
+    return levw;
 }
 
 int
 DeepTiledInputFile::levelHeight (int ly) const
 {
-    try
+    int32_t levh = 0;
+    if (EXR_ERR_SUCCESS != exr_get_level_sizes (
+            _ctxt, _data->partNumber, 0, ly, nullptr, &levh))
     {
-        return levelSize (
-            _data->minY, _data->maxY, ly, _data->tileDesc.roundingMode);
-    }
-    catch (IEX_NAMESPACE::BaseExc& e)
-    {
-        REPLACE_EXC (
-            e,
-            "Error calling levelHeight() on image "
+        THROW (
+            IEX_NAMESPACE::ArgExc,
+            "Error calling levelWidth() on image "
             "file \""
-                << fileName () << "\". " << e.what ());
-        throw;
+                << fileName () << "\".");
     }
+    return levh;
 }
 
 int
 DeepTiledInputFile::numXTiles (int lx) const
 {
-    if (lx < 0 || lx >= _data->numXLevels)
+    int32_t countx = 0;
+    if (EXR_ERR_SUCCESS != exr_get_tile_counts (
+            _ctxt, _data->partNumber, lx, 0, &countx, nullptr))
     {
         THROW (
             IEX_NAMESPACE::ArgExc,
             "Error calling numXTiles() on image "
             "file \""
-                << _data->_streamData->is->fileName ()
-                << "\" "
-                   "(Argument is not in valid range).");
+                << fileName () << "\".");
     }
-
-    return _data->numXTiles[lx];
+    return countx;
 }
 
 int
 DeepTiledInputFile::numYTiles (int ly) const
 {
-    if (ly < 0 || ly >= _data->numYLevels)
+    int32_t county = 0;
+    if (EXR_ERR_SUCCESS != exr_get_tile_counts (
+            _ctxt, _data->partNumber, 0, ly, nullptr, &county))
     {
         THROW (
             IEX_NAMESPACE::ArgExc,
             "Error calling numYTiles() on image "
             "file \""
-                << _data->_streamData->is->fileName ()
-                << "\" "
-                   "(Argument is not in valid range).");
+                << fileName () << "\".");
     }
-
-    return _data->numYTiles[ly];
+    return county;
 }
 
-Box2i
+IMATH_NAMESPACE::Box2i
 DeepTiledInputFile::dataWindowForLevel (int l) const
 {
     return dataWindowForLevel (l, l);
 }
 
-Box2i
+IMATH_NAMESPACE::Box2i
 DeepTiledInputFile::dataWindowForLevel (int lx, int ly) const
 {
-    try
+    int32_t levw = 0, levh = 0;
+    if (EXR_ERR_SUCCESS != exr_get_level_sizes (
+            _ctxt, _data->partNumber, lx, ly, &levw, &levh))
     {
-        return OPENEXR_IMF_INTERNAL_NAMESPACE::dataWindowForLevel (
-            _data->tileDesc,
-            _data->minX,
-            _data->maxX,
-            _data->minY,
-            _data->maxY,
-            lx,
-            ly);
-    }
-    catch (IEX_NAMESPACE::BaseExc& e)
-    {
-        REPLACE_EXC (
-            e,
+        THROW (
+            IEX_NAMESPACE::ArgExc,
             "Error calling dataWindowForLevel() on image "
             "file \""
-                << fileName () << "\". " << e.what ());
-        throw;
+                << fileName () << "\".");
     }
+    exr_attr_box2i_t dw = _ctxt.dataWindow (_data->partNumber);
+    return IMATH_NAMESPACE::Box2i (
+        IMATH_NAMESPACE::V2i (dw.min.x, dw.min.y),
+        IMATH_NAMESPACE::V2i (dw.min.x + levw - 1, dw.min.y + levh - 1));
 }
 
-Box2i
+IMATH_NAMESPACE::Box2i
 DeepTiledInputFile::dataWindowForTile (int dx, int dy, int l) const
 {
     return dataWindowForTile (dx, dy, l, l);
 }
 
-Box2i
+IMATH_NAMESPACE::Box2i
 DeepTiledInputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
 {
     try
@@ -1750,16 +631,24 @@ DeepTiledInputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
         if (!isValidTile (dx, dy, lx, ly))
             throw IEX_NAMESPACE::ArgExc ("Arguments not in valid range.");
 
-        return OPENEXR_IMF_INTERNAL_NAMESPACE::dataWindowForTile (
-            _data->tileDesc,
-            _data->minX,
-            _data->maxX,
-            _data->minY,
-            _data->maxY,
-            dx,
-            dy,
-            lx,
-            ly);
+        //exr_attr_box2i_t dw = _ctxt.dataWindow (_data->partNumber);
+        auto dw = dataWindowForLevel (lx, ly);
+
+        int32_t tileSizeX, tileSizeY;
+        if (EXR_ERR_SUCCESS !=
+            exr_get_tile_sizes (_ctxt, _data->partNumber, lx, ly, &tileSizeX, &tileSizeY))
+          throw IEX_NAMESPACE::ArgExc ("Unable to query the data window.");
+
+        dw.min.x += dx * tileSizeX;
+        dw.min.y += dy * tileSizeY;
+        int limX = dw.min.x + tileSizeX - 1;
+        int limY = dw.min.y + tileSizeY - 1;
+        limX = std::min (limX, dw.max.x);
+        limY = std::min (limY, dw.max.y);
+
+        return IMATH_NAMESPACE::Box2i (
+            IMATH_NAMESPACE::V2i (dw.min.x, dw.min.y),
+            IMATH_NAMESPACE::V2i (limX, limY));
     }
     catch (IEX_NAMESPACE::BaseExc& e)
     {
@@ -1775,28 +664,33 @@ DeepTiledInputFile::dataWindowForTile (int dx, int dy, int lx, int ly) const
 bool
 DeepTiledInputFile::isValidTile (int dx, int dy, int lx, int ly) const
 {
-    return (
-        (lx < _data->numXLevels && lx >= 0) &&
-        (ly < _data->numYLevels && ly >= 0) &&
-        (dx < _data->numXTiles[lx] && dx >= 0) &&
-        (dy < _data->numYTiles[ly] && dy >= 0));
+    int32_t countx = 0, county = 0;
+    if (EXR_ERR_SUCCESS == exr_get_tile_counts (
+            _ctxt, _data->partNumber, lx, ly, &countx, &county))
+    {
+        // get tile counts will check lx, ly for us
+        return ((dx < countx && dx >= 0) &&
+                (dy < county && dy >= 0));
+    }
+    return false;
 }
 
 void
 DeepTiledInputFile::readPixelSampleCounts (
     int dx1, int dx2, int dy1, int dy2, int lx, int ly)
 {
-    uint64_t savedFilePos = 0;
-
+    //
+    // Read a range of tiles from the file into the framebuffer
+    //
     try
     {
-#if ILMTHREAD_THREADING_ENABLED
-        std::lock_guard<std::mutex> lock (*_data->_streamData);
-#endif
-        savedFilePos = _data->_streamData->is->tellg ();
+        if (!_data->frameBufferValid)
+        {
+            throw IEX_NAMESPACE::ArgExc (
+                "readPixelSampleCounts called with no valid frame buffer");
+        }
 
         if (!isValidLevel (lx, ly))
-        {
             THROW (
                 IEX_NAMESPACE::ArgExc,
                 "Level coordinate "
@@ -1804,235 +698,19 @@ DeepTiledInputFile::readPixelSampleCounts (
                     << ", " << ly
                     << ") "
                        "is invalid.");
-        }
 
         if (dx1 > dx2) std::swap (dx1, dx2);
-
         if (dy1 > dy2) std::swap (dy1, dy2);
 
-        int dyStart = dy1;
-        int dyStop  = dy2 + 1;
-        int dY      = 1;
-
-        if (_data->lineOrder == DECREASING_Y)
-        {
-            dyStart = dy2;
-            dyStop  = dy1 - 1;
-            dY      = -1;
-        }
-
-        // (TODO) Check if we have read the sample counts for those tiles,
-        // if we have, no need to read again.
-        for (int dy = dyStart; dy != dyStop; dy += dY)
-        {
-            for (int dx = dx1; dx <= dx2; dx++)
-            {
-
-                if (!isValidTile (dx, dy, lx, ly))
-                {
-                    THROW (
-                        IEX_NAMESPACE::ArgExc,
-                        "Tile (" << dx << ", " << dy << ", " << lx << "," << ly
-                                 << ") is not a valid tile.");
-                }
-
-                Box2i tileRange =
-                    OPENEXR_IMF_INTERNAL_NAMESPACE::dataWindowForTile (
-                        _data->tileDesc,
-                        _data->minX,
-                        _data->maxX,
-                        _data->minY,
-                        _data->maxY,
-                        dx,
-                        dy,
-                        lx,
-                        ly);
-
-                int xOffset = _data->sampleCountXTileCoords * tileRange.min.x;
-                int yOffset = _data->sampleCountYTileCoords * tileRange.min.y;
-
-                //
-                // Skip and check the tile coordinates.
-                //
-
-                _data->_streamData->is->seekg (
-                    _data->tileOffsets (dx, dy, lx, ly));
-
-                if (isMultiPart (_data->version))
-                {
-                    int partNumber;
-                    Xdr::read<StreamIO> (*_data->_streamData->is, partNumber);
-
-                    if (partNumber != _data->partNumber)
-                        throw IEX_NAMESPACE::InputExc (
-                            "Unexpected part number " +
-                            std::to_string (partNumber) +
-                            " for tile offset.");
-                }
-
-                int xInFile, yInFile, lxInFile, lyInFile;
-                Xdr::read<StreamIO> (*_data->_streamData->is, xInFile);
-                Xdr::read<StreamIO> (*_data->_streamData->is, yInFile);
-                Xdr::read<StreamIO> (*_data->_streamData->is, lxInFile);
-                Xdr::read<StreamIO> (*_data->_streamData->is, lyInFile);
-
-                if (xInFile != dx)
-                    throw IEX_NAMESPACE::InputExc (
-                        "Unexpected tile x coordinate.");
-
-                if (yInFile != dy)
-                    throw IEX_NAMESPACE::InputExc (
-                        "Unexpected tile y coordinate.");
-
-                if (lxInFile != lx)
-                    throw IEX_NAMESPACE::InputExc (
-                        "Unexpected tile x level number coordinate.");
-
-                if (lyInFile != ly)
-                    throw IEX_NAMESPACE::InputExc (
-                        "Unexpected tile y level number coordinate.");
-
-                uint64_t tableSize, dataSize, unpackedDataSize;
-                Xdr::read<StreamIO> (*_data->_streamData->is, tableSize);
-                Xdr::read<StreamIO> (*_data->_streamData->is, dataSize);
-                Xdr::read<StreamIO> (*_data->_streamData->is, unpackedDataSize);
-
-                if (tableSize > _data->maxSampleCountTableSize)
-                {
-                    THROW (
-                        IEX_NAMESPACE::ArgExc,
-                        "Bad sampleCountTableDataSize read from tile "
-                            << dx << ',' << dy << ',' << lx << ',' << ly
-                            << ": expected " << _data->maxSampleCountTableSize
-                            << " or less, got " << tableSize);
-                }
-
-                //
-                // We make a check on the data size requirements here.
-                // Whilst we wish to store 64bit sizes on disk, not all the compressors
-                // have been made to work with such data sizes and are still limited to
-                // using signed 32 bit (int) for the data size. As such, this version
-                // insists that we validate that the data size does not exceed the data
-                // type max limit.
-                // @TODO refactor the compressor code to ensure full 64-bit support.
-                //
-
-                uint64_t compressorMaxDataSize =
-                    static_cast<uint64_t> (std::numeric_limits<int>::max ());
-                if (dataSize > compressorMaxDataSize ||
-                    unpackedDataSize > compressorMaxDataSize ||
-                    tableSize > compressorMaxDataSize)
-                {
-                    THROW (
-                        IEX_NAMESPACE::ArgExc,
-                        "This version of the library does not"
-                            << "support the allocation of data with size  > "
-                            << compressorMaxDataSize
-                            << " file table size    :" << tableSize
-                            << " file unpacked size :" << unpackedDataSize
-                            << " file packed size   :" << dataSize << ".\n");
-                }
-
-                //
-                // Read and uncompress the pixel sample count table.
-                //
-
-                _data->_streamData->is->read (
-                    _data->sampleCountTableBuffer,
-                    static_cast<int> (tableSize));
-
-                const char* readPtr;
-
-                size_t tileTableBytes =
-                    (sizeof(int) * (tileRange.max.y - tileRange.min.y + 1) *
-                     (tileRange.max.x - tileRange.min.x + 1));
-
-                if (tableSize < tileTableBytes)
-                {
-                    size_t uncto;
-                    if (!_data->sampleCountTableComp)
-                    {
-                        THROW (
-                            IEX_NAMESPACE::ArgExc,
-                            "Deep scanline data corrupt at tile "
-                                << dx << ',' << dy << ',' << lx << ',' << ly
-                                << " (sampleCountTableDataSize error)");
-                    }
-                    uncto = _data->sampleCountTableComp->uncompress (
-                        _data->sampleCountTableBuffer,
-                        static_cast<int> (tableSize),
-                        tileRange.min.y,
-                        readPtr);
-                    if (uncto < tileTableBytes)
-                    {
-                        THROW (
-                            IEX_NAMESPACE::ArgExc,
-                            "Deep scanline data corrupt at tile "
-                            << dx << ',' << dy << ',' << lx << ',' << ly
-                            << " sampleCountTableDataSize error: "
-                            << uncto << " bytes uncompressed, need "
-                            << tileTableBytes);
-                    }
-                }
-                else
-                    readPtr = _data->sampleCountTableBuffer;
-
-                size_t cumulative_total_samples = 0;
-                int    lastAccumulatedCount;
-                for (int j = tileRange.min.y; j <= tileRange.max.y; j++)
-                {
-                    lastAccumulatedCount = 0;
-                    for (int i = tileRange.min.x; i <= tileRange.max.x; i++)
-                    {
-                        int accumulatedCount;
-                        Xdr::read<CharPtrIO> (readPtr, accumulatedCount);
-
-                        if (accumulatedCount < lastAccumulatedCount)
-                        {
-                            THROW (
-                                IEX_NAMESPACE::ArgExc,
-                                "Deep tile sampleCount data corrupt at tile "
-                                    << dx << ',' << dy << ',' << lx << ',' << ly
-                                    << " (negative sample count detected)");
-                        }
-
-                        int count = accumulatedCount - lastAccumulatedCount;
-                        lastAccumulatedCount = accumulatedCount;
-
-                        _data->getSampleCount (i - xOffset, j - yOffset) =
-                            count;
-                    }
-                    cumulative_total_samples += lastAccumulatedCount;
-                }
-
-                if (cumulative_total_samples * _data->combinedSampleSize >
-                    unpackedDataSize)
-                {
-                    THROW (
-                        IEX_NAMESPACE::ArgExc,
-                        "Deep scanline sampleCount data corrupt at tile "
-                            << dx << ',' << dy << ',' << lx << ',' << ly
-                            << ": pixel data only contains " << unpackedDataSize
-                            << " bytes of data but table references at least "
-                            << cumulative_total_samples *
-                                   _data->combinedSampleSize
-                            << " bytes of sample data");
-                }
-            }
-        }
-
-        _data->_streamData->is->seekg (savedFilePos);
+        _data->readTiles (dx1, dx2, dy1, dy2, lx, ly, true);
     }
     catch (IEX_NAMESPACE::BaseExc& e)
     {
         REPLACE_EXC (
             e,
-            "Error reading sample count data from image "
+            "Error reading deep pixel sample counts data from image "
             "file \""
                 << fileName () << "\". " << e.what ());
-
-        _data->_streamData->is->seekg (savedFilePos);
-
         throw;
     }
 }
@@ -2088,10 +766,497 @@ DeepTiledInputFile::totalTiles () const
     return numAllTiles;
 }
 
+namespace
+{
+struct tilepos
+{
+    uint64_t filePos;
+    int      dx;
+    int      dy;
+    int      lx;
+    int      ly;
+    bool     operator< (const tilepos& other) const
+    {
+        return filePos < other.filePos;
+    }
+};
+} // namespace
+
 void
 DeepTiledInputFile::getTileOrder (int dx[], int dy[], int lx[], int ly[]) const
 {
-    return _data->tileOffsets.getTileOrder (dx, dy, lx, ly);
+    // TODO: remove once TiledOutputFile copy is converted
+    switch (_ctxt.lineOrder (_data->partNumber))
+    {
+        case EXR_LINEORDER_RANDOM_Y:
+            // calc below outside the nest
+            break;
+
+        case EXR_LINEORDER_DECREASING_Y:
+        {
+            dx[0] = 0;
+            dy[0] = numYTiles (0) - 1;
+            lx[0] = 0;
+            ly[0] = 0;
+            return;
+        }
+        case EXR_LINEORDER_INCREASING_Y:
+            dx[0] = 0;
+            dy[0] = 0;
+            lx[0] = 0;
+            ly[0] = 0;
+            return;
+
+        case EXR_LINEORDER_LAST_TYPE: /* invalid but should never be here */
+        default:
+            throw IEX_NAMESPACE::ArgExc ("Unknown LineOrder.");
+    }
+
+    size_t numAllTiles = 0;
+    int numX = numXLevels ();
+    int numY = numYLevels ();
+
+    switch (levelMode ())
+    {
+        case ONE_LEVEL:
+        case MIPMAP_LEVELS:
+            for (int i_l = 0; i_l < numY; ++i_l)
+                numAllTiles += size_t (numXTiles (i_l)) * size_t (numYTiles (i_l));
+            break;
+
+        case RIPMAP_LEVELS:
+            for (int i_ly = 0; i_ly < numY; ++i_ly)
+                for (int i_lx = 0; i_lx < numX; ++i_lx)
+                    numAllTiles += size_t (numXTiles (i_lx)) * size_t (numYTiles (i_ly));
+            break;
+
+        default:
+            throw IEX_NAMESPACE::ArgExc ("Unknown LevelMode format.");
+    }
+
+    std::vector<tilepos> table;
+
+    table.resize (numAllTiles);
+    size_t tIdx = 0;
+    switch (levelMode ())
+    {
+        case ONE_LEVEL:
+        case MIPMAP_LEVELS:
+            for (int i_l = 0; i_l < numY; ++i_l)
+            {
+                int nY = numYTiles (i_l);
+                int nX = numXTiles (i_l);
+
+                for ( int y = 0; y < nY; ++y )
+                    for ( int x = 0; x < nX; ++x )
+                    {
+                        exr_chunk_info_t cinfo;
+                        if (EXR_ERR_SUCCESS == exr_read_tile_chunk_info (
+                                _ctxt, _data->partNumber, x, y, i_l, i_l, &cinfo))
+                        {
+                            tilepos &tp = table[tIdx++];
+                            tp.filePos = cinfo.data_offset;
+                            tp.dx = x;
+                            tp.dy = y;
+                            tp.lx = i_l;
+                            tp.ly = i_l;
+                        }
+                        else
+                        {
+                            throw IEX_NAMESPACE::ArgExc ("Unable to get tile offset.");
+                        }
+                    }
+            }
+            break;
+
+        case RIPMAP_LEVELS:
+            for (int i_ly = 0; i_ly < numY; ++i_ly)
+            {
+                int nY = numYTiles (i_ly);
+                for (int i_lx = 0; i_lx < numX; ++i_lx)
+                {
+                    int nX = numXTiles (i_lx);
+                    for ( int y = 0; y < nY; ++y )
+                        for ( int x = 0; x < nX; ++x )
+                        {
+                            exr_chunk_info_t cinfo;
+                            if (EXR_ERR_SUCCESS == exr_read_tile_chunk_info (
+                                    _ctxt, _data->partNumber, x, y, i_lx, i_ly, &cinfo))
+                            {
+                                tilepos &tp = table[tIdx++];
+                                tp.filePos = cinfo.data_offset;
+                                tp.dx = x;
+                                tp.dy = y;
+                                tp.lx = i_lx;
+                                tp.ly = i_ly;
+                            }
+                            else
+                            {
+                                throw IEX_NAMESPACE::ArgExc ("Unable to get tile offset.");
+                            }
+                        }
+                }
+            }
+            break;
+
+        default: throw IEX_NAMESPACE::ArgExc ("Unknown LevelMode format.");
+    }
+
+    std::sort (table.begin(), table.end ());
+
+    for (size_t i = 0; i < numAllTiles; ++i)
+    {
+        const auto& tp = table[i];
+        dx[i] = tp.dx;
+        dy[i] = tp.dy;
+        lx[i] = tp.lx;
+        ly[i] = tp.ly;
+    }
+}
+
+void DeepTiledInputFile::Data::readTiles (
+    int dx1, int dx2, int dy1, int dy2, int lx, int ly, bool countsOnly)
+{
+    int nTiles = dx2 - dx1 + 1;
+    nTiles *= dy2 - dy1 + 1;
+
+    exr_chunk_info_t      cinfo;
+#if ILMTHREAD_THREADING_ENABLED
+    if (nTiles > 1 && numThreads > 1)
+    {
+        ILMTHREAD_NAMESPACE::TaskGroup tg;
+
+        for (int ty = dy1; ty <= dy2; ++ty)
+        {
+            for (int tx = dx1; tx <= dx2; ++tx)
+            {
+                exr_result_t rv = exr_read_tile_chunk_info (
+                    *_ctxt, partNumber, tx, ty, lx, ly, &cinfo);
+                if (EXR_ERR_INCOMPLETE_CHUNK_TABLE == rv)
+                {
+                    THROW (
+                        IEX_NAMESPACE::InputExc,
+                        "Tile (" << tx << ", " << ty << ", " << lx << ", " << ly
+                        << ") is missing.");
+                }
+                else if (EXR_ERR_SUCCESS != rv)
+                    throw IEX_NAMESPACE::InputExc ("Unable to query tile information");
+
+                // used for honoring the numThreads
+                _sem.wait ();
+
+                ILMTHREAD_NAMESPACE::ThreadPool::addGlobalTask (
+                    new TileBufferTask (&tg, this, &frameBuffer, cinfo, countsOnly) );
+            }
+        }
+    }
+    else
+#endif
+    {
+        auto tp = getChunkProcess ();
+
+        tp->counts_only = countsOnly;
+        for (int ty = dy1; ty <= dy2; ++ty)
+        {
+            for (int tx = dx1; tx <= dx2; ++tx)
+            {
+                exr_result_t rv = exr_read_tile_chunk_info (
+                    *_ctxt, partNumber, tx, ty, lx, ly, &cinfo);
+                if (EXR_ERR_INCOMPLETE_CHUNK_TABLE == rv)
+                {
+                    THROW (
+                        IEX_NAMESPACE::InputExc,
+                        "Tile (" << tx << ", " << ty << ", " << lx << ", " << ly
+                        << ") is missing.");
+                }
+                else if (EXR_ERR_SUCCESS != rv)
+                    throw IEX_NAMESPACE::InputExc ("Unable to query tile information");
+
+                tp->cinfo = cinfo;
+                tp->run_decode (
+                    *_ctxt,
+                    partNumber,
+                    &frameBuffer,
+                    fill_list);
+            }
+        }
+
+        putChunkProcess (std::move(tp));
+    }
+
+    if (! _failures.empty())
+    {
+        std::string fail = _failures[0];
+        _failures.clear ();
+        throw IEX_NAMESPACE::IoExc (fail);
+    }
+}
+
+////////////////////////////////////////
+
+#if ILMTHREAD_THREADING_ENABLED
+void DeepTiledInputFile::Data::TileBufferTask::execute ()
+{
+    try
+    {
+        _tile->run_decode (
+            *(_ifd->_ctxt),
+            _ifd->partNumber,
+            _outfb,
+            _ifd->fill_list);
+    }
+    catch (std::exception &e)
+    {
+        std::lock_guard<std::mutex> lock (_ifd->_mx);
+        _ifd->_failures.emplace_back (std::string (e.what()));
+    }
+}
+#endif
+
+////////////////////////////////////////
+
+void TileProcess::run_decode (
+    exr_const_context_t ctxt,
+    int pn,
+    const DeepFrameBuffer *outfb,
+    const std::vector<DeepSlice> &filllist)
+{
+    int absX, absY, tileX, tileY;
+    exr_attr_box2i_t dw;
+    uint8_t flags;
+
+    if (first)
+    {
+        if (EXR_ERR_SUCCESS !=
+            exr_decoding_initialize (ctxt, pn, &cinfo, &decoder))
+        {
+            throw IEX_NAMESPACE::IoExc ("Unable to initialize decode pipeline");
+        }
+        decoder.decode_flags |= EXR_DECODE_NON_IMAGE_DATA_AS_POINTERS;
+        decoder.decode_flags |= EXR_DECODE_SAMPLE_COUNTS_AS_INDIVIDUAL;
+        flags = 0;
+
+        first = false;
+    }
+    else
+    {
+        if (EXR_ERR_SUCCESS !=
+            exr_decoding_update (ctxt, pn, &cinfo, &decoder))
+        {
+            throw IEX_NAMESPACE::IoExc ("Unable to update decode pipeline");
+        }
+        flags = decoder.decode_flags;
+    }
+
+    if (EXR_ERR_SUCCESS != exr_get_data_window (ctxt, pn, &dw))
+        throw IEX_NAMESPACE::ArgExc ("Unable to query the data window.");
+
+    if (EXR_ERR_SUCCESS != exr_get_tile_sizes (
+            ctxt, pn, cinfo.level_x, cinfo.level_y, &tileX, &tileY))
+        throw IEX_NAMESPACE::ArgExc ("Unable to query the data window.");
+
+    absX = dw.min.x + tileX * cinfo.start_x;
+    absY = dw.min.y + tileY * cinfo.start_y;
+
+    if (counts_only)
+        decoder.decode_flags |= EXR_DECODE_SAMPLE_DATA_ONLY;
+    else
+        decoder.decode_flags = decoder.decode_flags & ~EXR_DECODE_SAMPLE_DATA_ONLY;
+
+    update_pointers (outfb, dw.min.x, dw.min.y, absX, absY);
+
+    if (flags != decoder.decode_flags)
+    {
+        if (EXR_ERR_SUCCESS !=
+            exr_decoding_choose_default_routines (ctxt, pn, &decoder))
+        {
+            throw IEX_NAMESPACE::IoExc ("Unable to choose decoder routines");
+        }
+    }
+
+    last_decode_err = exr_decoding_run (ctxt, pn, &decoder);
+    if (EXR_ERR_SUCCESS != last_decode_err)
+    {
+        THROW (
+            IEX_NAMESPACE::IoExc,
+            "Unable to run decoder: "
+            << exr_get_error_code_as_string (last_decode_err));
+    }
+
+    copy_sample_count (outfb, dw.min.x, dw.min.y, absX, absY);
+
+    if (counts_only)
+        return;
+
+    run_fill (outfb, dw.min.x, dw.min.y, absX, absY, filllist);
+}
+
+////////////////////////////////////////
+
+void TileProcess::update_pointers (const DeepFrameBuffer *outfb, int fb_absX, int fb_absY, int t_absX, int t_absY)
+{
+    decoder.user_line_begin_skip = 0;
+    decoder.user_line_end_ignore = 0;
+
+    for (int c = 0; c < decoder.channel_count; ++c)
+    {
+        exr_coding_channel_info_t& curchan = decoder.channels[c];
+        uint8_t*                   ptr;
+        const DeepSlice*           fbslice;
+
+        fbslice = outfb->findSlice (curchan.channel_name);
+
+        if (curchan.height == 0 || !fbslice)
+        {
+            curchan.decode_to_ptr     = NULL;
+            curchan.user_pixel_stride = 0;
+            curchan.user_line_stride  = 0;
+            continue;
+        }
+
+        if (fbslice->xSampling != 1 || fbslice->ySampling != 1)
+            throw IEX_NAMESPACE::ArgExc ("Tiled data should not have subsampling.");
+
+        if (curchan.user_bytes_per_element != fbslice->sampleStride)
+            throw IEX_NAMESPACE::ArgExc ("Un-implemented deep sample stride optimization");
+
+        int xOffset = fbslice->xTileCoords ? 0 : t_absX;
+        int yOffset = fbslice->yTileCoords ? 0 : t_absY;
+
+        curchan.user_bytes_per_element = (fbslice->type == HALF) ? 2 : 4;
+        curchan.user_data_type         = (exr_pixel_type_t)fbslice->type;
+        curchan.user_pixel_stride      = fbslice->xStride;
+        curchan.user_line_stride       = fbslice->yStride;
+
+        ptr  = reinterpret_cast<uint8_t*> (fbslice->base);
+        ptr += int64_t (xOffset) * int64_t (fbslice->xStride);
+        ptr += int64_t (yOffset) * int64_t (fbslice->yStride);
+
+        curchan.decode_to_ptr = ptr;
+    }
+}
+
+////////////////////////////////////////
+
+void TileProcess::run_fill (
+    const DeepFrameBuffer *outfb, int fb_absX, int fb_absY, int t_absX, int t_absY,
+    const std::vector<DeepSlice> &filllist)
+{
+    for (auto& fills: filllist)
+    {
+        uint8_t* ptr;
+
+        if (fills.xSampling != 1 || fills.ySampling != 1)
+            throw IEX_NAMESPACE::ArgExc ("Tiled data should not have subsampling.");
+
+        int xOffset = fills.xTileCoords ? 0 : t_absX;
+        int yOffset = fills.yTileCoords ? 0 : t_absY;
+
+        ptr  = reinterpret_cast<uint8_t*> (fills.base);
+        ptr += int64_t (xOffset) * int64_t (fills.xStride);
+        ptr += int64_t (yOffset) * int64_t (fills.yStride);
+
+        // TODO: update ImfMisc, lift fill type / value
+        for ( int start = 0; start < cinfo.height; ++start )
+        {
+            const int32_t* counts = decoder.sample_count_table;
+            counts += (int64_t) start * (int64_t) cinfo.width;
+
+            uint8_t* outptr = ptr;
+            for ( int sx = 0; sx < cinfo.width; ++sx )
+            {
+                int32_t samps = counts[sx];
+                void *dest = *((void **)outptr);
+
+                if (samps == 0)
+                {
+                    outptr += fills.xStride;
+                    continue;
+                }
+
+                switch (fills.type)
+                {
+                    case OPENEXR_IMF_INTERNAL_NAMESPACE::UINT:
+                    {
+                        unsigned int fillVal = (unsigned int) (fills.fillValue);
+                        unsigned int* fillptr = static_cast<unsigned int*> (dest);
+
+                        for ( int32_t s = 0; s < samps; ++s )
+                            fillptr[s] = fillVal;
+                        break;
+                    }
+
+                    case OPENEXR_IMF_INTERNAL_NAMESPACE::HALF:
+                    {
+                        half fillVal = half (fills.fillValue);
+                        half* fillptr = static_cast<half*> (dest);
+
+                        for ( int32_t s = 0; s < samps; ++s )
+                            fillptr[s] = fillVal;
+                        break;
+                    }
+
+                    case OPENEXR_IMF_INTERNAL_NAMESPACE::FLOAT:
+                    {
+                        float fillVal = float (fills.fillValue);
+                        float* fillptr = static_cast<float*> (dest);
+
+                        for ( int32_t s = 0; s < samps; ++s )
+                            fillptr[s] = fillVal;
+                        break;
+                    }
+                    default:
+                        throw IEX_NAMESPACE::ArgExc ("Unknown pixel data type.");
+                }
+                outptr += fills.xStride;
+            }
+
+            ptr += fills.yStride;
+        }
+    }
+}
+
+////////////////////////////////////////
+
+void TileProcess::copy_sample_count (
+    const DeepFrameBuffer *outfb,
+    int fb_absX, int fb_absY,
+    int t_absX, int t_absY)
+{
+    uint8_t*     ptr;
+    const Slice& s = outfb->getSampleCountSlice ();
+    if (s.xSampling != 1 || s.ySampling != 1)
+        throw IEX_NAMESPACE::ArgExc ("Tiled data should not have subsampling.");
+
+    int xOffset = s.xTileCoords ? 0 : t_absX;
+    int yOffset = s.yTileCoords ? 0 : t_absY;
+
+    ptr  = reinterpret_cast<uint8_t*> (s.base);
+    ptr += int64_t (xOffset) * int64_t (s.xStride);
+    ptr += int64_t (yOffset) * int64_t (s.yStride);
+
+    int64_t xS = int64_t (s.xStride);
+    int64_t yS = int64_t (s.yStride);
+
+    for ( int y = 0; y < cinfo.height; ++y )
+    {
+        const int32_t* counts = decoder.sample_count_table + y * cinfo.width;
+
+        if (xS == sizeof(int32_t))
+        {
+            memcpy (ptr, counts, cinfo.width * sizeof(int32_t));
+        }
+        else
+        {
+            uint8_t* lineptr = ptr;
+            for ( int x = 0; x < cinfo.width; ++x )
+            {
+                *((int32_t *)lineptr) = counts[x];
+                lineptr += xS;
+            }
+        }
+        ptr += yS;
+    }
 }
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -14,17 +14,17 @@
 
 #include "ImfForward.h"
 
-#include "ImfGenericInputFile.h"
+#include "ImfContext.h"
+
 #include "ImfThreading.h"
 
 #include "ImfTileDescription.h"
 
-#include <cstdint>
 #include <ImathBox.h>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
-class IMF_EXPORT_TYPE DeepTiledInputFile : public GenericInputFile
+class IMF_EXPORT_TYPE DeepTiledInputFile
 {
 public:
     //--------------------------------------------------------------------
@@ -54,12 +54,11 @@ public:
         OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is,
         int numThreads = globalThreadCount ());
 
-    //-----------
-    // Destructor
-    //-----------
-
     IMF_EXPORT
-    virtual ~DeepTiledInputFile ();
+    DeepTiledInputFile (
+        const char*               filename,
+        const ContextInitializer& ctxtinit,
+        int                       numThreads = globalThreadCount ());
 
     //------------------------
     // Access to the file name
@@ -378,28 +377,13 @@ public:
     IMF_EXPORT
     void readPixelSampleCounts (int dx1, int dx2, int dy1, int dy2, int l = 0);
 
-    struct Data;
-
 private:
-    friend class InputFile;
-    friend class MultiPartInputFile;
+    Context _ctxt;
+    struct IMF_HIDDEN Data;
+    std::shared_ptr<Data> _data;
 
+    IMF_HIDDEN
     DeepTiledInputFile (InputPartData* part);
-
-    DeepTiledInputFile (const DeepTiledInputFile&)            = delete;
-    DeepTiledInputFile& operator= (const DeepTiledInputFile&) = delete;
-    DeepTiledInputFile (DeepTiledInputFile&&)                 = delete;
-    DeepTiledInputFile& operator= (DeepTiledInputFile&&)      = delete;
-
-    DeepTiledInputFile (
-        const Header&                            header,
-        OPENEXR_IMF_INTERNAL_NAMESPACE::IStream* is,
-        int                                      version,
-        int                                      numThreads);
-
-    void initialize ();
-    void multiPartInitialize (InputPartData* part);
-    void compatibilityInitialize (OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is);
 
     bool isValidTile (int dx, int dy, int lx, int ly) const;
 
@@ -407,7 +391,8 @@ private:
 
     void getTileOrder (int dx[], int dy[], int lx[], int ly[]) const;
 
-    Data* _data;
+    friend class InputFile;
+    friend class MultiPartInputFile;
 
     // needed for copyPixels
     friend class DeepTiledOutputFile;

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -471,8 +471,9 @@ void ScanLineInputFile::Data::readPixels (
             if (EXR_ERR_SUCCESS != exr_read_scanline_chunk_info (*_ctxt, partNumber, y, &cinfo))
                 throw IEX_NAMESPACE::InputExc ("Unable to query scanline information");
 
-            // do we have the same chunk where we can just re-run the unpack
-            // (i.e. people reading 1 scan at a time in a multi-scanline chunk)
+            // check if we have the same chunk where we can just
+            // re-run the unpack (i.e. people reading 1 scan at a time
+            // in a multi-scanline chunk)
             if (!sp->first && sp->cinfo.idx == cinfo.idx &&
                 sp->last_decode_err == EXR_ERR_SUCCESS)
             {

--- a/src/lib/OpenEXR/ImfTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputFile.cpp
@@ -73,9 +73,6 @@ struct TileProcess
 //
 
 struct TiledInputFile::Data
-#if ILMTHREAD_THREADING_ENABLED
-    : public std::mutex
-#endif
 {
     Data (Context *ctxt, int pN, int nT)
     : _ctxt (ctxt)


### PR DESCRIPTION
This has a couple of initial commits to clean up previous comments, but primary purpose is to switch deep tiled input to use the core library.

At this point, all the input side is converted, the output side is next.