### PR TITLE
Start adding stateless api

### DIFF
--- a/src/lib/OpenEXR/ImfIO.cpp
+++ b/src/lib/OpenEXR/ImfIO.cpp
@@ -50,6 +50,25 @@ IStream::fileName () const
     return _fileName.c_str ();
 }
 
+int64_t
+IStream::size ()
+{
+    return -1;
+}
+
+bool
+IStream::isStatelessRead () const
+{
+    return false;
+}
+
+int64_t
+IStream::read (void *, uint64_t, uint64_t)
+{
+    throw IEX_NAMESPACE::InputExc ("Attempt to perform a stateless read "
+                                   "on a stream without support.");
+}
+
 OStream::OStream (const char fileName[]) : _fileName (fileName)
 {
     // empty

--- a/src/lib/OpenEXR/ImfIO.h
+++ b/src/lib/OpenEXR/ImfIO.h
@@ -95,6 +95,54 @@ public:
 
     IMF_EXPORT const char* fileName () const;
 
+    //------------------------------------------------------
+    // Get the size of the file (or buffer) associated with
+    // this stream.
+    //
+    // by default, this will return -1. That value will skip a few
+    // safety checks. However, if you provide the size, it will apply
+    // a number of file consistency checks as the file is read.
+    // ------------------------------------------------------
+
+    IMF_EXPORT virtual int64_t size ();
+
+    //-------------------------------------------------
+    // Does this input stream support stateless reading?
+    //
+    // Stateless reading allows multiple threads to
+    // read from the stream concurrently from different
+    // locations in the file
+    //-------------------------------------------------
+
+    IMF_EXPORT virtual bool isStatelessRead () const;
+
+    //------------------------------------------------------
+    // Read from the stream with an offset:
+    //
+    // read(b,s,o) should read up to sz bytes from the
+    // stream using something like pread or ReadFileEx with
+    // overlapped data at the provided offset in the stream.
+    //
+    // for this function, the buffer size requested may be
+    // either larger than the file or request a read past
+    // the end of the file. This should NOT be treated as
+    // an error - the library will handle whether that is
+    // an error (if the offset is past the end, it should
+    // read 0)
+    //
+    // If there is an error, it should either return -1
+    // or throw an exception (an exception could provide
+    // a message).
+    //
+    // This will only be used if isStatelessRead returns true.
+    //
+    // NB: It is expected that this is thread safe such
+    // that multiple threads can be reading from the stream
+    // at the same time
+    //------------------------------------------------------
+
+    IMF_EXPORT virtual int64_t read (void *buf, uint64_t sz, uint64_t offset);
+
 protected:
     IMF_EXPORT IStream (const char fileName[]);
 

--- a/src/lib/OpenEXR/ImfInputFile.h
+++ b/src/lib/OpenEXR/ImfInputFile.h
@@ -201,6 +201,27 @@ public:
     void readPixels (int scanLine);
 
     //----------------------------------------------
+    // Combines the setFrameBuffer and readPixels into a singular
+    // call. This does more than that in that it can, with the right
+    // conditions, not require a lock on the file, such that multiple
+    // (external to OpenEXR) threads can read at the same time on
+    // different framebuffers
+    //
+    // NB: if the underlying file is deep or tiled, that requires
+    // translation, so will not do the pass through, but will behave
+    // in a threadsafe manner (where the only way that was possible
+    // before was to have a larger framebuffer, set the framebuffer
+    // once, then call readPixels by the external threads, although
+    // that occured with a mutex and so the reads were serialized.
+    // There are reasons why that might still be serialized, such as a
+    // non-threadable stream.
+    //----------------------------------------------
+
+    IMF_EXPORT
+    void readPixels (
+        const FrameBuffer& frameBuffer, int scanLine1, int scanLine2);
+
+    //----------------------------------------------
     // Read a block of raw pixel data from the file,
     // without uncompressing it (this function is
     // used to implement OutputFile::copyPixels()).

--- a/src/lib/OpenEXR/ImfInputPart.cpp
+++ b/src/lib/OpenEXR/ImfInputPart.cpp
@@ -71,6 +71,13 @@ InputPart::readPixels (int scanLine)
 }
 
 void
+InputPart::readPixels (
+    const FrameBuffer& frameBuffer, int scanLine1, int scanLine2)
+{
+    file->readPixels (frameBuffer, scanLine1, scanLine2);
+}
+
+void
 InputPart::rawPixelData (
     int firstScanLine, const char*& pixelData, int& pixelDataSize)
 {

--- a/src/lib/OpenEXR/ImfInputPart.h
+++ b/src/lib/OpenEXR/ImfInputPart.h
@@ -41,6 +41,9 @@ public:
     IMF_EXPORT
     void readPixels (int scanLine);
     IMF_EXPORT
+    void readPixels (
+        const FrameBuffer& frameBuffer, int scanLine1, int scanLine2);
+    IMF_EXPORT
     void rawPixelData (
         int firstScanLine, const char*& pixelData, int& pixelDataSize);
 

--- a/src/lib/OpenEXR/ImfMultiPartInputFile.h
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.h
@@ -99,7 +99,7 @@ private:
     //
     // used internally by 'Part' types to access individual parts of the multipart file
     //
-    // TODO: change these to value / reference semantics
+    // TODO: change these to value / reference semantics (smart ptr)
     template <class T> IMF_HIDDEN T* getInputPart (int partNumber);
     IMF_HIDDEN InputPartData*  getPart (int) const;
 

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -312,6 +312,13 @@ ScanLineInputFile::readPixels (int scanLine1, int scanLine2)
     _data->readPixels (frameBuffer (), scanLine1, scanLine2);
 }
 
+void
+ScanLineInputFile::readPixels (
+    const FrameBuffer& frame, int scanLine1, int scanLine2)
+{
+    _data->readPixels (frame, scanLine1, scanLine2);
+}
+
 ////////////////////////////////////////
 
 void

--- a/src/lib/OpenEXR/ImfScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.h
@@ -141,6 +141,18 @@ public:
     void readPixels (int scanLine);
 
     //----------------------------------------------
+    // Combines the setFrameBuffer and readPixels into a singular
+    // call. This does more than that in that it can, with the right
+    // conditions, not require a lock on the file, such that multiple
+    // (external to OpenEXR) threads can read at the same time on
+    // different framebuffers
+    //----------------------------------------------
+
+    IMF_EXPORT
+    void readPixels (
+        const FrameBuffer& frame, int scanLine1, int scanLine2);
+
+    //----------------------------------------------
     // Read a block of raw pixel data from the file,
     // without uncompressing it (this function is
     // used to implement OutputFile::copyPixels()).


### PR DESCRIPTION
This enables reading of scanlines without having to first set a framebuffer, enabling multiple threads to read into different frame buffers against the same file at the same time