### PR TITLE
Fix build failure with -march=sandybridge

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -15,7 +15,7 @@
 
 /* TODO: learn arm neon intrinsics for this */
 #if (defined(__x86_64__) || defined(_M_X64))
-#    if defined(__AVX__) && (defined(__F16C__) || defined(__GNUC__) || defined(__clang__))
+#    if defined(__AVX__) && defined(__F16C__) && (defined(__GNUC__) || defined(__clang__))
 #        define USE_F16C_INTRINSICS
 #    elif (defined(__GNUC__) || defined(__clang__))
 #        define ENABLE_F16C_TEST


### PR DESCRIPTION
The USE_F16C_INTRINSICS macro was incorrectly defined when __AVX__ was set with either __GNUC__ or __clang__, even when __F16C__ was not defined. This caused build failures on CPUs that have AVX but not F16C (e.g., Sandy Bridge).

Fix by requiring __F16C__ to be defined (via AND) rather than being optional (via OR).

Addresses #2231