### PR TITLE
release notes and news for 3.4.6, 3.3.8, and 3.2.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,14 @@
 
 # OpenEXR Release Notes
 
+* [Version 3.4.6](#version-346-march-1-2026) March 1, 2026
 * [Version 3.4.5](#version-345-february-21-2026) February 21, 2026
 * [Version 3.4.4](#version-344-november-19-2025) November 19, 2025
 * [Version 3.4.3](#version-343-november-4-2025) November 4, 2025
 * [Version 3.4.2](#version-342-october-15-2025) October 15, 2025
 * [Version 3.4.1](#version-341-october-8-2025) October 8, 2025
 * [Version 3.4.0](#version-340-september-5-2025) September 5, 2025
+* [Version 3.3.8](#version-338-march-1-2026) March 1, 2026
 * [Version 3.3.7](#version-337-february-19-2026) February 19, 2026
 * [Version 3.3.6](#version-336-november-4-2025) November 5, 2025
 * [Version 3.3.5](#version-335-july-26-2025) July 26, 2025
@@ -17,6 +19,7 @@
 * [Version 3.3.2](#version-332-november-11-2024) November 11, 2024
 * [Version 3.3.1](#version-331-october-8-2024) October 8, 2024
 * [Version 3.3.0](#version-330-september-30-2024) September 30, 2024
+* [Version 3.2.6](#version-326-march-1-2026) March 1, 2026
 * [Version 3.2.5](#version-325-november-4-2025) November 4, 2025
 * [Version 3.2.4](#version-324-march-26-2024) March 26, 2024
 * [Version 3.2.3](#version-323-march-6-2024) March 6, 2024
@@ -88,6 +91,158 @@
 * [Version 1.0.2](#version-102)
 * [Version 1.0.1](#version-101)
 * [Version 1.0](#version-10)
+
+## Version 3.4.6 (March 1, 2026)
+
+Patch release with several bug fixes, enhancements, and build improvements.
+
+* :bug: A limit of ``UINT_MAX`` deep samples per pixel is now
+  enforced, which prevents an integer overflow when using the
+  `CompositeDeepScanLine` API to combine multiple deep parts.
+
+* :wrench: In `IlmThreadPool`, replace deprecated `std::atomic_load /
+  std::atomic_exchange` overloads for `std::shared_ptr` with the C++20
+  `std::atomic<std::shared_ptr<T>>` interface when available.
+
+* :bug: The ``ZIP`` and ``ZIPS`` Compressor objects had incorrect
+  compression types set, although the ill effects were minimal as the
+  value is seldom used.
+  
+* :bug: Enable SSE2 on 32-bit x86 builds to fix test failures
+
+Build improvements:
+
+* :hammer_and_wrench: OpenEXR now ships with an internal "vendored" copy of the
+  ``OpenJPH`` library. At configuration time, if CMake finds an
+  external installation of ``OpenJPH``, it will use it, but if that
+  fails, or the CMake configuration option
+  ``OPENEXR_FORCE_INTERNAL_OPENJPH`` is set, it will use the internal
+  copy. For OpenEXR v3.4.6, the vendored version of OpenJPH is 0.26.3.
+
+* :hammer_and_wrench: A new CMake build option `DOPENEXR_FORCE_EMBEDDED_CORE`
+  builds the `OpenEXRCore` library statically and links it into the
+  `OpenEXR` library with symbols hidden, making it possible to link
+  multiple versions of OpenEXR into the same executable. The `OpenEXR`
+  library has namespaces for this situation, but the `OpenEXRCore`
+  library is written in C with no configurable namespace. See [Linking
+  Multiple OpenEXR Versions in the
+  Executable](https://openexr.com/en/latest/install.html#linking-multiple-openexr-versions-in-the-executable)
+  for details.
+
+* :hammer_and_wrench: Fix build failure with ``-march=sandybridge``
+
+Python:
+
+* :snake: :sparkles: Add python support for Opaque Attributes
+
+* :rocket: Python module I/O operations now release the GIL,
+  preventing blocking.
+
+Tools:
+
+* :sparkles: Add sanity check for correct arguments to exrstdattr, to
+  catch mistakes such as ``exrstdattr input.exr output.exr -comment
+  hello`` which would formerly write to a file called ``hello`` but
+  now fails with a usage error.
+
+Also, this release bumps the vendered version of `libdeflate` to 1.25.
+
+### Merged Pull Requests:
+
+* [2274](https://github.com/AcademySoftwareFoundation/openexr/pulls/2274)
+Update the vendored libdeflate to 1.25
+* [2273](https://github.com/AcademySoftwareFoundation/openexr/pulls/2273)
+Release Python GIL during I/O operations in bindings
+* [2272](https://github.com/AcademySoftwareFoundation/openexr/pulls/2272)
+Fix build failure with -march=sandybridge (#2231)
+* [2271](https://github.com/AcademySoftwareFoundation/openexr/pulls/2271)
+Enable SSE2 on 32-bit x86 builds to fix test failures
+* [2269](https://github.com/AcademySoftwareFoundation/openexr/pulls/2269)
+Mention OpenEXR dependencies on README
+* [2268](https://github.com/AcademySoftwareFoundation/openexr/pulls/2268)
+Bazel: Use openjph 0.26.3
+* [2267](https://github.com/AcademySoftwareFoundation/openexr/pulls/2267)
+Bump rules_cc from 0.2.16 to 0.2.17
+* [2265](https://github.com/AcademySoftwareFoundation/openexr/pulls/2265)
+Bump jmertic/slack-release-notifier
+* [2264](https://github.com/AcademySoftwareFoundation/openexr/pulls/2264)
+Bump github/codeql-action from 4.32.3 to 4.32.4
+* [2263](https://github.com/AcademySoftwareFoundation/openexr/pulls/2263)
+Add sanity check for correct arguments to exrstdattr
+* [2261](https://github.com/AcademySoftwareFoundation/openexr/pulls/2261)
+Fix sentence fragment typo in website python docs
+* [2260](https://github.com/AcademySoftwareFoundation/openexr/pulls/2260)
+Add reference to `OPENEXR_FORCE_EMBEDDED_CORE` on install page
+* [2259](https://github.com/AcademySoftwareFoundation/openexr/pulls/2259)
+Fix ZipCompressor to initialize compresson type correctly
+* [2258](https://github.com/AcademySoftwareFoundation/openexr/pulls/2258)
+Bazel: Remove WORKSPACE.bazel file
+* [2256](https://github.com/AcademySoftwareFoundation/openexr/pulls/2256)
+Report an error if a deep pixel as more than `UINT_MAX` samples
+* [2253](https://github.com/AcademySoftwareFoundation/openexr/pulls/2253)
+Add CVE-2025-64181 to SECURITY.md
+* [2252](https://github.com/AcademySoftwareFoundation/openexr/pulls/2252)
+Add news and release notes for v3.4.5 and v3.3.7
+* [2250](https://github.com/AcademySoftwareFoundation/openexr/pulls/2250)
+Vendor OpenJPH v0.26.3
+* [2249](https://github.com/AcademySoftwareFoundation/openexr/pulls/2249)
+Add python support for Opaque Attributes
+* [2248](https://github.com/AcademySoftwareFoundation/openexr/pulls/2248)
+Fix tag check, git rm, and sed calls in vendor_openjph.sh
+* [2247](https://github.com/AcademySoftwareFoundation/openexr/pulls/2247)
+Bump github/codeql-action from 4.31.9 to 4.32.3
+* [2243](https://github.com/AcademySoftwareFoundation/openexr/pulls/2243)
+IlmThread: fix deprecated atomic `shared_ptr` ops for `shared_ptr` (GCC 15)
+* [2240](https://github.com/AcademySoftwareFoundation/openexr/pulls/2240)
+Bump actions/cache from 5.0.1 to 5.0.3
+* [2239](https://github.com/AcademySoftwareFoundation/openexr/pulls/2239)
+Fix links and formatting in CONTRIBUTING.md
+* [2236](https://github.com/AcademySoftwareFoundation/openexr/pulls/2236)
+Bump actions/checkout from 6.0.1 to 6.0.2
+* [2235](https://github.com/AcademySoftwareFoundation/openexr/pulls/2235)
+Bump actions/setup-python from 6.1.0 to 6.2.0
+* [2227](https://github.com/AcademySoftwareFoundation/openexr/pulls/2227)
+Bump rules_cc from 0.2.14 to 0.2.16
+* [2226](https://github.com/AcademySoftwareFoundation/openexr/pulls/2226)
+Bump bazel_skylib from 1.8.2 to 1.9.0
+* [2225](https://github.com/AcademySoftwareFoundation/openexr/pulls/2225)
+Rename external/OpenJPH/src/core/common to openjph, instead of using a symlink
+* [2224](https://github.com/AcademySoftwareFoundation/openexr/pulls/2224)
+Bump github/codeql-action from 4.31.8 to 4.31.9
+* [2222](https://github.com/AcademySoftwareFoundation/openexr/pulls/2222)
+Bump actions/upload-artifact from 5 to 6
+* [2221](https://github.com/AcademySoftwareFoundation/openexr/pulls/2221)
+Bump actions/cache from 4.3.0 to 5.0.1
+* [2220](https://github.com/AcademySoftwareFoundation/openexr/pulls/2220)
+Bump msys2/setup-msys2 from 2.29.0 to 2.30.0
+* [2219](https://github.com/AcademySoftwareFoundation/openexr/pulls/2219)
+Bump actions/download-artifact from 6.0.0 to 7.0.0
+* [2218](https://github.com/AcademySoftwareFoundation/openexr/pulls/2218)
+Bump github/codeql-action from 4.31.7 to 4.31.8
+* [2216](https://github.com/AcademySoftwareFoundation/openexr/pulls/2216)
+Add option to compile c++ libraries with an embedded core library
+* [2215](https://github.com/AcademySoftwareFoundation/openexr/pulls/2215)
+Bump imath from 3.2.2 to 3.2.2.bcr.1
+* [2214](https://github.com/AcademySoftwareFoundation/openexr/pulls/2214)
+Bump github/codeql-action from 4.31.5 to 4.31.7
+* [2213](https://github.com/AcademySoftwareFoundation/openexr/pulls/2213)
+Bump sigstore/gh-action-sigstore-python from 3.1.0 to 3.2.0
+* [2212](https://github.com/AcademySoftwareFoundation/openexr/pulls/2212)
+Bump actions/checkout from 6.0.0 to 6.0.1
+* [2210](https://github.com/AcademySoftwareFoundation/openexr/pulls/2210)
+Bump actions/setup-python from 6.0.0 to 6.1.0
+* [2209](https://github.com/AcademySoftwareFoundation/openexr/pulls/2209)
+Bump github/codeql-action from 4.31.4 to 4.31.5
+* [2208](https://github.com/AcademySoftwareFoundation/openexr/pulls/2208)
+Remove enable-beta-ecosystem since Bazel is no officially supported
+* [2204](https://github.com/AcademySoftwareFoundation/openexr/pulls/2204)
+Bump actions/checkout from 3.6.0 to 6.0.0
+* [2202](https://github.com/AcademySoftwareFoundation/openexr/pulls/2202)
+Bump github/codeql-action from 4.31.3 to 4.31.4
+* [2193](https://github.com/AcademySoftwareFoundation/openexr/pulls/2193)
+Vendor in an internal version of OpenJPH
+* [2167](https://github.com/AcademySoftwareFoundation/openexr/pulls/2167)
+Bazel build: Bump openjph to 0.25.0 and libdeflate to 1.25
 
 ## Version 3.4.5 (February 21, 2026)
 
@@ -492,6 +647,16 @@ Bazel Support: Use Imath and libdeflate live at head
 Fetch master branch of libdeflate on main
 * [1852](https://github.com/AcademySoftwareFoundation/openexr/pull/1852)
 Add an option to use TBB as the global provider
+
+## Version 3.3.8 (March 1, 2026)
+
+Patch release that prevents an integer overflow when using the
+`CompositeDeepScanLine` API to combine multiple deep parts.
+
+### Merged Pull Requests:
+
+* [2256](https://github.com/AcademySoftwareFoundation/pulls/2256)
+Report an error if a deep pixel as more than UINT_MAX samples
 
 ## Version 3.3.7 (February 19, 2026)
 
@@ -1115,6 +1280,15 @@ Fix macOS arm64 build
 * [1423](https://github.com/AcademySoftwareFoundation/openexr/pull/1423)
 Propagate dwa core 3 1
 * [1418](https://github.com/AcademySoftwareFoundation/openexr/pull/1418)
+
+## Version 3.2.6 (March 1, 2026)
+
+Patch release that prevents an integer overflow when using the
+`CompositeDeepScanLine` API to combine multiple deep parts.
+
+### Merged Pull Requests:
+
+* [2256](https://github.com/AcademySoftwareFoundation/pulls/2256)
 
 ## Version 3.2.5 (November 4, 2025)
 

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -71,7 +71,14 @@ def markdown_to_rst(markdown_text):
     Convert simple Markdown text to reStructuredText (reST) manually.
     """
     # Replace markdown links [text](url) with reST format `text <url>`_
-    markdown_text = re.sub(r'\[(.*?)\]\((.*?)\)', r'`\1 <\2>`_', markdown_text)
+    markdown_text = re.sub(
+        r'\[([\s\S]*?)\]\(([\s\S]*?)\)',
+        r'`\1 <\2>`_',
+        markdown_text
+    )
+
+    # Convert `text to ``text`` (but skip existing ``)
+    markdown_text = re.sub(r'(?<!`)`([^`]+)`(?!`)', r'``\1``', markdown_text)
 
     # Convert the special symbols
     markdown_text = re.sub(r':bug:', "🐛", markdown_text, flags=re.DOTALL)

--- a/website/latest_news_title.rst
+++ b/website/latest_news_title.rst
@@ -1,4 +1,4 @@
 ..
   SPDX-License-Identifier: BSD-3-Clause
   Copyright (c) Contributors to the OpenEXR Project.
-.. |latest-news-title| replace:: **February 21, 2026 - OpenEXR 3.4.5 Released**
+.. |latest-news-title| replace:: **March  1, 2026 - OpenEXR 3.4.6 Released**

--- a/website/news.rst
+++ b/website/news.rst
@@ -17,15 +17,88 @@ News
 
 
 |latest-news-title|
-==========================================
+=======================================
 
 .. _LatestNewsStart:
+
+Patch release with several bug fixes, enhancements, and build improvements.
+
+* 🐛 A limit of ``UINT_MAX`` deep samples per pixel is now
+  enforced, which prevents an integer overflow when using the
+  `CompositeDeepScanLine` API to combine multiple deep parts.
+
+* 🐛 `IlmThread` now builds properl with glibc 2.43.
+
+* 🔧 In `IlmThreadPool`, replace deprecated `std::atomic_load /
+  std::atomic_exchange` overloads for `std::shared_ptr` with the C++20
+  `std::atomic<std::shared_ptr<T>>` interface when available.
+
+* 🐛 The ``ZIP`` and ``ZIPS`` Compressor objects had incorrect
+  compression types set, although the ill effects were miminal as the
+  value is seldom used.
+  
+* 🐛 Enable SSE2 on 32-bit x86 builds to fix test failures
+
+Build improvements:
+
+* 🛠️ OpenEXR now ships with an internal "vendored" copy of the
+  ``OpenJPH`` library. At configuration time, if CMake finds an
+  external installation of ``OpenJPH``, it will use it, but if that
+  fails, or the CMake configuration option
+  ``OPENEXR_FORCE_INTERNAL_OPENJPH`` is set, it will use the internal
+  copy. For OpenEXR v3.4.6, the vendored version of OpenJPH is 0.26.3.
+
+* 🛠️ A new CMake build option `DOPENEXR_FORCE_EMBEDDED_CORE`
+  builds the `OpenEXRCore` library statically and links it into the
+  `OpenEXR` library with symbols hidden, making it possible to link
+  multiple versions of OpenEXR into the same executable. The `OpenEXR`
+  library has namespaces for this situation, but the `OpenEXRCore`
+  library is written in C with no configurable namespace. See [Linking
+  Multiple OpenEXR Versions in the
+  Executable](https://openexr.com/en/latest/install.html#linking-multiple-openexr-versions-in-the-executable)
+  for details.
+
+* 🛠️ Fix build failure with ``-march=sandybridge``
+
+Python:
+
+* 🐍 ✨ Add python support for Opaque Attributes
+
+* 🚀 Python module I/O operations now release the GIL,
+  preventing blocking.
+
+Tools:
+
+* ✨ Add sanity check for correct arguments to exrstdattr, to
+  catch mistakes such as ``exrstdattr input.exr output.exr -comment
+  hello`` which would formerly write to a file called ``hello`` but
+  now fails with a usage error.
+
+Also, this release bumps the vendered version of `libdeflate` to 1.25.
+
+.. _LatestNewsEnd:
+
+March 1, 2026 - OpenEXR 3.3.8 Released
+======================================
+
+Patch release for the 3.3 release that prevents an integer overflow
+when using the `CompositeDeepScanLine` API to combine multiple deep
+parts.
+
+March 1, 2026 - OpenEXR 3.2.6 Released
+======================================
+
+Patch release for the 3.2 release that prevents an integer overflow
+when using the `CompositeDeepScanLine` API to combine multiple deep
+parts.
+
+February 21, 2026 - OpenEXR 3.4.5 Released
+==========================================
 
 Patch release that fixes an incorrect size check in
 `istream_nonparallel_read` that could lead to a buffer overflow on
 invalid input data.
 
-.. _LatestNewsEnd:
 
 February 19, 2026 - OpenEXR 3.3.7 Released
 ==========================================

--- a/website/news.rst
+++ b/website/news.rst
@@ -25,13 +25,13 @@ Patch release with several bug fixes, enhancements, and build improvements.
 
 * 🐛 A limit of ``UINT_MAX`` deep samples per pixel is now
   enforced, which prevents an integer overflow when using the
-  `CompositeDeepScanLine` API to combine multiple deep parts.
+  ``CompositeDeepScanLine`` API to combine multiple deep parts.
 
-* 🐛 `IlmThread` now builds properl with glibc 2.43.
+* 🐛 ``IlmThread`` now builds properl with glibc 2.43.
 
-* 🔧 In `IlmThreadPool`, replace deprecated `std::atomic_load /
-  std::atomic_exchange` overloads for `std::shared_ptr` with the C++20
-  `std::atomic<std::shared_ptr<T>>` interface when available.
+* 🔧 In ``IlmThreadPool``, replace deprecated ``std::atomic_load /
+  std::atomic_exchange`` overloads for ``std::shared_ptr`` with the C++20
+  ``std::atomic<std::shared_ptr<T>>`` interface when available.
 
 * 🐛 The ``ZIP`` and ``ZIPS`` Compressor objects had incorrect
   compression types set, although the ill effects were miminal as the
@@ -48,14 +48,14 @@ Build improvements:
   ``OPENEXR_FORCE_INTERNAL_OPENJPH`` is set, it will use the internal
   copy. For OpenEXR v3.4.6, the vendored version of OpenJPH is 0.26.3.
 
-* 🛠️ A new CMake build option `DOPENEXR_FORCE_EMBEDDED_CORE`
-  builds the `OpenEXRCore` library statically and links it into the
-  `OpenEXR` library with symbols hidden, making it possible to link
-  multiple versions of OpenEXR into the same executable. The `OpenEXR`
-  library has namespaces for this situation, but the `OpenEXRCore`
-  library is written in C with no configurable namespace. See [Linking
+* 🛠️ A new CMake build option ``DOPENEXR_FORCE_EMBEDDED_CORE``
+  builds the ``OpenEXRCore`` library statically and links it into the
+  ``OpenEXR`` library with symbols hidden, making it possible to link
+  multiple versions of OpenEXR into the same executable. The ``OpenEXR``
+  library has namespaces for this situation, but the ``OpenEXRCore``
+  library is written in C with no configurable namespace. See `Linking
   Multiple OpenEXR Versions in the
-  Executable](https://openexr.com/en/latest/install.html#linking-multiple-openexr-versions-in-the-executable)
+  Same Executable <https://openexr.com/en/latest/install.html#linking-multiple-openexr-versions-in-the-executable>`_
   for details.
 
 * 🛠️ Fix build failure with ``-march=sandybridge``
@@ -74,7 +74,7 @@ Tools:
   hello`` which would formerly write to a file called ``hello`` but
   now fails with a usage error.
 
-Also, this release bumps the vendered version of `libdeflate` to 1.25.
+Also, this release bumps the vendered version of ``libdeflate`` to 1.25.
 
 .. _LatestNewsEnd:
 
@@ -82,21 +82,21 @@ March 1, 2026 - OpenEXR 3.3.8 Released
 ======================================
 
 Patch release for the 3.3 release that prevents an integer overflow
-when using the `CompositeDeepScanLine` API to combine multiple deep
+when using the ``CompositeDeepScanLine`` API to combine multiple deep
 parts.
 
 March 1, 2026 - OpenEXR 3.2.6 Released
 ======================================
 
 Patch release for the 3.2 release that prevents an integer overflow
-when using the `CompositeDeepScanLine` API to combine multiple deep
+when using the ``CompositeDeepScanLine`` API to combine multiple deep
 parts.
 
 February 21, 2026 - OpenEXR 3.4.5 Released
 ==========================================
 
 Patch release that fixes an incorrect size check in
-`istream_nonparallel_read` that could lead to a buffer overflow on
+``istream_nonparallel_read`` that could lead to a buffer overflow on
 invalid input data.
 
 
@@ -104,7 +104,7 @@ February 19, 2026 - OpenEXR 3.3.7 Released
 ==========================================
 
 Patch release that fixes an incorrect size check in
-`istream_nonparallel_read` that could lead to a buffer overflow on
+``istream_nonparallel_read`` that could lead to a buffer overflow on
 invalid input data.
 
 
@@ -119,7 +119,7 @@ reduces the library size at a slight performance cost. Initialization
 takes under a millisecond, but the size of libOpenEXRCore.so is
 reduced from 890K to 360K. 
 
-This also fixes a build issue with `ILMTHREAD_THREADING_ENABLED` which
+This also fixes a build issue with ``ILMTHREAD_THREADING_ENABLED`` which
 inadvertently enabled threading when it should have been disabed.
 
 This also fixes a bug where importing the python module from a parent
@@ -134,7 +134,7 @@ properly rejecting corrupt input data.
 
 Specifically:
 
-* Buffer overflow in PyOpenEXR_old's `channels()` and `channel()` in
+* Buffer overflow in PyOpenEXR_old's ``channels()` and ``channel()` in
   legacy python, reported by Joshua Rogers (GitHub: MegaManSec).
 * Use after free in PyObject_StealAttrString in legacy python, reported
   by Joshua Rogers (GitHub: MegaManSec).


### PR DESCRIPTION
And remove` glibc 2.43 fix from 3.4.6 notes, that fix didn't make it in.

<!-- readthedocs-preview openexr start -->
Website preview: https://openexr--2280.org.readthedocs.build/en/2280/
<!-- readthedocs-preview openexr end -->