### PR TITLE
ImfCheckFile: handle partial deep tiles

### DIFF
--- a/src/lib/OpenEXRUtil/ImfCheckFile.cpp
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.cpp
@@ -694,15 +694,24 @@ readDeepTile (T& in, bool reduceMemory, bool reduceTime)
                             try
                             {
 
+
                                 in.readPixelSampleCounts (
                                     x, y, x, y, xlevel, ylevel);
 
                                 size_t bufferSize     = 0;
                                 size_t fileBufferSize = 0;
 
-                                for (int ty = 0; ty < tileHeight; ++ty)
+                                Box2i tileRange =
+                                    in.dataWindowForTile (x, y, xlevel, ylevel);
+
+                                int thisTileWidth =
+                                    tileRange.max.x - tileRange.min.x + 1;
+                                int thisTileHeight =
+                                    tileRange.max.y - tileRange.min.y + 1;
+
+                                for (int ty = 0; ty < thisTileHeight; ++ty)
                                 {
-                                    for (int tx = 0; tx < tileWidth; ++tx)
+                                    for (int tx = 0; tx < thisTileWidth; ++tx)
                                     {
                                         fileBufferSize +=
                                             channelCount *
@@ -731,9 +740,10 @@ readDeepTile (T& in, bool reduceMemory, bool reduceTime)
                                     pixelBuffer.resize (bufferSize);
                                     size_t bufferIndex = 0;
 
-                                    for (int ty = 0; ty < tileHeight; ++ty)
+                                    for (int ty = 0; ty < thisTileHeight; ++ty)
                                     {
-                                        for (int tx = 0; tx < tileWidth; ++tx)
+                                        for (int tx = 0; tx < thisTileWidth;
+                                             ++tx)
                                         {
                                             if (!reduceMemory ||
                                                 localSampleCount[ty][tx] *


### PR DESCRIPTION
Fixes some uninitialized memory warnings from valgrind when using ImfCheckFile (exrcheck) with deep tiled files.

When the datawindow is not a multiple of the tile size, the last tile on each row/column is not full size. This means parts of the localSampleCount array are not written to, so they may contain out-of-date or uninitialized values. 
This update checks the actual size of each tile to ensure only valid entries are accessed.
