### PR TITLE
Use default generator for oss_fuzz

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,6 @@
     "configurePresets": [
         {
             "name": "oss_fuzz",
-            "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_VERBOSE_MAKEFILE": "ON",
                 "BUILD_SHARED_LIBS": "OFF",

--- a/src/test/oss-fuzz/CMakeLists.txt
+++ b/src/test/oss-fuzz/CMakeLists.txt
@@ -16,6 +16,13 @@
 #
 
 message(STATUS "Configuring oss_fuzz with $ENV{LIB_FUZZING_ENGINE}")
+message(STATUS "SRC=$ENV{SRC}")
+message(STATUS "WORK=$ENV{WORK}")
+message(STATUS "OUT=$ENV{OUT}")
+message(status "CXX=$ENV{CXX}")
+message(status "CXX_FLAGS=$ENV{CXX_FLAGS}")
+message(status "CC=$ENV{CC}")
+message(status "CC_FLAGS=$ENV{CC_FLAGS}")
 
 set(OPENEXR_FUZZERS openexr_exrcheck_fuzzer openexr_exrcorecheck_fuzzer)
 add_custom_target(oss_fuzz ALL

--- a/src/test/oss-fuzz/test_build.sh
+++ b/src/test/oss-fuzz/test_build.sh
@@ -14,14 +14,15 @@
 
 set -x
 
-export SRC="$(git rev-parse --show-toplevel)"
-export WORK="$(dirname $SRC)"
+export GIT_ROOT="$(git rev-parse --show-toplevel)"
+export WORK="$(dirname $GIT_ROOT)"
+export SRC=$WORK
 export OSS_FUZZ_HOME=$WORK/oss-fuzz/projects/openexr
 export OUT=$OSS_FUZZ_HOME/_out
 
-export CXX=clang++
+export CXX=$(which g++)
 export CXX_FLAGS=""
-export CC=clang
+export CC=$(which gcc)
 export CC_FLAGS=""
 
 # stub of a fuzzing engine, just to confirm the target builds


### PR DESCRIPTION
It appears ninja is not supported.

Also, fix test_build.sh; SRC is the parent of openexr, not the repo itself. And add diagnostic output to cmake as well.