### PR TITLE
Fix documentation typo: screenWindowWidth is float, not V2f

### DIFF
--- a/website/StandardAttributes.rst
+++ b/website/StandardAttributes.rst
@@ -111,7 +111,7 @@ Basic Attributes
        <p> <tt> <b> screenWindowWidth </b> </tt> </p>
        <p> <i>required</i> </p>
      </td>
-     <td style="vertical-align: top; width:100px"> <tt> V2f </tt> </td>
+     <td style="vertical-align: top; width:100px"> <tt> float </tt> </td>
    </tr>
    <tr>
      <td style="vertical-align: top; width:150px">


### PR DESCRIPTION


<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1778.org.readthedocs.build/en/1778/
<!-- readthedocs-preview openexr end -->