### PR TITLE
OpenEXRCore: fix ILMTHREAD_THREADING_ENABLED checks

### DIFF
--- a/src/lib/OpenEXRCore/internal_posix_file_impl.h
+++ b/src/lib/OpenEXRCore/internal_posix_file_impl.h
@@ -13,7 +13,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    include <pthread.h>
 #endif
 #include <stdarg.h>
@@ -37,7 +37,7 @@ struct _internal_exr_filehandle
 struct _internal_exr_filehandle
 {
     int fd;
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     pthread_mutex_t mutex;
 #    endif
 };
@@ -54,7 +54,7 @@ default_shutdown (exr_const_context_t c, void* userdata, int failed)
     {
         if (fh->fd >= 0) close (fh->fd);
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
         pthread_mutex_destroy (&(fh->mutex));
 #    endif
 #endif
@@ -141,7 +141,7 @@ default_read_func (
     }
 
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     pthread_mutex_lock (&(fh->mutex));
 #    endif
     {
@@ -152,7 +152,7 @@ default_read_func (
 #    endif
         if (spos != offset)
         {
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
             pthread_mutex_unlock (&(fh->mutex));
 #    endif
             if (error_cb)
@@ -193,7 +193,7 @@ default_read_func (
     } while (retsz < (int64_t) sz);
 
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     pthread_mutex_unlock (&(fh->mutex));
 #    endif
 #endif
@@ -255,7 +255,7 @@ default_write_func (
     }
 
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     pthread_mutex_lock (&(fh->mutex));
 #    endif
     {
@@ -266,7 +266,7 @@ default_write_func (
 #    endif
         if (spos != offset)
         {
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
             pthread_mutex_unlock (&(fh->mutex));
 #    endif
             if (error_cb)
@@ -306,7 +306,7 @@ default_write_func (
     } while (retsz < (int64_t) sz);
 
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     pthread_mutex_unlock (&(fh->mutex));
 #    endif
 #endif
@@ -332,7 +332,7 @@ default_init_read_file (exr_context_t file)
 
     fh->fd = -1;
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     fd = pthread_mutex_init (&(fh->mutex), NULL);
     if (fd != 0)
         return file->print_error (
@@ -369,7 +369,7 @@ default_init_write_file (exr_context_t file)
     if (outfn == NULL) outfn = file->filename.str;
 
 #if !CAN_USE_PREAD
-#    ifdef ILMTHREAD_THREADING_ENABLED
+#    if ILMTHREAD_THREADING_ENABLED
     fd = pthread_mutex_init (&(fh->mutex), NULL);
     if (fd != 0)
         return file->print_error (

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
 #        include <synchapi.h>
 #        include <windows.h>
@@ -28,7 +28,7 @@ static void
 default_error_handler (
     exr_const_context_t ctxt, exr_result_t code, const char* msg)
 {
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
     static CRITICAL_SECTION sMutex;
     volatile static long    initialized = 0;
@@ -40,7 +40,7 @@ default_error_handler (
 #    endif
 #endif
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
     EnterCriticalSection (&sMutex);
 #    else
@@ -68,7 +68,7 @@ default_error_handler (
         fprintf (stderr, "<ERROR>: %s\n", msg);
     fflush (stderr);
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
     LeaveCriticalSection (&sMutex);
 #    else
@@ -404,7 +404,7 @@ internal_exr_alloc_context (
         ret->read_fn    = initializers->read_fn;
         ret->write_fn   = initializers->write_fn;
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
         InitializeCriticalSection (&(ret->mutex));
 #    else
@@ -461,7 +461,7 @@ internal_exr_destroy_context (exr_context_t ctxt)
     exr_attr_string_destroy (ctxt, &(ctxt->tmp_filename));
     exr_attr_list_destroy (ctxt, &(ctxt->custom_handlers));
     internal_exr_destroy_parts (ctxt);
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
     DeleteCriticalSection (&(ctxt->mutex));
 #    else

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -9,7 +9,7 @@
 #include "openexr_config.h"
 #include "internal_attr.h"
 
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
 #        include <windows.h>
 #        include <synchapi.h>
@@ -234,7 +234,7 @@ struct _priv_exr_context_t
 
     /* mostly needed for writing, but used during read to ensure
      * custom attribute handlers are safe */
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
     CRITICAL_SECTION mutex;
 #    else
@@ -252,7 +252,7 @@ struct _priv_exr_context_t
 static inline void
 internal_exr_lock (exr_const_context_t c)
 {
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
     exr_context_t nonc = EXR_CONST_CAST (exr_context_t, c);
 #    ifdef _WIN32
     EnterCriticalSection (&nonc->mutex);
@@ -265,7 +265,7 @@ internal_exr_lock (exr_const_context_t c)
 static inline void
 internal_exr_unlock (exr_const_context_t c)
 {
-#ifdef ILMTHREAD_THREADING_ENABLED
+#if ILMTHREAD_THREADING_ENABLED
     exr_context_t nonc = EXR_CONST_CAST (exr_context_t, c);
 #    ifdef _WIN32
     LeaveCriticalSection (&nonc->mutex);


### PR DESCRIPTION
The CMake setup is always defining `ILMTHREAD_THREADING_ENABLED` macro, just to either 1 or 0 value, so checking for it via `#ifdef` will always pass. The non-Core parts of the library were already using correct checks.