### PR TITLE
OpenEXRCore: avoid direct dependency on imath

### DIFF
--- a/src/lib/OpenEXRCore/internal_b44_table_init.c
+++ b/src/lib/OpenEXRCore/internal_b44_table_init.c
@@ -3,9 +3,9 @@
 // Copyright (c) DreamWorks Animation LLC and Contributors of the OpenEXR Project
 //
 
-#include <half.h>
 #include <stdint.h>
 
+#include "internal_coding.h"
 #include "internal_thread.h"
 
 extern uint16_t* exrcore_expTable;
@@ -21,9 +21,9 @@ b44_convertFromLinear (uint16_t x)
     if (x >= 0x558c && x < 0x8000) // >= 8 * log (HALF_MAX)
         return 0x7bff;             // HALF_MAX
 
-    float f = imath_half_to_float (x);
+    float f = half_to_float (x);
     f       = expf (f / 8);
-    return imath_float_to_half (f);
+    return float_to_half (f);
 }
 
 static inline uint16_t
@@ -34,9 +34,9 @@ b44_convertToLinear (uint16_t x)
     if (x > 0x8000) // negative? (excluding -0.0 which is accepted)
         return 0;
 
-    float f = imath_half_to_float (x);
+    float f = half_to_float (x);
     f       = 8 * logf (f);
-    return imath_float_to_half (f);
+    return float_to_half (f);
 }
 
 

--- a/src/lib/OpenEXRCore/internal_dwa_table_init.c
+++ b/src/lib/OpenEXRCore/internal_dwa_table_init.c
@@ -3,9 +3,9 @@
 // Copyright (c) DreamWorks Animation LLC and Contributors of the OpenEXR Project
 //
 
-#include <half.h>
 #include <stdint.h>
 
+#include "internal_coding.h"
 #include "internal_thread.h"
 
 extern uint16_t* exrcore_dwaToLinearTable;
@@ -47,7 +47,7 @@ dwa_convertToLinear (uint16_t x)
     if ((x & 0x7c00) == 0x7c00) // infinity/nan?
         return 0;
     
-    float f = imath_half_to_float(x);
+    float f = half_to_float(x);
     float sign = f < 0.0f ? -1.0f : 1.0f;
     f = fabsf(f);
     
@@ -63,7 +63,7 @@ dwa_convertToLinear (uint16_t x)
         py = f - 1.0f;
     }
     float z = sign * powf(px, py);
-    return imath_float_to_half(z);
+    return float_to_half(z);
 }
 
 static inline uint16_t
@@ -74,7 +74,7 @@ dwa_convertToNonLinear (uint16_t x)
     if ((x & 0x7c00) == 0x7c00) // infinity/nan?
         return 0;
     
-    float f = imath_half_to_float(x);
+    float f = half_to_float(x);
     float sign = f < 0.0f ? -1.0f : 1.0f;
     f = fabsf(f);
     
@@ -87,7 +87,7 @@ dwa_convertToNonLinear (uint16_t x)
     {
         z = logf (f) / 2.2f + 1.0f;
     }
-    return imath_float_to_half(sign * z);
+    return float_to_half(sign * z);
 }
 
 


### PR DESCRIPTION
All other Core code uses `internal_coding.h` functions `half_to_float` & `float_to_half`, in order to make it compile when IMath is not present at all; follow the same pattern. This dependency was accidentally introduced in #2174 and #2126. For any regular OpenEXR build this is not a problem; only becomes a problem if someone manually builds OpenEXRCore without IMath.