### PR TITLE
Initialise members of Rgba

### DIFF
--- a/src/lib/OpenEXR/ImfRgba.h
+++ b/src/lib/OpenEXR/ImfRgba.h
@@ -28,7 +28,7 @@ struct Rgba
     half r = 0.0f;
     half g = 0.0f;
     half b = 0.0f;
-    half a = 1.0f;
+    half a = 0.0f;
 
     constexpr Rgba () noexcept = default;
     constexpr Rgba (half r, half g, half b, half a = 1.f) noexcept

--- a/src/lib/OpenEXR/ImfRgba.h
+++ b/src/lib/OpenEXR/ImfRgba.h
@@ -25,13 +25,15 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
 struct Rgba
 {
-    half r;
-    half g;
-    half b;
-    half a;
+    half r = 0.0f;
+    half g = 0.0f;
+    half b = 0.0f;
+    half a = 1.0f;
 
-    Rgba () {}
-    Rgba (half r, half g, half b, half a = 1.f) : r (r), g (g), b (b), a (a) {}
+    constexpr Rgba () noexcept = default;
+    constexpr Rgba (half r, half g, half b, half a = 1.f) noexcept
+        : r (r), g (g), b (b), a (a)
+    {}
 };
 
 //


### PR DESCRIPTION
Currently the members of a default constructed Rgba are uninitialised.  This PR initialises r/g/b/a to 0/0/0/1 for a default constructed object.

This is motivated by a warning about uninitialised values in an unrelated project.  However, I think having no uninitialised values in default constructed objects should be the general expectation.