### PR TITLE
Remove duplicate cmake dependency from skbuild plugin

### DIFF
--- a/src/wrappers/python/openexr_skbuild_plugin.py
+++ b/src/wrappers/python/openexr_skbuild_plugin.py
@@ -99,8 +99,3 @@ def dynamic_metadata(
     print("openexr_skbuild_plugin: Computed version: {0}".format(version))
 
     return version
-
-def get_requires_for_dynamic_metadata(
-    _settings: Optional[Dict[str, object]] = None,
-) -> List[str]:
-    return ["cmake"]


### PR DESCRIPTION
Remove the duplicate `cmake` dependency that was added by `openexr_skbuild_plugin.py`.  Scikit-build-core is adding a dependency on CMake if necessary itself, and adding one unconditionally has a side effect of installing a local PyPI version of CMake that overrides the system CMake that scikit-build-core would be using instead.  This can be particularly problematic when downstream patching of CMake is required on the system in question.

Fixes #1957