### PR TITLE
Adjust the clamping on the dwa compression

### DIFF
--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -609,7 +609,12 @@ exr_set_dwa_compression_level (exr_context_t ctxt, int part_index, float level)
         return EXR_UNLOCK_AND_RETURN (
             ctxt->standard_error (ctxt, EXR_ERR_NOT_OPEN_WRITE));
 
-    if (level > 0.f && level <= 100.f)
+    // avoid bad math (fp exceptions or whatever) by clamping here
+    // there has always been a clamp to 0, but on the upper end, there
+    // is a limit too, where you only get black images anyway, so that
+    // is not particularly useful, not that any large value will
+    // really be crushing the image
+    if (level >= 0.f && level <= (65504.f*100000.f))
     {
         part->dwa_compression_level = level;
         rv                          = EXR_ERR_SUCCESS;

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -435,10 +435,16 @@ testWriteBaseHeader (const std::string& tempdir)
         exr_set_dwa_compression_level (outf, 0, -2.f));
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT,
-        exr_set_dwa_compression_level (outf, 0, 420.f));
+        exr_set_dwa_compression_level (outf, 0, INFINITY));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_dwa_compression_level (outf, 0, NAN));
     EXRCORE_TEST_RVAL (exr_set_dwa_compression_level (outf, 0, 42.f));
     EXRCORE_TEST_RVAL (exr_get_dwa_compression_level (outf, 0, &dlev));
     EXRCORE_TEST (dlev == 42.f);
+    EXRCORE_TEST_RVAL (exr_set_dwa_compression_level (outf, 0, 420.f));
+    EXRCORE_TEST_RVAL (exr_get_dwa_compression_level (outf, 0, &dlev));
+    EXRCORE_TEST (dlev == 420.f);
 
     EXRCORE_TEST_RVAL (exr_finish (&outf));
     remove (outfn.c_str ());


### PR DESCRIPTION
The dwa compression is not truly a quality level like other things, so a maximal value is controlling quantization, not quality. A value of 0 is allowed, but negative is not.

Fixes #1982  