### PR TITLE
Fix Deep Scanline Input crash when using a framebuffer as parameter

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -629,7 +629,7 @@ DeepScanLineInputFile::Data::readMemData (
         *_ctxt,
         partNumber,
         rawPixelData,
-        &frameBuffer,
+        &fb,
         scanLine1,
         scanLine2,
         fills);


### PR DESCRIPTION
The Deep Scanline Input code has recently been rewritten to make use of the EXR core library. As a result a bug was introduced when using the overloads of readPixels() and readPixelSampleCounts() that use externally provided framebuffers as parameters, a hard crash was occuring. According to the comment on the header of these functions, when these overloads are used the InputFile's frameBuffer is not used.
However both these functions call into readMemData(), which does use the InputFile's member framebuffer, which has not been allocated, resulting into a segmentation fault.
This commit fixes the above issue, by using the parameter framebuffer that is passed in, which should be allocated by the caller application.

Closes https://github.com/AcademySoftwareFoundation/openexr/issues/2020