### PR TITLE
handle CMake CREATE_LINK failures for openjph headers

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -324,8 +324,17 @@ if(NOT EXR_OPENJPH_LIB)
   file(CREATE_LINK
     "${openjph_SOURCE_DIR}/src/core/common"
     "${openjph_SOURCE_DIR}/src/core/openjph"
+    RESULT openjph_create_link_result
     SYMBOLIC
   )
+  # Creating a symlink may fail, for example on Windows without developer
+  # mode enabled, so fallback to copying in that case.
+  if (NOT openjph_create_link_result EQUAL 0)
+    file(COPY
+      "${openjph_SOURCE_DIR}/src/core/common/"
+      DESTINATION "${openjph_SOURCE_DIR}/src/core/openjph"
+    )
+  endif()
   include_directories("${openjph_SOURCE_DIR}/src/core")
 
   # extract the openjph version variables from ojph_version.h


### PR DESCRIPTION
Hello!

I ran into an issue trying out the new 3.4.1 release on Windows where the use of `file(CREATE_LINK ... SYMBOLIC)` to deal with the openjph headers seemed to be failing reporting that "A required privilege is not held by the client", causing the build to fail.

The Internet would seem to suggest that there's a ["developer mode" in Windows](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) that can be enabled which would allow the creation of symlinks, but my company's security policy is setup such that I am not able to turn on developer mode on my workstation.

To get around this and not require that developer mode be enabled, I made the change here to detect the case where creating a symlink fails and then fall back to a regular copy.

CREATE_LINK does have a COPY_ON_ERROR option, but apparently that is only intended for individual files and will not copy an entire directory's contents:
https://gitlab.kitware.com/cmake/cmake/-/issues/25278

I've tested this on Windows and Mac and verified that on the former I see a full copy of the `common` directory named `openjph`, and on the latter I see `openjph` symlinked back to `common`.