### PR TITLE
Remove enable-beta-ecosystem since Bazel is no officially supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@
 
 version: 2
 
-enable-beta-ecosystems: true # Required to use the Bazel ecosystems
 updates:
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Remove enable-beta-ecosystem since Bazel is no officially supported