### PR TITLE
Use FetchContent_MakeAvailable instead of FetchContent_Populate

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -227,7 +227,7 @@ else()
 
   FetchContent_GetProperties(Deflate)
   if(NOT Deflate_POPULATED)
-    FetchContent_Populate(Deflate)
+    FetchContent_MakeAvailable(Deflate)
   endif()
 
   # Rather than actually compile something, just embed the sources
@@ -289,7 +289,7 @@ if(NOT TARGET Imath::Imath AND NOT Imath_FOUND)
     
   FetchContent_GetProperties(Imath)
   if(NOT Imath_POPULATED)
-    FetchContent_Populate(Imath)
+    FetchContent_MakeAvailable(Imath)
 
     # Propagate OpenEXR's install setting to Imath
     set(IMATH_INSTALL ${OPENEXR_INSTALL})
@@ -297,9 +297,6 @@ if(NOT TARGET Imath::Imath AND NOT Imath_FOUND)
     # Propagate OpenEXR's setting for pkg-config generation to Imath:
     # If OpenEXR is generating it, the internal Imath should, too.
     set(IMATH_INSTALL_PKG_CONFIG ${OPENEXR_INSTALL_PKG_CONFIG}) 
-    
-    # hrm, cmake makes Imath lowercase for the properties (to imath)
-    add_subdirectory(${imath_SOURCE_DIR} ${imath_BINARY_DIR})
   endif()
   # the install creates this but if we're using the library locally we
   # haven't installed the header files yet, so need to extract those


### PR DESCRIPTION
The cmake docs say:

  The FetchContent_Populate() command is a self-contained call which
  can be used to perform content population as an isolated
  operation. It is rarely the right command to use, projects should
  almost always use FetchContent_Declare() and
  FetchContent_MakeAvailable() instead.

And the python wheel sdist build reports warnings (macOS 12.7):

  CMake Warning (dev) at /private/var/folders/zd/1cs92n8x61j06hj_gbv7qlvr0000gn/T/pip-build-env-t9wrh100/normal/lib/python3.12/site-packages/cmake/data/share/cmake-3.30/Modules/FetchContent.cmake:1953 (message):
  Calling FetchContent_Populate(Deflate) is deprecated, call
  FetchContent_MakeAvailable(Deflate) instead.  Policy CMP0169 can be set to
  OLD to allow FetchContent_Populate(Deflate) to be called directly for now,
  but the ability to call it with declared details will be removed completely
  in a future version.