### PR TITLE
Fix FreeBSD build failure involving threads.h, and add FreeBSD CI build

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build and test on FreeBSD
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f  # v1
         with:
           release: '15.0'
           envs: GITHUB_REPOSITORY GITHUB_REF GITHUB_SHA

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) Contributors to the OpenEXR Project.
+#
+# Build and test on FreeBSD using a community VM action.
+# GitHub does not provide native FreeBSD runners; this uses vmactions/freebsd-vm.
+# Validates the pthread fallback in internal_thread.h (issue #2299).
+
+name: CI (FreeBSD)
+
+on:
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!website/**'
+      - '!bazel/**'
+      - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ci_freebsd.yml'
+  pull_request:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!website/**'
+      - '!bazel/**'
+      - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ci_freebsd.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and test on FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: '15.0'
+          envs: GITHUB_REPOSITORY GITHUB_REF GITHUB_SHA
+          usesh: true
+          prepare: |
+            pkg install -y cmake ninja git
+          run: |
+            set -e
+            git clone --depth 1 "https://github.com/${GITHUB_REPOSITORY}.git" src
+            cd src
+            # shallow clone, only the commit that triggered the run, i.e. GITHUB_SHA
+            git fetch --depth 1 origin "${GITHUB_SHA}"
+            git checkout "${GITHUB_SHA}"
+            cmake -B _build -S . -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DOPENEXR_FORCE_INTERNAL_IMATH=ON \
+              -DOPENEXR_FORCE_INTERNAL_DEFLATE=ON \
+              -DOPENEXR_FORCE_INTERNAL_OPENJPH=ON \
+              -DBUILD_TESTING=ON
+            cmake --build _build
+            ctest --test-dir _build --output-on-failure

--- a/src/lib/OpenEXRCore/internal_thread.h
+++ b/src/lib/OpenEXRCore/internal_thread.h
@@ -29,9 +29,10 @@ call_once (once_flag* flag, void (*func) (void))
 {
     InitOnceExecuteOnce (flag, once_init_fn, (PVOID) func, NULL);
 }
-#    elif __has_include(<threads.h>)
+#    elif __has_include(<threads.h>) && !defined(__FreeBSD__)
 /*
- * On Linux (glibc 2.28+), use standard <threads.h>
+ * On Linux (glibc 2.28+), use standard <threads.h>.
+ * FreeBSD requires -lstdthreads for <threads.h>; use pthread fallback instead.
  */
 #        include <threads.h>
 


### PR DESCRIPTION
- internal_thread.h: skip <threads.h> on FreeBSD so the pthread fallback is used (fixes #2299)

- Add ci_freebsd.yml: build and test on FreeBSD via vmactions/freebsd-vm

Written with the assistance of Cursor/Claude Opus 4.5