### PR TITLE
Don't exclude src/test and website from python wheel sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ testpaths = ["tests"]
 
 [tool.scikit-build]
 wheel.expand-macos-universal-tags = true
-sdist.exclude = [".github", "src/test", "src/examples", "website", "ASWF", "bazel", "share"]
+sdist.exclude = [".github", "src/examples", "ASWF", "bazel", "share"]
 
 # Only build the PyOpenEXR (cmake --build --target PyOpenEXR).
 cmake.targets = ["PyOpenEXR"]


### PR DESCRIPTION
The source should appear in the sdist, since the build's cmake requires them.