### PR TITLE
Fix bug with re-reading scanline file with a different set of channels

### DIFF
--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -244,8 +244,7 @@ ScanLineInputFile::setFrameBuffer (const FrameBuffer& frameBuffer)
     std::lock_guard<std::mutex> lock (_data->_mx);
 #endif
     _data->fill_list.clear ();
-    if (_data->singleScan)
-        _data->singleScan->first = true;
+    _data->singleScan.reset();
 
     for (FrameBuffer::ConstIterator j = frameBuffer.begin ();
          j != frameBuffer.end ();

--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -244,6 +244,8 @@ ScanLineInputFile::setFrameBuffer (const FrameBuffer& frameBuffer)
     std::lock_guard<std::mutex> lock (_data->_mx);
 #endif
     _data->fill_list.clear ();
+    if (_data->singleScan)
+        _data->singleScan->first = true;
 
     for (FrameBuffer::ConstIterator j = frameBuffer.begin ();
          j != frameBuffer.end ();


### PR DESCRIPTION
Fixes #2141.

The `first` flag in the `ScanLineProcess` object should be reset to false in `ScanLineInputFile::setFrameBuffer()`, so subsequent calls to `readPixels()` do the proper initialization.

Also adds a test, which fails without the fix in `ScanLineInputFile::setFrameBuffer()`.