### PR TITLE
Update legacy Windows CI job from vfx2022 to vfx2023

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -247,8 +247,8 @@ jobs:
             BUILD_TESTING: 'OFF'
 
           - build: 6
-            label: vfx2022
-            os: windows-2019
+            label: vfx2023
+            os: windows-2022
 
             # Build w/msys2, mingw32 and ucrt64, shared and static. 
 


### PR DESCRIPTION
GitHub is deprecating windows-2019 runner, so drop coverage for VFX 2022.