### PR TITLE
Fix crash in exrmetrics when running in single part mode.

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -1001,7 +1001,7 @@ exrmetrics (
 
     bool compressionSet = false;
 
-    for (int p = 0; p < in.parts (); ++p)
+    for (int p = 0; p < outHeaders.size(); ++p)
     {
         if (compression < NUM_COMPRESSION_METHODS)
         {


### PR DESCRIPTION
When you run for example with a file that has more than 1 part:

`exrmetrics -p 0 -z zip zip256.exr`

you will crash on Linux (or get some obscure message about the compression token not existing).
This is because `outHeaders` is size 1, while in.parts () is larger, resulting in an out of bounds access for `outHeaders`