### PR TITLE
Add gdeflate compression and decompression with NVIDIA fork of libdeflate.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,6 +70,9 @@ expand_template(
     out = "src/lib/OpenEXR/OpenEXRConfigInternal.h",
     substitutions = {
         "#cmakedefine OPENEXR_USE_INTERNAL_DEFLATE 1": "#define OPENEXR_USE_INTERNAL_DEFLATE 0",
+        "#cmakedefine OPENEXR_ENABLE_GDEFLATE 1": "/* #undef OPENEXR_ENABLE_GDEFLATE */",
+        # For gdeflate, set `_enable_gdeflate` to True in `MODULE.bazel` and replace the above line with:
+        # "#cmakedefine OPENEXR_ENABLE_GDEFLATE 1": "#define OPENEXR_ENABLE_GDEFLATE 1",
         "#cmakedefine OPENEXR_IMF_HAVE_COMPLETE_IOMANIP 1": "#define OPENEXR_IMF_HAVE_COMPLETE_IOMANIP 1",
         "#cmakedefine OPENEXR_IMF_HAVE_DARWIN 1": "/* #undef OPENEXR_IMF_HAVE_DARWIN */",
         "#cmakedefine OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX 1": "/* #undef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX */",
@@ -193,6 +196,7 @@ cc_library(
         "src/lib/OpenEXRCore/internal_dwa_simd.h",
         "src/lib/OpenEXRCore/internal_file.h",
         "src/lib/OpenEXRCore/internal_float_vector.h",
+        "src/lib/OpenEXRCore/internal_gdeflate_wrapper.h",
         "src/lib/OpenEXRCore/internal_ht.cpp",
         "src/lib/OpenEXRCore/internal_ht_common.h",
         "src/lib/OpenEXRCore/internal_ht_common.cpp",
@@ -291,6 +295,7 @@ cc_library(
         "src/lib/OpenEXR/ImfCompression.cpp",
         "src/lib/OpenEXR/ImfCompressionAttribute.cpp",
         "src/lib/OpenEXR/ImfCompressor.cpp",
+        "src/lib/OpenEXR/ImfGdeflateCompressor.cpp",
         "src/lib/OpenEXR/ImfContext.cpp",
         "src/lib/OpenEXR/ImfContextInit.cpp",
         "src/lib/OpenEXR/ImfConvert.cpp",
@@ -395,6 +400,7 @@ cc_library(
         "src/lib/OpenEXR/ImfCompression.h",
         "src/lib/OpenEXR/ImfCompressionAttribute.h",
         "src/lib/OpenEXR/ImfCompressor.h",
+        "src/lib/OpenEXR/ImfGdeflateCompressor.h",
         "src/lib/OpenEXR/ImfContext.h",
         "src/lib/OpenEXR/ImfContextInit.h",
         "src/lib/OpenEXR/ImfConvert.h",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,19 @@ module(
     compatibility_level = 1,
 )
 
+# Toggle this to fetch the NVIDIA libdeflate fork, then update OPENEXR_ENABLE_GDEFLATE in BUILD.bazel.
+_enable_gdeflate = False
+
+_enable_gdeflate and archive_override(
+    module_name = "libdeflate",
+    patches = [
+        "//bazel:libdeflate_gdeflate_add_build_file.patch",
+        "//bazel:libdeflate_module_dot_bazel.patch",
+    ],
+    strip_prefix = "libdeflate-gdeflate",
+    urls = ["https://github.com/NVIDIA/libdeflate/archive/refs/heads/gdeflate.zip"],
+)
+
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "imath", version = "3.2.2")
 bazel_dep(name = "libdeflate", version = "1.24")

--- a/cmake/OpenEXRConfigInternal.h.in
+++ b/cmake/OpenEXRConfigInternal.h.in
@@ -18,6 +18,10 @@
 #cmakedefine OPENEXR_USE_INTERNAL_DEFLATE 1
 
 //
+// Whether libdeflate has gdeflate support (NVIDIA fork)
+#cmakedefine OPENEXR_ENABLE_GDEFLATE 1
+
+//
 // Define and set to 1 if the target system supports a proc filesystem
 // compatible with the Linux kernel's proc filesystem.  Note that this
 // is only used by a program in the OpenEXRTest test suite, it's not

--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -24,6 +24,8 @@ openexr_define_library(OpenEXR
     ImfCompressionAttribute.cpp
     ImfCompressor.cpp
     ImfCompressor.h
+    ImfGdeflateCompressor.cpp
+    ImfGdeflateCompressor.h
     ImfContext.cpp
     ImfContextInit.cpp
     ImfConvert.cpp

--- a/src/lib/OpenEXR/ImfCRgbaFile.h
+++ b/src/lib/OpenEXR/ImfCRgbaFile.h
@@ -82,7 +82,8 @@ typedef struct ImfRgba ImfRgba;
 #define IMF_DWAB_COMPRESSION 9
 #define IMF_HTJ2K256_COMPRESSION 10
 #define IMF_HTJ2K32_COMPRESSION 11
-#define IMF_NUM_COMPRESSION_METHODS 12
+#define IMF_GDEFLATE_COMPRESSION 12
+#define IMF_NUM_COMPRESSION_METHODS 13
 
 /*
 ** Channels; values must be the same as in Imf::RgbaChannels.

--- a/src/lib/OpenEXR/ImfCompression.cpp
+++ b/src/lib/OpenEXR/ImfCompression.cpp
@@ -188,6 +188,12 @@ static const CompressionDesc IdToDesc[] = {
         32,
         true,
         false),
+    CompressionDesc (
+        "gdeflate",
+        "gdeflate compression, in blocks of 16 scan lines.",
+        16,
+        false,
+        false),
 };
 // clang-format on
 
@@ -206,6 +212,7 @@ static const std::map<std::string, Compression> CompressionNameToId = {
     {"dwab", Compression::DWAB_COMPRESSION},
     {"htj2k256", Compression::HTJ2K256_COMPRESSION},
     {"htj2k32", Compression::HTJ2K32_COMPRESSION},
+    {"gdeflate", Compression::GDEFLATE_COMPRESSION},
 };
 
 #define UNKNOWN_COMPRESSION_ID_MSG "INVALID COMPRESSION ID"

--- a/src/lib/OpenEXR/ImfCompression.h
+++ b/src/lib/OpenEXR/ImfCompression.h
@@ -55,6 +55,8 @@ enum IMF_EXPORT_ENUM Compression
 
     HTJ2K32_COMPRESSION = 11,    // High-Throughput JPEG2000 (HTJ2K), 32 scanlines
 
+    GDEFLATE_COMPRESSION = 12,   // gdeflate compression, in blocks of 16 scan lines
+
     NUM_COMPRESSION_METHODS // number of different compression methods
 };
 

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -13,6 +13,7 @@
 #include "ImfNamespace.h"
 #include "ImfCompressor.h"
 #include "ImfB44Compressor.h"
+#include "ImfGdeflateCompressor.h"
 #include "ImfDwaCompressor.h"
 #include "ImfPizCompressor.h"
 #include "ImfPxr24Compressor.h"
@@ -344,6 +345,11 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
 
             return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), 32);
 
+        case GDEFLATE_COMPRESSION:
+
+            ret = new GdeflateCompressor (hdr, maxScanLineSize, 16);
+            break;
+
         default: break;
     }
     // clang-format on
@@ -432,6 +438,12 @@ newTileCompressor (
                 hdr,
                 static_cast<int> (tileLineSize),
                 static_cast<int> (numTileLines));
+
+        case GDEFLATE_COMPRESSION:
+
+            ret = new GdeflateCompressor (
+                hdr, tileLineSize, static_cast<int> (numTileLines));
+            break;
 
         default: break;
     }

--- a/src/lib/OpenEXR/ImfGdeflateCompressor.cpp
+++ b/src/lib/OpenEXR/ImfGdeflateCompressor.cpp
@@ -1,0 +1,55 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+//-----------------------------------------------------------------------------
+//
+//  class GdeflateCompressor
+//
+//-----------------------------------------------------------------------------
+
+#include "ImfGdeflateCompressor.h"
+#include "OpenEXRConfigInternal.h"
+
+#ifndef OPENEXR_ENABLE_GDEFLATE
+#include "IexBaseExc.h"
+#endif
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
+
+#ifdef OPENEXR_ENABLE_GDEFLATE
+
+GdeflateCompressor::GdeflateCompressor (
+    const Header& hdr, size_t maxScanLineSize, int numScanLines)
+    : Compressor (
+          hdr,
+          EXR_COMPRESSION_GDEFLATE,
+          maxScanLineSize,
+          numScanLines)
+{
+}
+
+GdeflateCompressor::~GdeflateCompressor ()
+{
+}
+
+#else
+
+GdeflateCompressor::GdeflateCompressor (
+    const Header& hdr, size_t maxScanLineSize, int numScanLines)
+    : Compressor (hdr, EXR_COMPRESSION_LAST_TYPE, maxScanLineSize, numScanLines)
+{
+    throw IEX_NAMESPACE::NoImplExc (
+        "Gdeflate support is not enabled in this build of OpenEXR.");
+}
+
+GdeflateCompressor::~GdeflateCompressor ()
+{
+}
+
+#endif
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT
+
+

--- a/src/lib/OpenEXR/ImfGdeflateCompressor.h
+++ b/src/lib/OpenEXR/ImfGdeflateCompressor.h
@@ -1,0 +1,38 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#ifndef INCLUDED_IMF_GDEFLATE_COMPRESSOR_H
+#define INCLUDED_IMF_GDEFLATE_COMPRESSOR_H
+
+//-----------------------------------------------------------------------------
+//
+//  class GdeflateCompressor -- performs gdeflate compression
+//
+//-----------------------------------------------------------------------------
+
+#include "ImfCompressor.h"
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
+class GdeflateCompressor : public Compressor
+{
+public:
+    GdeflateCompressor (
+        const Header& hdr, size_t maxScanLineSize, int numScanLines);
+
+    virtual ~GdeflateCompressor ();
+
+    GdeflateCompressor (const GdeflateCompressor& other)            = delete;
+    GdeflateCompressor& operator= (const GdeflateCompressor& other) = delete;
+    GdeflateCompressor (GdeflateCompressor&& other)                 = delete;
+    GdeflateCompressor& operator= (GdeflateCompressor&& other)      = delete;
+};
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#endif
+
+
+

--- a/src/lib/OpenEXRCore/internal_compress.h
+++ b/src/lib/OpenEXRCore/internal_compress.h
@@ -21,6 +21,8 @@ exr_result_t internal_exr_apply_rle (exr_encode_pipeline_t* encode);
 
 exr_result_t internal_exr_apply_zip (exr_encode_pipeline_t* encode);
 
+exr_result_t internal_exr_apply_gdeflate (exr_encode_pipeline_t* encode);
+
 exr_result_t internal_exr_apply_piz (exr_encode_pipeline_t* encode);
 
 exr_result_t internal_exr_apply_pxr24 (exr_encode_pipeline_t* encode);

--- a/src/lib/OpenEXRCore/internal_decompress.h
+++ b/src/lib/OpenEXRCore/internal_decompress.h
@@ -31,6 +31,13 @@ exr_result_t internal_exr_undo_zip (
     void*                  uncompressed_data,
     uint64_t               uncompressed_size);
 
+exr_result_t internal_exr_undo_gdeflate (
+    exr_decode_pipeline_t* decode,
+    const void*            compressed_data,
+    uint64_t               comp_buf_size,
+    void*                  uncompressed_data,
+    uint64_t               uncompressed_size);
+
 exr_result_t internal_exr_undo_piz (
     exr_decode_pipeline_t* decode,
     const void*            compressed_data,

--- a/src/lib/OpenEXRCore/internal_gdeflate_wrapper.h
+++ b/src/lib/OpenEXRCore/internal_gdeflate_wrapper.h
@@ -1,0 +1,173 @@
+/*
+** SPDX-License-Identifier: BSD-3-Clause
+** Copyright Contributors to the OpenEXR Project.
+*/
+
+#ifndef OPENEXR_CORE_GDEFLATE_WRAPPER_H
+#define OPENEXR_CORE_GDEFLATE_WRAPPER_H
+
+/*
+ * GDEFLATE SUPPORT WRAPPERS
+ *
+ * Conditional compilation for gdeflate support is isolated here.
+ * OPENEXR_ENABLE_GDEFLATE is set by CMake based on libdeflate detection.
+ *
+ * Note: This header must be included after libdeflate.h (or internal deflate
+ * sources) are already included, as it depends on libdeflate types.
+ */
+
+#include "internal_memory.h"
+#include "openexr_context.h"
+#include "openexr_errors.h"
+
+/* libdeflate types already available via compression.c includes */
+
+#ifndef OPENEXR_ENABLE_GDEFLATE
+/* Stub types when gdeflate not available */
+struct libdeflate_gdeflate_compressor
+{
+    int unused;
+};
+struct libdeflate_gdeflate_decompressor
+{
+    int unused;
+};
+struct libdeflate_gdeflate_out_page
+{
+    void*  data;
+    size_t nbytes;
+};
+struct libdeflate_gdeflate_in_page
+{
+    const void* data;
+    size_t      nbytes;
+};
+#endif
+
+static inline size_t
+wrap_gdeflate_compress_bound (
+    void* compressor, size_t in_bytes, uint64_t* out_page_count)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    size_t page_count;
+    size_t result = libdeflate_gdeflate_compress_bound (
+        compressor, in_bytes, &page_count);
+    *out_page_count = page_count;
+    return result;
+#else
+    (void) compressor;
+    (void) in_bytes;
+    *out_page_count = 0;
+    return 0;
+#endif
+}
+
+static inline exr_result_t
+wrap_alloc_gdeflate_compressor (
+    int level,
+    exr_const_context_t ctxt,
+    struct libdeflate_gdeflate_compressor** out_comp)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    /* Note: gdeflate does not have _ex() allocator variants, so we always use
+     * libdeflate_set_memory_allocator() regardless of libdeflate version */
+    libdeflate_set_memory_allocator (
+        ctxt ? ctxt->alloc_fn : internal_exr_alloc,
+        ctxt ? ctxt->free_fn : internal_exr_free);
+    *out_comp = libdeflate_alloc_gdeflate_compressor (level);
+    return *out_comp ? EXR_ERR_SUCCESS : EXR_ERR_OUT_OF_MEMORY;
+#else
+    (void) level;
+    (void) ctxt;
+    *out_comp = NULL;
+    return EXR_ERR_FEATURE_NOT_IMPLEMENTED;
+#endif
+}
+
+static inline void
+wrap_free_gdeflate_compressor (struct libdeflate_gdeflate_compressor* comp)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    libdeflate_free_gdeflate_compressor (comp);
+#else
+    (void) comp;
+#endif
+}
+
+static inline size_t
+wrap_gdeflate_compress (
+    struct libdeflate_gdeflate_compressor*  comp,
+    const void*                             in,
+    size_t                                  in_bytes,
+    struct libdeflate_gdeflate_out_page*    out_pages,
+    size_t                                  out_page_count)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    return libdeflate_gdeflate_compress (
+        comp, in, in_bytes, out_pages, out_page_count);
+#else
+    (void) comp;
+    (void) in;
+    (void) in_bytes;
+    (void) out_pages;
+    (void) out_page_count;
+    return 0;
+#endif
+}
+
+static inline exr_result_t
+wrap_alloc_gdeflate_decompressor (
+    exr_const_context_t ctxt,
+    struct libdeflate_gdeflate_decompressor** out_decomp)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    /* Note: gdeflate does not have _ex() allocator variants, so we always use
+     * libdeflate_set_memory_allocator() regardless of libdeflate version */
+    libdeflate_set_memory_allocator (
+        ctxt ? ctxt->alloc_fn : internal_exr_alloc,
+        ctxt ? ctxt->free_fn : internal_exr_free);
+    *out_decomp = libdeflate_alloc_gdeflate_decompressor ();
+    return *out_decomp ? EXR_ERR_SUCCESS : EXR_ERR_OUT_OF_MEMORY;
+#else
+    (void) ctxt;
+    *out_decomp = NULL;
+    return EXR_ERR_FEATURE_NOT_IMPLEMENTED;
+#endif
+}
+
+static inline void
+wrap_free_gdeflate_decompressor (
+    struct libdeflate_gdeflate_decompressor* decomp)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    libdeflate_free_gdeflate_decompressor (decomp);
+#else
+    (void) decomp;
+#endif
+}
+
+static inline enum libdeflate_result
+wrap_gdeflate_decompress (
+    struct libdeflate_gdeflate_decompressor* decomp,
+    struct libdeflate_gdeflate_in_page*    in_pages,
+    size_t                                 in_page_count,
+    void*                                  out,
+    size_t                                 out_bytes_avail,
+    size_t*                                actual_out)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    return libdeflate_gdeflate_decompress (
+        decomp, in_pages, in_page_count, out, out_bytes_avail, actual_out);
+#else
+    (void) decomp;
+    (void) in_pages;
+    (void) in_page_count;
+    (void) out;
+    (void) out_bytes_avail;
+    (void) actual_out;
+    return LIBDEFLATE_BAD_DATA;
+#endif
+}
+
+#endif /* OPENEXR_CORE_GDEFLATE_WRAPPER_H */
+

--- a/src/lib/OpenEXRCore/openexr_attr.h
+++ b/src/lib/OpenEXRCore/openexr_attr.h
@@ -47,6 +47,7 @@ typedef enum
     EXR_COMPRESSION_DWAB  = 9,
     EXR_COMPRESSION_HTJ2K256  = 10,
     EXR_COMPRESSION_HTJ2K32   = 11,
+    EXR_COMPRESSION_GDEFLATE  = 12,
     EXR_COMPRESSION_LAST_TYPE /**< Invalid value, provided for range checking. */
 } exr_compression_t;
 

--- a/src/lib/OpenEXRCore/openexr_compression.h
+++ b/src/lib/OpenEXRCore/openexr_compression.h
@@ -65,6 +65,37 @@ size_t exr_rle_uncompress_buffer (
     const void* in,
     void* out);
 
+/** Computes a buffer large enough to hold gdeflate-compressed data and returns
+ * the page count and size required for compression. */
+EXR_EXPORT
+size_t exr_compress_gdeflate_max_buffer_size (
+    size_t in_bytes,
+    uint64_t* out_page_count,
+    uint64_t* out_page_size);
+
+/** Compresses a buffer using gdeflate compression with page-based output.
+ *
+ * If the level is -1, will use the default compression set to the library
+ * \ref exr_set_default_zip_compression_level */
+EXR_EXPORT
+exr_result_t exr_compress_buffer_gdeflate (
+    exr_const_context_t ctxt,
+    int                 level,
+    const void*         in,
+    size_t              in_bytes,
+    void*               out,
+    size_t              out_bytes_avail,
+    size_t*             actual_out);
+
+/** Decompresses a buffer using gdeflate compression. */
+EXR_EXPORT
+exr_result_t exr_uncompress_buffer_gdeflate (
+    exr_const_context_t ctxt,
+    const void*         in,
+    size_t              in_bytes,
+    void*               out,
+    size_t              out_bytes_avail,
+    size_t*             actual_out);
 
 /** Routine to query the lines required per chunk to compress with the
  * specified method.

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -120,6 +120,7 @@ define_openexrcore_tests(
  testRLECompression
  testZIPCompression
  testZIPSCompression
+ testGdeflateCompression
  testPIZCompression
  testPXR24Compression
  testB44Compression

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -9,6 +9,8 @@
 #    define NOMINMAX
 #endif
 
+#include "OpenEXRConfigInternal.h"
+
 #include "write.h"
 
 #include "test_value.h"
@@ -686,9 +688,9 @@ struct pixels
         }
     }
 };
-static const int IMG_WIDTH    = 1371;
+static const int IMG_WIDTH    = 2049;  // large enough to trigger a multi-page chunk in gdeflate
 static const int IMG_HEIGHT   = 159;
-static const int IMG_STRIDE_X = 1376;
+static const int IMG_STRIDE_X = 2064;
 static const int IMG_DATA_X   = 17;
 static const int IMG_DATA_Y   = 29;
 
@@ -1433,6 +1435,7 @@ doWriteRead (
         case EXR_COMPRESSION_RLE:
         case EXR_COMPRESSION_ZIP:
         case EXR_COMPRESSION_ZIPS:
+        case EXR_COMPRESSION_GDEFLATE:
             restore.compareExact (p, "orig", "C loaded C");
             break;
         case EXR_COMPRESSION_PIZ:
@@ -1658,6 +1661,17 @@ void
 testZIPSCompression (const std::string& tempdir)
 {
     testComp (tempdir, EXR_COMPRESSION_ZIPS);
+}
+
+void
+testGdeflateCompression (const std::string& tempdir)
+{
+#ifdef OPENEXR_ENABLE_GDEFLATE
+    testComp (tempdir, EXR_COMPRESSION_GDEFLATE);
+#else
+    std::cout << "  gdeflate support not available - test skipped" << std::endl;
+    (void) tempdir;
+#endif
 }
 
 void

--- a/src/test/OpenEXRCoreTest/compression.h
+++ b/src/test/OpenEXRCoreTest/compression.h
@@ -16,6 +16,7 @@ void testNoCompression (const std::string& tempdir);
 void testRLECompression (const std::string& tempdir);
 void testZIPCompression (const std::string& tempdir);
 void testZIPSCompression (const std::string& tempdir);
+void testGdeflateCompression (const std::string& tempdir);
 void testPIZCompression (const std::string& tempdir);
 void testPXR24Compression (const std::string& tempdir);
 void testB44Compression (const std::string& tempdir);

--- a/src/test/OpenEXRCoreTest/main.cpp
+++ b/src/test/OpenEXRCoreTest/main.cpp
@@ -202,6 +202,7 @@ main (int argc, char* argv[])
     TEST (testRLECompression, "core_compression");
     TEST (testZIPCompression, "core_compression");
     TEST (testZIPSCompression, "core_compression");
+    TEST (testGdeflateCompression, "core_compression");
     TEST (testPIZCompression, "core_compression");
     TEST (testPXR24Compression, "core_compression");
     TEST (testB44Compression, "core_compression");

--- a/src/test/OpenEXRTest/testCompressionApi.cpp
+++ b/src/test/OpenEXRTest/testCompressionApi.cpp
@@ -28,11 +28,11 @@ testCompressionApi (const string& tempDir)
         cout << "Testing compression API functions." << endl;
 
         // update this if you add a new compressor.
-        string codecList = "none/rle/zips/zip/piz/pxr24/b44/b44a/dwaa/dwab/htj2k256/htj2k32";
+        string codecList = "none/rle/zips/zip/piz/pxr24/b44/b44a/dwaa/dwab/htj2k256/htj2k32/gdeflate";
 
         int numMethods = static_cast<int> (NUM_COMPRESSION_METHODS);
         // update this if you add a new compressor.
-        assert (numMethods == 12);
+        assert (numMethods == 13);
 
         for (int i = 0; i < numMethods; i++)
         {
@@ -64,6 +64,7 @@ testCompressionApi (const string& tempDir)
                 case ZIPS_COMPRESSION:
                 case ZIP_COMPRESSION:
                 case PIZ_COMPRESSION:
+                case GDEFLATE_COMPRESSION:
                     assert (isLossyCompression (c) == false);
                     break;
 


### PR DESCRIPTION
- Gdeflate compression can yield multiple 64K pages.
- Each chunk includes number of pages and size of each page.
- Off by default.  gdeflate calls are wrapped and conditionally compiled in.
- CMake and Bazel builds can optionally fetch NVIDIA fork of libdeflate.
Additional info and discussion on openexr-dev@lists.aswf.io