### PR TITLE
Remove openjph includes from ImfHTCompressor.h

### DIFF
--- a/src/lib/OpenEXR/ImfHTCompressor.cpp
+++ b/src/lib/OpenEXR/ImfHTCompressor.cpp
@@ -23,11 +23,6 @@
 
 #include <ImathBox.h>
 
-#include <ojph_arch.h>
-#include <ojph_file.h>
-#include <ojph_params.h>
-#include <ojph_mem.h>
-
 using IMATH_NAMESPACE::Box2i;
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER

--- a/src/lib/OpenEXR/ImfHTCompressor.h
+++ b/src/lib/OpenEXR/ImfHTCompressor.h
@@ -18,9 +18,6 @@
 
 #include "ImfCompressor.h"
 
-#include <ojph_codestream.h>
-#include <ojph_file.h>
-
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
 class HTCompressor : public Compressor


### PR DESCRIPTION
These appear to have been left in ImfHTCompressor.h inadvertently from an earlier implementation:

```
    #include <ojph_codestream.h>
    #include <ojph_file.h>

```
They aren't necessary, and they inject an unnecessary compile-time dependence on the openjph headers.