### PR TITLE
Bazel build: Bump openjph to 0.25.0 and libdeflate to 1.25

### DIFF
--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -35,8 +35,8 @@ permissions:
 
 jobs:
   build_and_test_ubuntu:
-    name: Linux Ubuntu 22.04 Bazel build <GCC 11.4.0>
-    runs-on: ubuntu-22.04
+    name: Linux Ubuntu 24.04 Bazel build <GCC 13.3.0>
+    runs-on: ubuntu-24.04
     
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -45,12 +45,12 @@ jobs:
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: "/home/runner/.cache/bazel"
-        key: bazel-ubuntu-22
+        key: bazel-ubuntu-24
 
     - name: Build
       run: |
-        bazelisk build //...
-        bazelisk test --test_output=errors //...
+        bazel build //...
+        bazel test --test_output=errors //...
 
   build_and_test_windows:
     name: Windows Server 2025 build <Visual Studio 2022>
@@ -67,8 +67,8 @@ jobs:
 
     - name: Build
       run: |
-        bazelisk build //...
-        bazelisk test --test_output=errors //...
+        bazel build //...
+        bazel test --test_output=errors //...
 
   build_and_test_macos:
     name: macOS 15 Bazel build <Apple Clang14>
@@ -85,5 +85,5 @@ jobs:
 
     - name: Build
       run: |
-        bazelisk build //...
-        bazelisk test --test_output=errors //...
+        bazel build //...
+        bazel test --test_output=errors //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -582,3 +582,9 @@ cc_binary(
         ":OpenEXR",
     ],
 )
+
+alias(
+    name = "openexr",
+    actual = ":OpenEXR",
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,8 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 config_setting(
@@ -194,8 +196,8 @@ cc_library(
         "src/lib/OpenEXRCore/internal_file.h",
         "src/lib/OpenEXRCore/internal_float_vector.h",
         "src/lib/OpenEXRCore/internal_ht.cpp",
-        "src/lib/OpenEXRCore/internal_ht_common.h",
         "src/lib/OpenEXRCore/internal_ht_common.cpp",
+        "src/lib/OpenEXRCore/internal_ht_common.h",
         "src/lib/OpenEXRCore/internal_huf.c",
         "src/lib/OpenEXRCore/internal_huf.h",
         "src/lib/OpenEXRCore/internal_memory.h",
@@ -269,8 +271,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@imath",
-        "@openjph",
         "@libdeflate//:deflate",
+        "@openjph",
     ],
 )
 
@@ -316,8 +318,8 @@ cc_library(
         "src/lib/OpenEXR/ImfFramesPerSecond.cpp",
         "src/lib/OpenEXR/ImfGenericInputFile.cpp",
         "src/lib/OpenEXR/ImfGenericOutputFile.cpp",
-        "src/lib/OpenEXR/ImfHeader.cpp",
         "src/lib/OpenEXR/ImfHTCompressor.cpp",
+        "src/lib/OpenEXR/ImfHeader.cpp",
         "src/lib/OpenEXR/ImfHuf.cpp",
         "src/lib/OpenEXR/ImfIDManifest.cpp",
         "src/lib/OpenEXR/ImfIDManifestAttribute.cpp",
@@ -423,8 +425,8 @@ cc_library(
         "src/lib/OpenEXR/ImfFramesPerSecond.h",
         "src/lib/OpenEXR/ImfGenericInputFile.h",
         "src/lib/OpenEXR/ImfGenericOutputFile.h",
-        "src/lib/OpenEXR/ImfHeader.h",
         "src/lib/OpenEXR/ImfHTCompressor.h",
+        "src/lib/OpenEXR/ImfHeader.h",
         "src/lib/OpenEXR/ImfHuf.h",
         "src/lib/OpenEXR/ImfIDManifest.h",
         "src/lib/OpenEXR/ImfIDManifestAttribute.h",
@@ -516,7 +518,7 @@ cc_library(
         ":IlmThread",
         ":OpenEXRCore",
         "@imath",
-        "@openjph"
+        "@openjph",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -526,8 +526,12 @@ cc_test(
     name = "IexTest",
     srcs = [
         "src/test/IexTest/main.cpp",
+        "src/test/IexTest/mathFuncs.cpp",
+        "src/test/IexTest/mathFuncs.h",
         "src/test/IexTest/testBaseExc.cpp",
         "src/test/IexTest/testBaseExc.h",
+        "src/test/IexTest/testMathExc.cpp",
+        "src/test/IexTest/testMathExc.h",
     ],
     includes = ["src/test/IexTest"],
     tags = ["manual"],  # This test is not build and executed in the CI

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,6 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "imath", version = "3.2.2")
 bazel_dep(name = "libdeflate", version = "1.24")
-bazel_dep(name = "openjph", version = "0.24.2")
+bazel_dep(name = "openjph", version = "0.25.0")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.9")
+bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "imath", version = "3.2.2")
-bazel_dep(name = "libdeflate", version = "1.24")
+bazel_dep(name = "libdeflate", version = "1.25")
 bazel_dep(name = "openjph", version = "0.25.0")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.13")

--- a/src/examples/BUILD.bazel
+++ b/src/examples/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "OpenEXRExamples",
     srcs = [


### PR DESCRIPTION
This PR only affects the Bazel build of OpenEXR (not CMake)

- Bump openjph to 0.25.0 (https://github.com/bazelbuild/bazel-central-registry/pull/6362)
- Bump libdeflate to 1.25 (https://github.com/bazelbuild/bazel-central-registry/pull/6363)
- Fix IexTest
- Introduce openexr alias (allows users to write `deps = ["@openexr"]` instead of `deps = ["@openexr//:OpenEXR"]` )
- CI: Rename bazelisk to bazel switch to Ubuntu 24.04
- Run `buildifier -lint=fix -r . `