### PR TITLE
Update actions/upload-artifact to @v4

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -154,9 +154,9 @@ jobs:
 
       - name: Upload install_manifest.txt
         # Upload the manifest to make it possible to download for inspection and debugging
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: install_manifest
+          name: ${{ env.INSTALL_MANIFEST }}
           path: _build/${{ env.INSTALL_MANIFEST }}
 
       - name: Validate install


### PR DESCRIPTION
This requires all artifacts to have unique names, so the install_manifest.txt files need to uploaded with the name that includes the os and build number.