### PR TITLE
Add missing namespace macros

### DIFF
--- a/src/bin/exrmanifest/main.cpp
+++ b/src/bin/exrmanifest/main.cpp
@@ -135,7 +135,7 @@ printManifest (const char fileName[])
         if (in.parts () > 1) { cout << fileName << " part " << part << ":\n"; }
         if (hasIDManifest (in.header (part)))
         {
-            const Imf::CompressedIDManifest& mfst =
+            const OPENEXR_IMF_NAMESPACE::CompressedIDManifest& mfst =
                 idManifest (in.header (part));
             size_t size = dumpManifest (mfst);
             cout << "raw text size    : " << size << endl;

--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -30,8 +30,8 @@
 #include <vector>
 #include <sys/stat.h>
 
-using namespace Imf;
-using Imath::Box2i;
+using namespace OPENEXR_IMF_NAMESPACE;
+using IMATH_NAMESPACE::Box2i;
 
 using std::cerr;
 using namespace std::chrono;
@@ -462,7 +462,7 @@ exrmetrics (
     const char       inFileName[],
     const char       outFileName[],
     int              part,
-    Imf::Compression compression,
+    OPENEXR_IMF_NAMESPACE::Compression compression,
     float            level,
     int              halfMode)
 {

--- a/src/bin/exrmetrics/exrmetrics.h
+++ b/src/bin/exrmetrics/exrmetrics.h
@@ -14,7 +14,7 @@ void exrmetrics (
     const char       inFileName[],
     const char       outFileName[],
     int              part,
-    Imf::Compression compression,
+    OPENEXR_IMF_NAMESPACE::Compression compression,
     float            level,
     int              halfMode);
 #endif

--- a/src/lib/OpenEXR/ImfInputFile.cpp
+++ b/src/lib/OpenEXR/ImfInputFile.cpp
@@ -69,7 +69,7 @@ struct InputFile::Data
         else
         {
             THROW (
-                Iex::ArgExc,
+                IEX_NAMESPACE::ArgExc,
                 "Invalid out of bounds part number " << part << ", only " << pc
                                                      << " parts in "
                                                      << _ctxt->fileName ());

--- a/website/src/previewImageExamples.cpp
+++ b/website/src/previewImageExamples.cpp
@@ -28,7 +28,7 @@ unsigned char
 gamma (float x)
 {
     x = pow (5.5555f * max (0.f, x), 0.4545f) * 84.66f;
-    return (unsigned char) Imath::clamp (x, 0.f, 255.f);
+    return (unsigned char) IMATH_NAMESPACE::clamp (x, 0.f, 255.f);
 }
 // [end gamma]
 
@@ -60,7 +60,7 @@ makePreviewImage (
             outPixel.r = gamma (inPixel.r);
             outPixel.g = gamma (inPixel.g);
             outPixel.b = gamma (inPixel.b);
-            outPixel.a = static_cast<int> (Imath::clamp (inPixel.a * 255.f, 0.f, 255.f) + 0.5f);
+            outPixel.a = static_cast<int> (IMATH_NAMESPACE::clamp (inPixel.a * 255.f, 0.f, 255.f) + 0.5f);
         }
     }
 }


### PR DESCRIPTION
To properly support custom namespaces, all namespace references should use the appropriate macros, not hard-coded literals.

Addresses #1911.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--1912.org.readthedocs.build/en/1912/
<!-- readthedocs-preview openexr end -->