### PR TITLE
 Fixed formatting issue in website/OpenEXRFileLayout.rst

### DIFF
--- a/website/OpenEXRFileLayout.rst
+++ b/website/OpenEXRFileLayout.rst
@@ -749,7 +749,7 @@ pixel data size
 pixel data
 =================== =
 
-The ``tile coordinates``, a sequence of four ``int`'s (``tileX``, ``tileY``,
+The ``tile coordinates``, a sequence of four ``int``'s (``tileX``, ``tileY``,
 ``levelX``, ``levelY``) indicates the tile's position and resolution level. The
 ``pixel data size``, of type ``int``, indicates the number of bytes
 occupied by the pixel data.
@@ -918,8 +918,10 @@ The OpenEXR library predefines the following attribute types:
 | ``double``         | ``double``                                                     |
 +--------------------+----------------------------------------------------------------+
 | ``envmap``         | ``unsigned char``, possible values are:                        |
+|                    |                                                                |
 |                    | * ``ENVMAP_LATLONG`` = 0                                       |
 |                    | * ``ENVMAP_CUBE`` = 1                                          |
+|                    |                                                                |
 +--------------------+----------------------------------------------------------------+
 | ``float``          | ``float``                                                      |
 +--------------------+----------------------------------------------------------------+
@@ -929,6 +931,7 @@ The OpenEXR library predefines the following attribute types:
 |                    | ``count``,``perfOffset``, ``perfsPerFrame``, ``perfsPerCount`` |
 +--------------------+----------------------------------------------------------------+
 | ``lineOrder``      | ``unsigned char``, possible values are:                        |
+|                    |                                                                |
 |                    | * ``INCREASING_Y`` = 0                                         |
 |                    | * ``DECREASING_Y`` = 1                                         |
 |                    | * ``RANDOM_Y`` = 2                                             |
@@ -961,11 +964,13 @@ The OpenEXR library predefines the following attribute types:
 |                    |     mode = levelMode + roundingMode×16                         |
 |                    |                                                                |
 |                    | Possible values for ``levelMode``:                             |
+|                    |                                                                |
 |                    | * ``ONE_LEVEL`` = 0                                            |
 |                    | * ``MIPMAP_LEVELS`` = 1                                        |
 |                    | * ``RIPMAP_LEVELS`` = 2                                        |
 |                    |                                                                |
 |                    | Possible values for ``roundingMode``:                          |
+|                    |                                                                |
 |                    | * ``ROUND_DOWN`` = 0                                           |
 |                    | * ``ROUND_UP`` = 1                                             |
 |                    |                                                                |

--- a/website/OpenEXRFileLayout.rst
+++ b/website/OpenEXRFileLayout.rst
@@ -521,7 +521,7 @@ deep data OpenEXR files.
        * ``tiledimage``
        * ``deepscanline``, or
        * ``deeptile``
-       
+
        **Note:** This value must agree with the version field's tile bit (9) and
        non-image (deep data) bit (11) settings.  
    * - ``version``

--- a/website/OpenEXRFileLayout.rst
+++ b/website/OpenEXRFileLayout.rst
@@ -516,10 +516,12 @@ deep data OpenEXR files.
      - ``string``
      - Required if either the multipart bit (12) or the non-image bit (11) is set.
        Set to one of:
+
        * ``scanlineimage``
        * ``tiledimage``
        * ``deepscanline``, or
        * ``deeptile``
+       
        **Note:** This value must agree with the version field's tile bit (9) and
        non-image (deep data) bit (11) settings.  
    * - ``version``


### PR DESCRIPTION
There were some formatting issues in the document, which are now fixed.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1830.org.readthedocs.build/en/1830/
<!-- readthedocs-preview openexr end -->