### PR TITLE
check storage_mode when computing chunk sizes

### DIFF
--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -2492,7 +2492,9 @@ internal_exr_compute_chunk_offset_size (exr_priv_part_t curpart)
 
     w = (uint64_t) (((int64_t) dw.max.x) - ((int64_t) dw.min.x) + 1);
 
-    if (curpart->tiles)
+    if (curpart->storage_mode != EXR_STORAGE_SCANLINE &&
+       curpart->storage_mode != EXR_STORAGE_DEEP_SCANLINE &&
+       curpart->tiles)
     {
         const exr_attr_tiledesc_t* tiledesc  = curpart->tiles->tiledesc;
         int64_t                    tilecount = 0;


### PR DESCRIPTION
Tools that read tiled images and write scanline images with the same header may write the original tile description attribute into the header of the output scanline file. In some cases, this will cause the Core library to allocate memory assuming the output file is tiled, which is likely to allocate insufficient memory to write the scanlines