### PR TITLE
Supplemental to 2051: Adjust the "Unknown" compression threshold to 11

### DIFF
--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -87,7 +87,7 @@ print_attr (const exr_attribute_t* a, int verbose)
                 "dwab",
                 "htj2k"};
             printf (
-                "'%s'", (a->uc < 11 ? compressionnames[a->uc] : "<UNKNOWN>"));
+                "'%s'", (a->uc < EXR_COMPRESSION_LAST_TYPE ? compressionnames[a->uc] : "<UNKNOWN>"));
             if (verbose) printf (" (0x%02X)", a->uc);
             break;
         }

--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -87,7 +87,7 @@ print_attr (const exr_attribute_t* a, int verbose)
                 "dwab",
                 "htj2k"};
             printf (
-                "'%s'", (a->uc < 10 ? compressionnames[a->uc] : "<UNKNOWN>"));
+                "'%s'", (a->uc < 11 ? compressionnames[a->uc] : "<UNKNOWN>"));
             if (verbose) printf (" (0x%02X)", a->uc);
             break;
         }


### PR DESCRIPTION
A supplemental patch following !2051 that changes the "Unknown" compression mode threshold to 11, now we have 10 (0xA) assigned to htj2k. 

As with 2051, this affects the `exrinfo` bin tool, in addition to the core debug facilities.