### PR TITLE
Feature/add part indices to write pyapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Contrib/DtexToExr/DtexToExr
 .DS_Store
 abi_check
 _build/
+pybuild/
 build/
 build-win/
 build-nuget/

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
@@ -321,6 +321,36 @@ MultiPartOutputFile::getOutputPart (int partNumber)
         return (T*) _data->_outputFiles[partNumber];
 }
 
+template <class T> void MultiPartOutputFile::deleteOutputPart (int partNumber) {
+    // Remove this OutputFile object to save memory when writing in a streaming fasion
+    if (partNumber < 0 || partNumber >= int (_data->_headers.size ()))
+    {
+        THROW (
+            IEX_NAMESPACE::ArgExc,
+            "MultiPartOutputFile::deleteOutputPart called with invalid part number  "
+                << partNumber << " on file with " << _data->_headers.size ()
+                << " parts");
+    }
+
+#if ILMTHREAD_THREADING_ENABLED
+    std::lock_guard<std::mutex> lock (*_data);
+#endif
+    auto it = _data->_outputFiles.find(partNumber);
+    if (it == _data->_outputFiles.end()) {
+        THROW (IEX_NAMESPACE::ArgExc, "MultiPartOutputFile::deleteOutputPart called with invalid part number  "
+                << partNumber << " on file with " << _data->_headers.size ()
+                << " parts");
+    }
+    delete it->second; // created using new
+    _data->_outputFiles.erase(it);
+};
+
+// instance above function for all four types
+template void MultiPartOutputFile::deleteOutputPart<OutputFile> (int);
+template void MultiPartOutputFile::deleteOutputPart<TiledOutputFile> (int);
+template void MultiPartOutputFile::deleteOutputPart<DeepScanLineOutputFile> (int);
+template void MultiPartOutputFile::deleteOutputPart<DeepTiledOutputFile> (int);
+
 // instance above function for all four types
 template OutputFile* MultiPartOutputFile::getOutputPart<OutputFile> (int);
 template TiledOutputFile*

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.cpp
@@ -332,9 +332,9 @@ template <class T> void MultiPartOutputFile::deleteOutputPart (int partNumber) {
                 << " parts");
     }
 
-#if ILMTHREAD_THREADING_ENABLED
-    std::lock_guard<std::mutex> lock (*_data);
-#endif
+// #if ILMTHREAD_THREADING_ENABLED
+//     std::lock_guard<std::mutex> lock (*_data);
+// #endif
     auto it = _data->_outputFiles.find(partNumber);
     if (it == _data->_outputFiles.end()) {
         THROW (IEX_NAMESPACE::ArgExc, "MultiPartOutputFile::deleteOutputPart called with invalid part number  "

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.h
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.h
@@ -79,6 +79,7 @@ private:
     Data* _data;
 
     template <class T> IMF_HIDDEN T* getOutputPart (int partNumber);
+    template <class T> IMF_HIDDEN void deleteOutputPart (int partNumber);
 
     friend class OutputPart;
     friend class TiledOutputPart;

--- a/src/lib/OpenEXR/ImfOutputPart.cpp
+++ b/src/lib/OpenEXR/ImfOutputPart.cpp
@@ -15,6 +15,11 @@ OutputPart::OutputPart (MultiPartOutputFile& multiPartFile, int partNumber)
     file = multiPartFile.getOutputPart<OutputFile> (partNumber);
 }
 
+void OutputPart::deleteFile (MultiPartOutputFile& multiPartFile, int partNumber)
+{
+    multiPartFile.deleteOutputPart<OutputFile> (partNumber);
+}
+
 const char*
 OutputPart::fileName () const
 {

--- a/src/lib/OpenEXR/ImfOutputPart.h
+++ b/src/lib/OpenEXR/ImfOutputPart.h
@@ -21,6 +21,8 @@ class IMF_EXPORT_TYPE OutputPart
 public:
     IMF_EXPORT
     OutputPart (MultiPartOutputFile& multiPartFile, int partNumber);
+    IMF_EXPORT
+    void deleteFile (MultiPartOutputFile& multiPartFile, int partNumber);
 
     IMF_EXPORT
     const char* fileName () const;

--- a/src/lib/OpenEXR/ImfTiledOutputPart.cpp
+++ b/src/lib/OpenEXR/ImfTiledOutputPart.cpp
@@ -16,6 +16,11 @@ TiledOutputPart::TiledOutputPart (
     file = multiPartFile.getOutputPart<TiledOutputFile> (partNumber);
 }
 
+void TiledOutputPart::deleteFile (MultiPartOutputFile& multiPartFile, int partNumber)
+{
+    multiPartFile.deleteOutputPart<TiledOutputFile> (partNumber);
+}
+
 const char*
 TiledOutputPart::fileName () const
 {

--- a/src/lib/OpenEXR/ImfTiledOutputPart.h
+++ b/src/lib/OpenEXR/ImfTiledOutputPart.h
@@ -26,6 +26,9 @@ public:
     TiledOutputPart (MultiPartOutputFile& multiPartFile, int partNumber);
 
     IMF_EXPORT
+    void deleteFile (MultiPartOutputFile& multiPartFile, int partNumber);
+
+    IMF_EXPORT
     const char* fileName () const;
     IMF_EXPORT
     const Header& header () const;

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1056,6 +1056,11 @@ PyFile::channels(int part_index)
 // Write the PyFile to the given filename
 //
 
+void PyFile::close() {
+    // No matter whether a partial write has finished, always close the file
+    _outputFile = nullptr;
+}
+
 void
 PyFile::write(const char* outfilename, bool header_only, const py::list& part_indices)
 {
@@ -2948,6 +2953,11 @@ PYBIND11_MODULE(OpenEXR, m)
              -------
              >>> f = OpenEXR.File("image.exr")
              >>> f.write("out.exr"))pbdoc")
+        .def("close", &PyFile::close,
+             R"pbdoc(
+             Close the file.
+             No matter whether a partial write has finished, always close the file.
+             )pbdoc")
         ;
 }
 

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1220,7 +1220,7 @@ PyFile::write(const char* outfilename, bool header_only, const py::list& part_in
     _outputFile = std::make_unique<MultiPartOutputFile>(outfilename, headers.data(), headers.size());
 
     if (header_only) {
-        py::print("OpenEXR: Only wrote header for output file:", outfilename);
+        // py::print("OpenEXR: Only wrote header for output file:", outfilename);
         return; // early stop for only writing the header
     }
 

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -716,12 +716,14 @@ PyPart::writePixels(MultiPartOutputFile& outfile, const Box2i& dw) const
         OutputPart part(outfile, part_index);
         part.setFrameBuffer (frameBuffer);
         part.writePixels (height());
+        part.deleteFile(outfile, part_index);
     }
     else
     {
         TiledOutputPart part(outfile, part_index);
         part.setFrameBuffer (frameBuffer);
         part.writeTiles (0, part.numXTiles() - 1, 0, part.numYTiles() - 1);
+        part.deleteFile(outfile, part_index);
     }
 }
 

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -209,17 +209,29 @@ PyFile::PyFile(const std::string& filename, bool separate_channels, bool header_
             //
         
             auto type = header.type();
-            if (type == SCANLINEIMAGE || type == TILEDIMAGE)
+            try
             {
-                P.readPixels(*_inputFile, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                if (type == SCANLINEIMAGE || type == TILEDIMAGE)
+                {
+                    P.readPixels(*_inputFile, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                }
+                else if (type == DEEPSCANLINE || type == DEEPTILE)
+                {
+                    P.readDeepPixels(*_inputFile, type, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                }
+                parts.append(py::cast<PyPart>(PyPart(P)));
             }
-            else if (type == DEEPSCANLINE || type == DEEPTILE)
+            catch (const std::exception& e)
             {
-                P.readDeepPixels(*_inputFile, type, header.channels(), shape, rgbaChannels, dw, separate_channels);
+                // Log the error and skip appending this part
+                py::print("Warning: Exception raised reading pixel data for part", part_index, "-", e.what());
             }
         }
-        
-        parts.append(py::cast<PyPart>(PyPart(P)));
+        else
+        {
+            // If only reading the header, always append this part
+            parts.append(py::cast<PyPart>(PyPart(P)));
+        }
     } // for parts
 }
 

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -28,7 +28,7 @@ public:
     py::dict&    header(int part_index = 0);
     py::dict&    channels(int part_index = 0);
 
-    void         write(const char* filename);
+    void         write(const char* filename, bool header_only = false, const py::list& part_indices = py::list());
     
     std::string  filename;
     py::list     parts;
@@ -37,6 +37,7 @@ protected:
     
     bool                                _header_only;
     std::unique_ptr<MultiPartInputFile> _inputFile;
+    std::unique_ptr<MultiPartOutputFile> _outputFile;
     
     py::object   getAttributeObject(const std::string& name, const Attribute* a);
     

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -18,7 +18,7 @@ class PyFile
 {
 public:
     PyFile();
-    PyFile(const std::string& filename, bool separate_channels = false, bool header_only = false);
+    PyFile(const std::string& filename, bool separate_channels = false, bool header_only = false, const py::list& part_indices = py::list());
     PyFile(const py::dict& header, const py::dict& channels);
     PyFile(const py::list& parts);
 

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -24,6 +24,7 @@ public:
 
     py::object   __enter__();
     void         __exit__(py::args args);
+    void         close();
     
     py::dict&    header(int part_index = 0);
     py::dict&    channels(int part_index = 0);


### PR DESCRIPTION
This PR adds the part_indices api to the write function of the OpenEXR Python wrapper, similar to https://github.com/AcademySoftwareFoundation/openexr/pull/2149
However, different from the read API, we cannot create a new file every time a new part needs to be written on disk, which would result in the previously written data being overwritten. Thus, I added a persistent pointer to a MultiPartOutputFile, just like what we would do if using the C++ API. Another problem arises where the already written part would be cached in a map in the MultiPartOutputFile, leading to growing memory usage even though that part has already been written to the disk and that memory is not needed anymore, so I added another API for deleting this cache file in the MultiPartOutputFile object's map.

The current structure and API design might not be optimal, and I've only tested the regular case where a non-deep scanline multi-part image sequence is written to disk streamingly, where the generation of new part data and the operation of writing them to the disk is happening at the same time.