### PR TITLE
Remove iex_debugTrap() function

### DIFF
--- a/src/lib/Iex/IexBaseExc.cpp
+++ b/src/lib/Iex/IexBaseExc.cpp
@@ -350,19 +350,3 @@ DEFINE_EXC_EXP_IMPL (IEX_EXPORT, InvalidFpOpExc, MathExc)
 
 IEX_INTERNAL_NAMESPACE_SOURCE_EXIT
 
-#ifdef _WIN32
-
-#    pragma optimize("", off)
-void
-iex_debugTrap ()
-{
-    if (0 != getenv ("IEXDEBUGTHROW")) ::DebugBreak ();
-}
-#else
-void
-iex_debugTrap ()
-{
-    // how to in Linux?
-    if (0 != ::getenv ("IEXDEBUGTHROW")) __builtin_trap ();
-}
-#endif

--- a/src/lib/Iex/IexMacros.h
+++ b/src/lib/Iex/IexMacros.h
@@ -26,12 +26,9 @@
 #include "IexExport.h"
 #include "IexForward.h"
 
-IEX_EXPORT void iex_debugTrap ();
-
 #define THROW(type, text)                                                      \
     do                                                                         \
     {                                                                          \
-        iex_debugTrap ();                                                      \
         std::stringstream _iex_throw_s;                                        \
         _iex_throw_s << text;                                                  \
         throw type (_iex_throw_s);                                             \


### PR DESCRIPTION
This is an ancient utility function that at one point served as a debugging aide. It's problematic because it's not namespaced so it can lead to symbol collisions when linking multiple versions of the library into a single binary.

This is an API change, so it should only go into the next major release.