### PR TITLE
Improve RGB channel detection heuristics for the HT256 encoder

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -25,6 +25,14 @@ struct RGBChannelParams
     int         b_index;
 };
 
+static inline bool areEqual(const char* a, const char* b) {
+#ifdef _MSC_VER
+    return _stricmp (a, b) == 0;
+#else
+    return strcasecmp (a, b) == 0;
+#endif
+}
+
 bool
 make_channel_map (
     int                                 channel_count,
@@ -65,21 +73,21 @@ make_channel_map (
 
         for (size_t j = 0; j < params_count; j++)
         {
-            if (strcasecmp (suffix, params[j].r_suffix) == 0 &&
+            if (areEqual (suffix, params[j].r_suffix) &&
                 params[j].r_index < 0)
             {
                 params[j].r_index = i;
                 break;
             }
             else if (
-                strcasecmp (suffix, params[j].g_suffix) == 0 &&
+                areEqual (suffix, params[j].g_suffix) &&
                 params[j].g_index < 0)
             {
                 params[j].g_index = i;
                 break;
             }
             else if (
-                strcasecmp (suffix, params[j].b_suffix) == 0 &&
+                areEqual (suffix, params[j].b_suffix) &&
                 params[j].b_index < 0)
             {
                 params[j].b_index = i;

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -57,8 +57,7 @@ make_channel_map (
 
     RGBChannelParams params[] = {
         {"r", "g", "b", -1, -1, -1, NULL, 0},
-        {"red", "green", "blue", -1, -1, -1, NULL, 0},
-        {"red", "grn", "blu", -1, -1, -1, NULL, 0}};
+        {"red", "green", "blue", -1, -1, -1, NULL, 0}};
     constexpr size_t params_count = sizeof (params) / sizeof (params[0]);
 
     cs_to_file_ch.resize (channel_count);

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -7,6 +7,8 @@
 #include <vector>
 #include <string>
 #include <cassert>
+#include <algorithm>
+#include <cctype>
 
 bool
 make_channel_map (
@@ -22,9 +24,13 @@ make_channel_map (
     {
         std::string c_name(channels[i].channel_name);
 
-        if (c_name == "R") { r_index = i; }
-        else if (c_name == "G") { g_index = i; }
-        else if (c_name == "B") { b_index = i; }
+        /* heuristics to determine whether RGB channels are present */
+        std::transform(c_name.begin(), c_name.end(), c_name.begin(),
+                   [](unsigned char c){ return std::tolower(c); });
+
+        if (c_name == "r" || c_name.compare(0, 3, "red") == 0) { r_index = i; }
+        else if (c_name == "g" || c_name.compare(0, 5, "green") == 0) { g_index = i; }
+        else if (c_name == "b" || c_name.compare(0, 4, "blue")== 0) { b_index = i; }
     }
 
     bool isRGB = r_index >= 0 && g_index >= 0 && b_index >= 0 &&

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -118,6 +118,7 @@ define_openexrcore_tests(
  testB44ACompression
  testDWAACompression
  testDWABCompression
+ testHTChannelMap
  testDeepNoCompression
  testDeepZIPCompression
  testDeepZIPSCompression

--- a/src/test/OpenEXRCoreTest/compression.h
+++ b/src/test/OpenEXRCoreTest/compression.h
@@ -22,6 +22,7 @@ void testB44Compression (const std::string& tempdir);
 void testB44ACompression (const std::string& tempdir);
 void testDWAACompression (const std::string& tempdir);
 void testDWABCompression (const std::string& tempdir);
+void testHTChannelMap (const std::string& tempdir);
 
 void testDeepNoCompression (const std::string& tempdir);
 void testDeepZIPCompression (const std::string& tempdir);

--- a/src/test/OpenEXRCoreTest/main.cpp
+++ b/src/test/OpenEXRCoreTest/main.cpp
@@ -206,6 +206,7 @@ main (int argc, char* argv[])
     TEST (testB44ACompression, "core_compression");
     TEST (testDWAACompression, "core_compression");
     TEST (testDWABCompression, "core_compression");
+    TEST (testHTChannelMap, "core_compression");
 
     TEST (testDeepNoCompression, "core_compression");
     TEST (testDeepZIPCompression, "core_compression");


### PR DESCRIPTION
Updated algorithm:

      * RGB channels are present if the either (a) the names of the channels in
      * their entirety or (b) following the "." character match one of the
      * triplets defined in {params}. Order of the channels and case of the
      * channel names are ignored.
      *
      * Example 1: "main.b", "main.g", "main.r" match
      * Example 2: "MainR", "MainG", "MainB" do not match
      * Example 3: "R", "B", "B" match
      * Example 4: "red", "green", "blue" match