### PR TITLE
avoid large allocations

### DIFF
--- a/src/lib/OpenEXR/ImfInputFile.cpp
+++ b/src/lib/OpenEXR/ImfInputFile.cpp
@@ -377,9 +377,21 @@ InputFile::Data::lockedSetFrameBuffer (const FrameBuffer& frameBuffer)
             _cachedOffset               = dataWindow.min.x;
 
             uint64_t tileRowSize =
-                uint64_t (_tFile->tileYSize ()) *
-                (static_cast<uint64_t> (dataWindow.max.x - dataWindow.min.x) +
-                 1U);
+                static_cast<uint64_t> (_tFile->tileYSize ()) *
+                static_cast<uint64_t> (
+                    static_cast<int64_t> (dataWindow.max.x) -
+                    static_cast<int64_t> (dataWindow.min.x) +
+                    1LL );
+
+            // before we allocate a (potentially large) chunk of ram, let's
+            // quick ensure we can read the tiles
+            if (!_ctxt->chunkTableValid (getPartIdx ()))
+            {
+                THROW (
+                    IEX_NAMESPACE::ArgExc,
+                    "Unable to use generic API to read with (partially?) corrupt chunk table in "
+                    << _ctxt->fileName () << ", part " << getPartIdx () );
+            }
 
             for (FrameBuffer::ConstIterator k = frameBuffer.begin ();
                  k != frameBuffer.end ();

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -277,6 +277,9 @@ readTileRgba (T& in, bool reduceMemory, bool reduceTime)
         int dwx = dw.min.x;
         int dwy = dw.min.y;
 
+        if (!in.isComplete ())
+            return true;
+
         Array2D<Rgba> pixels (h, w);
         in.setFrameBuffer (&pixels[-dwy][-dwx], 1, w);
         in.readTiles (0, in.numXTiles () - 1, 0, in.numYTiles () - 1);


### PR DESCRIPTION
If the chunk table is unable to provide the specified data window, do not allocate the frame buffer (or cache framebuffer) to that size