### PR TITLE
Add OPENEXR_CORE_USE_NAMESPACE to build OpenEXRCore with C++

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -53,6 +53,8 @@ on:
         type: string
       OPENEXR_FORCE_INTERNAL_OPENJPH:
         type: string
+      OPENEXR_CORE_USE_NAMESPACE:
+        type: string
       CMAKE_OSX_ARCHITECTURES:
         type: string
       BUILD_TESTING:
@@ -222,6 +224,7 @@ jobs:
           cmake_args+=("-DOPENEXR_FORCE_INTERNAL_DEFLATE=${{ inputs.OPENEXR_FORCE_INTERNAL_DEFLATE }}")
           cmake_args+=("-DOPENEXR_FORCE_INTERNAL_OPENJPH=${{ inputs.OPENEXR_FORCE_INTERNAL_OPENJPH }}")
           cmake_args+=("-DBUILD_TESTING=${{ inputs.BUILD_TESTING }}")
+          cmake_args+=("-DOPENEXR_CORE_USE_NAMESPACE=${{ inputs.OPENEXR_CORE_USE_NAMESPACE }}")
           cmake_args+=("-DOPENEXR_RUN_FUZZ_TESTS=OFF")
           cmake_args+=("-DCMAKE_VERBOSE_MAKEFILE=ON")
           if [ -n "${{ inputs.namespace }}" ]; then

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -80,6 +80,7 @@ jobs:
       OPENEXR_FORCE_INTERNAL_IMATH: ${{ matrix.OPENEXR_FORCE_INTERNAL_IMATH || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_DEFLATE: ${{ matrix.OPENEXR_FORCE_INTERNAL_DEFLATE || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_OPENJPH: ${{ matrix.OPENEXR_FORCE_INTERNAL_OPENJPH || 'OFF' }}
+      OPENEXR_CORE_USE_NAMESPACE: ${{ matrix.OPENEXR_CORE_USE_NAMESPACE || 'OFF' }}
       BUILD_TESTING: ${{ matrix.BUILD_TESTING || 'ON' }}
       RUN_TESTING: ${{ matrix.RUN_TESTING || 'ON' }}
       namespace: ${{ matrix.namespace }}
@@ -147,6 +148,11 @@ jobs:
             RUN_TESTING: OFF
             validate_install: OFF
 
+          - build: 12
+            label: OPENEXR_CORE_USE_NAMESPACE
+            OPENEXR_CORE_USE_NAMESPACE: ON
+            validate_install: OFF
+
   macOS:
     name: 'macOS.${{ matrix.build}}: ${{ matrix.label }}'
     uses: ./.github/workflows/ci_steps.yml
@@ -169,6 +175,7 @@ jobs:
       OPENEXR_FORCE_INTERNAL_IMATH: ${{ matrix.OPENEXR_FORCE_INTERNAL_IMATH || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_DEFLATE: ${{ matrix.OPENEXR_FORCE_INTERNAL_DEFLATE || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_OPENJPH: ${{ matrix.OPENEXR_FORCE_INTERNAL_OPENJPH || 'OFF' }}
+      OPENEXR_CORE_USE_NAMESPACE: ${{ matrix.OPENEXR_CORE_USE_NAMESPACE || 'OFF' }}
       CMAKE_OSX_ARCHITECTURES: ${{ matrix.CMAKE_OSX_ARCHITECTURES }}
       BUILD_TESTING: ${{ matrix.BUILD_TESTING || 'ON' }}
       RUN_TESTING: ${{ matrix.RUN_TESTING || 'ON' }}
@@ -231,6 +238,11 @@ jobs:
             RUN_TESTING: OFF
             validate_install: OFF
 
+          - build: 11
+            label: OPENEXR_CORE_USE_NAMESPACE
+            OPENEXR_CORE_USE_NAMESPACE: ON
+            validate_install: OFF
+
   windows:
     name: 'Windows.${{ matrix.build}}: ${{ matrix.label }}'
     uses: ./.github/workflows/ci_steps.yml
@@ -251,6 +263,7 @@ jobs:
       OPENEXR_FORCE_INTERNAL_IMATH: ${{ matrix.OPENEXR_FORCE_INTERNAL_IMATH || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_DEFLATE: ${{ matrix.OPENEXR_FORCE_INTERNAL_DEFLATE || 'OFF' }}
       OPENEXR_FORCE_INTERNAL_OPENJPH: ${{ matrix.OPENEXR_FORCE_INTERNAL_OPENJPH || 'OFF' }}
+      OPENEXR_CORE_USE_NAMESPACE: ${{ matrix.OPENEXR_CORE_USE_NAMESPACE || 'OFF' }}
       msystem: ${{ matrix.msystem }}
       BUILD_TESTING: ${{ matrix.BUILD_TESTING || 'ON' }}
       RUN_TESTING: ${{ matrix.RUN_TESTING || 'ON' }}
@@ -317,3 +330,7 @@ jobs:
             RUN_TESTING: OFF
             validate_install: OFF
 
+          - build: 12
+            label: OPENEXR_CORE_USE_NAMESPACE
+            OPENEXR_CORE_USE_NAMESPACE: ON
+            validate_install: OFF

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,6 +63,7 @@ expand_template(
         "@OPENEXR_VERSION_PATCH@": "0",
         "#cmakedefine OPENEXR_ENABLE_API_VISIBILITY": "#define OPENEXR_ENABLE_API_VISIBILITY",
         "#cmakedefine OPENEXR_HAVE_LARGE_STACK 1": "/* #undef OPENEXR_HAVE_LARGE_STACK */",
+        "#cmakedefine OPENEXR_CORE_USE_NAMESPACE @OPENEXR_CORE_USE_NAMESPACE@": "/* #undef OPENEXR_CORE_USE_NAMESPACE */",
     },
     template = "cmake/OpenEXRConfig.h.in",
 )

--- a/cmake/OpenEXRConfig.h.in
+++ b/cmake/OpenEXRConfig.h.in
@@ -63,6 +63,33 @@
 #define OPENEXR_IMF_NAMESPACE @OPENEXR_IMF_NAMESPACE@
 
 //
+// Option to build OpenEXRCore in a namespace using C++ instead of C
+//
+// All code in OpenEXRCore is bracketed by ENTER/EXIT pairs. Some of the code
+// needs 'extern "C" {' directives, but when compiling with C++, this must
+// revert to 'namespace OPENEXR_IMF_INTERNAL_NAMESPACE {'. In C, the NAMESPACE
+// ENTER/EXIT pairs degenerate to no-ops.
+//
+#cmakedefine OPENEXR_CORE_USE_NAMESPACE @OPENEXR_CORE_USE_NAMESPACE@
+#if __cplusplus
+#  ifdef OPENEXR_CORE_USE_NAMESPACE
+#    define OPENEXR_CORE_NAMESPACE_ENTER namespace OPENEXR_IMF_INTERNAL_NAMESPACE {
+#    define OPENEXR_CORE_NAMESPACE_EXIT }
+#    define OPENEXR_CORE_EXTERN_C_ENTER namespace OPENEXR_IMF_INTERNAL_NAMESPACE {
+#  else
+#    define OPENEXR_CORE_NAMESPACE_ENTER
+#    define OPENEXR_CORE_NAMESPACE_EXIT
+#    define OPENEXR_CORE_EXTERN_C_ENTER extern "C" {
+#  endif
+#  define OPENEXR_CORE_EXTERN_C_EXIT }
+#else
+#  define OPENEXR_CORE_NAMESPACE_ENTER 
+#  define OPENEXR_CORE_NAMESPACE_EXIT 
+#  define OPENEXR_CORE_EXTERN_C_ENTER
+#  define OPENEXR_CORE_EXTERN_C_EXIT
+#endif
+
+//
 // Version string for runtime access
 //
 

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -74,6 +74,8 @@ option(OPENEXR_BUILD_EXAMPLES "Build and install OpenEXR examples" ON)
 
 option(OPENEXR_BUILD_PYTHON "Build python bindings" OFF)
 
+option(OPENEXR_CORE_USE_NAMESPACE "Build the OpenEXRCore library using C++ in a namespace" OFF)
+
 option(OPENEXR_BUILD_OSS_FUZZ "Build the oss-fuzz fuzzers" OFF)
 if (OPENEXR_BUILD_OSS_FUZZ)
   # If building the oss-fuzz fuzzers, accept the comiler/options from

--- a/external/deflate/lib/adler32.c
+++ b/external/deflate/lib/adler32.c
@@ -158,5 +158,5 @@ libdeflate_adler32(u32 adler, const void *buffer, size_t len)
 {
 	if (buffer == NULL) /* Return initial value. */
 		return 1;
-	return adler32_impl(adler, buffer, len);
+	return adler32_impl(adler, (const u8*) buffer, len);
 }

--- a/external/deflate/lib/decompress_template.h
+++ b/external/deflate/lib/decompress_template.h
@@ -47,13 +47,13 @@ FUNCNAME(struct libdeflate_decompressor * restrict d,
 	 void * restrict out, size_t out_nbytes_avail,
 	 size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret)
 {
-	u8 *out_next = out;
+        u8 *out_next = (u8*) out;
 	u8 * const out_end = out_next + out_nbytes_avail;
 	u8 * const out_fastloop_end =
 		out_end - MIN(out_nbytes_avail, FASTLOOP_MAX_BYTES_WRITTEN);
 
 	/* Input bitstream state; see deflate_decompress.c for documentation */
-	const u8 *in_next = in;
+	const u8 *in_next = (const u8*) in;
 	const u8 * const in_end = in_next + in_nbytes;
 	const u8 * const in_fastloop_end =
 		in_end - MIN(in_nbytes, FASTLOOP_MAX_BYTES_READ);

--- a/external/deflate/lib/deflate_compress.c
+++ b/external/deflate/lib/deflate_compress.c
@@ -2988,6 +2988,9 @@ static const struct {
 	u8 len_sym_cost;
 } default_litlen_costs[] = {
 	{ /* match_prob = 0.25 */
+#ifndef __cplusplus
+		.used_lits_to_lit_cost = 
+#endif
 		{
 			6, 6, 22, 32, 38, 43, 48, 51,
 			54, 57, 59, 61, 64, 65, 67, 69,
@@ -3023,9 +3026,15 @@ static const struct {
 			133, 134, 134, 134, 134, 134, 134, 134,
 			134,
 		},
-		109,
+#ifndef __cplusplus
+		.len_sym_cost =
+#endif
+                109,
 	}, { /* match_prob = 0.5 */
-		{
+#ifndef __cplusplus
+		.used_lits_to_lit_cost =
+#endif
+                {
 			16, 16, 32, 41, 48, 53, 57, 60,
 			64, 66, 69, 71, 73, 75, 76, 78,
 			80, 81, 82, 83, 85, 86, 87, 88,
@@ -3060,9 +3069,15 @@ static const struct {
 			143, 143, 143, 143, 143, 143, 143, 143,
 			144,
 		},
-		93,
+#ifndef __cplusplus
+		.len_sym_cost =
+#endif
+                93,
 	}, { /* match_prob = 0.75 */
-		{
+#ifndef __cplusplus
+		.used_lits_to_lit_cost =
+#endif
+                {
 			32, 32, 48, 57, 64, 69, 73, 76,
 			80, 82, 85, 87, 89, 91, 92, 94,
 			96, 97, 98, 99, 101, 102, 103, 104,
@@ -3097,6 +3112,9 @@ static const struct {
 			159, 159, 159, 159, 159, 159, 159, 159,
 			160,
 		},
+#ifndef __cplusplus
+                .len_sym_cost =
+#endif
 		84,
 	},
 };
@@ -4015,9 +4033,10 @@ LIBDEFLATEAPI struct libdeflate_compressor *
 libdeflate_alloc_compressor(int compression_level)
 {
 	static const struct libdeflate_options defaults = {
-		sizeof(struct libdeflate_options),
-		NULL,
-		NULL
+#ifndef __cplusplus
+		.sizeof_options =
+#endif
+                sizeof(defaults), NULL, NULL
 	};
 	return libdeflate_alloc_compressor_ex(compression_level, &defaults);
 }

--- a/external/deflate/lib/deflate_decompress.c
+++ b/external/deflate/lib/deflate_decompress.c
@@ -1164,7 +1164,7 @@ libdeflate_alloc_decompressor_ex(const struct libdeflate_options *options)
 	if (options->sizeof_options != sizeof(*options))
 		return NULL;
 
-	d = (options->malloc_func ? options->malloc_func :
+	d = (struct libdeflate_decompressor *) (options->malloc_func ? options->malloc_func :
 	     libdeflate_default_malloc_func)(sizeof(*d));
 	if (d == NULL)
 		return NULL;
@@ -1195,7 +1195,9 @@ LIBDEFLATEAPI struct libdeflate_decompressor *
 libdeflate_alloc_decompressor(void)
 {
 	static const struct libdeflate_options defaults = {
-		.sizeof_options = sizeof(defaults),
+		sizeof(struct libdeflate_options),
+		NULL,
+		NULL
 	};
 	return libdeflate_alloc_decompressor_ex(&defaults);
 }

--- a/external/deflate/lib/x86/adler32_template.h
+++ b/external/deflate/lib/x86/adler32_template.h
@@ -63,8 +63,8 @@
 #  else
 #    define VDPBUSD(a, b, c)	_mm_dpbusd_avx_epi32((a), (b), (c))
 #  endif
-#  define VLOAD(p)		_mm_load_si128((const void *)(p))
-#  define VLOADU(p)		_mm_loadu_si128((const void *)(p))
+#  define VLOAD(p)		_mm_load_si128((const __m128i *)(p))
+#  define VLOADU(p)		_mm_loadu_si128((const __m128i *)(p))
 #  define VMADD16(a, b)		_mm_madd_epi16((a), (b))
 #  define VMASKZ_LOADU(mask, p) _mm_maskz_loadu_epi8((mask), (p))
 #  define VMULLO32(a, b)	_mm_mullo_epi32((a), (b))
@@ -87,8 +87,8 @@
 #  else
 #    define VDPBUSD(a, b, c)	_mm256_dpbusd_avx_epi32((a), (b), (c))
 #  endif
-#  define VLOAD(p)		_mm256_load_si256((const void *)(p))
-#  define VLOADU(p)		_mm256_loadu_si256((const void *)(p))
+#  define VLOAD(p)		_mm256_load_si256((const __m256i *)(p))
+#  define VLOADU(p)		_mm256_loadu_si256((const __m256i *)(p))
 #  define VMADD16(a, b)		_mm256_madd_epi16((a), (b))
 #  define VMASKZ_LOADU(mask, p) _mm256_maskz_loadu_epi8((mask), (p))
 #  define VMULLO32(a, b)	_mm256_mullo_epi32((a), (b))
@@ -107,8 +107,8 @@
 #  define VADD16(a, b)		_mm512_add_epi16((a), (b))
 #  define VADD32(a, b)		_mm512_add_epi32((a), (b))
 #  define VDPBUSD(a, b, c)	_mm512_dpbusd_epi32((a), (b), (c))
-#  define VLOAD(p)		_mm512_load_si512((const void *)(p))
-#  define VLOADU(p)		_mm512_loadu_si512((const void *)(p))
+#  define VLOAD(p)		_mm512_load_si512((const __m512i *)(p))
+#  define VLOADU(p)		_mm512_loadu_si512((const __m512i *)(p))
 #  define VMADD16(a, b)		_mm512_madd_epi16((a), (b))
 #  define VMASKZ_LOADU(mask, p) _mm512_maskz_loadu_epi8((mask), (p))
 #  define VMULLO32(a, b)	_mm512_mullo_epi32((a), (b))

--- a/external/deflate/lib/zlib_compress.c
+++ b/external/deflate/lib/zlib_compress.c
@@ -33,7 +33,7 @@ libdeflate_zlib_compress(struct libdeflate_compressor *c,
 			 const void *in, size_t in_nbytes,
 			 void *out, size_t out_nbytes_avail)
 {
-	u8 *out_next = out;
+        u8 *out_next = (u8*) out;
 	u16 hdr;
 	unsigned compression_level;
 	unsigned level_hint;

--- a/external/deflate/lib/zlib_decompress.c
+++ b/external/deflate/lib/zlib_decompress.c
@@ -35,7 +35,7 @@ libdeflate_zlib_decompress_ex(struct libdeflate_decompressor *d,
 			      size_t *actual_in_nbytes_ret,
 			      size_t *actual_out_nbytes_ret)
 {
-	const u8 *in_next = in;
+        const u8 *in_next = (const u8*) in;
 	const u8 * const in_end = in_next + in_nbytes;
 	u16 hdr;
 	size_t actual_in_nbytes;

--- a/src/bin/exrinfo/CMakeLists.txt
+++ b/src/bin/exrinfo/CMakeLists.txt
@@ -2,3 +2,7 @@
 # Copyright Contributors to the OpenEXR Project.
 
 add_openexr_bin_program(exrinfo SOURCES main.c)
+
+if (OPENEXR_CORE_USE_NAMESPACE)
+  set_source_files_properties(main.c PROPERTIES LANGUAGE CXX)
+endif()

--- a/src/bin/exrinfo/main.c
+++ b/src/bin/exrinfo/main.c
@@ -17,6 +17,10 @@
 
 #include <stdlib.h>
 
+#if __cplusplus
+using namespace OPENEXR_IMF_INTERNAL_NAMESPACE;
+#endif
+
 static void
 usage (FILE* stream, const char* argv0, int verbose)
 {

--- a/src/lib/OpenEXRCore/CMakeLists.txt
+++ b/src/lib/OpenEXRCore/CMakeLists.txt
@@ -110,6 +110,26 @@ openexr_define_library(OpenEXRCore
     Imath::Imath
   )
 
+if (OPENEXR_CORE_USE_NAMESPACE)
+  message(STATUS "Building OpenEXRCore as C++")
+  get_target_property(OPENEXR_CORE_SOURCES OpenEXRCore SOURCES)
+  list(FILTER OPENEXR_CORE_SOURCES INCLUDE REGEX "\\.c$")
+
+  # clang++ defaults to interpreting .c files as c code, for force
+  # language to c++ 
+  if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(core_compile_options "/TP")
+  else()
+    set(core_compile_options "-xc++")
+  endif()
+  set_source_files_properties(${OPENEXR_CORE_SOURCES} PROPERTIES
+    LANGUAGE CXX
+    COMPILE_OPTIONS ${core_compile_options}
+  )
+else()
+  message(STATUS "Building OpenEXRCore as C")
+endif()
+
 if (DEFINED EXR_DEFLATE_LIB)
   if (BUILD_SHARED_LIBS)
     target_link_libraries(OpenEXRCore PRIVATE ${EXR_DEFLATE_LIB})

--- a/src/lib/OpenEXRCore/attributes.c
+++ b/src/lib/OpenEXRCore/attributes.c
@@ -3,12 +3,15 @@
 ** Copyright Contributors to the OpenEXR Project.
 */
 
+#include "OpenEXRConfig.h"
 #include "internal_attr.h"
 
 #include "internal_constants.h"
 #include "internal_structs.h"
 
 #include <string.h>
+
+OPENEXR_CORE_NAMESPACE_ENTER
 
 struct _internal_exr_attr_map
 {
@@ -1131,3 +1134,6 @@ exr_attr_list_remove (
 
     return attr_destroy (ctxt, attr);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/backward_compatibility.h
+++ b/src/lib/OpenEXRCore/backward_compatibility.h
@@ -6,6 +6,8 @@
 #ifndef OPENEXR_BACKWARD_COMPATIBILITY_H
 #define OPENEXR_BACKWARD_COMPATIBILITY_H
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 struct _exr_context_initializer_v1
 {
     size_t                        size;
@@ -41,5 +43,7 @@ struct _exr_context_initializer_v2
     int                           zip_level;
     float                         dwa_quality;
 };
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_BACKWARD_COMPATIBILITY_H */

--- a/src/lib/OpenEXRCore/base.c
+++ b/src/lib/OpenEXRCore/base.c
@@ -7,6 +7,8 @@
 #include "openexr_errors.h"
 #include "openexr_version.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 void
@@ -210,3 +212,5 @@ exr_get_default_dwa_compression_quality (float* q)
 {
     if (q) *q = sDefaultDwaLevel;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/bytes.c
+++ b/src/lib/OpenEXRCore/bytes.c
@@ -10,6 +10,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 int
@@ -124,3 +126,5 @@ exr_attr_bytes_copy (
         src_ud->type_hint,
         src_ud->data);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/channel_list.c
+++ b/src/lib/OpenEXRCore/channel_list.c
@@ -10,6 +10,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -267,3 +269,5 @@ exr_attr_chlist_destroy (exr_context_t ctxt, exr_attr_chlist_t* clist)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -14,6 +14,8 @@
 #include <limits.h>
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t extract_chunk_table (
@@ -2408,3 +2410,5 @@ internal_validate_next_chunk (
     }
     return rv;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/coding.c
+++ b/src/lib/OpenEXRCore/coding.c
@@ -8,6 +8,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 exr_result_t
 internal_coding_fill_channel_info (
     exr_coding_channel_info_t** channels,
@@ -26,7 +28,7 @@ internal_coding_fill_channel_info (
     if (chans <= 5) { chanfill = builtinextras; }
     else
     {
-        chanfill = ctxt->alloc_fn (
+        chanfill = (exr_coding_channel_info_t*) ctxt->alloc_fn (
             (size_t) (chans) * sizeof (exr_coding_channel_info_t));
         if (chanfill == NULL)
             return ctxt->standard_error (ctxt, EXR_ERR_OUT_OF_MEMORY);
@@ -273,3 +275,5 @@ internal_decode_alloc_buffer (
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -42,6 +42,8 @@
 /* value Aras found to be better trade off of speed vs size */
 #define EXR_DEFAULT_ZLIB_COMPRESS_LEVEL 4
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 size_t
@@ -99,9 +101,9 @@ exr_compress_buffer (
 
 #ifdef EXR_USE_CONFIG_DEFLATE_STRUCT
     struct libdeflate_options opt = {
-        .sizeof_options = sizeof (struct libdeflate_options),
-        .malloc_func    = ctxt ? ctxt->alloc_fn : internal_exr_alloc,
-        .free_func      = ctxt ? ctxt->free_fn : internal_exr_free};
+        sizeof (struct libdeflate_options),
+        ctxt ? ctxt->alloc_fn : internal_exr_alloc,
+        ctxt ? ctxt->free_fn : internal_exr_free};
 
 #else
     libdeflate_set_memory_allocator (
@@ -155,9 +157,9 @@ exr_uncompress_buffer (
     size_t                          actual_in_bytes;
 #ifdef EXR_USE_CONFIG_DEFLATE_STRUCT
     struct libdeflate_options opt = {
-        .sizeof_options = sizeof (struct libdeflate_options),
-        .malloc_func    = ctxt ? ctxt->alloc_fn : internal_exr_alloc,
-        .free_func      = ctxt ? ctxt->free_fn : internal_exr_free};
+        sizeof (struct libdeflate_options),
+        ctxt ? ctxt->alloc_fn : internal_exr_alloc,
+        ctxt ? ctxt->free_fn : internal_exr_free};
 #endif
 
 //    if (in_bytes == out_bytes_avail)
@@ -221,7 +223,7 @@ exr_rle_compress_buffer (size_t in_bytes, const void* in, void* out, size_t out_
 size_t
 exr_rle_uncompress_buffer (size_t in_bytes, size_t max_len, const void* in, void* out)
 {
-    return internal_rle_decompress (out, max_len, in, in_bytes);
+    return internal_rle_decompress ((uint8_t*) out, max_len, (const uint8_t*) in, in_bytes);
 }
 
 /**************************************/
@@ -561,3 +563,5 @@ exr_uncompress_chunk (exr_decode_pipeline_t* decode)
     }
     return rv;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/context.c
+++ b/src/lib/OpenEXRCore/context.c
@@ -23,6 +23,8 @@
 #    include "internal_posix_file_impl.h"
 #endif
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -726,3 +728,5 @@ exr_write_header (exr_context_t ctxt)
 
     return EXR_UNLOCK_AND_RETURN (rv);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static void
@@ -74,7 +76,7 @@ print_attr (const exr_attribute_t* a, int verbose)
                 (double) a->chromaticities->white_y);
             break;
         case EXR_ATTR_COMPRESSION: {
-            static char* compressionnames[] = {
+            static const char* compressionnames[] = {
                 "none",
                 "rle",
                 "zips",
@@ -361,3 +363,5 @@ exr_print_context_info (exr_const_context_t ctxt, int verbose)
     if (ctxt->mode == EXR_CONTEXT_WRITE) internal_exr_unlock (ctxt);
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -41,7 +43,7 @@ update_pack_unpack_ptrs (exr_decode_pipeline_t* decode)
                 (void**) &(decode->sample_count_table),
                 &(decode->sample_count_alloc_size));
 
-            decode->sample_count_table = decode->packed_sample_count_table;
+            decode->sample_count_table = (int32_t*) decode->packed_sample_count_table;
             rv                         = EXR_ERR_SUCCESS;
         }
         else
@@ -726,3 +728,5 @@ exr_decoding_destroy (exr_const_context_t ctxt, exr_decode_pipeline_t* decode)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/encoding.c
+++ b/src/lib/OpenEXRCore/encoding.c
@@ -12,6 +12,8 @@
 
 #include "openexr_compression.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -416,3 +418,5 @@ exr_encoding_destroy (exr_const_context_t ctxt, exr_encode_pipeline_t* encode)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/float_vector.c
+++ b/src/lib/OpenEXRCore/float_vector.c
@@ -9,6 +9,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 /* allocates ram, but does not fill any data */
@@ -141,3 +143,5 @@ exr_attr_float_vector_destroy (exr_context_t ctxt, exr_attr_float_vector_t* fv)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_attr.h
+++ b/src/lib/OpenEXRCore/internal_attr.h
@@ -33,9 +33,7 @@
 #include "internal_string.h"
 #include "internal_string_vector.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+OPENEXR_CORE_EXTERN_C_ENTER
 
 int internal_exr_is_standard_type (const char* typen);
 
@@ -136,8 +134,6 @@ exr_result_t exr_attr_list_remove (
  * @}
  */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_INTERNAL_ATTR_H */

--- a/src/lib/OpenEXRCore/internal_b44.c
+++ b/src/lib/OpenEXRCore/internal_b44.c
@@ -11,6 +11,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 extern uint16_t* exrcore_expTable;
@@ -338,7 +340,7 @@ unpack3 (const uint8_t b[3], uint16_t s[16])
 static exr_result_t
 compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
 {
-    uint8_t*       out  = encode->compressed_buffer;
+    uint8_t*       out  = (uint8_t*) encode->compressed_buffer;
     uint64_t       nOut = 0;
     uint8_t *      scratch, *tmp;
     const uint8_t* packed;
@@ -357,12 +359,12 @@ compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
     exrcore_ensure_b44_tables ();
 
     nOut   = 0;
-    packed = encode->packed_buffer;
+    packed = (const uint8_t*) encode->packed_buffer;
     for (int y = 0; y < encode->chunk.height; ++y)
     {
         int cury = y + encode->chunk.start_y;
 
-        scratch = encode->scratch_buffer_1;
+        scratch = (uint8_t*) encode->scratch_buffer_1;
         for (int c = 0; c < encode->channel_count; ++c)
         {
             const exr_coding_channel_info_t* curc = encode->channels + c;
@@ -394,7 +396,7 @@ compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
     }
 
     nOut    = 0;
-    scratch = encode->scratch_buffer_1;
+    scratch = (uint8_t*) encode->scratch_buffer_1;
     for (int c = 0; c < encode->channel_count; ++c)
     {
         const exr_coding_channel_info_t* curc = encode->channels + c;
@@ -526,9 +528,9 @@ uncompress_b44_impl (
     void*                  uncompressed_data,
     uint64_t               uncomp_buf_size)
 {
-    const uint8_t* in      = compressed_data;
-    uint8_t*       out     = uncompressed_data;
-    uint8_t*       scratch = decode->scratch_buffer_1;
+    const uint8_t* in      = (const uint8_t*) compressed_data;
+    uint8_t*       out     = (uint8_t*) uncompressed_data;
+    uint8_t*       scratch = (uint8_t*) decode->scratch_buffer_1;
     uint8_t*       tmp;
     uint16_t *     row0, *row1, *row2, *row3;
     uint64_t       n, nBytes, bpl = 0, bIn = 0;
@@ -615,7 +617,7 @@ uncompress_b44_impl (
     {
         int cury = y + decode->chunk.start_y;
 
-        scratch = decode->scratch_buffer_1;
+        scratch = (uint8_t*) decode->scratch_buffer_1;
         for (int c = 0; c < decode->channel_count; ++c)
         {
             const exr_coding_channel_info_t* curc = decode->channels + c;
@@ -735,3 +737,5 @@ internal_exr_undo_b44a (
         uncompressed_data,
         uncompressed_size);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_b44_table.c
+++ b/src/lib/OpenEXRCore/internal_b44_table.c
@@ -5,6 +5,10 @@
 
 #include <stdint.h>
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 extern uint16_t* exrcore_expTable;
 extern uint16_t* exrcore_logTable;
 
@@ -13,3 +17,5 @@ uint16_t* exrcore_expTable = exrcore_expTable_data;
 
 static uint16_t exrcore_logTable_data[65536];
 uint16_t* exrcore_logTable = exrcore_logTable_data;
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_b44_table_init.c
+++ b/src/lib/OpenEXRCore/internal_b44_table_init.c
@@ -8,6 +8,8 @@
 #include "internal_coding.h"
 #include "internal_thread.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 extern uint16_t* exrcore_expTable;
 extern uint16_t* exrcore_logTable;
 
@@ -55,3 +57,5 @@ exrcore_ensure_b44_tables()
 {
     call_once (&b44_tables_once, init_b44_tables);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_bytes.h
+++ b/src/lib/OpenEXRCore/internal_bytes.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_BYTES_H
 #define OPENEXR_ATTR_BYTES_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -33,8 +33,6 @@ exr_attr_bytes_copy (
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_BYTES_H */

--- a/src/lib/OpenEXRCore/internal_channel_list.h
+++ b/src/lib/OpenEXRCore/internal_channel_list.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_CHLIST_H
 #define OPENEXR_ATTR_CHLIST_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -50,8 +50,6 @@ exr_result_t exr_attr_chlist_destroy (exr_context_t ctxt, exr_attr_chlist_t*);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_CHLIST_H */

--- a/src/lib/OpenEXRCore/internal_coding.h
+++ b/src/lib/OpenEXRCore/internal_coding.h
@@ -32,9 +32,7 @@
 
 #include <math.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+OPENEXR_CORE_EXTERN_C_ENTER
 
 typedef exr_result_t (*internal_exr_unpack_fn) (exr_decode_pipeline_t*);
 
@@ -297,8 +295,6 @@ uint_to_float_int (uint32_t ui)
     return v.i;
 }
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_UNPACK_H */

--- a/src/lib/OpenEXRCore/internal_compress.h
+++ b/src/lib/OpenEXRCore/internal_compress.h
@@ -8,6 +8,10 @@
 
 #include "openexr_encode.h"
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 uint64_t internal_rle_compress (
     void* out, uint64_t outbytes, const void* src, uint64_t srcbytes);
 
@@ -33,12 +37,12 @@ exr_result_t internal_exr_apply_dwaa (exr_encode_pipeline_t* encode);
 
 exr_result_t internal_exr_apply_dwab (exr_encode_pipeline_t* encode);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+OPENEXR_CORE_NAMESPACE_EXIT
+
+OPENEXR_CORE_EXTERN_C_ENTER
+
 exr_result_t internal_exr_apply_ht (exr_encode_pipeline_t* encode);
-#ifdef __cplusplus
-}
-#endif
+
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_COMPRESS_H */

--- a/src/lib/OpenEXRCore/internal_decompress.h
+++ b/src/lib/OpenEXRCore/internal_decompress.h
@@ -8,6 +8,10 @@
 
 #include "openexr_decode.h"
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /*
  * for uncompressing, we might be doing either the deep sample count
  * table or the actual pixel data so need to receive the destination
@@ -73,17 +77,17 @@ exr_result_t internal_exr_undo_dwab (
     void*                  uncompressed_data,
     uint64_t               uncompressed_size);
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+OPENEXR_CORE_NAMESPACE_EXIT
+
+OPENEXR_CORE_EXTERN_C_ENTER
+
 exr_result_t internal_exr_undo_ht (
     exr_decode_pipeline_t* decode,
     const void*            compressed_data,
     uint64_t               comp_buf_size,
     void*                  uncompressed_data,
     uint64_t               uncompressed_size);
-#ifdef __cplusplus
-}
-#endif
+
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_DECOMPRESS_H */

--- a/src/lib/OpenEXRCore/internal_dwa.c
+++ b/src/lib/OpenEXRCore/internal_dwa.c
@@ -120,6 +120,8 @@
 
 #include "internal_dwa_helpers.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -201,7 +203,7 @@ internal_exr_undo_dwaa (
         if (rv == EXR_ERR_SUCCESS)
             rv = DwaCompressor_uncompress (
                 &dwaa,
-                compressed_data,
+                (const uint8_t*) compressed_data,
                 comp_buf_size,
                 uncompressed_data,
                 uncompressed_size);
@@ -236,7 +238,7 @@ internal_exr_undo_dwab (
         if (rv == EXR_ERR_SUCCESS)
             rv = DwaCompressor_uncompress (
                 &dwab,
-                compressed_data,
+                (const uint8_t*) compressed_data,
                 comp_buf_size,
                 uncompressed_data,
                 uncompressed_size);
@@ -247,3 +249,5 @@ internal_exr_undo_dwab (
 
     return rv;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_dwa_channeldata.h
+++ b/src/lib/OpenEXRCore/internal_dwa_channeldata.h
@@ -9,9 +9,15 @@
 
 #ifdef _MSC_VER
 #    define EXR_DCT_ALIGN __declspec (align (_SSE_ALIGNMENT))
+#elif __cplusplus
+#    define EXR_DCT_ALIGN alignas (_SSE_ALIGNMENT)
 #else
 #    define EXR_DCT_ALIGN _Alignas (_SSE_ALIGNMENT)
 #endif
+
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
 
 /**************************************/
 
@@ -52,7 +58,7 @@ DctCoderChannelData_push_row (
     if (d->_size == d->_row_alloc_count)
     {
         size_t    nsize = d->_size == 0 ? 16 : ((d->_size * 3) / 2);
-        uint8_t** n     = alloc_fn (nsize * sizeof (uint8_t*));
+        uint8_t** n     = (uint8_t**) alloc_fn (nsize * sizeof (uint8_t*));
         if (n)
         {
             if (d->_rows)
@@ -140,3 +146,6 @@ CscPrefixMap_find (
 
     return mapl + idx;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/internal_dwa_classifier.h
+++ b/src/lib/OpenEXRCore/internal_dwa_classifier.h
@@ -7,6 +7,10 @@
 #    error "only include internal_dwa_helpers.h"
 #endif
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 typedef struct _Classifier
@@ -106,7 +110,7 @@ Classifier_read (
         // account for extra byte for nil terminator
         len += 1;
 
-        mem = alloc_fn (len);
+        mem = (char*) alloc_fn (len);
         if (!mem) return EXR_ERR_OUT_OF_MEMORY;
 
         memcpy (mem, suffix, len);
@@ -190,3 +194,6 @@ Classifier_find_suffix (const char* channel_name)
     else { suffix = channel_name; }
     return suffix;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/internal_dwa_decoder.h
+++ b/src/lib/OpenEXRCore/internal_dwa_decoder.h
@@ -7,6 +7,20 @@
 #    error "only include internal_dwa_helpers.h"
 #endif
 
+#include "OpenEXRConfig.h"
+
+#ifdef __cplusplus
+#  if defined(_MSC_VER)
+#    define OPENEXR_RESTRICT __restrict
+#  else
+#    define OPENEXR_RESTRICT __restrict__
+#  endif
+#else
+#define OPENEXR_RESTRICT restrict
+#endif
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 //
 // 'class' for the LOSSY_DCT decoder classes
 //
@@ -320,7 +334,7 @@ LossyDctDecoder_execute (
     // Allocate a temp aligned buffer to hold a rows worth of full
     // 8x8 half-float blocks
     //
-    rowBlockHandle = alloc_fn (
+    rowBlockHandle = (uint8_t*) alloc_fn (
         (size_t) numComp * (size_t) numBlocksX * 64 * sizeof (uint16_t) +
         _SSE_ALIGNMENT);
     if (!rowBlockHandle) return EXR_ERR_OUT_OF_MEMORY;
@@ -580,8 +594,8 @@ LossyDctDecoder_execute (
             {
                 for (int y = 8 * blocky; y < 8 * blocky + maxY; ++y)
                 {
-                    __m128i* restrict dst = (__m128i *) chanData[comp]->_rows[y];
-                    __m128i const * restrict src = (__m128i const *)&rowBlock[comp][(y & 0x7) * 8];
+                    __m128i* OPENEXR_RESTRICT dst = (__m128i *) chanData[comp]->_rows[y];
+                    __m128i const * OPENEXR_RESTRICT src = (__m128i const *)&rowBlock[comp][(y & 0x7) * 8];
 
                     for (int blockx = 0; blockx < numFullBlocksX; ++blockx)
                     {
@@ -635,8 +649,8 @@ LossyDctDecoder_execute (
                 // no-op conversion to linear
                 for (int y = 8 * blocky; y < 8 * blocky + maxY; ++y)
                 {
-                    __m128i* restrict dst = (__m128i *) chanData[comp]->_rows[y];
-                    __m128i const * restrict src = (__m128i const *)&rowBlock[comp][(y & 0x7) * 8];
+                    __m128i* OPENEXR_RESTRICT dst = (__m128i *) chanData[comp]->_rows[y];
+                    __m128i const * OPENEXR_RESTRICT src = (__m128i const *)&rowBlock[comp][(y & 0x7) * 8];
 
                     for (int blockx = 0; blockx < numFullBlocksX; ++blockx)
                     {
@@ -656,11 +670,11 @@ LossyDctDecoder_execute (
 
                 for (int y = 8 * blocky; y < 8 * blocky + maxY; ++y)
                 {
-                    uint16_t* restrict dst = (uint16_t*) chanData[comp]->_rows[y];
+                    uint16_t* OPENEXR_RESTRICT dst = (uint16_t*) chanData[comp]->_rows[y];
 
                     for (int blockx = 0; blockx < numFullBlocksX; ++blockx)
                     {
-                        uint16_t* restrict src =
+                        uint16_t* OPENEXR_RESTRICT src =
                             &rowBlock[comp][blockx * 64 + ((y & 0x7) * 8)];
 
                         dst[0] = d->_toLinear[src[0]];
@@ -757,4 +771,5 @@ LossyDctDecoder_execute (
     return EXR_ERR_SUCCESS;
 }
 
-/**************************************/
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/internal_dwa_encoder.h
+++ b/src/lib/OpenEXRCore/internal_dwa_encoder.h
@@ -45,6 +45,10 @@ static int __inline __builtin_clz(uint32_t v)
 #    endif
 #endif
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 //
 // Base 'class' for encoding using the lossy DCT scheme
 //
@@ -890,12 +894,22 @@ static uint16_t algoQuantize (
     return sign | handleQuantizeCloseExp (abssrc, tolSig, errTol, srcFloat);
 }
 
+#ifdef __cplusplus
+#  if defined(_MSC_VER)
+#    define OPENEXR_RESTRICT __restrict
+#  else
+#    define OPENEXR_RESTRICT __restrict__
+#  endif
+#else
+#define OPENEXR_RESTRICT restrict
+#endif
+
 static void
 quantizeCoeffAndZigXDR (
-    uint16_t* restrict    halfZigCoeff,
-    const float* restrict dctvals,
-    const float* restrict tolerances,
-    const uint16_t* restrict halftols)
+    uint16_t* OPENEXR_RESTRICT    halfZigCoeff,
+    const float* OPENEXR_RESTRICT dctvals,
+    const float* OPENEXR_RESTRICT tolerances,
+    const uint16_t* OPENEXR_RESTRICT halftols)
 {
     //static const int remap[] = {
     //    0,  1,  8,  16, 9,  2,  3,  10, 17, 24, 32, 25, 18, 11, 4,  5,
@@ -1044,8 +1058,8 @@ LossyDctEncoder_execute (
         for (int blockx = 0; blockx < numBlocksX; ++blockx)
         {
             uint16_t              h;
-            const float* restrict quantTable;
-            const uint16_t* restrict hquantTable;
+            const float* OPENEXR_RESTRICT quantTable;
+            const uint16_t* OPENEXR_RESTRICT hquantTable;
 
             for (int chan = 0; chan < numComp; ++chan)
             {
@@ -1244,3 +1258,6 @@ LossyDctEncoder_rleAc (LossyDctEncoder* e, uint16_t* block, uint16_t** acPtr)
     }
     *acPtr = curAC;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/internal_dwa_helpers.h
+++ b/src/lib/OpenEXRCore/internal_dwa_helpers.h
@@ -6,6 +6,10 @@
 #ifndef IMF_INTERNAL_DWA_HELPERS_H_HAS_BEEN_INCLUDED
 #define IMF_INTERNAL_DWA_HELPERS_H_HAS_BEEN_INCLUDED
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 extern uint16_t* exrcore_dwaToLinearTable;
 extern uint16_t* exrcore_dwaToNonLinearTable;
 extern void      exrcore_ensure_dwa_tables ();
@@ -58,6 +62,8 @@ std_max (size_t a, size_t b)
 {
     return a < b ? b : a;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #include "internal_dwa_simd.h"
 #include "internal_dwa_channeldata.h"

--- a/src/lib/OpenEXRCore/internal_dwa_simd.h
+++ b/src/lib/OpenEXRCore/internal_dwa_simd.h
@@ -68,6 +68,10 @@ __extension__ extern __inline float32x4x2_t
 }
 #endif
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 static inline uint8_t *simd_align_pointer (uint8_t* ptr)
 {
     return ptr +
@@ -788,8 +792,18 @@ fromHalfZigZag_f16c (uint16_t* src, float* dst)
 
 #ifdef IMF_HAVE_NEON_AARCH64
 
+#ifdef __cplusplus
+#  if defined(_MSC_VER)
+#    define OPENEXR_RESTRICT __restrict
+#  else
+#    define OPENEXR_RESTRICT __restrict__
+#  endif
+#else
+#define OPENEXR_RESTRICT restrict
+#endif
+
 void
-fromHalfZigZag_neon (uint16_t* __restrict__ src, float* __restrict__ dst)
+fromHalfZigZag_neon (uint16_t* OPENEXR_RESTRICT src, float* OPENEXR_RESTRICT dst)
 {
     uint8x16_t res_tbl[4] = {
         {0, 1, 5, 6, 14, 15, 27, 28, 2, 4, 7, 13, 16, 26, 29, 42},
@@ -2311,7 +2325,6 @@ static void
 initializeFuncs (void)
 {
     static int done = 0;
-    int        f16c = 0, avx = 0, sse2 = 0;
     if (done) return;
     done = 1;
 
@@ -2321,6 +2334,8 @@ initializeFuncs (void)
         fromHalfZigZag       = fromHalfZigZag_neon;
     }
 #else
+    int        f16c = 0, avx = 0, sse2 = 0;
+
     convertFloatToHalf64 = convertFloatToHalf64_scalar;
     fromHalfZigZag       = fromHalfZigZag_scalar;
 
@@ -2368,3 +2383,6 @@ initializeFuncs (void)
     }
 #endif
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT
+

--- a/src/lib/OpenEXRCore/internal_dwa_table.c
+++ b/src/lib/OpenEXRCore/internal_dwa_table.c
@@ -5,6 +5,10 @@
 
 #include <stdint.h>
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 extern uint16_t* exrcore_dwaToLinearTable;
 extern uint16_t* exrcore_dwaToNonLinearTable;
 
@@ -13,3 +17,5 @@ uint16_t* exrcore_dwaToLinearTable = exrcore_dwaToLinearTable_data;
 
 static uint16_t exrcore_dwaToNonLinearTable_data[65536];
 uint16_t* exrcore_dwaToNonLinearTable = exrcore_dwaToNonLinearTable_data;
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_dwa_table_init.c
+++ b/src/lib/OpenEXRCore/internal_dwa_table_init.c
@@ -8,6 +8,8 @@
 #include "internal_coding.h"
 #include "internal_thread.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 extern uint16_t* exrcore_dwaToLinearTable;
 extern uint16_t* exrcore_dwaToNonLinearTable;
 
@@ -106,3 +108,5 @@ exrcore_ensure_dwa_tables()
 {
     call_once (&dwa_tables_once, init_dwa_tables);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_file.h
+++ b/src/lib/OpenEXRCore/internal_file.h
@@ -8,6 +8,10 @@
 
 #include "internal_structs.h"
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 #define EXR_FILE_VERSION 2
 #define EXR_FILE_VERSION_MASK 0x000000FF
 #define EXR_TILED_FLAG 0x00000200
@@ -41,5 +45,7 @@ internal_exr_validate_shared_attrs (exr_context_t ctxt,
                                     int *mismatchcount);
 exr_result_t
 internal_exr_validate_write_part (exr_context_t ctxt, exr_priv_part_t curpart);
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_PRIVATE_FILE_UTIL_H */

--- a/src/lib/OpenEXRCore/internal_float_vector.h
+++ b/src/lib/OpenEXRCore/internal_float_vector.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_FLOAT_VECTOR_H
 #define OPENEXR_ATTR_FLOAT_VECTOR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -45,8 +45,6 @@ exr_attr_float_vector_destroy (exr_context_t ctxt, exr_attr_float_vector_t* fv);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_FLOAT_VECTOR_H */

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -18,6 +18,12 @@
 #include "openexr_encode.h"
 #include "internal_ht_common.h"
 
+#include "OpenEXRConfig.h"
+
+#ifdef OPENEXR_CORE_USE_NAMESPACE
+using namespace OPENEXR_IMF_INTERNAL_NAMESPACE;
+#endif
+
 /**
  * OpenJPH output file that is backed by a fixed-size memory buffer
  */
@@ -325,7 +331,9 @@ ht_undo_impl (
     return rv;
 }
 
-extern "C" exr_result_t
+OPENEXR_CORE_EXTERN_C_ENTER
+
+exr_result_t
 internal_exr_undo_ht (
     exr_decode_pipeline_t* decode,
     const void*            compressed_data,
@@ -345,6 +353,7 @@ internal_exr_undo_ht (
     return EXR_ERR_CORRUPT_CHUNK;
 }
 
+OPENEXR_CORE_EXTERN_C_EXIT
 
 ////////////////////////////////////////
 
@@ -526,7 +535,9 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
     return rv;
 }
 
-extern "C" exr_result_t
+OPENEXR_CORE_EXTERN_C_ENTER
+
+exr_result_t
 internal_exr_apply_ht (exr_encode_pipeline_t* encode)
 {
     try
@@ -539,3 +550,5 @@ internal_exr_apply_ht (exr_encode_pipeline_t* encode)
 
     return EXR_ERR_INCORRECT_CHUNK;
 }
+
+OPENEXR_CORE_EXTERN_C_EXIT

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -12,6 +12,8 @@
 #include <cctype>
 #include <stdexcept>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 struct RGBChannelParams
 {
     const char* r_suffix;
@@ -308,3 +310,5 @@ read_header (
 
     return length;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_ht_common.h
+++ b/src/lib/OpenEXRCore/internal_ht_common.h
@@ -10,6 +10,10 @@
 #include <stdlib.h>
 #include "openexr_coding.h"
 
+#include <OpenEXRConfig.h>
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 struct CodestreamChannelInfo
 {
     int    file_index;
@@ -30,5 +34,7 @@ size_t read_header (
     void*                               buffer,
     size_t                              max_sz,
     std::vector<CodestreamChannelInfo>& map);
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_PRIVATE_HT_COMMON_H */

--- a/src/lib/OpenEXRCore/internal_huf.c
+++ b/src/lib/OpenEXRCore/internal_huf.c
@@ -47,6 +47,8 @@
 #    define NO_ALIAS
 #endif
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 typedef struct _HufDec
 {
     int32_t   len;
@@ -1992,3 +1994,5 @@ internal_huf_decompress (
     }
     return rv;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_huf.h
+++ b/src/lib/OpenEXRCore/internal_huf.h
@@ -9,6 +9,10 @@
 #include "openexr_errors.h"
 #include "openexr_decode.h"
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 uint64_t internal_exr_huf_compress_spare_bytes (void);
 uint64_t internal_exr_huf_decompress_spare_bytes (void);
 
@@ -29,5 +33,7 @@ exr_result_t internal_huf_decompress (
     uint64_t               nRaw,
     void*                  spare,
     uint64_t               sparebytes);
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_CORE_HUF_CODING_H */

--- a/src/lib/OpenEXRCore/internal_memory.h
+++ b/src/lib/OpenEXRCore/internal_memory.h
@@ -8,8 +8,15 @@
 
 #include "openexr_base.h"
 
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
+
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__ ((malloc))
+#endif
+#if __cplusplus && defined(OPENEXR_CORE_USE_NAMESPACE)
+EXR_EXPORT
 #endif
 void*
 internal_exr_alloc (size_t bytes);
@@ -17,10 +24,18 @@ internal_exr_alloc (size_t bytes);
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__ ((malloc))
 #endif
+#if __cplusplus && defined(OPENEXR_CORE_USE_NAMESPACE)
+EXR_EXPORT
+#endif
 void*
 internal_exr_alloc_aligned (
     void* (*alloc_fn) (size_t), void** tofreeptr, size_t bytes, size_t align);
 
+#if __cplusplus && defined(OPENEXR_CORE_USE_NAMESPACE)
+EXR_EXPORT
+#endif
 void internal_exr_free (void* ptr);
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_PRIVATE_MEMORY_H */

--- a/src/lib/OpenEXRCore/internal_opaque.h
+++ b/src/lib/OpenEXRCore/internal_opaque.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_OPAQUE_H
 #define OPENEXR_ATTR_OPAQUE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -55,8 +55,6 @@ exr_result_t exr_attr_opaquedata_set_packed (
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_OPAQUE_H */

--- a/src/lib/OpenEXRCore/internal_posix_file_impl.h
+++ b/src/lib/OpenEXRCore/internal_posix_file_impl.h
@@ -43,13 +43,15 @@ struct _internal_exr_filehandle
 };
 #endif
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static void
 default_shutdown (exr_const_context_t c, void* userdata, int failed)
 {
     /* we will handle failure before here */
-    struct _internal_exr_filehandle* fh = userdata;
+    struct _internal_exr_filehandle* fh = (struct _internal_exr_filehandle*) userdata;
     if (fh)
     {
         if (fh->fd >= 0) close (fh->fd);
@@ -105,7 +107,7 @@ default_read_func (
     exr_stream_error_func_ptr_t error_cb)
 {
     int64_t                          rv, retsz = -1;
-    struct _internal_exr_filehandle* fh     = userdata;
+    struct _internal_exr_filehandle* fh     = (struct _internal_exr_filehandle*) userdata;
     int                              fd     = -1;
     char*                            curbuf = (char*) buffer;
     uint64_t                         readsz = sz;
@@ -219,7 +221,7 @@ default_write_func (
     exr_stream_error_func_ptr_t error_cb)
 {
     int64_t                          rv, retsz = -1;
-    struct _internal_exr_filehandle* fh      = userdata;
+    struct _internal_exr_filehandle* fh      = (struct _internal_exr_filehandle*) userdata;
     int                              fd      = -1;
     const uint8_t*                   curbuf  = (const uint8_t*) buffer;
     uint64_t                         writesz = sz;
@@ -328,7 +330,7 @@ static exr_result_t
 default_init_read_file (exr_context_t file)
 {
     int                              fd;
-    struct _internal_exr_filehandle* fh = file->user_data;
+    struct _internal_exr_filehandle* fh = (struct _internal_exr_filehandle*) file->user_data;
 
     fh->fd = -1;
 #if !CAN_USE_PREAD
@@ -364,7 +366,7 @@ static exr_result_t
 default_init_write_file (exr_context_t file)
 {
     int                              fd;
-    struct _internal_exr_filehandle* fh    = file->user_data;
+    struct _internal_exr_filehandle* fh    = (struct _internal_exr_filehandle*) file->user_data;
     const char*                      outfn = file->tmp_filename.str;
     if (outfn == NULL) outfn = file->filename.str;
 
@@ -405,7 +407,7 @@ static int64_t
 default_query_size_func (exr_const_context_t ctxt, void* userdata)
 {
     struct stat                      sbuf;
-    struct _internal_exr_filehandle* fh = userdata;
+    struct _internal_exr_filehandle* fh = (struct _internal_exr_filehandle*) userdata;
     int64_t                          sz = -1;
 
     if (fh->fd >= 0)
@@ -441,7 +443,7 @@ make_temp_filename (exr_context_t ret)
     if (newlen >= INT32_MAX)
         return ret->standard_error (ret, EXR_ERR_OUT_OF_MEMORY);
 
-    tmpname = ret->alloc_fn (newlen + 1);
+    tmpname = (char*) ret->alloc_fn (newlen + 1);
     if (tmpname)
     {
         const char* lastslash = strrchr (srcfile, '/');
@@ -476,3 +478,5 @@ make_temp_filename (exr_context_t ret)
             newlen + 1);
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_preview.h
+++ b/src/lib/OpenEXRCore/internal_preview.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_PREVIEW_H
 #define OPENEXR_ATTR_PREVIEW_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -54,8 +54,6 @@ exr_attr_preview_destroy (exr_context_t ctxt, exr_attr_preview_t* p);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_ATTR_PREVIEW_H */

--- a/src/lib/OpenEXRCore/internal_pxr24.c
+++ b/src/lib/OpenEXRCore/internal_pxr24.c
@@ -12,6 +12,9 @@
 #include <string.h>
 #include "openexr_compression.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
+
 /**************************************/
 
 static inline uint32_t
@@ -89,9 +92,9 @@ float_to_float24 (float f)
 static exr_result_t
 apply_pxr24_impl (exr_encode_pipeline_t* encode)
 {
-    uint8_t*       out    = encode->scratch_buffer_1;
+    uint8_t*       out    = (uint8_t*) encode->scratch_buffer_1;
     uint64_t       nOut   = 0;
-    const uint8_t* lastIn = encode->packed_buffer;
+    const uint8_t* lastIn = (const uint8_t*) encode->packed_buffer;
     size_t         compbufsz;
     exr_result_t   rv;
 
@@ -269,10 +272,10 @@ undo_pxr24_impl (
 {
     size_t         outSize;
     exr_result_t   rstat;
-    uint8_t*       out    = uncompressed_data;
+    uint8_t*       out    = (uint8_t*) uncompressed_data;
     uint64_t       nOut   = 0;
     uint64_t       nDec   = 0;
-    const uint8_t* lastIn = scratch_data;
+    const uint8_t* lastIn = (const uint8_t*) scratch_data;
 
     if (scratch_size < uncompressed_size) return EXR_ERR_INVALID_ARGUMENT;
 
@@ -425,3 +428,5 @@ internal_exr_undo_pxr24 (
         decode->scratch_buffer_1,
         decode->scratch_alloc_size_1);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_rle.c
+++ b/src/lib/OpenEXRCore/internal_rle.c
@@ -14,12 +14,14 @@
 #define MIN_RUN_LENGTH 3
 #define MAX_RUN_LENGTH 127
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 uint64_t
 internal_rle_compress (
     void* out, uint64_t outbytes, const void* src, uint64_t srcbytes)
 {
-    int8_t*       cbuf = out;
-    const int8_t* runs = src;
+    int8_t*       cbuf = (int8_t*) out;
+    const int8_t* runs = (const int8_t*) src;
     const int8_t* end  = runs + srcbytes;
     const int8_t* rune = runs + 1;
     uint64_t      outb = 0;
@@ -67,9 +69,9 @@ internal_rle_compress (
 static void
 reorder_and_predict (void* scratch, const void* packed, uint64_t packedbytes)
 {
-    int8_t*       t1   = scratch;
+    int8_t*       t1   = (int8_t*) scratch;
     int8_t*       t2   = t1 + (packedbytes + 1) / 2;
-    const int8_t* in   = packed;
+    const int8_t* in   = (const int8_t*) packed;
     const int8_t* stop = in + packedbytes;
     int           d, p;
 
@@ -79,7 +81,7 @@ reorder_and_predict (void* scratch, const void* packed, uint64_t packedbytes)
         if (in < stop) *(t2++) = *(in++);
     }
 
-    t1   = scratch;
+    t1   = (int8_t*) scratch;
     stop = t1 + packedbytes;
     p    = *(t1++);
     while (t1 < stop)
@@ -170,9 +172,9 @@ internal_rle_decompress (
 static void
 unpredict_and_reorder (void* out, void* scratch, uint64_t packedbytes)
 {
-    int8_t*       t1   = scratch;
+    int8_t*       t1   = (int8_t*) scratch;
     int8_t*       t2   = t1 + (packedbytes + 1) / 2;
-    int8_t*       s    = out;
+    int8_t*       s    = (int8_t*) out;
     const int8_t* stop = t1 + packedbytes;
 
     ++t1;
@@ -183,7 +185,7 @@ unpredict_and_reorder (void* out, void* scratch, uint64_t packedbytes)
         ++t1;
     }
 
-    t1   = scratch;
+    t1   = (int8_t*) scratch;
     stop = s + packedbytes;
     while (s < stop)
     {
@@ -218,7 +220,7 @@ internal_exr_undo_rle (
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     unpackb =
-        internal_rle_decompress (decode->scratch_buffer_1, outsz, src, packsz);
+        internal_rle_decompress ((uint8_t*)decode->scratch_buffer_1, outsz, (const uint8_t*) src, packsz);
     if (unpackb != outsz)
         return EXR_ERR_CORRUPT_CHUNK;
 
@@ -228,3 +230,5 @@ internal_exr_undo_rle (
 
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/internal_string.h
+++ b/src/lib/OpenEXRCore/internal_string.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_STRING_H
 #define OPENEXR_ATTR_STRING_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -69,8 +69,6 @@ exr_result_t exr_attr_string_destroy (exr_context_t ctxt, exr_attr_string_t* s);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_STRING_H */

--- a/src/lib/OpenEXRCore/internal_string_vector.h
+++ b/src/lib/OpenEXRCore/internal_string_vector.h
@@ -6,9 +6,9 @@
 #ifndef OPENEXR_ATTR_STRING_VECTOR_H
 #define OPENEXR_ATTR_STRING_VECTOR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** 
  * @addtogroup InternalAttributeFunctions
@@ -80,8 +80,6 @@ exr_result_t exr_attr_string_vector_add_entry (
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_STRING_VECTOR_H */

--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -186,6 +186,13 @@ internal_exr_destroy_parts (exr_context_t ctxt)
         if (cur != &(ctxt->first_part)) { dofree (cur); }
         else
         {
+            /*
+             * IMPORTANT: The following two initialization paths (C++ and C)
+             * must produce equivalent results. The struct _priv_exr_part_t
+             * should remain a POD type with all members defaulting to zero.
+             * If any member is added with a non-zero default, both branches
+             * must be updated accordingly. Any mismatch could lead to subtle bugs.
+             */
 #if __cplusplus
             struct _priv_exr_part_t nil;
             *cur = nil;

--- a/src/lib/OpenEXRCore/internal_structs.h
+++ b/src/lib/OpenEXRCore/internal_structs.h
@@ -11,6 +11,10 @@
 
 #if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
+#    ifdef NOMINMAX
+#      undef NOMINMAX
+#    endif
+#    define NOMINMAX
 #        include <windows.h>
 #        include <synchapi.h>
 #    else
@@ -54,6 +58,10 @@ using atomic_uintptr_t = std::atomic_uintptr_t;
 #    elif defined(_MSC_VER)
 /* msvc w/ c11 support is only very new, until we know what the preprocessor checks are, provide defaults */
 #        include <stdint.h>
+#    ifdef NOMINMAX
+#      undef NOMINMAX
+#    endif
+#    define NOMINMAX
 #        include <windows.h>
 typedef uintptr_t volatile atomic_uintptr_t;
 
@@ -87,6 +95,10 @@ atomic_compare_exchange_strong (
 #        error OS unimplemented support for atomics
 #    endif
 #endif
+
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_NAMESPACE_ENTER
 
 struct _priv_exr_part_t
 {
@@ -140,6 +152,97 @@ struct _priv_exr_part_t
     int32_t          chunk_count;
     uint64_t         chunk_table_offset;
     atomic_uintptr_t chunk_table;
+
+#if __cplusplus && defined(OPENEXR_CORE_USE_NAMESPACE)
+    // default constructor initialized all fields to 0
+    _priv_exr_part_t ()
+        : part_index (0)
+        , storage_mode (EXR_STORAGE_LAST_TYPE)
+        , attributes {}
+        , channels (nullptr)
+        , compression (nullptr)
+        , dataWindow (nullptr)
+        , displayWindow (nullptr)
+        , lineOrder (nullptr)
+        , pixelAspectRatio (nullptr)
+        , screenWindowCenter (nullptr)
+        , screenWindowWidth (nullptr)
+        , tiles (nullptr)
+        , name (nullptr)
+        , type (nullptr)
+        , version (nullptr)
+        , chunkCount (nullptr)
+        , maxSamplesPerPixel (nullptr)
+        , data_window {}
+        , display_window {}
+        , comp_type (EXR_COMPRESSION_LAST_TYPE)
+        , lineorder (EXR_LINEORDER_LAST_TYPE)
+        , zip_compression_level (0)
+        , dwa_compression_level (0.0f)
+        , num_tile_levels_x (0)
+        , num_tile_levels_y (0)
+        , tile_level_tile_count_x (nullptr)
+        , tile_level_tile_count_y (nullptr)
+        , tile_level_tile_size_x (nullptr)
+        , tile_level_tile_size_y (nullptr)
+        , unpacked_size_per_chunk (0)
+        , lines_per_chunk (0)
+        , chan_has_line_sampling (0)
+        , chunk_count (0)
+        , chunk_table_offset (0)
+        , chunk_table (0)
+    {
+    }
+    
+    _priv_exr_part_t (const _priv_exr_part_t& other)
+    {
+        *this = other;
+    }
+
+    // Copy assignment operator - properly handles the atomic member
+    _priv_exr_part_t& operator= (const _priv_exr_part_t& other)
+    {
+        if (this != &other)
+        {
+            part_index              = other.part_index;
+            storage_mode            = other.storage_mode;
+            attributes              = other.attributes;
+            channels                = other.channels;
+            compression             = other.compression;
+            dataWindow              = other.dataWindow;
+            displayWindow           = other.displayWindow;
+            lineOrder               = other.lineOrder;
+            pixelAspectRatio        = other.pixelAspectRatio;
+            screenWindowCenter      = other.screenWindowCenter;
+            screenWindowWidth       = other.screenWindowWidth;
+            tiles                   = other.tiles;
+            name                    = other.name;
+            type                    = other.type;
+            version                 = other.version;
+            chunkCount              = other.chunkCount;
+            maxSamplesPerPixel      = other.maxSamplesPerPixel;
+            data_window             = other.data_window;
+            display_window          = other.display_window;
+            comp_type               = other.comp_type;
+            lineorder               = other.lineorder;
+            zip_compression_level   = other.zip_compression_level;
+            dwa_compression_level   = other.dwa_compression_level;
+            num_tile_levels_x       = other.num_tile_levels_x;
+            num_tile_levels_y       = other.num_tile_levels_y;
+            tile_level_tile_count_x = other.tile_level_tile_count_x;
+            tile_level_tile_count_y = other.tile_level_tile_count_y;
+            tile_level_tile_size_x  = other.tile_level_tile_size_x;
+            tile_level_tile_size_y  = other.tile_level_tile_size_y;
+            unpacked_size_per_chunk = other.unpacked_size_per_chunk;
+            lines_per_chunk         = other.lines_per_chunk;
+            chan_has_line_sampling  = other.chan_has_line_sampling;
+            chunk_count             = other.chunk_count;
+            chunk_table_offset      = other.chunk_table_offset;
+            chunk_table.store (other.chunk_table.load ());
+        }
+        return *this;
+    }
+#endif
 };
 
 typedef struct _priv_exr_part_t*       exr_priv_part_t;
@@ -349,5 +452,7 @@ exr_result_t internal_exr_alloc_context (
     enum _INTERNAL_EXR_CONTEXT_MODE  mode,
     size_t                           extra_data);
 void internal_exr_destroy_context (exr_context_t ctxt);
+
+OPENEXR_CORE_NAMESPACE_EXIT
 
 #endif /* OPENEXR_PRIVATE_STRUCTS_H */

--- a/src/lib/OpenEXRCore/internal_thread.h
+++ b/src/lib/OpenEXRCore/internal_thread.h
@@ -12,6 +12,10 @@
 // pthread_once elsewhere, or a simple variable if threading is completely disabled.
 #if ILMTHREAD_THREADING_ENABLED
 #    ifdef _WIN32
+#    ifdef NOMINMAX
+#      undef NOMINMAX
+#    endif
+#    define NOMINMAX
 #        include <windows.h>
 #        define ONCE_FLAG_INIT INIT_ONCE_STATIC_INIT
 typedef INIT_ONCE once_flag;

--- a/src/lib/OpenEXRCore/internal_xdr.h
+++ b/src/lib/OpenEXRCore/internal_xdr.h
@@ -19,6 +19,10 @@
 #elif defined(_WIN32) || defined(_WIN64)
 
 #    include <stdlib.h>
+#    ifdef NOMINMAX
+#      undef NOMINMAX
+#    endif
+#    define NOMINMAX
 #    include <windows.h>
 #    define EXR_HOST_IS_NOT_LITTLE_ENDIAN (BYTE_ORDER != LITTLE_ENDIAN)
 #    if EXR_HOST_IS_NOT_LITTLE_ENDIAN

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -15,6 +15,8 @@
 
 #include "openexr_compression.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 #if defined __SSE2__ || (_MSC_VER >= 1300 && (_M_IX86 || _M_X64))
 #    define IMF_HAVE_SSE2 1
 #    include <emmintrin.h>
@@ -301,8 +303,7 @@ undo_zip_impl (
         if (comp_buf_size > actual_out_bytes || actual_out_bytes > uncompressed_size)
             res = EXR_ERR_CORRUPT_CHUNK;
         else
-            internal_zip_reconstruct_bytes (
-                uncompressed_data, scratch_data, actual_out_bytes);
+            internal_zip_reconstruct_bytes ((uint8_t*) uncompressed_data, (uint8_t*) scratch_data, actual_out_bytes);
     }
 
     return res;
@@ -361,7 +362,7 @@ apply_zip_impl (exr_encode_pipeline_t* encode)
     if (rv != EXR_ERR_SUCCESS) return rv;
 
     internal_zip_deconstruct_bytes (
-        encode->scratch_buffer_1, encode->packed_buffer, encode->packed_bytes);
+                                    (uint8_t*) encode->scratch_buffer_1, (const uint8_t*) encode->packed_buffer, encode->packed_bytes);
 
     rv = exr_compress_buffer (
         encode->context,
@@ -427,3 +428,5 @@ internal_exr_apply_zip (exr_encode_pipeline_t* encode)
 
     return apply_zip_impl (encode);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/memory.c
+++ b/src/lib/OpenEXRCore/memory.c
@@ -6,11 +6,17 @@
 #include "internal_memory.h"
 
 #ifdef _WIN32
+#    ifdef NOMINMAX
+#      undef NOMINMAX
+#    endif
+#    define NOMINMAX
 #    include <windows.h>
 #else
 #    include <stdlib.h>
 #endif
 #include <inttypes.h>
+
+OPENEXR_CORE_NAMESPACE_ENTER
 
 /**************************************/
 
@@ -77,3 +83,5 @@ internal_exr_free (void* ptr)
 #endif
     }
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/opaque.c
+++ b/src/lib/OpenEXRCore/opaque.c
@@ -10,6 +10,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 int
@@ -314,3 +316,5 @@ exr_attr_opaquedata_set_packed (
 
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/openexr_attr.h
+++ b/src/lib/OpenEXRCore/openexr_attr.h
@@ -11,9 +11,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -514,8 +514,6 @@ typedef struct
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ATTR_H */

--- a/src/lib/OpenEXRCore/openexr_base.h
+++ b/src/lib/OpenEXRCore/openexr_base.h
@@ -10,9 +10,9 @@
 
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -194,8 +194,6 @@ EXR_EXPORT void exr_set_default_memory_routines (
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_BASE_H */

--- a/src/lib/OpenEXRCore/openexr_chunkio.h
+++ b/src/lib/OpenEXRCore/openexr_chunkio.h
@@ -10,9 +10,9 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -188,8 +188,6 @@ exr_result_t exr_write_deep_tile_chunk (
     const void*   sample_data,
     uint64_t      sample_data_size);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_CHUNKIO_H */

--- a/src/lib/OpenEXRCore/openexr_coding.h
+++ b/src/lib/OpenEXRCore/openexr_coding.h
@@ -8,9 +8,9 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -134,8 +134,6 @@ typedef struct
     };
 } exr_coding_channel_info_t;
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_CODING_H */

--- a/src/lib/OpenEXRCore/openexr_compression.h
+++ b/src/lib/OpenEXRCore/openexr_compression.h
@@ -13,9 +13,9 @@
 
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -104,8 +104,6 @@ exr_result_t exr_compress_chunk (exr_encode_pipeline_t *encode_state);
 EXR_EXPORT
 exr_result_t exr_uncompress_chunk (exr_decode_pipeline_t *decode_state);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_COMPRESSION_H */

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -13,9 +13,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -581,8 +581,6 @@ EXR_EXPORT exr_result_t exr_write_header (exr_context_t ctxt);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CONTEXT_H */

--- a/src/lib/OpenEXRCore/openexr_debug.h
+++ b/src/lib/OpenEXRCore/openexr_debug.h
@@ -8,9 +8,9 @@
 
 #include "openexr_context.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -20,8 +20,6 @@ extern "C" {
 EXR_EXPORT exr_result_t
 exr_print_context_info (exr_const_context_t c, int verbose);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_DEBUG_H */

--- a/src/lib/OpenEXRCore/openexr_decode.h
+++ b/src/lib/OpenEXRCore/openexr_decode.h
@@ -9,9 +9,9 @@
 #include "openexr_chunkio.h"
 #include "openexr_coding.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -327,8 +327,6 @@ EXR_EXPORT
 exr_result_t
 exr_decoding_destroy (exr_const_context_t ctxt, exr_decode_pipeline_t* decode);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_DECODE_H */

--- a/src/lib/OpenEXRCore/openexr_encode.h
+++ b/src/lib/OpenEXRCore/openexr_encode.h
@@ -9,9 +9,9 @@
 #include "openexr_chunkio.h"
 #include "openexr_coding.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -343,8 +343,6 @@ EXR_EXPORT
 exr_result_t exr_encoding_destroy (
     exr_const_context_t ctxt, exr_encode_pipeline_t* encode_pipe);
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_ENCODE_H */

--- a/src/lib/OpenEXRCore/openexr_errors.h
+++ b/src/lib/OpenEXRCore/openexr_errors.h
@@ -10,9 +10,9 @@
 
 #include <stdint.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -83,8 +83,6 @@ EXR_EXPORT const char* exr_get_error_code_as_string (exr_result_t code);
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_ERRORS_H */

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -10,9 +10,9 @@
 
 #include "openexr_attr.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -856,8 +856,6 @@ EXR_EXPORT exr_result_t exr_attr_set_user (
 
 /** @} */ /* part group */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_PART_H */

--- a/src/lib/OpenEXRCore/openexr_std_attr.h
+++ b/src/lib/OpenEXRCore/openexr_std_attr.h
@@ -8,9 +8,9 @@
 
 #include "openexr_attr.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "OpenEXRConfig.h"
+
+OPENEXR_CORE_EXTERN_C_ENTER
 
 /** @file */
 
@@ -52,8 +52,6 @@ originalDataWindow
 
 /** @} */
 
-#ifdef __cplusplus
-} /* extern "C" */
-#endif
+OPENEXR_CORE_EXTERN_C_EXIT
 
 #endif /* OPENEXR_CORE_STD_ATTR_H */

--- a/src/lib/OpenEXRCore/pack.c
+++ b/src/lib/OpenEXRCore/pack.c
@@ -8,6 +8,8 @@
 #include "internal_coding.h"
 #include "internal_xdr.h"
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -20,7 +22,7 @@ default_pack_deep (exr_encode_pipeline_t* encode)
 static exr_result_t
 default_pack (exr_encode_pipeline_t* encode)
 {
-    uint8_t*       dstbuffer = encode->packed_buffer;
+    uint8_t*       dstbuffer = (uint8_t*) encode->packed_buffer;
     const uint8_t* cdata;
     int            w, bpc, pixincrement;
     uint64_t       packed_bytes = 0;
@@ -195,3 +197,5 @@ internal_exr_match_encode (exr_encode_pipeline_t* encode, int isdeep)
 
     return &default_pack;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -84,7 +86,7 @@ scratch_attr_too_big (struct _internal_exr_seq_scratch* scr, int32_t attrsz)
 static exr_result_t
 scratch_seq_read (struct _internal_exr_seq_scratch* scr, void* buf, uint64_t sz)
 {
-    uint8_t*     outbuf  = buf;
+    uint8_t*     outbuf  = (uint8_t*) buf;
     uint64_t     nCopied = 0;
     uint64_t     notdone = sz;
     exr_result_t rv      = -1;
@@ -244,7 +246,7 @@ priv_init_scratch (
     scr->sequential_read = &scratch_seq_read;
     scr->sequential_skip = &scratch_seq_skip;
     scr->ctxt            = ctxt;
-    scr->scratch         = ctxt->alloc_fn (SCRATCH_BUFFER_SIZE);
+    scr->scratch         = (uint8_t*) ctxt->alloc_fn (SCRATCH_BUFFER_SIZE);
     if (scr->scratch == NULL)
         return ctxt->standard_error (ctxt, EXR_ERR_OUT_OF_MEMORY);
     return EXR_ERR_SUCCESS;
@@ -409,7 +411,7 @@ extract_attr_chlist (
             chname,
             chlen,
             (exr_pixel_type_t) ptype,
-            flags[0],
+            (exr_perceptual_treatment_t) flags[0],
             xsamp,
             ysamp);
     }
@@ -638,7 +640,7 @@ extract_attr_string_vector (
 
         if (nalloced == 0)
         {
-            clist = ctxt->alloc_fn (4 * sizeof (exr_attr_string_t));
+            clist = (exr_attr_string_t*) ctxt->alloc_fn (4 * sizeof (exr_attr_string_t));
             if (clist == NULL)
             {
                 rv = ctxt->standard_error (ctxt, EXR_ERR_OUT_OF_MEMORY);
@@ -649,7 +651,7 @@ extract_attr_string_vector (
         if ((nstr + 1) >= nalloced)
         {
             nalloced *= 2;
-            nlist = ctxt->alloc_fn (
+            nlist = (exr_attr_string_t*) ctxt->alloc_fn (
                 (size_t) (nalloced) * sizeof (exr_attr_string_t));
             if (nlist == NULL)
             {
@@ -1259,7 +1261,7 @@ check_populate_lineOrder (
          * that behavior (barring other failure)
          */
         curpart->lineOrder->uc = data;
-        curpart->lineorder     = data;
+        curpart->lineorder     = (exr_lineorder_t) data;
         return EXR_ERR_SUCCESS;
     }
 
@@ -1279,7 +1281,7 @@ check_populate_lineOrder (
             EXR_REQ_LO_STR);
 
     curpart->lineOrder->uc = data;
-    curpart->lineorder     = data;
+    curpart->lineorder     = (exr_lineorder_t) data;
     return rv;
 }
 
@@ -2894,3 +2896,5 @@ internal_exr_parse_header (exr_context_t ctxt)
     priv_destroy_scratch (&scratch);
     return internal_exr_context_restore_handlers (ctxt, rv);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -11,6 +11,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -629,3 +631,5 @@ exr_set_dwa_compression_level (exr_context_t ctxt, int part_index, float level)
 
     return EXR_UNLOCK_AND_RETURN (rv);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -19,12 +19,12 @@ OPENEXR_CORE_NAMESPACE_ENTER
 
 #ifdef _MSC_VER
 #    ifdef __cplusplus
-#        define EXR_CAST_TO_TYPE_OF(x) (decltype(x))
+#        define EXR_CAST_TO_TYPE_OF(t, x) (decltype(t))(x)
 #    else
-#        define EXR_CAST_TO_TYPE_OF(x) 
+#        define EXR_CAST_TO_TYPE_OF(t, x) (x)
 #    endif
 #else
-#    define EXR_CAST_TO_TYPE_OF(x) (__typeof__(x))
+#    define EXR_CAST_TO_TYPE_OF(t, x) (__typeof__(t))(x)
 #endif
 
 /**************************************/
@@ -1161,7 +1161,7 @@ exr_set_chunk_count (exr_context_t ctxt, int part_index, int32_t val)
     if (!out)                                                                  \
         return EXR_UNLOCK_WRITE_AND_RETURN (ctxt->print_error (                \
             ctxt, EXR_ERR_INVALID_ARGUMENT, "NULL output for '%s'", name));    \
-    *out = EXR_CAST_TO_TYPE_OF(*out) attr->entry;                                     \
+    *out = EXR_CAST_TO_TYPE_OF(*out, attr->entry);                             \
     return EXR_UNLOCK_WRITE_AND_RETURN (rv)
 
 #define ATTR_GET_IMPL_DEREF(t, entry)                                          \

--- a/src/lib/OpenEXRCore/preview.c
+++ b/src/lib/OpenEXRCore/preview.c
@@ -9,6 +9,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -85,3 +87,5 @@ exr_attr_preview_destroy (exr_context_t ctxt, exr_attr_preview_t* p)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/string.c
+++ b/src/lib/OpenEXRCore/string.c
@@ -10,6 +10,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -267,3 +269,5 @@ exr_attr_string_destroy (exr_context_t ctxt, exr_attr_string_t* s)
     }
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/string_vector.c
+++ b/src/lib/OpenEXRCore/string_vector.c
@@ -9,6 +9,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 exr_result_t
@@ -244,3 +246,5 @@ exr_attr_string_vector_add_entry (
     if (s) len = (int32_t) strlen (s);
     return exr_attr_string_vector_add_entry_with_length (ctxt, sv, s, len);
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -11,6 +11,8 @@
 
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 /* TODO: learn arm neon intrinsics for this */
@@ -216,7 +218,7 @@ static exr_result_t
 unpack_16bit_3chan_interleave (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t*        out0;
     int             w, h;
@@ -262,7 +264,7 @@ static exr_result_t
 unpack_16bit_3chan_interleave_rev (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t*        out0;
     int             w, h;
@@ -308,7 +310,7 @@ static exr_result_t
 unpack_half_to_float_3chan_interleave (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t*        out0;
     int             w, h;
@@ -354,7 +356,7 @@ static exr_result_t
 unpack_half_to_float_3chan_interleave_rev (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t*        out0;
     int             w, h;
@@ -400,7 +402,7 @@ static exr_result_t
 unpack_16bit_3chan_planar (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t *       out0, *out1, *out2;
     int             w, h;
@@ -456,7 +458,7 @@ static exr_result_t
 unpack_half_to_float_3chan_planar (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t *       out0, *out1, *out2;
     int             w, h;
@@ -504,7 +506,7 @@ static exr_result_t
 unpack_16bit_3chan (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2;
     uint8_t *       out0, *out1, *out2;
     int             w, h;
@@ -556,7 +558,7 @@ static exr_result_t
 unpack_16bit_4chan_interleave (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t*        out0;
     int             w, h;
@@ -615,7 +617,7 @@ static exr_result_t
 unpack_16bit_4chan_interleave_rev (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t*        out0;
     int             w, h;
@@ -674,7 +676,7 @@ static exr_result_t
 unpack_half_to_float_4chan_interleave (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t*        out0;
     int             w, h;
@@ -721,7 +723,7 @@ static exr_result_t
 unpack_half_to_float_4chan_interleave_rev (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t*        out0;
     int             w, h;
@@ -768,7 +770,7 @@ static exr_result_t
 unpack_16bit_4chan_planar (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t *       out0, *out1, *out2, *out3;
     int             w, h;
@@ -830,7 +832,7 @@ static exr_result_t
 unpack_half_to_float_4chan_planar (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t *       out0, *out1, *out2, *out3;
     int             w, h;
@@ -882,7 +884,7 @@ static exr_result_t
 unpack_16bit_4chan (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t*  srcbuffer = decode->unpacked_buffer;
+    const uint8_t*  srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     const uint16_t *in0, *in1, *in2, *in3;
     uint8_t *       out0, *out1, *out2, *out3;
     int             w, h;
@@ -940,7 +942,7 @@ static exr_result_t
 unpack_16bit (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t* srcbuffer = decode->unpacked_buffer;
+    const uint8_t* srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     uint8_t*       cdata;
     int            w, h, pixincrement;
 
@@ -1014,7 +1016,7 @@ static exr_result_t
 unpack_32bit (exr_decode_pipeline_t* decode)
 {
     /* we know we're unpacking all the channels and there is no subsampling */
-    const uint8_t* srcbuffer = decode->unpacked_buffer;
+    const uint8_t* srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     uint8_t*       cdata;
     int64_t        w, h, pixincrement;
     int            chans = decode->channel_count;
@@ -1232,7 +1234,7 @@ unpack_32bit (exr_decode_pipeline_t* decode)
 static exr_result_t
 generic_unpack (exr_decode_pipeline_t* decode)
 {
-    const uint8_t* srcbuffer = decode->unpacked_buffer;
+    const uint8_t* srcbuffer = (const uint8_t*) decode->unpacked_buffer;
     uint8_t*       cdata;
     int            w, h, bpc, ubpc, uls;
 
@@ -1302,7 +1304,7 @@ generic_unpack (exr_decode_pipeline_t* decode)
 static exr_result_t
 generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
 {
-    const uint8_t* srcbuffer  = decode->unpacked_buffer;
+    const uint8_t* srcbuffer  = (const uint8_t*) decode->unpacked_buffer;
     const int32_t* sampbuffer = decode->sample_count_table;
     void**         pdata;
     int            w, h, bpc, ubpc, uls;
@@ -1355,7 +1357,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_HALF_TO_HALF_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1370,7 +1372,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_HALF_TO_FLOAT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1385,7 +1387,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_HALF_TO_UINT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1406,7 +1408,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_FLOAT_TO_HALF_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1421,7 +1423,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_FLOAT_TO_FLOAT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1436,7 +1438,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_FLOAT_TO_UINT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1457,7 +1459,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_UINT_TO_HALF_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1472,7 +1474,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_UINT_TO_FLOAT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1487,7 +1489,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
                                 pdata += pixstride;
                                 if (outpix)
                                 {
-                                    uint8_t* cdata = outpix;
+                                    uint8_t* cdata = (uint8_t*) outpix;
                                     UNPACK_UINT_TO_UINT_SAMPLES(samps)
                                 }
                                 srcbuffer += ((size_t) bpc) * ((size_t) samps);
@@ -1508,7 +1510,7 @@ generic_unpack_deep_pointers (exr_decode_pipeline_t* decode)
 static exr_result_t
 generic_unpack_deep (exr_decode_pipeline_t* decode)
 {
-    const uint8_t* srcbuffer  = decode->unpacked_buffer;
+    const uint8_t* srcbuffer  = (uint8_t*) decode->unpacked_buffer;
     const int32_t* sampbuffer = decode->sample_count_table;
     uint8_t*       cdata;
     int            w, h, bpc, ubpc, uls;
@@ -1803,3 +1805,5 @@ internal_exr_match_decode (
 
     return &generic_unpack;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/validation.c
+++ b/src/lib/OpenEXRCore/validation.c
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -55,7 +57,11 @@ validate_req_attr (exr_context_t f, exr_priv_part_t curpart, int adddefault)
     {
         if (adddefault)
         {
-            exr_attr_box2i_t defdw = {{.x = 0, .y = 0}, {.x = 63, .y = 63}};
+            exr_attr_box2i_t defdw;
+            defdw.min.x = 0;
+            defdw.min.y = 0;
+            defdw.max.x = 63;
+            defdw.max.y = 63;
             rv                     = exr_attr_list_add_static_name (
                 (exr_context_t) f,
                 &(curpart->attributes),
@@ -88,7 +94,11 @@ validate_req_attr (exr_context_t f, exr_priv_part_t curpart, int adddefault)
     {
         if (adddefault)
         {
-            exr_attr_box2i_t defdw = {{.x = 0, .y = 0}, {.x = 63, .y = 63}};
+            exr_attr_box2i_t defdw;
+            defdw.min.x = 0;
+            defdw.min.y = 0;
+            defdw.max.x = 63;
+            defdw.max.y = 63;
             rv                     = exr_attr_list_add_static_name (
                 (exr_context_t) f,
                 &(curpart->attributes),
@@ -176,7 +186,9 @@ validate_req_attr (exr_context_t f, exr_priv_part_t curpart, int adddefault)
     {
         if (adddefault)
         {
-            exr_attr_v2f_t defswc = {.x = 0.f, .y = 0.f};
+            exr_attr_v2f_t defswc;
+            defswc.x = 0.f;
+            defswc.y = 0.f;
             rv                    = exr_attr_list_add_static_name (
                 (exr_context_t) f,
                 &(curpart->attributes),
@@ -861,3 +873,5 @@ internal_exr_validate_write_part (exr_context_t f, exr_priv_part_t curpart)
 
     return EXR_ERR_SUCCESS;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/lib/OpenEXRCore/write_header.c
+++ b/src/lib/OpenEXRCore/write_header.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+OPENEXR_CORE_NAMESPACE_ENTER
+
 /**************************************/
 
 static exr_result_t
@@ -265,7 +267,7 @@ save_float_vector (exr_context_t ctxt, const exr_attribute_t* a)
         else
         {
             /* might be static data, take a copy first */
-            float* tmp = ctxt->alloc_fn (
+            float* tmp = (float*) ctxt->alloc_fn (
                 (size_t) (a->floatvector->length) * sizeof (float));
             if (tmp == NULL)
                 return ctxt->standard_error (ctxt, EXR_ERR_OUT_OF_MEMORY);
@@ -761,3 +763,5 @@ internal_exr_write_header (exr_context_t ctxt)
 
     return rv;
 }
+
+OPENEXR_CORE_NAMESPACE_EXIT

--- a/src/test/OpenEXRCoreTest/base_units.cpp
+++ b/src/test/OpenEXRCoreTest/base_units.cpp
@@ -26,6 +26,8 @@
 #include "../../lib/OpenEXRCore/openexr_context.h"
 #include "../../lib/OpenEXRCore/openexr_part.h"
 
+using namespace OPENEXR_IMF_NAMESPACE;
+
 void
 testBase (const std::string& tempdir)
 {

--- a/src/test/OpenEXRCoreTest/buffer.cpp
+++ b/src/test/OpenEXRCoreTest/buffer.cpp
@@ -11,8 +11,12 @@
 
 #include <openexr.h>
 
+#include <ImfNamespace.h>
+
 #include "test_value.h"
 #include <vector>
+
+using namespace OPENEXR_IMF_NAMESPACE;
 
 void
 testBufferCompression (const std::string& tempdir)

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -37,6 +37,7 @@
 #include <ImfTiledOutputFile.h>
 #include <half.h>
 
+#include <ImfNamespace.h>
 #include "internal_ht_common.cpp"
 
 #ifdef __linux
@@ -146,8 +147,7 @@ internal_exr_free (void* p)
 #endif
 
 using namespace IMATH_NAMESPACE;
-namespace IMF = OPENEXR_IMF_NAMESPACE;
-using namespace IMF;
+using namespace OPENEXR_IMF_NAMESPACE;
 
 #if (IMATH_VERSION_MAJOR < 3) ||                                               \
     (IMATH_VERSION_MAJOR == 3 && IMATH_VERSION_MINOR < 1)
@@ -1074,21 +1074,21 @@ saveCPP (
         (Box2i (V2i (0, 0), V2i (fw - 1, fh - 1))),
         (Box2i (V2i (dwx, dwy), V2i (dwx + fw - 1, dwy + fh - 1))));
 
-    hdr.compression ()         = (IMF::Compression) ((int) comp);
+    hdr.compression ()         = (OPENEXR_IMF_NAMESPACE::Compression) ((int) comp);
     hdr.zipCompressionLevel () = 4;
     EXRCORE_TEST (((const Header&) hdr).zipCompressionLevel () == 4);
 
-    hdr.channels ().insert ("I", Channel (IMF::UINT, xs, ys));
+    hdr.channels ().insert ("I", Channel (OPENEXR_IMF_NAMESPACE::UINT, xs, ys));
     for (int c = 0; c < 5; ++c)
-        hdr.channels ().insert (channels[c], Channel (IMF::HALF, xs, ys));
-    hdr.channels ().insert ("F", Channel (IMF::FLOAT, xs, ys));
+        hdr.channels ().insert (channels[c], Channel (OPENEXR_IMF_NAMESPACE::HALF, xs, ys));
+    hdr.channels ().insert ("F", Channel (OPENEXR_IMF_NAMESPACE::FLOAT, xs, ys));
     {
         FrameBuffer fb;
         V2i         origin{dwx, dwy};
         fb.insert (
             "I",
             Slice::Make (
-                IMF::UINT,
+                OPENEXR_IMF_NAMESPACE::UINT,
                 p.i.data (),
                 origin,
                 fw,
@@ -1103,7 +1103,7 @@ saveCPP (
         fb.insert (
             "H",
             Slice::Make (
-                IMF::HALF,
+                OPENEXR_IMF_NAMESPACE::HALF,
                 p.h.data (),
                 origin,
                 fw,
@@ -1118,7 +1118,7 @@ saveCPP (
         fb.insert (
             "F",
             Slice::Make (
-                IMF::FLOAT,
+                OPENEXR_IMF_NAMESPACE::FLOAT,
                 p.f.data (),
                 origin,
                 fw,
@@ -1136,7 +1136,7 @@ saveCPP (
             fb.insert (
                 channels[c],
                 Slice::Make (
-                    IMF::HALF,
+                    OPENEXR_IMF_NAMESPACE::HALF,
                     p.rgba[c].data (),
                     origin,
                     fw,
@@ -1198,7 +1198,7 @@ loadCPP (
         fb.insert (
             "I",
             Slice::Make (
-                IMF::UINT,
+                OPENEXR_IMF_NAMESPACE::UINT,
                 p.i.data (),
                 origin,
                 fw,
@@ -1213,7 +1213,7 @@ loadCPP (
         fb.insert (
             "H",
             Slice::Make (
-                IMF::HALF,
+                OPENEXR_IMF_NAMESPACE::HALF,
                 p.h.data (),
                 origin,
                 fw,
@@ -1231,7 +1231,7 @@ loadCPP (
             fb.insert (
                 channels[c],
                 Slice::Make (
-                    IMF::HALF,
+                    OPENEXR_IMF_NAMESPACE::HALF,
                     p.rgba[c].data (),
                     origin,
                     fw,
@@ -1247,7 +1247,7 @@ loadCPP (
         fb.insert (
             "F",
             Slice::Make (
-                IMF::FLOAT,
+                OPENEXR_IMF_NAMESPACE::FLOAT,
                 p.f.data (),
                 origin,
                 fw,

--- a/src/test/OpenEXRCoreTest/deep.cpp
+++ b/src/test/OpenEXRCoreTest/deep.cpp
@@ -18,8 +18,7 @@
 #include <random>
 #include <vector>
 
-namespace IMF = OPENEXR_IMF_NAMESPACE;
-using namespace IMF;
+using namespace OPENEXR_IMF_NAMESPACE;
 using namespace IMATH_NAMESPACE;
 
 namespace
@@ -47,18 +46,18 @@ Header                         header;
 
 void
 generateRandomScanFile (
-    const std::string& filename, int channelCount, Compression compression)
+                        const std::string& filename, int channelCount, Compression compression)
 {
     std::cout << "  generating deep scanline file '" << filename
               << "' compression " << compression << std::endl;
     header = Header (
-        displayWindow,
-        dataWindow,
-        1,
-        IMATH_NAMESPACE::V2f (0, 0),
-        1,
-        INCREASING_Y,
-        compression);
+                     displayWindow,
+                     dataWindow,
+                     1,
+                     IMATH_NAMESPACE::V2f (0, 0),
+                     1,
+                     INCREASING_Y,
+                     compression);
 
     std::default_random_engine generator;
     auto                       generate_random_int = [&] (int range) -> int {
@@ -77,9 +76,9 @@ generateRandomScanFile (
         std::stringstream ss;
         ss << i;
         std::string str = ss.str ();
-        if (type == 0) header.channels ().insert (str, Channel (IMF::UINT));
-        if (type == 1) header.channels ().insert (str, Channel (IMF::HALF));
-        if (type == 2) header.channels ().insert (str, Channel (IMF::FLOAT));
+        if (type == 0) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::UINT));
+        if (type == 1) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::HALF));
+        if (type == 2) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::FLOAT));
         channelTypes.push_back (type);
     }
 
@@ -97,18 +96,18 @@ generateRandomScanFile (
     DeepFrameBuffer frameBuffer;
 
     frameBuffer.insertSampleCountSlice (Slice (
-        IMF::UINT, // type // 7
-        (char*) (&sampleCountScans[0][0] - dataWindow.min.x -
-                 dataWindow.min.y * width), // base
-        sizeof (unsigned int) * 1,          // xStride
-        sizeof (unsigned int) * width));    // yStride
+                                               OPENEXR_IMF_NAMESPACE::UINT, // type // 7
+                                               (char*) (&sampleCountScans[0][0] - dataWindow.min.x -
+                                                        dataWindow.min.y * width), // base
+                                               sizeof (unsigned int) * 1,          // xStride
+                                               sizeof (unsigned int) * width));    // yStride
 
     for (int i = 0; i < channelCount; i++)
     {
         PixelType type = NUM_PIXELTYPES;
-        if (channelTypes[i] == 0) type = IMF::UINT;
-        if (channelTypes[i] == 1) type = IMF::HALF;
-        if (channelTypes[i] == 2) type = IMF::FLOAT;
+        if (channelTypes[i] == 0) type = OPENEXR_IMF_NAMESPACE::UINT;
+        if (channelTypes[i] == 1) type = OPENEXR_IMF_NAMESPACE::HALF;
+        if (channelTypes[i] == 2) type = OPENEXR_IMF_NAMESPACE::FLOAT;
 
         std::stringstream ss;
         ss << i;
@@ -122,14 +121,14 @@ generateRandomScanFile (
         int pointerSize = sizeof (char*);
 
         frameBuffer.insert (
-            str, // name // 6
-            DeepSlice (
-                type, // type // 7
-                (char*) (&data[i][0][0] - dataWindow.min.x -
-                         dataWindow.min.y * width), // base // 8
-                pointerSize * 1,                    // xStride// 9
-                pointerSize * width,                // yStride// 10
-                sampleSize));                       // sampleStride
+                            str, // name // 6
+                            DeepSlice (
+                                       type, // type // 7
+                                       (char*) (&data[i][0][0] - dataWindow.min.x -
+                                                dataWindow.min.y * width), // base // 8
+                                       pointerSize * 1,                    // xStride// 9
+                                       pointerSize * width,                // yStride// 10
+                                       sampleSize));                       // sampleStride
     }
 
     file.setFrameBuffer (frameBuffer);
@@ -213,9 +212,9 @@ generateRandomTileFile (
         std::stringstream ss;
         ss << i;
         std::string str = ss.str ();
-        if (type == 0) header.channels ().insert (str, Channel (IMF::UINT));
-        if (type == 1) header.channels ().insert (str, Channel (IMF::HALF));
-        if (type == 2) header.channels ().insert (str, Channel (IMF::FLOAT));
+        if (type == 0) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::UINT));
+        if (type == 1) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::HALF));
+        if (type == 2) header.channels ().insert (str, Channel (OPENEXR_IMF_NAMESPACE::FLOAT));
         channelTypes.push_back (type);
     }
 
@@ -255,7 +254,7 @@ generateRandomTileFile (
         memOffset = dataWindow.min.x + dataWindow.min.y * width;
 
     frameBuffer.insertSampleCountSlice (Slice (
-        IMF::UINT,
+        OPENEXR_IMF_NAMESPACE::UINT,
         (char*) (&sampleCount[0][0] - memOffset),
         sizeof (unsigned int) * 1,
         sizeof (unsigned int) * width,
@@ -268,9 +267,9 @@ generateRandomTileFile (
     for (int i = 0; i < channelCount; i++)
     {
         PixelType type = NUM_PIXELTYPES;
-        if (channelTypes[i] == 0) type = IMF::UINT;
-        if (channelTypes[i] == 1) type = IMF::HALF;
-        if (channelTypes[i] == 2) type = IMF::FLOAT;
+        if (channelTypes[i] == 0) type = OPENEXR_IMF_NAMESPACE::UINT;
+        if (channelTypes[i] == 1) type = OPENEXR_IMF_NAMESPACE::HALF;
+        if (channelTypes[i] == 2) type = OPENEXR_IMF_NAMESPACE::FLOAT;
 
         std::stringstream ss;
         ss << i;

--- a/src/test/OpenEXRCoreTest/general_attr.cpp
+++ b/src/test/OpenEXRCoreTest/general_attr.cpp
@@ -6,6 +6,8 @@
 #include "test_value.h"
 #include <openexr.h>
 
+#include <ImfNamespace.h>
+
 #include <limits.h>
 #include <string.h>
 
@@ -32,6 +34,8 @@
 #    include "../../lib/OpenEXRCore/internal_attr.h"
 #    include "../../lib/OpenEXRCore/internal_xdr.h"
 #endif
+
+using namespace OPENEXR_IMF_NAMESPACE;
 
 int64_t
 dummy_write (

--- a/src/test/OpenEXRCoreTest/main.cpp
+++ b/src/test/OpenEXRCoreTest/main.cpp
@@ -5,6 +5,8 @@
 
 #include <openexr.h>
 
+#include <ImfNamespace.h>
+
 #include <errno.h>
 #include <iostream>
 #include <set>
@@ -27,6 +29,8 @@
 #include "read.h"
 #include "write.h"
 #include "buffer.h"
+
+using namespace OPENEXR_IMF_NAMESPACE;
 
 #if defined(ANDROID) || defined(__ANDROID_API__)
 #    define IMF_TMP_DIR "/sdcard/"

--- a/src/test/OpenEXRCoreTest/read.cpp
+++ b/src/test/OpenEXRCoreTest/read.cpp
@@ -7,6 +7,8 @@
 
 #include <openexr.h>
 
+#include <ImfNamespace.h>
+
 #include <float.h>
 #include <limits.h>
 #include <math.h>
@@ -15,6 +17,8 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+
+using namespace OPENEXR_IMF_NAMESPACE;
 
 static void
 err_cb (exr_const_context_t f, int code, const char* msg)

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -17,6 +17,8 @@
 
 #include <openexr.h>
 
+#include <ImfNamespace.h>
+
 #include <float.h>
 #include <limits.h>
 #include <math.h>
@@ -26,6 +28,8 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+
+using namespace OPENEXR_IMF_NAMESPACE;
 
 static void
 err_cb (exr_const_context_t f, exr_result_t code, const char* msg)

--- a/website/install.rst
+++ b/website/install.rst
@@ -460,6 +460,12 @@ To enable this, set the flag during config:
 Namespace Options
 ~~~~~~~~~~~~~~~~~
 
+* ``OPENEXR_CORE_USE_NAMESPACE``
+
+  If ``ON``, compile the OpenEXRCore library with C++ (rather than the
+  default C) with symbols in the same namespace as OpenEXR, as defined
+  by other options.
+
 * ``OPENEXR_IMF_NAMESPACE``
 
   Public namespace alias for OpenEXR. Default is ``Imf``.
@@ -498,6 +504,26 @@ Namespace Options
 * ``ILMTHREAD_NAMESPACE_CUSTOM``
 
   Whether the namespace has been customized (so external users know)
+
+Notes on Linking Multiple Versions of OpenEXR in a Single Program
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes a plugin needs to link against a custom version of OpenEXR
+that is different from the version that the main application comes
+built against. You can accomplish this via the custom namespace
+options described above.
+
+However, the OpenEXRCore library presents an additional wrinkle, since
+it is implemented in C and by default has no namespace.
+
+In situations like this, the recommended solution is to build the
+custom version of OpenEXR with the ``OPENEXR_CORE_USE_NAMESPACE``
+option, which compiles the OpenEXRCore library as C++ with the symbols
+in the same namespace as the OpenEXR library:
+
+.. code-block::
+
+    % cmake -DOPENEXR_IMF_NAMESPACE=MyImf -DOPENEXR_CORE_USE_NAMESPACE=ON ...
 
 Component Options
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When `OPENEXR_CORE_USE_NAMESPACE=ON`, the .c and .h files in OpenEXRCore are built with C++ rather than C, with all symbols in the `OPENEXR_IMF_INTERNAL_NAMESPACE` namespace just like the OpenEXR library.

This makes is possible to trade the benefits of the C implementation for the benefits of C++ and the namespacing of all symbols.

All code in the OpenEXRCore .c and .h files is now bracketed inside `OPENEXR_CORE_NAMESPACE_ENTER` and `OPENEXR_CORE_NAMESPACE_EXIT`, which add namespace directives (e.g. `namepace Imf_3_4 {`). These degenerate to empty when compiling with C, which is still the default.

There are also macros `OPENEXR_CORE_EXTERN_C_ENTER/OPENEXR_CORE_EXTERN_C_EXIT` for the OpenEXRCore code that needs `extern "C" {`, which reverts the the C++ OpenEXR namespace in C++.

This also adds missing C++ casts to OpenEXRCore, required by C++ even though the are not necessary in C.

Also, the `_priv_exr_part_t` struct now has a custom constructor and assignment operator because its `chunk_table` field is a `atomic_uintptr_t`, which has those methods deleted.

This also includes some necessary changes to the vendored `libdeflate` code to compile in C++.

When building OpenEXR with the default configuration, this produces the same object code as before.  The namespaced symbols are only generated when configured to do so. As as test, I ran `nm` on the shared library and got the same symbols as before.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--2205.org.readthedocs.build/en/2205/
<!-- readthedocs-preview openexr end -->