### PR TITLE
Fix crash in exrmetrics when running in single part mode.

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -1001,7 +1001,7 @@ exrmetrics (
 
     bool compressionSet = false;
 
-    for (int p = 0; p < in.parts (); ++p)
+    for (int p = 0; p < outHeaders.size(); ++p)
     {
         if (compression < NUM_COMPRESSION_METHODS)
         {

--- a/src/test/bin/test_exrmetrics.py
+++ b/src/test/bin/test_exrmetrics.py
@@ -77,4 +77,11 @@ for image in [f"{image_dir}/TestImages/GrayRampsHorizontal.exr",f"{image_dir}/Be
                   for x in ['file','pixels','compression','part type','total raw size']:
                      assert(x in data[0]),"\n Missing field "+x
 
+# test -p 0 with multipart file
+multipart = f"{image_dir}/Beachball/multipart.0001.exr"
+result = run ([exrmetrics, multipart, "-p", "0", "-z","zip"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
+assert(result.returncode == 0), "\n"+result.stderr
+data = json.loads(result.stdout)
+assert(len(data)==1),"\n Unexpected list size in JSON object"
+
 print("success")


### PR DESCRIPTION
When you run for example with a file that has more than 1 part:

exrmetrics -p 0 -z zip zip256.exr

you will crash on Linux (or get some obscure message about the compression token not existing on osx).
This is because outHeaders is size 1, while in.parts () is larger, resulting in an out of bounds access for outHeaders