### PR TITLE
Revert CodeQL to 2.18.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,8 +59,14 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      # cary: Pin the version to the SHA for 2.18.0, since there appears to
+      # be a problem with 2.18.1 leading to a "No space left on
+      # device" failure
+      uses: github/codeql-action/init@5cf07d8b700b67e235fbb65cbc84f69c0cf10464
       with:
+        # cary: the "linked" setting is necessary to force the run to pick up
+        # the version specified in the action.
+        tools: linked 
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -86,6 +92,7 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      # Pin the version to the SHA for 2.18.0 
+      uses: github/codeql-action/analyze@5cf07d8b700b67e235fbb65cbc84f69c0cf10464
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Scanning with CodeQL vesion 2.18.1 appears to run amok and fail with "no space left on device". The runs have traditionally taken around 5 minutes, but after the 2.18.1 release, they're failing after an hour.

Pin to the SHA for 2.18.0 for now, until there's a solution.