### PR TITLE
Prevent crash when saving RGBA image where only one channel was added…

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -1432,6 +1432,10 @@ internal_exr_match_decode (
         return &generic_unpack_deep;
     }
 
+    if (hassampling || chanstofill != decode->channel_count || samebpc <= 0 ||
+        sameoutbpc <= 0)
+        return &generic_unpack;
+
     if (hastypechange > 0)
     {
         /* other optimizations would not be difficult, but this will
@@ -1469,10 +1473,6 @@ internal_exr_match_decode (
 
         return &generic_unpack;
     }
-
-    if (hassampling || chanstofill != decode->channel_count || samebpc <= 0 ||
-        sameoutbpc <= 0)
-        return &generic_unpack;
 
     (void) chanstounpack;
     (void) simplineoff;


### PR DESCRIPTION
… to Imf::FrameBuffer

Do this by considering the chanstofill != channel_count case before the channel_count special cases.