### PR TITLE
Add includes for Windows

### DIFF
--- a/src/lib/OpenEXR/ImfCompression.cpp
+++ b/src/lib/OpenEXR/ImfCompression.cpp
@@ -83,6 +83,7 @@
 #include "ImfNamespace.h"
 #include "ImfCompression.h"
 #include <map>
+#include <cctype>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -20,6 +20,7 @@
 #include "ImfZipCompressor.h"
 #include "ImfZip.h"
 
+#include <algorithm>
 #include <stdexcept>
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER


### PR DESCRIPTION
Windows isn't happy unless I add these #includes. At least with Visual Studio 2017.