### PR TITLE
Update CI to install OpenJPH from master

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -191,7 +191,7 @@ jobs:
         if: inputs.OPENEXR_FORCE_INTERNAL_OPENJPH == 'OFF' && inputs.msystem == ''
         run: |
           set -x
-          share/ci/scripts/install_openjph.sh 0.22.0
+          share/ci/scripts/install_openjph.sh master
           echo "OPENEXR_PATH=$OPENEXR_PATH:$PROGRAM_FILES/openjph/bin:$PROGRAM_FILES/openjph/lib" >> $GITHUB_ENV
         shell: bash
 


### PR DESCRIPTION
Currently, the CI is hard-coded to install OpenJPH 0.22.0, which is ancient. Better for the CI to validate the bleeding edge of OpenJPH.

Note that this tests building OpenEXR against an external implementation of OpenJPH, which is done in addition to testing a build with the vendored version.  Ideally, we should test against multiple OpenJPH versions for compatibility, but that's for a later time.