### PR TITLE
Bazel Build: Bump libdeflate to 1.21

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,5 +8,5 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "imath", version = "3.1.11")
-bazel_dep(name = "libdeflate", version = "1.20.bcr.1")
+bazel_dep(name = "libdeflate", version = "1.21")
 bazel_dep(name = "platforms", version = "0.0.10")


### PR DESCRIPTION
Bazel Build: Bump libdeflate to 1.21