### PR TITLE
verify packed vs unpacked size with uncompressed data

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1486,6 +1486,18 @@ exr_read_tile_chunk_info (
         return ctxt->report_error (
             ctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid packed size of 0");
 
+    if (part->comp_type == EXR_COMPRESSION_NONE &&
+       cinfo->packed_size != cinfo->unpacked_size)
+    {
+         return ctxt->print_error (
+             ctxt,
+             EXR_ERR_BAD_CHUNK_LEADER,
+             "Mismatch between unpacked and packed size with uncompressed data: packed is %" PRIu64 "; unpacked is %" PRIu64,
+             cinfo->packed_size, cinfo->unpacked_size);
+    }
+
+
+
     return EXR_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
Where compression is set to None, the packed data size should be identical to the unpacked size, but that wasn't being verified on read. 
If the packed data size stored in the chunk header is too small, the data array was only partially filled on read; the remainder would contain uninitialized values, which could be copied to the output buffer.