### PR TITLE
Address issues with small exr files and header parse

### DIFF
--- a/src/lib/OpenEXR/ImfContextInit.cpp
+++ b/src/lib/OpenEXR/ImfContextInit.cpp
@@ -118,9 +118,27 @@ istream_nonparallel_read (
             }
         }
 
+        int64_t stream_sz = s->size ();
+        int64_t nend = nread + (int64_t)sz;
+        if (stream_sz > 0 && nend > stream_sz)
+        {
+            sz = stream_sz - nend;
+        }
+
         try
         {
-            s->read (static_cast<char*> (buffer), static_cast<int> (sz));
+            if (s->isMemoryMapped ())
+            {
+                char* data = s->readMemoryMapped (static_cast<int> (sz));
+                // TODO: in a future release, pass this through to
+                // core directly
+                if (data)
+                    memcpy (buffer, data, sz);
+            }
+            else
+            {
+                s->read (static_cast<char*> (buffer), static_cast<int> (sz));
+            }
         }
         catch (...)
         {

--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -975,6 +975,8 @@ public:
 
     virtual bool isMemoryMapped () const { return false; }
 
+    virtual int64_t size () { return end - base; }
+
     virtual char* readMemoryMapped (int n)
     {
 


### PR DESCRIPTION
If we know the file size, we should truncate the header parse to only read the file at most. Otherwise, if the file size is unknown (stream) then be conservative (and slower) and read 1 byte at a time for the header parse. Once we know the file, that should be free to read chunks.

Addresses issue found in #1984 