### PR TITLE
Fix utf8 handling in C++ with the default Std IO streams

### DIFF
--- a/src/lib/OpenEXR/ImfStdIO.cpp
+++ b/src/lib/OpenEXR/ImfStdIO.cpp
@@ -15,6 +15,10 @@
 #include <ImfStdIO.h>
 #include <errno.h>
 #include <filesystem>
+#if __cplusplus >= 202002L
+#    include <ranges>
+#    include <span>
+#endif
 
 using namespace std;
 #include "ImfNamespace.h"
@@ -27,15 +31,29 @@ namespace
 inline ifstream*
 make_ifstream (const char* filename)
 {
-    return new ifstream (std::filesystem::path (filename),
+#if __cplusplus >= 202002L
+    auto u8view = ranges::views::transform (span{filename, strlen(filename)},
+                                            [](char c) -> char8_t { return c; });
+    return new ifstream (filesystem::path (u8view.begin (), u8view.end ()),
                          ios_base::in | ios_base::binary);
+#else
+    return new ifstream (filesystem::u8path (filename),
+                         ios_base::in | ios_base::binary);
+#endif
 }
 
 inline ofstream*
 make_ofstream (const char* filename)
 {
-    return new ofstream (std::filesystem::path (filename),
+#if __cplusplus >= 202002L
+    auto u8view = ranges::views::transform (span{filename, strlen(filename)},
+                                            [](char c) -> char8_t { return c; });
+    return new ofstream (filesystem::path (u8view.begin (), u8view.end ()),
                          ios_base::out | ios_base::binary);
+#else
+    return new ofstream (filesystem::u8path (filename),
+                         ios_base::out | ios_base::binary);
+#endif
 }
 
 void

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -361,6 +361,13 @@ typedef struct _exr_context_initializer_v3
 /** @brief Check the magic number of the file and report
  * `EXR_ERR_SUCCESS` if the file appears to be a valid file (or at least
  * has the correct magic number and can be read).
+ *
+ * The filename is assumed to be a UTF-8 encoded
+ * filename, as is standard on current Unix filesystems. Under
+ * windows, this will be widened to be a wchar_t. If the user provides
+ * custom I/O routines, the responsibility passes to the user for that
+ * behavior.
+ *
  */
 EXR_EXPORT exr_result_t exr_test_file_header (
     const char* filename, const exr_context_initializer_t* ctxtdata);
@@ -379,6 +386,12 @@ EXR_EXPORT exr_result_t exr_finish (exr_context_t* ctxt);
  * informational purposes only, the system assumes the user has
  * previously opened a stream, file, or whatever and placed relevant
  * data in userdata to access that.
+ *
+ * In the default case, the filename is assumed to be a UTF-8 encoded
+ * filename, as is standard on current Unix filesystems. Under
+ * windows, this will be widened to be a wchar_t. If the user provides
+ * custom I/O routines, the responsibility passes to the user for that
+ * behavior.
  *
  * One notable attribute of the context is that once it has been
  * created and returned a successful code, it has parsed all the
@@ -414,6 +427,12 @@ typedef enum exr_default_write_mode
  * ignored. As such, the system assumes the user has previously opened
  * a stream, file, or whatever and placed relevant data in userdata to
  * access that.
+ *
+ * In the default case, the filename is assumed to be a UTF-8 encoded
+ * filename, as is standard on current Unix filesystems. Under
+ * windows, this will be widened to be a wchar_t. If the user provides
+ * custom I/O routines, the responsibility passes to the user for that
+ * behavior.
  *
  * Multi-Threading: To avoid issues with creating multi-part EXR
  * files, the library approaches writing as a multi-step process, so

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -98,6 +98,7 @@ define_openexrcore_tests(
  testStartWriteDeepScan
  testStartWriteTile
  testStartWriteDeepTile
+ testStartWriteUTF8
  testWriteAttrs
  testWriteScans
  testWriteTiles

--- a/src/test/OpenEXRCoreTest/main.cpp
+++ b/src/test/OpenEXRCoreTest/main.cpp
@@ -187,6 +187,7 @@ main (int argc, char* argv[])
     TEST (testStartWriteTile, "core_write");
     TEST (testStartWriteDeepScan, "core_write");
     TEST (testStartWriteDeepTile, "core_write");
+    TEST (testStartWriteUTF8, "core_write");
     TEST (testWriteScans, "core_write");
     TEST (testWriteTiles, "core_write");
     TEST (testWriteMultiPart, "core_write");

--- a/src/test/OpenEXRCoreTest/write.h
+++ b/src/test/OpenEXRCoreTest/write.h
@@ -16,6 +16,7 @@ void testStartWriteScan (const std::string& tempdir);
 void testStartWriteTile (const std::string& tempdir);
 void testStartWriteDeepScan (const std::string& tempdir);
 void testStartWriteDeepTile (const std::string& tempdir);
+void testStartWriteUTF8 (const std::string& tempdir);
 
 void testUpdateMeta (const std::string& tempdir);
 

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -167,6 +167,7 @@ define_openexr_tests(
  testDeepTiledBasic
  testDwaLookups
  testExistingStreams
+ testExistingStreamsUTF8
  testFutureProofing
  testHeader
  testHuf

--- a/src/test/OpenEXRTest/main.cpp
+++ b/src/test/OpenEXRTest/main.cpp
@@ -202,6 +202,7 @@ main (int argc, char* argv[])
     TEST (testTiledLineOrder, "basic");
     TEST (testScanLineApi, "basic");
     TEST (testExistingStreams, "core");
+    TEST (testExistingStreamsUTF8, "core");
     TEST (testStandardAttributes, "core");
     TEST (testOptimized, "basic");
     TEST (testOptimizedInterleavePatterns, "basic");

--- a/src/test/OpenEXRTest/testExistingStreams.h
+++ b/src/test/OpenEXRTest/testExistingStreams.h
@@ -6,3 +6,4 @@
 #include <string>
 
 void testExistingStreams (const std::string& tempDir);
+void testExistingStreamsUTF8 (const std::string& tempDir);


### PR DESCRIPTION
The use of the new std::filesystem::path to cleanup messy filebuf manipulations to create a stream was incorrectly not using u8path under windows. This also adds future support for C++20 where they change the API.

Adds tests to test the utf-8 support which was previously incomplete