### PR TITLE
Add "htj2k" in exr_print_context_info for exrinfo tool

### DIFF
--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -84,7 +84,8 @@ print_attr (const exr_attribute_t* a, int verbose)
                 "b44",
                 "b44a",
                 "dwaa",
-                "dwab"};
+                "dwab",
+                "htj2k"};
             printf (
                 "'%s'", (a->uc < 10 ? compressionnames[a->uc] : "<UNKNOWN>"));
             if (verbose) printf (" (0x%02X)", a->uc);


### PR DESCRIPTION
The recently added htj2k compression codec doesn't have a corresponding name string in `debug.c\exr_print_context_info`.

In particular, this has caused the `exrinfo` bin tool to print out `Unknown (0xA)` for any htj2k compressed exr files.

Here we add this name string into the print info method and enable `exrinfo` to correctly report compression type of htj2k files.