### PR TITLE
Bazel: Use openjph 0.26.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,6 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "imath", version = "3.2.2.bcr.1")
 bazel_dep(name = "libdeflate", version = "1.25")
-bazel_dep(name = "openjph", version = "0.25.3")
+bazel_dep(name = "openjph", version = "0.26.3.bcr.1")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")


### PR DESCRIPTION
Switch to OpenJPH 0.26.3(.bcr.1) for Bazel build

(.bcr.1) contains a missing include directive...