### PR TITLE
Imporve Bazel support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@
 # Copyright (c) Contributors to the OpenEXR Project.
 
 version: 2
+
+enable-beta-ecosystems: true # Required to use the Bazel ecosystems
 updates:
 
   - package-ecosystem: "github-actions"
@@ -19,4 +21,9 @@ updates:
     directory: "/"
     schedule:
       day: "monday"
+      interval: "weekly"
+
+  - package-ecosystem: "bazel" 
+    directory: "/"
+    schedule:
       interval: "weekly"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,6 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "imath", version = "3.2.2")
 bazel_dep(name = "libdeflate", version = "1.25")
-bazel_dep(name = "openjph", version = "0.25.0")
+bazel_dep(name = "openjph", version = "0.25.2")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "rules_cc", version = "0.2.14")


### PR DESCRIPTION
This PR only affects the Bazel build experience:

- Bump openjph to 0.25.2
- Add Bazel update to Dependabot