### PR TITLE
Fix incorrect vec3 array size validation

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1554,7 +1554,7 @@ objectToV3(const py::object& object, Vec3<T>& v)
     else if (py::isinstance<py::array_t<T>>(object))
     {
         auto a = object.cast<py::array_t<T>>();
-        if (a.ndim() == 1 && a.size() == 2)
+        if (a.ndim() == 1 && a.size() == 3)
         {
             auto p = static_cast<T*>(a.request().ptr);
             v.x = p[0];

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -172,7 +172,9 @@ class TestUnittest(unittest.TestCase):
         header["t3i"] = (0,1,2)
         header["t3f"] = (3.4,5.6,7.8)
 
+        header["a2f"] = np.array((1.2, 3.4), 'float32')
         header["a2d"] = np.array((1.2, 3.4), 'float64')
+        header["a3f"] = np.array((1.2, 3.4, 5.6), 'float32')
         header["a3d"] = np.array((1.2, 3.4, 5.6), 'float64')
 
         header["a33f"] = np.identity(3, 'float32') 


### PR DESCRIPTION
Copy/paste error in objectToV3, should be looking for a.size()==3, not 2.