### PR TITLE
Build oss-fuzz via oss-fuzz_build.sh

### DIFF
--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -288,18 +288,26 @@ else()
   # Using internal openjph
 
   # extract the openjph version variables from ojph_version.h
-  set(openjph_SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/openjph")
+  set(openjph_SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/OpenJPH")
   set(openjph_version "${openjph_SOURCE_DIR}/src/core/openjph/ojph_version.h")
   if(EXISTS "${openjph_version}")
     file(STRINGS "${openjph_version}" _openjph_major REGEX "#define OPENJPH_VERSION_MAJOR")
     file(STRINGS "${openjph_version}" _openjph_minor REGEX "#define OPENJPH_VERSION_MINOR")
     file(STRINGS "${openjph_version}" _openjph_patch REGEX "#define OPENJPH_VERSION_PATCH")
+    file(STRINGS "${openjph_version}" _openjph_sha REGEX "#define OPENJPH_VERSION_SHA")
     string(REGEX REPLACE ".*OPENJPH_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" openjph_VERSION_MAJOR "${_openjph_major}")
     string(REGEX REPLACE ".*OPENJPH_VERSION_MINOR[ \t]+([0-9]+).*" "\\1" openjph_VERSION_MINOR "${_openjph_minor}")
     string(REGEX REPLACE ".*OPENJPH_VERSION_PATCH[ \t]+([0-9]+).*" "\\1" openjph_VERSION_PATCH "${_openjph_patch}")
+    string(REGEX REPLACE ".*OPENJPH_VERSION_SHA[ \t]+([0-9a-f]+).*" "\\1" openjph_VERSION_SHA "${_openjph_sha}")
+  else()
+    message(STATUS "can't find openjph_version.h: ${openjph_version}")
   endif()
 
-  set(openjph_VERSION "${openjph_VERSION_MAJOR}.${openjph_VERSION_MINOR}.${openjph_VERSION_PATCH}")
+  if(openjph_VERSION_SHA)
+    set(openjph_VERSION "${openjph_VERSION_SHA}")
+  else()
+    set(openjph_VERSION "${openjph_VERSION_MAJOR}.${openjph_VERSION_MINOR}.${openjph_VERSION_PATCH}")
+  endif()
   
   if(OPENEXR_FORCE_INTERNAL_OPENJPH)
     message(STATUS "openjph forced internal, using vendored code, version ${openjph_VERSION}")

--- a/src/test/oss-fuzz/oss-fuzz_build.sh
+++ b/src/test/oss-fuzz/oss-fuzz_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eux
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+
+# This script is invoked by
+# https://github.com/google/oss-fuzz/blob/master/projects/openexr/build.sh
+# to build the OpenEXR fuzzers.
+#
+
+set -x
+
+# Vendor in OpenJPH from its master branch, so we're sure the fuzzer gets
+# the bleeding edge.
+./share/util/vendor_openjph.sh master
+
+cmake -S $SRC/openexr -B $BUILD_DIR --preset oss_fuzz
+cmake --build $BUILD_DIR --target oss_fuzz -j"$(nproc)"
+cmake --install $BUILD_DIR --component oss_fuzz


### PR DESCRIPTION
This localizes the oss-fuzz building logic inside the OpenEXR project, minimizing the changes we have to request of the oss-fuzz project itself.

Once this is merged, I have an edit of the oss-fuzz/projects/openexr/build.sh that invokes the new script, I'll submit that as an oss-fuzz PR.