### PR TITLE
Fix issues with negative coordinates and sampling != 0

### DIFF
--- a/src/lib/OpenEXRCore/internal_util.h
+++ b/src/lib/OpenEXRCore/internal_util.h
@@ -30,11 +30,12 @@ compute_sampled_height (int height, int y_sampling, int start_y)
             start = start_y + (y_sampling - start);
         else
             start = start_y;
+
         end = start_y + height - 1;
-        end -= (end < 0) ? (-end % y_sampling) : (end % y_sampling);
+        end -= (end < 0 ? -end : end) % y_sampling;
 
         if (start > end)
-            nlines = 0;
+            nlines = start == start_y ? 1 : 0;
         else
             nlines = (end - start) / y_sampling + 1;
     }

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -761,7 +761,6 @@ extract_attr_bytes(
     int32_t n;
     int32_t hint_length;
     size_t bytes_length;
-    const char* type_hint;
     exr_result_t rv;
 
     rv = check_bad_attrsz(scratch, attrsz, 1, aname, tname, &n);


### PR DESCRIPTION
When sampling is larger than the chunk height, you can have scenarios where the previous logic would say 0 lines, but a line is valid when the start_y lines up with the y_sampling

Addresses: https://issues.oss-fuzz.com/issues/435779241