### PR TITLE
Fix issue #2009 of failing build on 32-bit MinGW

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -565,7 +565,13 @@ extract_chunk_table (
     if (ctable == NULL)
     {
         int64_t      nread = 0;
+#ifdef EXR_HAS_STD_ATOMICS
+        uintptr_t eptr = 0, nptr = 0;
+#elif defined(_MSC_VER)
         uint64_t     eptr = 0, nptr = 0;
+#else
+#    error OS unimplemented support for atomics
+#endif
         int          complete = 1;
         uint64_t     maxoff   = ((uint64_t) -1);
         exr_result_t rv;
@@ -639,7 +645,13 @@ extract_chunk_table (
         }
         else { priv_to_native64 (ctable, part->chunk_count); }
 
+#ifdef EXR_HAS_STD_ATOMICS
+        nptr = (uintptr_t) ctable;
+#elif defined(_MSC_VER)
         nptr = (uint64_t) ctable;
+#else
+#    error OS unimplemented support for atomics
+#endif
         // see if we win or not
         if (!atomic_compare_exchange_strong (
                 EXR_CONST_CAST (atomic_uintptr_t*, &(part->chunk_table)),


### PR DESCRIPTION
This PR refines the minimal fix for 32 bit MSVC introduced in #1952 by adding preprocessor define based distinctions of the fixed code.
This fixes issue #2009 of failing builds on 32-bit MinGW toolchains.

As pointed out in more detail in https://github.com/AcademySoftwareFoundation/openexr/pull/1952#issuecomment-2754248630, there are similar distinctions for `atomic_uintptr_t` and `atomic_compare_exchange_strong`  here:

https://github.com/AcademySoftwareFoundation/openexr/blob/75b70c6cba7d4fc02f08e5627a202b228d5a3ddc/src/lib/OpenEXRCore/internal_structs.h#L41-L62

https://github.com/AcademySoftwareFoundation/openexr/blob/75b70c6cba7d4fc02f08e5627a202b228d5a3ddc/src/lib/OpenEXRCore/chunk.c#L29-L51

For that reason the behavior differs on 32 bit MSVC and MINGW builds.

The define based distinction added by this PR restores the old (working) behavior for MINGW (and possibly other toolchains) while keeping the fix for 32 bit builds with MSVC.