### PR TITLE
Report an error if a deep pixel as more than UINT_MAX samples

### DIFF
--- a/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
+++ b/src/lib/OpenEXR/ImfCompositeDeepScanLine.cpp
@@ -508,6 +508,10 @@ CompositeDeepScanLine::readPixels (int start, int end)
         num_sources[ptr] = 0;
         for (size_t j = 0; j < parts; j++)
         {
+            if (total_sizes[ptr] > std::numeric_limits<unsigned int>::max() - counts[j][ptr])
+                throw IEX_NAMESPACE::ArgExc (
+                    "Cannot composite scanline: pixel cannot have more than UINT_MAX samples");
+                
             total_sizes[ptr] += counts[j][ptr];
             if (counts[j][ptr] > 0) num_sources[ptr]++;
         }


### PR DESCRIPTION
There was no overflow check in totalling the samples per pixel, so a pixel with more samples than could fit in an unsigned int would overflow.

This formalizes a limit of 4,294,967,295 samples per pixel, which the library has always had by virtue of failing when attempting to add more.