### PR TITLE
Fix handling of box2f in python module

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1660,11 +1660,8 @@ objectToBox2f(const py::object& object, Box2f& b)
     {
         auto tup = object.cast<py::tuple>();
         if (tup.size() == 2)
-        {
-            Box2f box;
-            if (objectToV2f(tup[0], box.min) && objectToV2f(tup[1], box.max))
+            if (objectToV2f(tup[0], b.min) && objectToV2f(tup[1], b.max))
                 return true;
-        }
     }
 
     return false;

--- a/src/wrappers/python/PyOpenEXR_old.cpp
+++ b/src/wrappers/python/PyOpenEXR_old.cpp
@@ -373,7 +373,7 @@ channel (PyObject* self, PyObject* args, PyObject* kw)
             PyExc_TypeError, "There is no channel '%s' in the image", cname);
     }
 
-    Imf::PixelType pt;
+    PixelType pt;
     if (pixel_type != NULL)
     {
         if (PyObject_GetAttrString (pixel_type, "v") == NULL)
@@ -500,7 +500,7 @@ channels (PyObject* self, PyObject* args, PyObject* kw)
                 cname);
         }
 
-        Imf::PixelType pt;
+        PixelType pt;
         if (pixel_type != NULL)
         {
             pt = PixelType (
@@ -1013,7 +1013,7 @@ outwrite (PyObject* self, PyObject* args)
             PyDict_GetItem (pixeldata, PyUnicode_FromString (i.name ()));
         if (channel_spec != NULL)
         {
-            Imf::PixelType pt       = i.channel ().type;
+            PixelType pt       = i.channel ().type;
             int            typeSize = 4;
             switch (pt)
             {
@@ -1289,7 +1289,7 @@ makeOutputFile (PyObject* self, PyObject* args, PyObject* kwds)
             PreviewImage pi (
                 PyLong_AsLong (PyObject_StealAttrString (value, "width")),
                 PyLong_AsLong (PyObject_StealAttrString (value, "height")),
-                (Imf::PreviewRgba*) PyString_AsString (
+                (PreviewRgba*) PyString_AsString (
                     PyObject_StealAttrString (value, "pixels")));
             header.insert (ks, PreviewImageAttribute (pi));
         }
@@ -1398,9 +1398,9 @@ makeOutputFile (PyObject* self, PyObject* args, PyObject* kwds)
             TileDescription td (
                 PyInt_AsLong (PyObject_StealAttrString (value, "xSize")),
                 PyInt_AsLong (PyObject_StealAttrString (value, "ySize")),
-                (Imf::LevelMode) PyInt_AsLong (PyObject_StealAttrString (
+                (LevelMode) PyInt_AsLong (PyObject_StealAttrString (
                     PyObject_StealAttrString (value, "mode"), "v")),
-                (Imf::LevelRoundingMode) PyInt_AsLong (
+                (LevelRoundingMode) PyInt_AsLong (
                     PyObject_StealAttrString (
                         PyObject_StealAttrString (value, "roundingMode"),
                         "v")));
@@ -1511,7 +1511,7 @@ isOpenExrFile (const char fileName[])
     std::ifstream f (fileName, std::ios_base::binary);
     char          bytes[4];
     f.read (bytes, sizeof (bytes));
-    return !!f && Imf::isImfMagic (bytes);
+    return !!f && isImfMagic (bytes);
 }
 
 PyObject*

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -454,7 +454,7 @@ class TestUnittest(unittest.TestCase):
         header["stringvector"] = ["do", "re", "me"]
         header["chromaticities"] = (1.0,2.0, 3.0,4.0, 5.0,6.0,7.0,8.0)
         header["box2i"] = ((0,1), (2,3))
-        header["box2f"] = ((0,1), (2,3))
+        header["box2f"] = ((0.0,1.0), (2.0,3.0))
         header["compression"] = OpenEXR.ZIPS_COMPRESSION
         header["double"] = np.array([42000.0], 'float64')
         header["float"] = 4.2
@@ -484,7 +484,7 @@ class TestUnittest(unittest.TestCase):
             # Verify reading it back gives the same data
             with OpenEXR.File(outfilename, separate_channels=True) as infile:
                 compare_files (infile, outfile)
-
+                
     def test_write_2part(self):
 
         #
@@ -523,7 +523,7 @@ class TestUnittest(unittest.TestCase):
             header["stringvector"] = ["do", "re", "me"]
             header["chromaticities"] = (1.0,2.0, 3.0,4.0, 5.0,6.0,7.0,8.0)
             header["box2i"] = ((0,1),(2,3))
-            header["box2f"] = ((0,1),(2,3))
+            header["box2f"] = ((0.0,1.0),(2.0,3.0))
             header["compression"] = OpenEXR.ZIPS_COMPRESSION
             header["double"] = np.array([42000.0], 'float64')
             header["float"] = 4.2


### PR DESCRIPTION
`objectToBox2f` was failing to store the value in the proper argument.

Also, the test was never actually creating a `box2f` out of floats, it was only testing integers.

This also fixes an as-yet-undetected error with the use of Imf namespace in PyOpenEXR_old.cpp, where there's already a `using` statement.