### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -1001,7 +1001,7 @@ exrmetrics (
 
     bool compressionSet = false;
 
-    for (int p = 0; p < outHeaders.size(); ++p)
+    for (size_t p = 0; p < outHeaders.size(); ++p)
     {
         if (compression < NUM_COMPRESSION_METHODS)
         {

--- a/src/lib/OpenEXR/ImfBytesAttribute.cpp
+++ b/src/lib/OpenEXR/ImfBytesAttribute.cpp
@@ -28,7 +28,7 @@ BytesAttribute::BytesAttribute (
     size_t      size,
     const void* data,
     const std::string& typeHint)
-    : _data (size), typeHint (typeHint)
+    : typeHint (typeHint), _data (size) 
 {
     if (size > 0 && ! data)
     {
@@ -41,7 +41,7 @@ BytesAttribute::BytesAttribute (
 }
 
 BytesAttribute::BytesAttribute (const BytesAttribute& other)
-    : _data (other._data.size ()), typeHint (other.typeHint)
+    : typeHint (other.typeHint), _data (other._data.size ())
 {
     memcpy (
         (unsigned char*) _data,
@@ -115,7 +115,7 @@ BytesAttribute::readValueFrom (
     unsigned int hintLength = 0;
     Xdr::read<StreamIO> (is, hintLength);
 
-    if (size < sizeof(hintLength) + hintLength)
+    if (size < static_cast<int>(sizeof(hintLength) + hintLength))
         THROW (IEX_NAMESPACE::InputExc,
                "Invalid bytes attribute type string length: " << hintLength);
 

--- a/src/lib/OpenEXR/ImfBytesAttribute.h
+++ b/src/lib/OpenEXR/ImfBytesAttribute.h
@@ -60,19 +60,19 @@ public:
     // Make a copy of this attribute
     //------------------------------
 
-    IMF_EXPORT virtual Attribute* copy () const;
+    IMF_EXPORT Attribute* copy () const override;
 
     //----------------
     // I/O and copying
     //----------------
 
-    IMF_EXPORT virtual void writeValueTo (
-        OPENEXR_IMF_INTERNAL_NAMESPACE::OStream& os, int version) const;
+    IMF_EXPORT void writeValueTo (
+        OPENEXR_IMF_INTERNAL_NAMESPACE::OStream& os, int version) const override;
 
-    IMF_EXPORT virtual void readValueFrom (
-        OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is, int size, int version);
+    IMF_EXPORT void readValueFrom (
+        OPENEXR_IMF_INTERNAL_NAMESPACE::IStream& is, int size, int version) override;
 
-    IMF_EXPORT virtual void copyValueFrom (const Attribute& other);
+    IMF_EXPORT void copyValueFrom (const Attribute& other) override;
 
     size_t size () const { return _data.size (); }
     const Array<unsigned char>& data () const { return _data; }

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -205,7 +205,7 @@ ht_undo_impl (
 
     int  bpl       = 0;
     bool is_planar = false;
-    for (ojph::ui32 c = 0; c < static_cast<ojph::ui32>(decode->channel_count); c++)
+    for (int16_t c = 0; c < decode->channel_count; c++)
     {
         bpl +=
             decode->channels[c].bytes_per_element * decode->channels[c].width;
@@ -227,7 +227,7 @@ ht_undo_impl (
     ojph::line_buf* cur_line;
     if (cs.is_planar ())
     {
-        for (uint32_t c = 0; c < static_cast<uint32_t>(decode->channel_count); c++)
+        for (int16_t c = 0; c < decode->channel_count; c++)
         {
             int file_c = cs_to_file_ch[c].file_index;
             assert (
@@ -242,7 +242,7 @@ ht_undo_impl (
                  y < image_height + decode->chunk.start_y;
                  y++)
             {
-                for (ojph::ui32 line_c = 0; line_c < static_cast<ojph::ui32>(decode->channel_count);
+                for (int16_t line_c = 0; line_c < decode->channel_count;
                      line_c++)
                 {
                     if (y % decode->channels[line_c].y_samples != 0) continue;
@@ -256,8 +256,8 @@ ht_undo_impl (
                             EXR_PIXEL_HALF)
                         {
                             int16_t* channel_pixels = (int16_t*) line_pixels;
-                            for (uint32_t p = 0;
-                                 p < static_cast<uint32_t>(decode->channels[file_c].width);
+                            for (int16_t p = 0;
+                                 p < decode->channels[file_c].width;
                                  p++)
                             {
                                 *channel_pixels++ = cur_line->i32[p];
@@ -266,8 +266,8 @@ ht_undo_impl (
                         else
                         {
                             int32_t* channel_pixels = (int32_t*) line_pixels;
-                            for (uint32_t p = 0;
-                                 p < static_cast<uint32_t>(decode->channels[file_c].width);
+                            for (int16_t p = 0;
+                                 p < decode->channels[file_c].width;
                                  p++)
                             {
                                 *channel_pixels++ = cur_line->i32[p];
@@ -289,7 +289,7 @@ ht_undo_impl (
 
         for (uint32_t y = 0; y < image_height; ++y)
         {
-            for (uint32_t c = 0; c < static_cast<uint32_t>(decode->channel_count); c++)
+            for (int16_t c = 0; c < decode->channel_count; c++)
             {
                 int file_c = cs_to_file_ch[c].file_index;
                 cur_line   = cs.pull (next_comp);
@@ -298,7 +298,7 @@ ht_undo_impl (
                 {
                     int16_t* channel_pixels =
                         (int16_t*) (line_pixels + cs_to_file_ch[c].raster_line_offset);
-                    for (uint32_t p = 0; p < static_cast<uint32_t>(decode->channels[file_c].width);
+                    for (int16_t p = 0; p < decode->channels[file_c].width;
                          p++)
                     {
                         *channel_pixels++ = cur_line->i32[p];
@@ -308,7 +308,7 @@ ht_undo_impl (
                 {
                     int32_t* channel_pixels =
                         (int32_t*) (line_pixels + cs_to_file_ch[c].raster_line_offset);
-                    for (uint32_t p = 0; p < static_cast<uint32_t>(decode->channels[file_c].width);
+                    for (int16_t p = 0; p < decode->channels[file_c].width;
                          p++)
                     {
                         *channel_pixels++ = cur_line->i32[p];
@@ -368,7 +368,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
     bool isPlanar = false;
     siz.set_num_components (encode->channel_count);
     int bpl = 0;
-    for (ojph::ui32 c = 0; c < static_cast<ojph::ui32>(encode->channel_count); c++)
+    for (int16_t c = 0; c < encode->channel_count; c++)
     {
         int file_c = cs_to_file_ch[c].file_index;
         if (encode->channels[file_c].data_type != EXR_PIXEL_UINT)
@@ -422,32 +422,32 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
 
         if (cs.is_planar ())
         {
-            for (ojph::ui32 c = 0; c < static_cast<ojph::ui32>(encode->channel_count); c++)
+            for (int16_t c = 0; c < encode->channel_count; c++)
             {
                 if (encode->channels[c].height == 0) continue;
 
                 const uint8_t* line_pixels =
                     static_cast<const uint8_t*> (encode->packed_buffer);
-                int file_c = cs_to_file_ch[c].file_index;
+                int16_t file_c = cs_to_file_ch[c].file_index;
 
                 for (int64_t y = encode->chunk.start_y;
                     y < image_height + encode->chunk.start_y;
                     y++)
                 {
-                    for (ojph::ui32 line_c = 0; line_c < static_cast<ojph::ui32>(encode->channel_count);
+                    for (int16_t line_c = 0; line_c < encode->channel_count;
                         line_c++)
                     {
 
                         if (y % encode->channels[line_c].y_samples != 0) continue;
 
-                        if (line_c == static_cast<ojph::ui32>(file_c))
+                        if (line_c == file_c)
                         {
                             if (encode->channels[file_c].data_type ==
                                 EXR_PIXEL_HALF)
                             {
                                 int16_t* channel_pixels = (int16_t*) (line_pixels);
-                                for (uint32_t p = 0;
-                                     p < static_cast<ojph::ui32>(encode->channels[file_c].width);
+                                for (int32_t p = 0;
+                                     p < encode->channels[file_c].width;
                                     p++)
                                 {
                                     cur_line->i32[p] = *channel_pixels++;
@@ -456,8 +456,8 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                             else
                             {
                                 int32_t* channel_pixels = (int32_t*) (line_pixels);
-                                for (uint32_t p = 0;
-                                     p < static_cast<ojph::ui32>(encode->channels[file_c].width);
+                                for (int32_t p = 0;
+                                     p < encode->channels[file_c].width;
                                     p++)
                                 {
                                     cur_line->i32[p] = *channel_pixels++;
@@ -483,7 +483,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
 
             for (int y = 0; y < image_height; y++)
             {
-                for (ojph::ui32 c = 0; c < static_cast<ojph::ui32>(encode->channel_count); c++)
+                for (int16_t c = 0; c < encode->channel_count; c++)
                 {
                     int file_c = cs_to_file_ch[c].file_index;
 
@@ -491,7 +491,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                     {
                         int16_t* channel_pixels =
                             (int16_t*) (line_pixels + cs_to_file_ch[c].raster_line_offset);
-                        for (uint32_t p = 0; p < static_cast<uint32_t>(encode->channels[file_c].width);
+                        for (int32_t p = 0; p < encode->channels[file_c].width;
                             p++)
                         {
                             cur_line->i32[p] = *channel_pixels++;
@@ -501,7 +501,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                     {
                         int32_t* channel_pixels =
                             (int32_t*) (line_pixels + cs_to_file_ch[c].raster_line_offset);
-                        for (uint32_t p = 0; p < static_cast<uint32_t>(encode->channels[file_c].width);
+                        for (int32_t p = 0; p < encode->channels[file_c].width;
                             p++)
                         {
                             cur_line->i32[p] = *channel_pixels++;

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -59,7 +59,7 @@ make_channel_map (
 
     cs_to_file_ch.resize (channel_count);
 
-    for (size_t i = 0; i < static_cast<size_t>(channel_count); i++)
+    for (int i = 0; i < channel_count; i++)
     {
         const char* channel_name = channels[i].channel_name;
         const char* suffix       = strrchr (channel_name, '.');
@@ -143,14 +143,14 @@ make_channel_map (
 
         int avail_cs_i = 3;
         int offset = 0;
-        for (size_t file_i = 0; file_i < static_cast<size_t>(channel_count); file_i++)
+        for (int file_i = 0; file_i < channel_count; file_i++)
         {
             int cs_i;
-            if (static_cast<int>(file_i) == r_index) {
+            if (file_i == r_index) {
                 cs_i = 0;
-            } else if (static_cast<int>(file_i) == g_index) {
+            } else if (file_i == g_index) {
                 cs_i = 1;
-            } else if (static_cast<int>(file_i) == b_index) {
+            } else if (file_i == b_index) {
                 cs_i = 2;
             } else {
                 cs_i = avail_cs_i++;

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -12,10 +12,6 @@
 #include <cctype>
 #include <stdexcept>
 
-const std::string RED_CH_FULLNAME = "red";
-const std::string GREEN_CH_FULLNAME = "green";
-const std::string BLUE_CH_FULLNAME = "blue";
-
 struct RGBChannelParams
 {
     const char* r_suffix;
@@ -63,7 +59,7 @@ make_channel_map (
 
     cs_to_file_ch.resize (channel_count);
 
-    for (size_t i = 0; i < channel_count; i++)
+    for (size_t i = 0; i < static_cast<size_t>(channel_count); i++)
     {
         const char* channel_name = channels[i].channel_name;
         const char* suffix       = strrchr (channel_name, '.');
@@ -147,14 +143,14 @@ make_channel_map (
 
         int avail_cs_i = 3;
         int offset = 0;
-        for (size_t file_i = 0; file_i < channel_count; file_i++)
+        for (size_t file_i = 0; file_i < static_cast<size_t>(channel_count); file_i++)
         {
             int cs_i;
-            if (file_i == r_index) {
+            if (static_cast<int>(file_i) == r_index) {
                 cs_i = 0;
-            } else if (file_i == g_index) {
+            } else if (static_cast<int>(file_i) == g_index) {
                 cs_i = 1;
-            } else if (file_i == b_index) {
+            } else if (static_cast<int>(file_i) == b_index) {
                 cs_i = 2;
             } else {
                 cs_i = avail_cs_i++;
@@ -168,7 +164,7 @@ make_channel_map (
     else
     {
         int offset = 0;
-        for (size_t file_i = 0; file_i < channel_count; file_i++)
+        for (size_t file_i = 0; file_i < static_cast<size_t>(channel_count); file_i++)
         {
             cs_to_file_ch[file_i].file_index = file_i;
             cs_to_file_ch[file_i].raster_line_offset = offset;

--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -1722,7 +1722,7 @@ fasthuf_decode (
         // 8 bits of data in the buffer
         //
 
-        if (symbol == rleSym)
+        if (symbol == (int) rleSym)
         {
             uint32_t rleCount;
 

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -773,7 +773,7 @@ extract_attr_bytes(
         return ctxt->print_error (
             ctxt,
             EXR_ERR_ATTR_SIZE_MISMATCH,
-            "Attribute '%s': Invalid size %d (exp '%s' size >= %d)",
+            "Attribute '%s': Invalid size %d (exp '%s' size >= %ld)",
             aname,
             attrsz,
             tname,

--- a/src/lib/OpenEXRCore/string.c
+++ b/src/lib/OpenEXRCore/string.c
@@ -125,6 +125,8 @@ exr_attr_string_create_with_length (
 #ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4996)
+#elif defined(__clang__)
+// clang: do nothing
 #elif defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wstringop-truncation"
@@ -135,6 +137,8 @@ exr_attr_string_create_with_length (
                 memset (outs, 0, (size_t) len);
 #ifdef _MSC_VER
 #    pragma warning(pop)
+#elif defined(__clang__)
+// clang: do nothing
 #elif defined(__GNUC__)
 #    pragma GCC diagnostic pop
 #endif
@@ -199,6 +203,8 @@ exr_attr_string_set_with_length (
 #ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4996)
+#elif defined(__clang__)
+// clang: do nothing
 #elif defined(__GNUC__)
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wstringop-truncation"
@@ -209,6 +215,8 @@ exr_attr_string_set_with_length (
                 memset (sstr, 0, (size_t) len);
 #ifdef _MSC_VER
 #    pragma warning(pop)
+#elif defined(__clang__)
+// clang: do nothing
 #elif defined(__GNUC__)
 #    pragma GCC diagnostic pop
 #endif

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -1720,9 +1720,9 @@ testHTChannelMap (const std::string& tempdir)
         {{{"redqueen"}, {"greens"}, {"blueberry"}}, 3, false, {0, 1, 2}},
         {{{"hello.R"}, {"bye.G"}, {"hello.B"}}, 3, false, {0, 2, 4}},
     };
-    int test_count = sizeof(tests) / sizeof(ht_channel_map_tests);
+    size_t test_count = sizeof(tests) / sizeof(ht_channel_map_tests);
 
-    for (size_t i = 0; i < static_cast<size_t>(test_count); i++)
+    for (size_t i = 0; i < test_count; i++)
     {
         EXRCORE_TEST (
             make_channel_map (

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -1722,7 +1722,7 @@ testHTChannelMap (const std::string& tempdir)
     };
     int test_count = sizeof(tests) / sizeof(ht_channel_map_tests);
 
-    for (size_t i = 0; i < test_count; i++)
+    for (size_t i = 0; i < static_cast<size_t>(test_count); i++)
     {
         EXRCORE_TEST (
             make_channel_map (


### PR DESCRIPTION
* static_cast for signed/unsigned integer comparisons
* remove unused variables
* fix order of member initialization
* use override instead of virtual
* printf %d -> %ld
* clang pragmas