### PR TITLE
Fix aliases for IexConfig and IlmThreadConfig

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -156,7 +156,7 @@ target_include_directories(IexConfig INTERFACE
 if(OPENEXR_INSTALL)
   install(TARGETS IexConfig EXPORT ${PROJECT_NAME})
 endif()
-add_library(${PROJECT_NAME}::Config ALIAS IexConfig)
+add_library(Iex::Config ALIAS IexConfig)
 
 add_library(IlmThreadConfig INTERFACE)
 target_include_directories(IlmThreadConfig INTERFACE
@@ -167,7 +167,7 @@ target_include_directories(IlmThreadConfig INTERFACE
 if(OPENEXR_INSTALL)
   install(TARGETS IlmThreadConfig EXPORT ${PROJECT_NAME})
 endif()
-add_library(${PROJECT_NAME}::Config ALIAS IlmThreadConfig)
+add_library(IlmThread::Config ALIAS IlmThreadConfig)
 
 ###################################################
 ####### Install pkg-config files if requested


### PR DESCRIPTION
These have been incorrectly specified from the project's earliest cmake configuration as:
```
  add_library(${PROJECT_NAME}::Config ALIAS IexConfig)
  add_library(${PROJECT_NAME}::Config ALIAS IlmThreadConfig)
```
but these conflict with:
```
 add_library(${PROJECT_NAME}::Config ALIAS OpenEXRConfig)
```
Each duplicating a declaration of OpenEXR::Config. These have likely never been used. This changes updates them to what was likely original intention:
```
  add_library(Iex::Config ALIAS IexConfig)
  add_library(IlmThread::Config ALIAS IlmThreadConfig)
```
CMake prior to 3.26 didn't complain, but 3.26+ has new aliasing features which encounter the problem when OpenEXR is configured in an application via `add_subdirectory(openexr)`.

This should resolve #1817, using openexr via cmake add_subdirectory 
