### PR TITLE
Add freeBuffers() function to InputFile classes

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
@@ -233,6 +233,12 @@ public:
         int                    scanLine1,
         int                    scanLine2) const;
 
+    IMF_EXPORT
+    size_t bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
+
 private:
     Context _ctxt;
     struct IMF_HIDDEN Data;

--- a/src/lib/OpenEXR/ImfDeepScanLineInputPart.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputPart.cpp
@@ -116,4 +116,16 @@ DeepScanLineInputPart::readPixelSampleCounts (
         rawdata, frameBuffer, scanLine1, scanLine2);
 }
 
+unsigned long long
+DeepScanLineInputPart::bufferSize () const
+{
+    return file->bufferSize ();
+}
+
+void
+DeepScanLineInputPart::freeBuffers ()
+{
+    file->freeBuffers ();
+}
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfDeepScanLineInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputPart.h
@@ -145,6 +145,11 @@ public:
     int firstScanLineInChunk (int y) const;
     IMF_EXPORT
     int lastScanLineInChunk (int y) const;
+    
+    IMF_EXPORT
+    unsigned long long bufferSize () const;
+    IMF_EXPORT
+    void freeBuffers ();
 
 private:
     DeepScanLineInputFile* file;

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -65,6 +65,16 @@ struct TileProcess
         int fb_absX, int fb_absY,
         int t_absX, int t_absY);
 
+    size_t get_buffer_size ()
+    {
+        return exr_decoding_get_buffer_size (&decoder);
+    }
+    
+    void free_buffers ()
+    {
+        exr_decoding_free_buffers (&decoder);
+    }
+
     exr_result_t          last_decode_err = EXR_ERR_UNKNOWN;
     bool                  first = true;
     bool                  counts_only = false;
@@ -911,6 +921,42 @@ DeepTiledInputFile::getTileOrder (int dx[], int dy[], int lx[], int ly[]) const
         dy[i] = tp.dy;
         lx[i] = tp.lx;
         ly[i] = tp.ly;
+    }
+}
+
+size_t
+DeepTiledInputFile::bufferSize () const
+{
+#if ILMTHREAD_THREADING_ENABLED
+    std::lock_guard<std::mutex> lock (_data->_mx);
+#endif
+    size_t retval = 0;
+    
+    std::shared_ptr<TileProcess> sp = _data->processStack;
+    
+    while (sp)
+    {
+        retval += sp->get_buffer_size();
+        
+        sp = sp->next;
+    }
+    
+    return retval;
+}
+
+void
+DeepTiledInputFile::freeBuffers ()
+{
+#if ILMTHREAD_THREADING_ENABLED
+    std::lock_guard<std::mutex> lock (_data->_mx);
+#endif
+    std::shared_ptr<TileProcess> sp = _data->processStack;
+    
+    while (sp)
+    {
+        sp->free_buffers();
+        
+        sp = sp->next;
     }
 }
 

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -377,6 +377,12 @@ public:
     IMF_EXPORT
     void readPixelSampleCounts (int dx1, int dx2, int dy1, int dy2, int l = 0);
 
+    IMF_EXPORT
+    size_t bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
+
 private:
     Context _ctxt;
     struct IMF_HIDDEN Data;

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.cpp
@@ -207,4 +207,16 @@ DeepTiledInputPart::readPixelSampleCounts (
     file->readPixelSampleCounts (dx1, dx2, dy1, dy2, l);
 }
 
+unsigned long long
+DeepTiledInputPart::bufferSize () const
+{
+    return file->bufferSize ();
+}
+
+void
+DeepTiledInputPart::freeBuffers ()
+{
+    file->freeBuffers ();
+}
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfDeepTiledInputPart.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputPart.h
@@ -334,6 +334,11 @@ public:
     IMF_EXPORT
     void readPixelSampleCounts (int dx1, int dx2, int dy1, int dy2, int l = 0);
 
+    IMF_EXPORT
+    unsigned long long bufferSize () const;
+    IMF_EXPORT
+    void freeBuffers ();
+
 private:
     DeepTiledInputFile* file;
 

--- a/src/lib/OpenEXR/ImfInputFile.cpp
+++ b/src/lib/OpenEXR/ImfInputFile.cpp
@@ -5,7 +5,7 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class InputFile
+//  class InputFile
 //
 //-----------------------------------------------------------------------------
 
@@ -268,6 +268,60 @@ InputFile::rawTileData (
             "file \""
                 << fileName () << "\". " << e.what ());
         throw;
+    }
+}
+
+size_t
+InputFile::bufferSize () const
+{
+    if (_data->_storage == EXR_STORAGE_DEEP_SCANLINE)
+    {
+        return _data->_dsFile->bufferSize ();
+    }
+    else if (
+        _data->_storage == EXR_STORAGE_DEEP_TILED ||
+        _data->_storage == EXR_STORAGE_TILED)
+    {
+        return _data->_tFile->bufferSize ();
+    }
+    else if (_data->_storage == EXR_STORAGE_SCANLINE)
+    {
+        return _data->_sFile->bufferSize ();
+    }
+    else
+    {
+        THROW (
+            IEX_NAMESPACE::ArgExc,
+            "Unable to handle data storage type in file '" << fileName ()
+                                                           << "'");
+    }
+}
+    
+void
+InputFile::freeBuffers ()
+{
+    _data->deleteCachedBuffer ();
+
+    if (_data->_storage == EXR_STORAGE_DEEP_SCANLINE)
+    {
+        _data->_dsFile->freeBuffers ();
+    }
+    else if (
+        _data->_storage == EXR_STORAGE_DEEP_TILED ||
+        _data->_storage == EXR_STORAGE_TILED)
+    {
+        _data->_tFile->freeBuffers ();
+    }
+    else if (_data->_storage == EXR_STORAGE_SCANLINE)
+    {
+        _data->_sFile->freeBuffers ();
+    }
+    else
+    {
+        THROW (
+            IEX_NAMESPACE::ArgExc,
+            "Unable to handle data storage type in file '" << fileName ()
+                                                           << "'");
     }
 }
 

--- a/src/lib/OpenEXR/ImfInputFile.h
+++ b/src/lib/OpenEXR/ImfInputFile.h
@@ -245,6 +245,12 @@ public:
         const char*& pixelData,
         int&         pixelDataSize);
 
+    IMF_EXPORT
+    size_t bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
+
 private:
     IMF_HIDDEN void initialize (void);
 

--- a/src/lib/OpenEXR/ImfInputPart.cpp
+++ b/src/lib/OpenEXR/ImfInputPart.cpp
@@ -96,4 +96,16 @@ InputPart::rawTileData (
     file->rawTileData (dx, dy, lx, ly, pixelData, pixelDataSize);
 }
 
+unsigned long long
+InputPart::bufferSize () const
+{
+    return file->bufferSize ();
+}
+    
+void
+InputPart::freeBuffers ()
+{
+    file->freeBuffers ();
+}
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfInputPart.h
+++ b/src/lib/OpenEXR/ImfInputPart.h
@@ -57,6 +57,12 @@ public:
         const char*& pixelData,
         int&         pixelDataSize);
 
+    IMF_EXPORT
+    unsigned long long bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
+
 private:
     InputFile* file;
     // for internal use - give OutputFile and TiledOutputFile access to file for copyPixels

--- a/src/lib/OpenEXR/ImfScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.h
@@ -8,7 +8,7 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class ScanLineInputFile
+//  class ScanLineInputFile
 //
 //-----------------------------------------------------------------------------
 
@@ -169,6 +169,12 @@ public:
     IMF_EXPORT
     void rawPixelDataToBuffer (
         int scanLine, char* pixelData, int& pixelDataSize) const;
+    
+    IMF_EXPORT
+    size_t bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
 
 private:
     Context _ctxt;

--- a/src/lib/OpenEXR/ImfTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfTiledInputFile.h
@@ -8,7 +8,7 @@
 
 //-----------------------------------------------------------------------------
 //
-//	class TiledInputFile
+//  class TiledInputFile
 //
 //-----------------------------------------------------------------------------
 
@@ -138,37 +138,37 @@ public:
     //
     // numXLevels() returns the file's number of levels in x direction.
     //
-    //	if levelMode() == ONE_LEVEL:
+    //  if levelMode() == ONE_LEVEL:
     //      return value is: 1
     //
-    //	if levelMode() == MIPMAP_LEVELS:
+    //  if levelMode() == MIPMAP_LEVELS:
     //      return value is: rfunc (log (max (w, h)) / log (2)) + 1
     //
-    //	if levelMode() == RIPMAP_LEVELS:
+    //  if levelMode() == RIPMAP_LEVELS:
     //      return value is: rfunc (log (w) / log (2)) + 1
     //
-    //	where
-    //	    w is the width of the image's data window,  max.x - min.x + 1,
-    //	    y is the height of the image's data window, max.y - min.y + 1,
-    //	    and rfunc(x) is either floor(x), or ceil(x), depending on
-    //	    whether levelRoundingMode() returns ROUND_DOWN or ROUND_UP.
+    //  where
+    //      w is the width of the image's data window,  max.x - min.x + 1,
+    //      y is the height of the image's data window, max.y - min.y + 1,
+    //      and rfunc(x) is either floor(x), or ceil(x), depending on
+    //      whether levelRoundingMode() returns ROUND_DOWN or ROUND_UP.
     //
     // numYLevels() returns the file's number of levels in y direction.
     //
-    //	if levelMode() == ONE_LEVEL or levelMode() == MIPMAP_LEVELS:
+    //  if levelMode() == ONE_LEVEL or levelMode() == MIPMAP_LEVELS:
     //      return value is the same as for numXLevels()
     //
-    //	if levelMode() == RIPMAP_LEVELS:
+    //  if levelMode() == RIPMAP_LEVELS:
     //      return value is: rfunc (log (h) / log (2)) + 1
     //
     //
     // numLevels() is a convenience function for use with
     // MIPMAP_LEVELS files.
     //
-    //	if levelMode() == ONE_LEVEL or levelMode() == MIPMAP_LEVELS:
+    //  if levelMode() == ONE_LEVEL or levelMode() == MIPMAP_LEVELS:
     //      return value is the same as for numXLevels()
     //
-    //	if levelMode() == RIPMAP_LEVELS:
+    //  if levelMode() == RIPMAP_LEVELS:
     //      an IEX_NAMESPACE::LogicExc exception is thrown
     //
     // isValidLevel(lx, ly) returns true if the file contains
@@ -191,14 +191,14 @@ public:
     // levelWidth(lx) returns the width of a level with level
     // number (lx, *), where * is any number.
     //
-    //	return value is:
+    //  return value is:
     //      max (1, rfunc (w / pow (2, lx)))
     //
     //
     // levelHeight(ly) returns the height of a level with level
     // number (*, ly), where * is any number.
     //
-    //	return value is:
+    //  return value is:
     //      max (1, rfunc (h / pow (2, ly)))
     //
     //----------------------------------------------------------
@@ -215,7 +215,7 @@ public:
     // that cover a level with level number (lx, *), where * is
     // any number.
     //
-    //	return value is:
+    //  return value is:
     //      (levelWidth(lx) + tileXSize() - 1) / tileXSize()
     //
     //
@@ -223,7 +223,7 @@ public:
     // that cover a level with level number (*, ly), where * is
     // any number.
     //
-    //	return value is:
+    //  return value is:
     //      (levelHeight(ly) + tileXSize() - 1) / tileXSize()
     //
     //--------------------------------------------------------------
@@ -239,10 +239,10 @@ public:
     // dataWindowForLevel(lx, ly) returns a 2-dimensional region of
     // valid pixel coordinates for a level with level number (lx, ly)
     //
-    //	return value is a Box2i with min value:
+    //  return value is a Box2i with min value:
     //      (dataWindow.min.x, dataWindow.min.y)
     //
-    //	and max value:
+    //  and max value:
     //      (dataWindow.min.x + levelWidth(lx) - 1,
     //       dataWindow.min.y + levelHeight(ly) - 1)
     //
@@ -264,11 +264,11 @@ public:
     // region of valid pixel coordinates for a tile with tile coordinates
     // (dx,dy) and level number (lx, ly).
     //
-    //	return value is a Box2i with min value:
+    //  return value is a Box2i with min value:
     //      (dataWindow.min.x + dx * tileXSize(),
     //       dataWindow.min.y + dy * tileYSize())
     //
-    //	and max value:
+    //  and max value:
     //      (dataWindow.min.x + (dx + 1) * tileXSize() - 1,
     //       dataWindow.min.y + (dy + 1) * tileYSize() - 1)
     //
@@ -343,6 +343,12 @@ public:
         int&         ly,
         const char*& pixelData,
         int&         pixelDataSize);
+
+    IMF_EXPORT
+    size_t bufferSize () const;
+    
+    IMF_EXPORT
+    void freeBuffers ();
 
 private:
     Context _ctxt;

--- a/src/lib/OpenEXR/ImfTiledInputPart.cpp
+++ b/src/lib/OpenEXR/ImfTiledInputPart.cpp
@@ -184,4 +184,16 @@ TiledInputPart::rawTileData (
     file->rawTileData (dx, dy, lx, ly, pixelData, pixelDataSize);
 }
 
+unsigned long long
+TiledInputPart::bufferSize () const
+{
+    return file->bufferSize ();
+}
+
+void
+TiledInputPart::freeBuffers ()
+{
+    file->freeBuffers ();
+}
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfTiledInputPart.h
+++ b/src/lib/OpenEXR/ImfTiledInputPart.h
@@ -86,6 +86,10 @@ public:
         int&         ly,
         const char*& pixelData,
         int&         pixelDataSize);
+    IMF_EXPORT
+    unsigned long long bufferSize () const;
+    IMF_EXPORT
+    void freeBuffers ();
 
 private:
     TiledInputFile* file;

--- a/src/lib/OpenEXRCore/openexr_decode.h
+++ b/src/lib/OpenEXRCore/openexr_decode.h
@@ -317,12 +317,27 @@ EXR_EXPORT
 exr_result_t exr_decoding_run (
     exr_const_context_t ctxt, int part_index, exr_decode_pipeline_t* decode);
 
+EXR_EXPORT
+size_t
+exr_decoding_get_buffer_size (exr_decode_pipeline_t* decode);
+
 /** Free any intermediate memory in the decoding pipeline.
  *
  * This does *not* free any pointers referred to in the channel info
  * areas, but rather only the intermediate buffers and memory needed
  * for the structure itself.
  */
+ 
+EXR_EXPORT
+exr_result_t
+exr_decoding_free_buffers (exr_decode_pipeline_t* decode);
+ 
+ /** Destroy the decoder.
+ *
+ * decode struct will be zeroed out.
+ */
+
+ 
 EXR_EXPORT
 exr_result_t
 exr_decoding_destroy (exr_const_context_t ctxt, exr_decode_pipeline_t* decode);


### PR DESCRIPTION
The idea here is to provide a way to get InputFile objects back to their initial state after pixels have been read, which involves the allocating of various memory buffers that usually aren't freed until the objects are destroyed.  This can be useful if an application wants to keep an object around for additional reading, but doesn't want unnecessary memory overhead in the meantime.

Also provided is a bufferSize() function that the application might use to determine if freeing the buffers is enough of a memory savings to be worth the trouble.