### PR TITLE
support subsampling in exrmetrics

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -82,15 +82,17 @@ initScanLine (
     uint64_t offsetToOrigin = width * static_cast<uint64_t> (dw.min.y) +
                               static_cast<uint64_t> (dw.min.x);
 
-    int channelNumber = 0;
-    int pixelSize     = 0;
+    int    channelNumber = 0;
+    size_t rawSize       = 0;
 
     for (ChannelList::ConstIterator i = outHeader.channels ().begin ();
          i != outHeader.channels ().end ();
          ++i)
     {
-        int samplesize = pixelTypeSize (i.channel ().type);
-        pixelSize += samplesize;
+        int    samplesize      = pixelTypeSize (i.channel ().type);
+        size_t pixelsInChannel = (width / i.channel ().xSampling) *
+                                 (height / i.channel ().ySampling);
+        rawSize += pixelsInChannel * samplesize;
         pixelData[channelNumber].resize (numPixels * samplesize);
 
         buf.insert (
@@ -99,12 +101,14 @@ initScanLine (
                 i.channel ().type,
                 pixelData[channelNumber].data () - offsetToOrigin * samplesize,
                 samplesize,
-                samplesize * width));
+                samplesize * width,
+                i.channel ().xSampling,
+                i.channel ().ySampling));
         ++channelNumber;
     }
 
     partSizeData data;
-    data.rawSize      = width * height * pixelSize;
+    data.rawSize      = rawSize;
     data.pixelCount   = width * height;
     data.partType     = in.header ().type ();
     data.compression  = in.header ().compression ();

--- a/src/bin/exrmetrics/main.cpp
+++ b/src/bin/exrmetrics/main.cpp
@@ -30,8 +30,8 @@ using std::endl;
 using std::list;
 using std::max;
 using std::min;
-using std::sort;
 using std::quoted;
+using std::sort;
 
 using std::numeric_limits;
 using std::ostream;
@@ -261,7 +261,7 @@ jsonStats (
                 out << " },\n";
             }
             out << " {\n"
-                << "  \"file\":" <<  quoted(run.file) << ",\n";
+                << "  \"file\":" << quoted (run.file) << ",\n";
             lastFileName = run.file;
             if (outputSizeData)
             {
@@ -366,11 +366,11 @@ jsonStats (
             out << ",\n";
             out << "      \"output size\": " << run.metrics.outputFileSize;
         }
-        if(timing)
+        if (timing)
         {
-             out << ",\n";
-             printPartStats ( out, run.metrics.totalStats, "      ", timing, raw, stats);
-
+            out << ",\n";
+            printPartStats (
+                out, run.metrics.totalStats, "      ", timing, raw, stats);
         }
         if (timing && run.metrics.stats.size () > 1)
         {
@@ -396,10 +396,7 @@ jsonStats (
             }
             out << "       ]\n";
         }
-        else
-        {
-             out << "\n";
-        }
+        else { out << "\n"; }
         out << "    }";
         firstEntryForFile = false;
     }

--- a/src/test/bin/test_exrmetrics.py
+++ b/src/test/bin/test_exrmetrics.py
@@ -55,7 +55,7 @@ for a in ["-p","-l","-16","-z","-t","-i","--passes","-o","--pixelmode","--time"]
     assert(result.returncode != 0), "\n"+result.stderr
     assert("Missing" in result.stderr),"expected 'Missing argument' error"
 
-for image in [f"{image_dir}/TestImages/GrayRampsHorizontal.exr",f"{image_dir}/Beachball/multipart.0001.exr"]:
+for image in [f"{image_dir}/TestImages/GrayRampsHorizontal.exr",f"{image_dir}/Beachball/multipart.0001.exr",f"{image_dir}/LuminanceChroma/Flowers.exr"]:
     for time in ["none","read","write","reread","read,write","read,reread","read,write,reread"]:
         for passes in ["1","2"]:
             for nosize in range(0,2):


### PR DESCRIPTION
Fixes #2000 : support subsampling in scanline EXRs. OpenEXR only supports subsampling in regular scanline images; tiled and deep images are not supported. Also adds a subsampled image to the test

There are also minor changes due to a clang-reformat of src/bin/exrmetrics/main.cpp, since I forgot to do that last time