### PR TITLE
fix crash if user does not provide memory when filling

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -926,7 +926,7 @@ void ScanLineProcess::run_fill (
                 int32_t samps = counts[sx];
                 void *dest = *((void **)outptr);
 
-                if (samps == 0)
+                if (samps == 0 || dest == nullptr)
                 {
                     outptr += fills.xStride;
                     continue;

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -1139,7 +1139,7 @@ void TileProcess::run_fill (
                 int32_t samps = counts[sx];
                 void *dest = *((void **)outptr);
 
-                if (samps == 0)
+                if (samps == 0 || dest == nullptr)
                 {
                     outptr += fills.xStride;
                     continue;


### PR DESCRIPTION
for deep frame buffers, when filling, if the caller does not provide output memory for a particular sample set, do not crash.