### PR TITLE
Allow empty file name

### DIFF
--- a/src/lib/OpenEXRCore/context.c
+++ b/src/lib/OpenEXRCore/context.c
@@ -150,7 +150,7 @@ exr_test_file_header (
     exr_context_t             ret   = NULL;
     exr_context_initializer_t inits = fill_context_data (ctxtdata);
 
-    if (filename && filename[0] != '\0')
+    if (filename)
     {
         rv = internal_exr_alloc_context (
             &ret,
@@ -244,7 +244,7 @@ exr_start_read (
         return EXR_ERR_INVALID_ARGUMENT;
     }
 
-    if (filename && filename[0] != '\0')
+    if (filename)
     {
         rv = internal_exr_alloc_context (
             &ret,
@@ -311,7 +311,7 @@ exr_start_write (
         return EXR_ERR_INVALID_ARGUMENT;
     }
 
-    if (filename && filename[0] != '\0')
+    if (filename)
     {
         rv = internal_exr_alloc_context (
             &ret,

--- a/src/test/OpenEXRCoreTest/read.cpp
+++ b/src/test/OpenEXRCoreTest/read.cpp
@@ -79,7 +79,7 @@ testReadBadArgs (const std::string& tempdir)
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT, exr_start_read (&f, NULL, &cinit));
     EXRCORE_TEST_RVAL_FAIL (
-        EXR_ERR_INVALID_ARGUMENT, exr_start_read (&f, "", &cinit));
+        EXR_ERR_FILE_ACCESS, exr_start_read (&f, "", &cinit));
     // windows fails on directory open, where under unix you can open
     // the directory as a file handle but not read from it
 #ifdef _WIN32


### PR DESCRIPTION
When providing a custom stream, there is no reason a filename needs to be provided beyond clearer error messages. Because std::string does not allow null, continue to disallow a null filename. Add a test case

Fixes #1894 