### PR TITLE
Update 3.3 CI to current standards

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -174,7 +174,42 @@ jobs:
         shell: bash
 
       - name: Test
+        if: ${{ inputs.BUILD_TESTING == 'ON' }}
         run: |
+          set -x
+
+          # force downloading of test images, since CMake's file download is flakey
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+              WORKSPACE=$(cygpath -u "$GITHUB_WORKSPACE")
+              echo "PROGRAM_FILES=$PROGRAM_FILES" >> $GITHUB_ENV
+          else
+              WORKSPACE=$GITHUB_WORKSPACE
+          fi
+          IMAGES_URL=https://raw.githubusercontent.com/AcademySoftwareFoundation/openexr-images/v1.0
+          images=(
+            "TestImages/GrayRampsHorizontal.exr"
+            "LuminanceChroma/Garden.exr"
+            "MultiResolution/ColorCodedLevels.exr"
+            "MultiResolution/WavyLinesLatLong.exr"
+            "MultiResolution/WavyLinesCube.exr"
+            "LuminanceChroma/Flowers.exr"
+            "MultiView/Adjuster.exr"
+             "Chromaticities/Rec709_YC.exr"
+             "Chromaticities/Rec709.exr"
+             "Chromaticities/XYZ_YC.exr"
+             "Chromaticities/XYZ.exr"
+             "TestImages/GammaChart.exr"
+             "Beachball/singlepart.0001.exr"
+             "v2/LeftView/Balls.exr"
+             "v2/Stereo/Trunks.exr"
+             "Beachball/multipart.0001.exr"
+          )
+          for image in "${images[@]}"; do
+            outfile="$WORKSPACE/_build/src/test/bin/$image"
+            mkdir -p "$(dirname "$outfile")"
+            curl -L -o "$outfile" "$IMAGES_URL/$image"
+          done
+
           ctest -T Test -C ${{ inputs.build-type }} --timeout 7200 --output-on-failure -VV
         working-directory: _build
         shell: bash

--- a/share/ci/scripts/install_help2man.sh
+++ b/share/ci/scripts/install_help2man.sh
@@ -5,7 +5,7 @@
 set -ex
 
 HELP2MAN_VERSION="1.49.3"
-HELP2MAN_URL="https://ftp.gnu.org/gnu/help2man/help2man-$HELP2MAN_VERSION.tar.xz"
+HELP2MAN_URL="https://mirror.cs.odu.edu/gnu/help2man/help2man-$HELP2MAN_VERSION.tar.xz"
 HELP2MAN_DIR="help2man-$HELP2MAN_VERSION"
 
 if [[ $OSTYPE == *msys* ]]; then

--- a/src/test/bin/test_exr2aces.py
+++ b/src/test/bin/test_exr2aces.py
@@ -56,6 +56,9 @@ def cleanup():
 atexit.register(cleanup)
 
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
+
 result = run ([exr2aces, "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0), "\n"+result.stderr

--- a/src/test/bin/test_exrheader.py
+++ b/src/test/bin/test_exrheader.py
@@ -50,6 +50,9 @@ def find_line(keyword, lines):
 
 # attributes
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
+    
 result = run ([exrheader, image], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0), "\n"+result.stderr

--- a/src/test/bin/test_exrinfo.py
+++ b/src/test/bin/test_exrinfo.py
@@ -31,8 +31,13 @@ assert(result.stdout.startswith ("exrinfo")), "\n"+result.stdout
 assert(version in result.stdout), "\n"+result.stdout
 
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
+
 result = run ([exrinfo, image, "-a", "-v"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
+print(f"result.stdout: {result.stdout}")
+print(f"result.stderr: {result.stderr}")
 assert(result.returncode == 0), "\n"+result.stderr
 output = result.stdout.split('\n')
 try:

--- a/src/test/bin/test_exrmakepreview.py
+++ b/src/test/bin/test_exrmakepreview.py
@@ -56,6 +56,9 @@ def cleanup():
 atexit.register(cleanup)
 
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
+    
 result = run ([exrmakepreview, "-w", "50", "-e", "1", "-v", image, outimage], stdout=PIPE, stderr=PIPE, universal_newlines=True)
 print(" ".join(result.args))
 assert(result.returncode == 0), "\n"+result.stderr

--- a/src/test/bin/test_exrmaketiled.py
+++ b/src/test/bin/test_exrmaketiled.py
@@ -14,6 +14,8 @@ image_dir = sys.argv[3]
 version = sys.argv[4]
 
 image = f"{image_dir}/TestImages/GammaChart.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
 
 assert(os.path.isfile(exrmaketiled)), "\nMissing " + exrmaketiled
 assert(os.path.isfile(exrinfo)), "\nMissing " + exrinfo

--- a/src/test/bin/test_exrmetrics.py
+++ b/src/test/bin/test_exrmetrics.py
@@ -56,6 +56,9 @@ for a in ["-p","-l","-16","-z","-t","-i","--passes","-o","--pixelmode","--time"]
     assert("Missing" in result.stderr),"expected 'Missing argument' error"
 
 for image in [f"{image_dir}/TestImages/GrayRampsHorizontal.exr",f"{image_dir}/Beachball/multipart.0001.exr",f"{image_dir}/LuminanceChroma/Flowers.exr"]:
+    if not os.path.isfile(image) or os.path.getsize(image) == 0:
+        sys.exit(f"WARNING: test image {image} is not valid.")
+
     for time in ["none","read","write","reread","read,write","read,reread","read,write,reread"]:
         for passes in ["1","2"]:
             for nosize in range(0,2):

--- a/src/test/bin/test_exrmultiview.py
+++ b/src/test/bin/test_exrmultiview.py
@@ -37,7 +37,12 @@ assert(result.stdout.startswith ("exrmultiview")), "\n"+result.stdout
 assert(version in result.stdout), "\n"+result.stdout
 
 left_image = f"{image_dir}/TestImages/GammaChart.exr"
+if not os.path.isfile(left_image) or os.path.getsize(left_image) == 0:
+    sys.exit(f"WARNING: test image {left_image} is not valid.")
+    
 right_image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(right_image) or os.path.getsize(right_image) == 0:
+    sys.exit(f"WARNING: test image {right_image} is not valid.")
 
 fd, outimage = tempfile.mkstemp(".exr")
 os.close(fd)

--- a/src/test/bin/test_exrstdattr.py
+++ b/src/test/bin/test_exrstdattr.py
@@ -94,6 +94,9 @@ command = [exrstdattr]
 for a in attrs:
     command += a 
 image = f"{image_dir}/TestImages/GrayRampsHorizontal.exr"
+if not os.path.isfile(image) or os.path.getsize(image) == 0:
+    sys.exit(f"WARNING: test image {image} is not valid.")
+    
 command += [image, outimage]
 
 result = run (command, stdout=PIPE, stderr=PIPE, universal_newlines=True)


### PR DESCRIPTION
This backports the update for help2man, and also works around the problem with cmake file download producing empty files by forcing download of the necessary test images.
