### PR TITLE
Fetch master branch of libdeflate on main

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -174,7 +174,7 @@ endif()
 
 option(OPENEXR_FORCE_INTERNAL_DEFLATE "Force using an internal libdeflate" OFF)
 set(OPENEXR_DEFLATE_REPO "https://github.com/ebiggers/libdeflate.git" CACHE STRING "Repo path for libdeflate source")
-set(OPENEXR_DEFLATE_TAG "v1.18" CACHE STRING "Tag to use for libdeflate source repo (defaults to primary if empty)")
+set(OPENEXR_DEFLATE_TAG "master" CACHE STRING "Tag to use for libdeflate source repo (defaults to primary if empty)")
 
 if(NOT OPENEXR_FORCE_INTERNAL_DEFLATE)
   #TODO: ^^ Release should not clone from main, this is a place holder


### PR DESCRIPTION
Rather than pinning libdeflate to a specific version, we should have the OpenEXR main branch fetch from libdeflate's master branch, so our bleeding edge uses their bleeding edge. Then, we pin to the most recent libdeflate release on our minor release, or patch release if it's ABI compatible. Similar to what we do with Imath.