### PR TITLE
Add Multi scanline HTJ2K

### DIFF
--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -243,7 +243,7 @@ int exr_compression_lines_per_chunk (exr_compression_t comptype)
         case EXR_COMPRESSION_B44A:
         case EXR_COMPRESSION_DWAA: linePerChunk = 32; break;
         case EXR_COMPRESSION_DWAB: linePerChunk = 256; break;
-        case EXR_COMPRESSION_HTJ2K: linePerChunk = 256; break;
+        case EXR_COMPRESSION_HTJ2K: linePerChunk = exr_get_htj2k_lines_per_chunk(); break;
         case EXR_COMPRESSION_LAST_TYPE:
         default:
             /* ERROR CONDITION */

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -18,6 +18,11 @@
 #include "openexr_encode.h"
 #include "internal_ht_common.h"
 
+size_t exr_get_htj2k_lines_per_chunk ()
+{
+    return 32;
+}
+
 /**
  * OpenJPH output file that is backed by a fixed-size memory buffer
  */

--- a/src/lib/OpenEXRCore/openexr_compression.h
+++ b/src/lib/OpenEXRCore/openexr_compression.h
@@ -104,6 +104,9 @@ exr_result_t exr_compress_chunk (exr_encode_pipeline_t *encode_state);
 EXR_EXPORT
 exr_result_t exr_uncompress_chunk (exr_decode_pipeline_t *decode_state);
 
+EXR_EXPORT
+size_t exr_get_htj2k_lines_per_chunk();
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
`exr_get_htj2k_lines_per_chunk` like 32-line chunks
<img width="752" height="452" alt="image" src="https://github.com/user-attachments/assets/6cc16e7c-5d29-4555-a5a5-f3ac42fae888" />
