### PR TITLE
Add details about branches to install instructions

### DIFF
--- a/website/index.rst
+++ b/website/index.rst
@@ -78,6 +78,10 @@ arrays.
 Quick Start
 ===========
 
+You can :doc:`install <install>` OpenEXR using package managers or
+build the library yourself from the `source on github <https://github.com/AcademySoftwareFoundation/openexr>`_
+following the :ref:`compile instructions <build-from-source>`
+
 For a simple program that uses the C++ API to read and write a ``.exr`` file, see the
 :doc:`HelloWorld` examples.
 

--- a/website/install.rst
+++ b/website/install.rst
@@ -66,6 +66,8 @@ Install via `vcpkg <https://vcpkg.io/en/packages>`_:
    % .\vcpkg install openexr
 
 
+.. _build-from-source:
+
 Build from Source
 -----------------
 
@@ -76,8 +78,18 @@ Download the source from the `GitHub releases page
 <https://github.com/AcademySoftwareFoundation/openexr/releases>`_
 page, or clone the `repo <https://github.com/AcademySoftwareFoundation/openexr>`_.
 
-The ``release`` branch of the repo always points to the most advanced
-release.
+If cloning the repo, check out the ``release`` branch:
+
+.. code-block::
+
+   % git checkout release
+
+The ``release`` branch of the repo always points to the most advanced stable
+release. Other branches may contain compatible updates to older releases.
+
+The default ``main`` branch may contain experimental features which could change in future
+versions. It should only be used for testing, or for developers contributing to
+the OpenEXR project.
 
 
 Prerequisites


### PR DESCRIPTION
Updates the install instructions to more explicitly state why it's wise to build the release branch instead of main.
Also adds a link to the install instructions from the Quick Start section, since I was expecting to find it there.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--2105.org.readthedocs.build/en/2105/
<!-- readthedocs-preview openexr end -->