### PR TITLE
CMake: use EXCLUDE_FROM_ALL when declaring Fetch for deflate library

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -219,15 +219,37 @@ else()
     message(STATUS "libdeflate was not found, installing from ${OPENEXR_DEFLATE_REPO} (${OPENEXR_DEFLATE_TAG})")
   endif()
   include(FetchContent)
+  # Fetch deflate but exclude it from the "all" target.
+  # This prevents the library from being built.
   FetchContent_Declare(Deflate
     GIT_REPOSITORY "${OPENEXR_DEFLATE_REPO}"
     GIT_TAG "${OPENEXR_DEFLATE_TAG}"
     GIT_SHALLOW ON
+    EXCLUDE_FROM_ALL
     )
 
   FetchContent_GetProperties(Deflate)
   if(NOT deflate_POPULATED)
-    FetchContent_MakeAvailable(Deflate)
+    if(CMAKE_VERSION VERSION_LESS "3.30")
+      # CMake 3.30 deprecated this single argument version of
+      # FetchContent_Populate():
+      #   https://cmake.org/cmake/help/latest/policy/CMP0169.html
+      # Prior to CMake 3.28, passing the EXCLUDE_FROM_ALL option to
+      # FetchContent_Declare() does *not* have the desired effect of
+      # excluding the fetched content from the build when
+      # FetchContent_MakeAvailable() is called.
+      # Ideally we could "manually" set the EXCLUDE_FROM_ALL property on the
+      # deflate SOURCE_DIR and BINARY_DIR, but a bug that was only fixed as of
+      # CMake 3.20.3 prevents that from properly excluding the directories:
+      #   https://gitlab.kitware.com/cmake/cmake/-/issues/22234
+      # To support the full range of CMake versions without overly
+      # complicating the logic here with workarounds, we continue to use
+      # Populate for CMake versions before 3.30, and switch to MakeAvailable
+      # for CMake 3.30 and later.
+      FetchContent_Populate(Deflate)
+    else()
+      FetchContent_MakeAvailable(Deflate)
+    endif()
   endif()
 
   # Rather than actually compile something, just embed the sources

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -226,7 +226,7 @@ else()
     )
 
   FetchContent_GetProperties(Deflate)
-  if(NOT Deflate_POPULATED)
+  if(NOT deflate_POPULATED)
     FetchContent_MakeAvailable(Deflate)
   endif()
 


### PR DESCRIPTION
Commit af9ef0e made a change in the CMake setup to switch from using `FetchContent_Populate()` to `FetchContent_MakeAvailable()` to bring in `libdeflate` (and `Imath`) as dependencies. Using `FetchContent_MakeAvailable()` has the side effect that `libdeflate` is now being included as part of the build, causing libraries and headers to be built and installed.

The intent with fetching the deflate source is solely to copy select files into OpenEXRCore, so this change adds the `EXCLUDE_FROM_ALL` option to the call to `FetchContent_Declare()` to prevent deflate from being included in the build.


Testing this on Mac, I ran a build of the current tip of the main branch (3d34ea0) using these commands:
```
cd /Users/matt.johnson/Developer/openexr
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX="/Users/matt.johnson/Developer/openexr_inst" -DCMAKE_PREFIX_PATH="/Users/matt.johnson/Developer/openexr_inst" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -G "Xcode" -DOPENEXR_BUILD_TOOLS=OFF -DOPENEXR_BUILD_EXAMPLES=OFF -DOPENEXR_INSTALL_PKG_CONFIG=OFF -DBUILD_TESTING=OFF -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES -DCMAKE_OSX_ARCHITECTURES=arm64 "/Users/matt.johnson/Developer/openexr"
cmake --build . --config Release --target install -- -j 10
```

And looking at the build products in the `include` and `lib` directories, I see this:
```
% ls -l /Users/matt.johnson/Developer/openexr_inst/include 
total 32
drwxr-xr-x@  37 matt.johnson  staff   1184 Oct 11 09:48 Imath
drwxr-xr-x@ 148 matt.johnson  staff   4736 Oct 11 09:48 OpenEXR
-rw-r--r--@   1 matt.johnson  staff  15748 Oct 11 09:47 libdeflate.h
% ls -l /Users/matt.johnson/Developer/openexr_inst/lib    
total 10560
drwxr-xr-x@ 5 matt.johnson  staff      160 Oct 11 09:48 cmake
-rwxr-xr-x@ 1 matt.johnson  staff   963664 Oct 11 09:48 libIex-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       25 Oct 11 09:48 libIex-3_4.99.dylib -> libIex-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       19 Oct 11 09:48 libIex-3_4.dylib -> libIex-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       16 Oct 11 09:48 libIex.dylib -> libIex-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff    85088 Oct 11 09:48 libIlmThread-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       31 Oct 11 09:48 libIlmThread-3_4.99.dylib -> libIlmThread-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       25 Oct 11 09:48 libIlmThread-3_4.dylib -> libIlmThread-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       22 Oct 11 09:48 libIlmThread.dylib -> libIlmThread-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff   374624 Oct 11 09:48 libImath-3_2.30.3.2.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:48 libImath-3_2.30.dylib -> libImath-3_2.30.3.2.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       21 Oct 11 09:48 libImath-3_2.dylib -> libImath-3_2.30.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       18 Oct 11 09:48 libImath.dylib -> libImath-3_2.dylib
-rwxr-xr-x@ 1 matt.johnson  staff  1154256 Oct 11 09:48 libOpenEXR-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       29 Oct 11 09:48 libOpenEXR-3_4.99.dylib -> libOpenEXR-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       23 Oct 11 09:48 libOpenEXR-3_4.dylib -> libOpenEXR-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       20 Oct 11 09:48 libOpenEXR.dylib -> libOpenEXR-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff  2388240 Oct 11 09:48 libOpenEXRCore-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       33 Oct 11 09:48 libOpenEXRCore-3_4.99.dylib -> libOpenEXRCore-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:48 libOpenEXRCore-3_4.dylib -> libOpenEXRCore-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       24 Oct 11 09:48 libOpenEXRCore.dylib -> libOpenEXRCore-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff   231248 Oct 11 09:48 libOpenEXRUtil-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       33 Oct 11 09:48 libOpenEXRUtil-3_4.99.dylib -> libOpenEXRUtil-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:48 libOpenEXRUtil-3_4.dylib -> libOpenEXRUtil-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       24 Oct 11 09:48 libOpenEXRUtil.dylib -> libOpenEXRUtil-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff   120928 Oct 11 09:48 libdeflate.0.dylib
-rw-r--r--@ 1 matt.johnson  staff    70496 Oct 11 09:48 libdeflate.a
lrwxr-xr-x@ 1 matt.johnson  staff       18 Oct 11 09:48 libdeflate.dylib -> libdeflate.0.dylib
drwxr-xr-x@ 4 matt.johnson  staff      128 Oct 11 09:48 pkgconfig
```

In particular, `include` contains `libdeflate.h`, and `lib` contains `libdeflate.*` libraries.


Applying the change in this PR and re-running the same build, those are no longer being produced and installed:
```
% ls -l /Users/matt.johnson/Developer/openexr_inst/include 
total 0
drwxr-xr-x@  37 matt.johnson  staff  1184 Oct 11 09:50 Imath
drwxr-xr-x@ 148 matt.johnson  staff  4736 Oct 11 09:50 OpenEXR
% ls -l /Users/matt.johnson/Developer/openexr_inst/lib    
total 10176
drwxr-xr-x@ 4 matt.johnson  staff      128 Oct 11 09:50 cmake
-rwxr-xr-x@ 1 matt.johnson  staff   963664 Oct 11 09:50 libIex-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       25 Oct 11 09:50 libIex-3_4.99.dylib -> libIex-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       19 Oct 11 09:50 libIex-3_4.dylib -> libIex-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       16 Oct 11 09:50 libIex.dylib -> libIex-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff    85088 Oct 11 09:50 libIlmThread-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       31 Oct 11 09:50 libIlmThread-3_4.99.dylib -> libIlmThread-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       25 Oct 11 09:50 libIlmThread-3_4.dylib -> libIlmThread-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       22 Oct 11 09:50 libIlmThread.dylib -> libIlmThread-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff   374624 Oct 11 09:50 libImath-3_2.30.3.2.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:50 libImath-3_2.30.dylib -> libImath-3_2.30.3.2.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       21 Oct 11 09:50 libImath-3_2.dylib -> libImath-3_2.30.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       18 Oct 11 09:50 libImath.dylib -> libImath-3_2.dylib
-rwxr-xr-x@ 1 matt.johnson  staff  1154256 Oct 11 09:50 libOpenEXR-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       29 Oct 11 09:50 libOpenEXR-3_4.99.dylib -> libOpenEXR-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       23 Oct 11 09:50 libOpenEXR-3_4.dylib -> libOpenEXR-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       20 Oct 11 09:50 libOpenEXR.dylib -> libOpenEXR-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff  2388240 Oct 11 09:50 libOpenEXRCore-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       33 Oct 11 09:50 libOpenEXRCore-3_4.99.dylib -> libOpenEXRCore-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:50 libOpenEXRCore-3_4.dylib -> libOpenEXRCore-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       24 Oct 11 09:50 libOpenEXRCore.dylib -> libOpenEXRCore-3_4.dylib
-rwxr-xr-x@ 1 matt.johnson  staff   231248 Oct 11 09:50 libOpenEXRUtil-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       33 Oct 11 09:50 libOpenEXRUtil-3_4.99.dylib -> libOpenEXRUtil-3_4.99.3.4.0.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       27 Oct 11 09:50 libOpenEXRUtil-3_4.dylib -> libOpenEXRUtil-3_4.99.dylib
lrwxr-xr-x@ 1 matt.johnson  staff       24 Oct 11 09:50 libOpenEXRUtil.dylib -> libOpenEXRUtil-3_4.dylib
drwxr-xr-x@ 3 matt.johnson  staff       96 Oct 11 09:50 pkgconfig
```