### PR TITLE
Build: compile source files in parallel under MSVC

### DIFF
--- a/cmake/LibraryDefine.cmake
+++ b/cmake/LibraryDefine.cmake
@@ -10,7 +10,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
   cmake_parse_arguments(OPENEXR_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if (MSVC)
-    set(_openexr_extra_flags "/EHsc")
+    set(_openexr_extra_flags "/EHsc" "/MP")
   endif()
   set(objlib ${libname})
   add_library(${objlib}


### PR DESCRIPTION
Compiling OpenEXRTest with dependencies from a fresh checkout, in Release config with VS2022 on Ryzen 5950X: **75sec -> 12sec**.