### PR TITLE
add checks to avoid using optimizations when inappropriate

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -1437,7 +1437,9 @@ internal_exr_match_decode (
         /* other optimizations would not be difficult, but this will
          * be the common one (where on encode / pack we want to do the
          * opposite) */
-        if (sametype == (int) EXR_PIXEL_HALF &&
+        if (!hassampling &&
+            chanstofill == decode->channel_count &&
+            sametype == (int) EXR_PIXEL_HALF &&
             sameouttype == (int) EXR_PIXEL_FLOAT)
         {
             if (simpinterleave > 0)


### PR DESCRIPTION
The fast unpack routines for 3 and 4 channels were not designed to handle sub-sampled images, but need to appear before other fallback disablement in the choice logic. Until that choice logic can be simplified, add additional checks to avoid heading to that branch.

This addresses a crash found when trying to test #1949 