### PR TITLE
Feature: add part indices to pyapi

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -209,17 +209,29 @@ PyFile::PyFile(const std::string& filename, bool separate_channels, bool header_
             //
         
             auto type = header.type();
-            if (type == SCANLINEIMAGE || type == TILEDIMAGE)
+            try
             {
-                P.readPixels(*_inputFile, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                if (type == SCANLINEIMAGE || type == TILEDIMAGE)
+                {
+                    P.readPixels(*_inputFile, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                }
+                else if (type == DEEPSCANLINE || type == DEEPTILE)
+                {
+                    P.readDeepPixels(*_inputFile, type, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                }
+                parts.append(py::cast<PyPart>(PyPart(P)));
             }
-            else if (type == DEEPSCANLINE || type == DEEPTILE)
+            catch (const std::exception& e)
             {
-                P.readDeepPixels(*_inputFile, type, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                // Log the error and skip appending this part
+                py::print("Warning: Exception raised reading pixel data for part", part_index, "-", e.what());
             }
         }
-        
-        parts.append(py::cast<PyPart>(PyPart(P)));
+        else
+        {
+            // If only reading the header, always append this part
+            parts.append(py::cast<PyPart>(PyPart(P)));
+        }
     } // for parts
 }
 

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -18,7 +18,7 @@ class PyFile
 {
 public:
     PyFile();
-    PyFile(const std::string& filename, bool separate_channels = false, bool header_only = false);
+    PyFile(const std::string& filename, bool separate_channels = false, bool header_only = false, const py::list& part_indices = py::list());
     PyFile(const py::dict& header, const py::dict& channels);
     PyFile(const py::list& parts);
 


### PR DESCRIPTION
Add part_indices for the Python File API

This can specify the specific parts of a multi-part EXR file to be loaded to avoid excessive IO when only some parts of the file are needed by the program. This functionality could be particularly useful when the file is very large, and only a very small portion of it is required in memory.

Test EXR file:
https://drive.google.com/file/d/1A0ciiL0BeF0RA6Do-8sd81slqdckdP0p/view?usp=sharing

Test script:
```shell
# Load only the first part
# 100 loops, best of 5: 7.56 msec per loop
python -m timeit -n 100 -s "import OpenEXR" "f = OpenEXR.File('000000.exr', part_indices=[0])"

# Load the full EXR
# 1 loop, best of 5: 1.7 sec per loop
python -m timeit -n 1 -s "import OpenEXR" "f = OpenEXR.File('000000.exr')"
```