### PR TITLE
Fix handling of corrupt RLE data

### DIFF
--- a/src/lib/OpenEXRCore/internal_rle.c
+++ b/src/lib/OpenEXRCore/internal_rle.c
@@ -219,7 +219,7 @@ internal_exr_undo_rle (
 
     unpackb =
         internal_rle_decompress (decode->scratch_buffer_1, outsz, src, packsz);
-    if (packsz > 0 && unpackb != outsz)
+    if (unpackb != outsz)
         return EXR_ERR_CORRUPT_CHUNK;
 
     unpredict_and_reorder (out, decode->scratch_buffer_1, unpackb);

--- a/src/lib/OpenEXRCore/internal_rle.c
+++ b/src/lib/OpenEXRCore/internal_rle.c
@@ -219,7 +219,7 @@ internal_exr_undo_rle (
 
     unpackb =
         internal_rle_decompress (decode->scratch_buffer_1, outsz, src, packsz);
-    if (packsz > 0 && unpackb == 0)
+    if (packsz > 0 && unpackb != outsz)
         return EXR_ERR_CORRUPT_CHUNK;
 
     unpredict_and_reorder (out, decode->scratch_buffer_1, unpackb);


### PR DESCRIPTION
If the size of the uncompressed RLE data does not match the expected output size, the chunk is corrupt, so report an error.