### PR TITLE
Enable SSE2 on 32-bit x86 builds to fix test failures

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -400,3 +400,16 @@ int main() {
     set(OPENEXR_MISSING_ARM_VLD1 TRUE)
   endif()
 endif()
+
+###########################################
+# Enable SSE2 on 32-bit x86
+###########################################
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3-6]86|x86)$" AND NOT MSVC)
+  include(CheckCCompilerFlag)
+  check_c_compiler_flag("-msse2" HAS_SSE2_FLAG)
+  if(HAS_SSE2_FLAG)
+    add_compile_options(-msse2 -mfpmath=sse)
+    message(STATUS "Enabling SSE2 for 32-bit x86 build")
+  endif()
+endif()


### PR DESCRIPTION
On 32-bit x86 (i386/i686), the build assumes SSE2 is available at runtime but doesn't enable SSE2 code generation at compile time. This mismatch causes testCPUIdent and testDWATable to fail because the compiled code doesn't match the CPU capability detection.
    
Add -msse2 and -mfpmath=sse compiler flags for 32-bit x86 builds (excluding MSVC which handles this differently). This aligns the compiled code with the runtime expectations.
    
Fixes #2257