### PR TITLE
Only define CMAKE_DEBUG_POSTFIX if it is not already defined

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -100,7 +100,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Suffix for debug configuration libraries
 # (if you should choose to install those)
 # Don't override if the user has set it and don't save it in the cache
-if (NOT CMAKE_DEBUG_POSTFIX)
+if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX "_d")
 endif()
 


### PR DESCRIPTION
This makes it possible to set CMAKE_DEBUG_POSTFIX="", which wasn't possible before but is desirable in the case where the debug libraries should have the same name as the release build.

Should fix #1981.