### PR TITLE
Fix windows build/CI with threading disabled

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -228,10 +228,10 @@ jobs:
                 -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }} \
                 -DOPENEXR_INSTALL_TOOLS='ON' \
                 -DOPENEXR_INSTALL_DOCS='OFF' \
-                -DOPENEXR_RUN_FUZZ_TESTS='OFF' \
-                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }}
+                -DOPENEXR_RUN_FUZZ_TESTS='OFF'
       - name: Build
         run: |
           cmake --build _build \
@@ -360,6 +360,7 @@ jobs:
                 -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }} \
                 -DOPENEXR_INSTALL_TOOLS='ON' \
                 -DOPENEXR_INSTALL_DOCS='OFF' \
                 -DOPENEXR_RUN_FUZZ_TESTS='OFF'
@@ -495,6 +496,7 @@ jobs:
                 -DCMAKE_CXX_FLAGS=${{ matrix.cxx-flags }} \
                 -DCMAKE_VERBOSE_MAKEFILE:BOOL='OFF' \
                 -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
+                -DOPENEXR_ENABLE_THREADING=${{ matrix.threads-enabled }} \
                 -DOPENEXR_INSTALL_TOOLS='ON' \
                 -DOPENEXR_INSTALL_DOCS='OFF' \
                 -DOPENEXR_RUN_FUZZ_TESTS='OFF' 

--- a/src/test/OpenEXRCoreTest/compressionTables.cpp
+++ b/src/test/OpenEXRCoreTest/compressionTables.cpp
@@ -39,6 +39,10 @@
 #include <stdlib.h>
 #include <vector>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #if defined(OPENEXR_ENABLE_API_VISIBILITY)
 #include "../../lib/OpenEXRCore/internal_b44_table.c"
 #else


### PR DESCRIPTION
The CI was failing to actually set OPENEXR_THREADING_ENABLED for the
macOS and Windows builds.

And the Windows build as failing with threading disabled, due to a missing header.