### PR TITLE
Fix WidenFilename deprecation warning on MinGW/Windows

### DIFF
--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -23,7 +23,7 @@
 #include <ImfTileDescription.h>
 #include <ImfXdr.h>
 
-#if defined(_WIN32) || defined(_WIN64)
+#ifdef _WIN32
 #    include <windows.h>
 #else
 #    include <codecvt>
@@ -2003,16 +2003,19 @@ getChunkOffsetTableSize (const Header& header)
 std::wstring
 WidenFilename (const char* filename)
 {
-#if defined(_WIN32) || defined(_WIN64)
-    if (!filename) return std::wstring ();
-    const int len = MultiByteToWideChar (
-        CP_UTF8, 0, filename, -1, nullptr, 0);
-    if (len <= 0) return std::wstring ();
-    std::wstring result (static_cast<size_t> (len - 1), 0);
-    MultiByteToWideChar (
-        CP_UTF8, 0, filename, -1, &result[0], len);
+#ifdef _WIN32
+    if (!filename)
+        return std::wstring();
+    const int len = MultiByteToWideChar(CP_UTF8, 0, filename, -1, nullptr, 0);
+    if (len <= 0)
+        return std::wstring();
+    std::wstring result(static_cast<size_t> (len - 1), 0);
+    MultiByteToWideChar(CP_UTF8, 0, filename, -1, &result[0], len);
     return result;
 #else
+    // On Linux/macOS, convert to std::wstring, although the conversion
+    // utilities are deprecated in C++17 and not yet replaced, so suppress
+    // the warnings.
 #    if defined(__GNUC__) || defined(__clang__)
 #        pragma GCC diagnostic push
 #        pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -23,8 +23,12 @@
 #include <ImfTileDescription.h>
 #include <ImfXdr.h>
 
-#include <codecvt>
-#include <locale>
+#if defined(_WIN32) || defined(_WIN64)
+#    include <windows.h>
+#else
+#    include <codecvt>
+#    include <locale>
+#endif
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
@@ -1999,8 +2003,27 @@ getChunkOffsetTableSize (const Header& header)
 std::wstring
 WidenFilename (const char* filename)
 {
+#if defined(_WIN32) || defined(_WIN64)
+    if (!filename) return std::wstring ();
+    const int len = MultiByteToWideChar (
+        CP_UTF8, 0, filename, -1, nullptr, 0);
+    if (len <= 0) return std::wstring ();
+    std::wstring result (static_cast<size_t> (len - 1), 0);
+    MultiByteToWideChar (
+        CP_UTF8, 0, filename, -1, &result[0], len);
+    return result;
+#else
+#    if defined(__GNUC__) || defined(__clang__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#    endif
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
-    return converter.from_bytes (filename);
+    std::wstring out = converter.from_bytes (filename);
+#    if defined(__GNUC__) || defined(__clang__)
+#        pragma GCC diagnostic pop
+#    endif
+    return out;
+#endif
 }
 
 const char*


### PR DESCRIPTION
This fixes the warning:

```
2026-03-16T22:57:12.4648885Z D:/a/openexr/openexr/src/lib/OpenEXR/ImfMisc.cpp: In function 'std::wstring Imf_4_0::WidenFilename(const char*)':
2026-03-16T22:57:12.4732551Z D:/a/openexr/openexr/src/lib/OpenEXR/ImfMisc.cpp:2002:10: warning: 'template<class _Codecvt, class _Elem, class _Wide_alloc, class _Byte_alloc> class std::__cxx11::wstring_convert' is deprecated [-Wdeprecated-declarations]
2026-03-16T22:57:12.4780038Z  2002 |     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
2026-03-16T22:57:12.5292586Z       |          ^~~~~~~~~~~~~~~
```
Use MultiByteToWideChar(CP_UTF8) on Windows instead of std::wstring_convert/std::codecvt_utf8, which are deprecated in C++17 and trigger -Wdeprecated-declarations on GCC 15 / MinGW.

On non-Windows, keep using the deprecated API and suppress the warning with pragmas, since the standard library does not yet provide a replacement.

Made with the help of: Cursor / Claude Opus 4.5