### PR TITLE
Update sigstore release signing action

### DIFF
--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -58,9 +58,11 @@ jobs:
         uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
         with:
           inputs: ${{ env.OPENEXR_TARBALL }}
+          upload-signing-artifacts: false
+          release-signing-artifacts: false
 
       - name: Upload release archive
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload ${{ github.ref_name }} ${OPENEXR_TARBALL} ${OPENEXR_TARBALL}.sigstore
+        run: gh release upload ${TAG} ${OPENEXR_TARBALL} ${OPENEXR_TARBALL}.sigstore.json
 


### PR DESCRIPTION
The default behavior of sigstore/gh-action-sigstore-python has changed. Disable the automatic uploading of signed artifacts, since this now includes artifacts named with just the tag, without the "openexr-" prefix.

Also, the signature file now has a .json suffix.