### PR TITLE
Deep Scanline Input file read memory leak fix

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -727,6 +727,10 @@ void ScanLineProcess::run_mem_decode (
     if (EXR_ERR_SUCCESS != exr_decoding_initialize (ctxt, pn, &cinfo, &decoder))
         throw IEX_NAMESPACE::IoExc ("Unable to initialize decode pipeline");
 
+    // Set first to false to allow destructor to deallocate any buffers
+    // allocated during decoding.
+    first = false;
+
     decoder.decode_flags |= EXR_DECODE_NON_IMAGE_DATA_AS_POINTERS;
     decoder.decode_flags |= EXR_DECODE_SAMPLE_COUNTS_AS_INDIVIDUAL;
     if (counts_only)


### PR DESCRIPTION
The Deep Scanline Input file read with an externally provided framebuffer was leaking lots of memory. The reason was the Scanline process, which has a boolean member variable check in its destructor that controls whether the member buffers will be freed or not.
However this boolean member variable was never set in the code path that uses an externally provided framebuffer, making Deep reading leaking massive amounts of memory.
This commit fixes the memory leak issue, but setting the member variable after the decoding initialisation.

Fixes #2068 
