### PR TITLE
Fix handling of /EHsc and /MP flags

### DIFF
--- a/cmake/LibraryDefine.cmake
+++ b/cmake/LibraryDefine.cmake
@@ -10,7 +10,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
   cmake_parse_arguments(OPENEXR_CURLIB "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if (MSVC)
-    set(_openexr_extra_flags "/EHsc" "/MP")
+    set(_openexr_extra_flags "$<$<COMPILE_LANGUAGE:CXX>:/EHsc>" "$<$<COMPILE_LANGUAGE:CXX>:/MP>")
   endif()
   set(objlib ${libname})
   add_library(${objlib}
@@ -59,7 +59,7 @@ function(OPENEXR_DEFINE_LIBRARY libname)
       target_compile_definitions(${objlib} PUBLIC OPENEXR_USE_DEFAULT_VISIBILITY)
   endif()
   if (_openexr_extra_flags)
-    target_compile_options(${objlib} PUBLIC ${_openexr_extra_flags})
+    target_compile_options(${objlib} PRIVATE ${_openexr_extra_flags})
   endif()
   set_property(TARGET ${objlib} PROPERTY PUBLIC_HEADER ${OPENEXR_CURLIB_HEADERS})
 


### PR DESCRIPTION
These flags are now specified via a generator expression, so they are only applied to C++ compilation, not CUDA.

This also makes the flags PRIVATE, not PUBLIC. They should not affect dependant projects, so they should not be a part of the public interface.

Resolves #2018