### PR TITLE
Add .pyi generation and specify numpy dependency for Python wrapper build

### DIFF
--- a/.github/workflows/python-wheels-publish-test.yml
+++ b/.github/workflows/python-wheels-publish-test.yml
@@ -62,6 +62,9 @@ jobs:
           CIBW_SKIP: "*-win32 *_i686"
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_ENVIRONMENT: OPENEXR_RELEASE_CANDIDATE_TAG="${{ github.ref_name }}"
+          # Explicitly install required dependencies before building each Python version.
+          CIBW_BEFORE_BUILD: |
+            pip install -r <(python -c "import tomli; print('\n'.join(tomli.load(open('pyproject.toml', 'rb'))['build-system']['requires']))")
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -55,6 +55,9 @@ jobs:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*-win32 *_i686"
           CIBW_TEST_SKIP: "*arm64"
+          # Explicitly install required dependencies before building each Python version.
+          CIBW_BEFORE_BUILD: |
+            pip install -r <(python -c "import tomli; print('\n'.join(tomli.load(open('pyproject.toml', 'rb'))['build-system']['requires']))")
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -68,6 +68,9 @@ jobs:
           CIBW_SKIP: "*-win32 *_i686"
           CIBW_TEST_SKIP: "*-macosx*arm64"
           OPENEXR_TEST_IMAGE_REPO: "https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/main"
+          # Explicitly install required dependencies before building each Python version.
+          CIBW_BEFORE_BUILD: |
+            pip install -r <(python -c "import tomli; print('\n'.join(tomli.load(open('pyproject.toml', 'rb'))['build-system']['requires']))")
 
       - name: Upload artifact
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ build-nuget/
 *~
 .vscode
 docs/_test_images/
+dist/*
+__pycache__/
+*.py[cod]
+*$py.class
 
 # Ignore Bazel generated files
 bazel-* 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 [build-system]
-requires = ["scikit-build-core==0.10.7", "pybind11", "numpy"]
+requires = ["scikit-build-core==0.10.7", "pybind11", "pybind11-stubgen", "numpy"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 [build-system]
-requires = ["scikit-build-core==0.10.7", "pybind11"]
+requires = ["scikit-build-core==0.10.7", "pybind11", "numpy"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -15,6 +15,10 @@ authors = [
   { name="Contributors to the OpenEXR project", email="info@openexr.com" },
 ]
 requires-python = ">=3.7"
+
+dependencies = [
+  "numpy>=1.18"
+]
 
 [project.urls]
 "Homepage" = "https://openexr.com"

--- a/src/wrappers/python/CMakeLists.txt
+++ b/src/wrappers/python/CMakeLists.txt
@@ -1,43 +1,155 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright Contributors to the OpenEXR Project.
+# Copyright (c) Contributors to the OpenEXR Project.
 
-message(STATUS "Building OpenEXR python bindings")
+# We require this to get object library link library support
+cmake_minimum_required(VERSION 3.14)
 
-if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "OpenEXR")
-  cmake_minimum_required(VERSION 3.12)
-  project(PyOpenEXR)
-  find_package(OpenEXR)
+if(POLICY CMP0074)
+  # enable find_package(<Package>) to use <Package>_ROOT as a hint
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
-find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
-find_package(pybind11 CONFIG REQUIRED)
-
-python_add_library (PyOpenEXR MODULE PyOpenEXR.cpp PyOpenEXR_old.cpp)
-
-target_link_libraries (PyOpenEXR PRIVATE "${Python_LIBRARIES}" OpenEXR::OpenEXR pybind11::headers)
-
-# The python module should be called "OpenEXR.so", not "PyOpenEXR.so",
-# but "OpenEXR" is taken as a library name by the main lib, so specify
-# the name explicitly here.
-
-set_target_properties (PyOpenEXR PROPERTIES OUTPUT_NAME "OpenEXR")
-
-configure_file(Imath.py ${CMAKE_CURRENT_BINARY_DIR}/Imath.py COPYONLY)
-
-set(PYTHON_INSTALL_DIR "python/OpenEXR")
-if(SKBUILD)
-  set(PYTHON_INSTALL_DIR ${SKBUILD_PLATLIB_DIR})
+if(POLICY CMP0077)
+  # enable variables set outside to override options
+  cmake_policy(SET CMP0077 NEW)
 endif()
 
-install(TARGETS PyOpenEXR DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/Imath.py DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
+#######################################
+# Create project and include cmake
+# configuration files
+#######################################
 
-if(BUILD_TESTING AND OPENEXR_TEST_PYTHON)
+file(READ "src/lib/OpenEXRCore/openexr_version.h" VERSION_H)
+string(REGEX MATCH "VERSION_MAJOR ([0-9]*)" _ ${VERSION_H})
+set(OPENEXR_VERSION_MAJOR ${CMAKE_MATCH_1})
+string(REGEX MATCH "VERSION_MINOR ([0-9]*)" _ ${VERSION_H})
+set(OPENEXR_VERSION_MINOR ${CMAKE_MATCH_1})
+string(REGEX MATCH "VERSION_PATCH ([0-9]*)" _ ${VERSION_H})
+set(OPENEXR_VERSION_PATCH ${CMAKE_MATCH_1})
 
-  add_test(OpenEXR.PyOpenEXR pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+project(OpenEXR VERSION ${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR}.${OPENEXR_VERSION_PATCH} LANGUAGES C CXX)
 
-  set_tests_properties(OpenEXR.PyOpenEXR PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
-  )
+set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for OpenEXR build, such as -dev, -beta1, etc.")
 
+set(OPENEXR_VERSION ${OpenEXR_VERSION})
+set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
+
+# The SOVERSION (i.e. numerical component of SONAME) tracks the ABI
+# version. Increment this number whenever, and only when, the ABI changes in
+# non-backwards-compatible ways.
+#
+# The OpenEXR project policy is to append the library version 
+# "major.minor.patch" to the SONAME to form the real shared library name.  
+# For example, in "libOpenEXR.so.31.3.2.0", "libOpenEXR.so.31" is the SONAME
+# and ".3.2.0" identifies the corresponding library release.
+
+set(OPENEXR_LIB_SOVERSION 99)
+set(OPENEXR_LIB_VERSION "${OPENEXR_LIB_SOVERSION}.${OPENEXR_VERSION}") # e.g. "31.3.2.0"
+
+option(OPENEXR_INSTALL "Install OpenEXR libraries" ON)
+option(OPENEXR_INSTALL_TOOLS "Install OpenEXR tools" ON)
+
+if(OPENEXR_INSTALL OR OPENEXR_INSTALL_TOOLS)
+  # uninstall target
+  if(NOT TARGET uninstall)
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+      IMMEDIATE @ONLY)
+    add_custom_target(uninstall
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+  endif()
+endif()
+
+include(cmake/LibraryDefine.cmake)
+include(cmake/OpenEXRSetup.cmake)
+add_subdirectory(cmake)
+message(STATUS "Configure ${OPENEXR_PACKAGE_NAME}, library API version: ${OPENEXR_LIB_VERSION}")
+
+# Hint: This can be set to enable custom find_package
+# search paths, probably best to set it when configuring
+# on the command line to cmake instead of setting it
+# here.
+###set(CMAKE_PREFIX_PATH "/prefix")
+
+#######################################
+# Add all source in subdirectories
+#######################################
+
+if(BUILD_TESTING AND NOT OPENEXR_IS_SUBPROJECT)
+  # Enable testing *before* adding any subdirectories that may include tests
+  enable_testing()
+endif()
+
+# Include these two modules without enable/disable options
+if (OPENEXR_BUILD_LIBS)
+  add_subdirectory(src/lib)
+endif()
+
+if(OPENEXR_BUILD_TOOLS AND OPENEXR_BUILD_LIBS)
+  add_subdirectory(src/bin)
+endif()
+
+# Tell CMake where to find the OpenEXRConfig.cmake file. Makes it possible to call 
+# find_package(OpenEXR) in downstream projects
+set(OpenEXR_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake" CACHE PATH "" FORCE)
+# Add an empty OpenEXRTargets.cmake file for the config to use. 
+# Can be empty since we already defined the targets in add_subdirectory
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cmake/OpenEXRTargets.cmake" "# Dummy file")
+
+if(OPENEXR_BUILD_EXAMPLES AND OPENEXR_BUILD_LIBS)
+  add_subdirectory( src/examples )
+endif()
+
+# If you want to use ctest to configure, build and
+# upload the results, cmake has builtin support for
+# submitting to CDash, or any server who speaks the
+# same protocol
+# 
+# These settings will need to be set for your environment,
+# and then a script such as the example in
+#
+# cmake/SampleCTestScript.cmake
+#
+# edited and placed into the CI system, then run:
+#
+# cmake -S cmake/SampleCTestScript.cmake
+#
+# [or whatever you name the file you edit]
+# 
+#set(CTEST_PROJECT_NAME "OpenEXR")
+#set(CTEST_NIGHTLY_START_TIME "01:01:01 UTC")
+#set(CTEST_DROP_METHOD "http") # there are others...
+#set(CTEST_DROP_SITE "open.cdash.org")
+#set(CTEST_DROP_LOCATION "/submit.php?project=MyProject")
+#set(CTEST_DROP_SITE_CDASH TRUE)
+include(CTest)
+
+if(BUILD_TESTING AND OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
+  add_subdirectory(src/test)
+endif()
+
+# Including this module will add a `clang-format` target to the build if
+# the clang-format executable can be found. Only do this if we are top level
+if(NOT OPENEXR_IS_SUBPROJECT)
+  include(cmake/clang-format.cmake)
+endif()
+
+option(OPENEXR_INSTALL_DOCS "Set ON to install tool manpages")
+if (OPENEXR_INSTALL_DOCS AND NOT OPENEXR_IS_SUBPROJECT)
+  add_subdirectory(docs)
+endif()
+
+option(BUILD_WEBSITE "Set ON to build website source")
+if (BUILD_WEBSITE AND NOT OPENEXR_IS_SUBPROJECT)
+  add_subdirectory(website)
+endif()
+
+if (OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
+  # Even if not building the website, still make sure the website example code compiles.
+  add_subdirectory(website/src)
+endif()
+
+if (OPENEXR_BUILD_PYTHON AND OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
+  add_subdirectory(src/wrappers/python)
 endif()

--- a/src/wrappers/python/CMakeLists.txt
+++ b/src/wrappers/python/CMakeLists.txt
@@ -34,7 +34,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/Imath.py DESTINATION ${PYTHON_INSTALL_
 
 # Generate .pyi stub file using pybind11-stubgen. And install the generated .pyi file
 add_custom_command(TARGET PyOpenEXR POST_BUILD
-  COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} pybind11-stubgen -o ${CMAKE_BINARY_DIR}/OpenEXR --ignore-all-errors OpenEXR
+  COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${Python_EXECUTABLE} -m pybind11_stubgen -o ${CMAKE_BINARY_DIR}/OpenEXR --ignore-all-errors OpenEXR
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMENT "Generating .pyi stub file"
 )

--- a/src/wrappers/python/CMakeLists.txt
+++ b/src/wrappers/python/CMakeLists.txt
@@ -1,155 +1,51 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) Contributors to the OpenEXR Project.
+# Copyright Contributors to the OpenEXR Project.
 
-# We require this to get object library link library support
-cmake_minimum_required(VERSION 3.14)
+message(STATUS "Building OpenEXR python bindings")
 
-if(POLICY CMP0074)
-  # enable find_package(<Package>) to use <Package>_ROOT as a hint
-  cmake_policy(SET CMP0074 NEW)
+if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "OpenEXR")
+  cmake_minimum_required(VERSION 3.12)
+  project(PyOpenEXR)
+  find_package(OpenEXR)
 endif()
 
-if(POLICY CMP0077)
-  # enable variables set outside to override options
-  cmake_policy(SET CMP0077 NEW)
+find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
+find_package(pybind11 CONFIG REQUIRED)
+
+python_add_library (PyOpenEXR MODULE PyOpenEXR.cpp PyOpenEXR_old.cpp)
+
+target_link_libraries (PyOpenEXR PRIVATE "${Python_LIBRARIES}" OpenEXR::OpenEXR pybind11::headers)
+
+# The python module should be called "OpenEXR.so", not "PyOpenEXR.so",
+# but "OpenEXR" is taken as a library name by the main lib, so specify
+# the name explicitly here.
+
+set_target_properties (PyOpenEXR PROPERTIES OUTPUT_NAME "OpenEXR")
+
+configure_file(Imath.py ${CMAKE_CURRENT_BINARY_DIR}/Imath.py COPYONLY)
+
+set(PYTHON_INSTALL_DIR "python/OpenEXR")
+if(SKBUILD)
+  set(PYTHON_INSTALL_DIR ${SKBUILD_PLATLIB_DIR})
 endif()
 
-#######################################
-# Create project and include cmake
-# configuration files
-#######################################
+install(TARGETS PyOpenEXR DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/Imath.py DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
 
-file(READ "src/lib/OpenEXRCore/openexr_version.h" VERSION_H)
-string(REGEX MATCH "VERSION_MAJOR ([0-9]*)" _ ${VERSION_H})
-set(OPENEXR_VERSION_MAJOR ${CMAKE_MATCH_1})
-string(REGEX MATCH "VERSION_MINOR ([0-9]*)" _ ${VERSION_H})
-set(OPENEXR_VERSION_MINOR ${CMAKE_MATCH_1})
-string(REGEX MATCH "VERSION_PATCH ([0-9]*)" _ ${VERSION_H})
-set(OPENEXR_VERSION_PATCH ${CMAKE_MATCH_1})
+# Generate .pyi stub file using pybind11-stubgen. And install the generated .pyi file
+add_custom_command(TARGET PyOpenEXR POST_BUILD
+  COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} pybind11-stubgen -o ${CMAKE_BINARY_DIR}/OpenEXR --ignore-all-errors OpenEXR
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMENT "Generating .pyi stub file"
+)
+install(FILES ${CMAKE_BINARY_DIR}/OpenEXR/OpenEXR.pyi DESTINATION ${PYTHON_INSTALL_DIR} COMPONENT python)
 
-project(OpenEXR VERSION ${OPENEXR_VERSION_MAJOR}.${OPENEXR_VERSION_MINOR}.${OPENEXR_VERSION_PATCH} LANGUAGES C CXX)
+if(BUILD_TESTING AND OPENEXR_TEST_PYTHON)
 
-set(OPENEXR_VERSION_RELEASE_TYPE "-dev" CACHE STRING "Extra version tag string for OpenEXR build, such as -dev, -beta1, etc.")
+  add_test(OpenEXR.PyOpenEXR pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 
-set(OPENEXR_VERSION ${OpenEXR_VERSION})
-set(OPENEXR_VERSION_API "${OpenEXR_VERSION_MAJOR}_${OpenEXR_VERSION_MINOR}")
+  set_tests_properties(OpenEXR.PyOpenEXR PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
+  )
 
-# The SOVERSION (i.e. numerical component of SONAME) tracks the ABI
-# version. Increment this number whenever, and only when, the ABI changes in
-# non-backwards-compatible ways.
-#
-# The OpenEXR project policy is to append the library version 
-# "major.minor.patch" to the SONAME to form the real shared library name.  
-# For example, in "libOpenEXR.so.31.3.2.0", "libOpenEXR.so.31" is the SONAME
-# and ".3.2.0" identifies the corresponding library release.
-
-set(OPENEXR_LIB_SOVERSION 99)
-set(OPENEXR_LIB_VERSION "${OPENEXR_LIB_SOVERSION}.${OPENEXR_VERSION}") # e.g. "31.3.2.0"
-
-option(OPENEXR_INSTALL "Install OpenEXR libraries" ON)
-option(OPENEXR_INSTALL_TOOLS "Install OpenEXR tools" ON)
-
-if(OPENEXR_INSTALL OR OPENEXR_INSTALL_TOOLS)
-  # uninstall target
-  if(NOT TARGET uninstall)
-    configure_file(
-      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-      "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-      IMMEDIATE @ONLY)
-    add_custom_target(uninstall
-      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-  endif()
-endif()
-
-include(cmake/LibraryDefine.cmake)
-include(cmake/OpenEXRSetup.cmake)
-add_subdirectory(cmake)
-message(STATUS "Configure ${OPENEXR_PACKAGE_NAME}, library API version: ${OPENEXR_LIB_VERSION}")
-
-# Hint: This can be set to enable custom find_package
-# search paths, probably best to set it when configuring
-# on the command line to cmake instead of setting it
-# here.
-###set(CMAKE_PREFIX_PATH "/prefix")
-
-#######################################
-# Add all source in subdirectories
-#######################################
-
-if(BUILD_TESTING AND NOT OPENEXR_IS_SUBPROJECT)
-  # Enable testing *before* adding any subdirectories that may include tests
-  enable_testing()
-endif()
-
-# Include these two modules without enable/disable options
-if (OPENEXR_BUILD_LIBS)
-  add_subdirectory(src/lib)
-endif()
-
-if(OPENEXR_BUILD_TOOLS AND OPENEXR_BUILD_LIBS)
-  add_subdirectory(src/bin)
-endif()
-
-# Tell CMake where to find the OpenEXRConfig.cmake file. Makes it possible to call 
-# find_package(OpenEXR) in downstream projects
-set(OpenEXR_DIR "${CMAKE_CURRENT_BINARY_DIR}/cmake" CACHE PATH "" FORCE)
-# Add an empty OpenEXRTargets.cmake file for the config to use. 
-# Can be empty since we already defined the targets in add_subdirectory
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cmake/OpenEXRTargets.cmake" "# Dummy file")
-
-if(OPENEXR_BUILD_EXAMPLES AND OPENEXR_BUILD_LIBS)
-  add_subdirectory( src/examples )
-endif()
-
-# If you want to use ctest to configure, build and
-# upload the results, cmake has builtin support for
-# submitting to CDash, or any server who speaks the
-# same protocol
-# 
-# These settings will need to be set for your environment,
-# and then a script such as the example in
-#
-# cmake/SampleCTestScript.cmake
-#
-# edited and placed into the CI system, then run:
-#
-# cmake -S cmake/SampleCTestScript.cmake
-#
-# [or whatever you name the file you edit]
-# 
-#set(CTEST_PROJECT_NAME "OpenEXR")
-#set(CTEST_NIGHTLY_START_TIME "01:01:01 UTC")
-#set(CTEST_DROP_METHOD "http") # there are others...
-#set(CTEST_DROP_SITE "open.cdash.org")
-#set(CTEST_DROP_LOCATION "/submit.php?project=MyProject")
-#set(CTEST_DROP_SITE_CDASH TRUE)
-include(CTest)
-
-if(BUILD_TESTING AND OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
-  add_subdirectory(src/test)
-endif()
-
-# Including this module will add a `clang-format` target to the build if
-# the clang-format executable can be found. Only do this if we are top level
-if(NOT OPENEXR_IS_SUBPROJECT)
-  include(cmake/clang-format.cmake)
-endif()
-
-option(OPENEXR_INSTALL_DOCS "Set ON to install tool manpages")
-if (OPENEXR_INSTALL_DOCS AND NOT OPENEXR_IS_SUBPROJECT)
-  add_subdirectory(docs)
-endif()
-
-option(BUILD_WEBSITE "Set ON to build website source")
-if (BUILD_WEBSITE AND NOT OPENEXR_IS_SUBPROJECT)
-  add_subdirectory(website)
-endif()
-
-if (OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
-  # Even if not building the website, still make sure the website example code compiles.
-  add_subdirectory(website/src)
-endif()
-
-if (OPENEXR_BUILD_PYTHON AND OPENEXR_BUILD_LIBS AND NOT OPENEXR_IS_SUBPROJECT)
-  add_subdirectory(src/wrappers/python)
 endif()


### PR DESCRIPTION
Thanks to @cary-ilm for writing the new python wrapper. I'm sure this contribution will make OpenEXR much more user-friendly for python users in the future.

I tested generating pyi files according to @Parskatt suggestion. And I was able to generate pyi files easily (automatically) using pybind11-stubgen.

There are some issues when generating .pyi files with this tool targeting OpenEXR.so.
For example, the type hints for methods like OpenEXR.File.header() are generated as dicts, which can lead to situations where the programmer cannot specifically identify the internal objects.

However, I think it is worth updating because it still shows a lot of information about what objects are inside.


------


This pull request introduces enhancements to the Python wrapper build process with the following changes:
	1.	Automatic .pyi Generation:
	•	Updates CMakeLists.txt to automatically generate .pyi files during the build process using pybind11-stubgen.
	•	This ensures better IDE support and type hinting for the generated Python bindings.
	2.	numpy Dependency Specification:
	•	Adds numpy as a required dependency in pyproject.toml.
	•	Ensures that numpy is automatically installed in the Python environment during the build process if it is not already present.
	3.	Dependency Updates:
	•	Includes pybind11-stubgen in the build requirements to facilitate .pyi generation.
	4.	Additional Updates:
	•	Updates .gitignore to include Python-related ignores.

These changes aim to improve the developer experience, streamline the build process, and ensure the generated Python bindings provide proper type annotations for enhanced usability.

closed #1607 #1919 