### PR TITLE
Update HELP2MAN_URL in install_help2man.sh

### DIFF
--- a/share/ci/scripts/install_help2man.sh
+++ b/share/ci/scripts/install_help2man.sh
@@ -5,7 +5,7 @@
 set -ex
 
 HELP2MAN_VERSION="1.49.3"
-HELP2MAN_URL="https://ftp.gnu.org/gnu/help2man/help2man-$HELP2MAN_VERSION.tar.xz"
+HELP2MAN_URL="https://mirror.cs.odu.edu/gnu/help2man/help2man-$HELP2MAN_VERSION.tar.xz"
 HELP2MAN_DIR="help2man-$HELP2MAN_VERSION"
 
 SUDO=$(command -v sudo >/dev/null 2>&1 && echo sudo || echo "")


### PR DESCRIPTION
Downloading from ftp.gnu.org has been timing out, and it turns out it's known to be slow. https://mirror.cs.odu.edu is apparently more reliable.