### PR TITLE
Fix bad pointer math

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -854,6 +854,7 @@ DwaCompressor_uncompress (
     if (version > 2) { return EXR_ERR_BAD_CHUNK_LEADER; }
 
     rv = DwaCompressor_setupChannelData (me);
+    if (rv != EXR_ERR_SUCCESS) { return rv; }
 
     //
     // Uncompress the UNKNOWN data into _planarUncBuffer[UNKNOWN]
@@ -1079,6 +1080,8 @@ DwaCompressor_uncompress (
         packedAcBufferEnd += decoder._packedAcCount * sizeof (uint16_t);
 
         packedDcBufferEnd += decoder._packedDcCount * sizeof (uint16_t);
+
+        totalAcUncompressedCount -= decoder._packedAcCount;
         totalDcUncompressedCount -= decoder._packedDcCount;
 
         me->_channelData[rChan].processed = 1;
@@ -1100,6 +1103,12 @@ DwaCompressor_uncompress (
         int                        pixelSize = chan->bytes_per_element;
 
         if (cd->processed) continue;
+
+        if (chan->width == 0 || chan->height == 0)
+        {
+            cd->processed = 1;
+            continue;
+        }
 
         switch (cd->compression)
         {
@@ -1138,6 +1147,7 @@ DwaCompressor_uncompress (
                     packedDcBufferEnd +=
                         (size_t) decoder._packedDcCount * sizeof (uint16_t);
 
+                    totalAcUncompressedCount -= decoder._packedAcCount;
                     totalDcUncompressedCount -= decoder._packedDcCount;
                     if (rv != EXR_ERR_SUCCESS) { return rv; }
                 }

--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -68,6 +68,14 @@ __extension__ extern __inline float32x4x2_t
 }
 #endif
 
+static inline uint8_t *simd_align_pointer (uint8_t* ptr)
+{
+    return ptr +
+        ((_SSE_ALIGNMENT - (((uintptr_t)ptr) & _SSE_ALIGNMENT_MASK)) &
+         _SSE_ALIGNMENT_MASK);
+}
+
+
 //
 // Color space conversion, Inverse 709 CSC, Y'CbCr -> R'G'B'
 //


### PR DESCRIPTION
In SSE, we were incrementing a pointer as if it were a uint16_t, not an si128, causing out of bounds accesses on non-block aligned chunks.

Similarly, simplify the alignment logic and check return values and pointers in related accesses (non-block aligned linear lut lookup).