### PR TITLE
Fix MinGW -Walloc-size-larger-than= in general_attr string test

### DIFF
--- a/src/test/OpenEXRCoreTest/general_attr.cpp
+++ b/src/test/OpenEXRCoreTest/general_attr.cpp
@@ -250,7 +250,13 @@ testStringHelper (exr_context_t f)
     EXRCORE_TEST_RVAL (exr_attr_string_destroy (f, &s));
 
     size_t nbytes = (size_t) INT32_MAX + 1;
-    char*  tmp    = (char*) malloc (nbytes + 1);
+#if defined(__SIZEOF_SIZE_T__) && __SIZEOF_SIZE_T__ >= 8
+    char* tmp = (char*) malloc (nbytes + 1);
+#else
+    // 32-bit: nbytes+1 exceeds max object size; skip to avoid -Walloc-size-larger-than=
+    (void) nbytes; // reference nbytes to avoid unused variable warning
+    char* tmp = nullptr;
+#endif
     // might be on a low memory machine, in which case just skip the test
     if (tmp)
     {


### PR DESCRIPTION

This fixes the warning:
```
2026-03-16T22:58:15.1920626Z In function 'void testStringHelper(exr_context_t)',
2026-03-16T22:58:15.2175947Z     inlined from 'void testAttrStrings(const std::string&)' at D:/a/openexr/openexr/src/test/OpenEXRCoreTest/general_attr.cpp:286:22:
2026-03-16T22:58:15.2488501Z D:/a/openexr/openexr/src/test/OpenEXRCoreTest/general_attr.cpp:253:36: warning: argument 1 value '2147483649' exceeds maximum object size 2147483647 [-Walloc-size-larger-than=]
2026-03-16T22:58:15.3898638Z   253 |     char*  tmp    = (char*) malloc (nbytes + 1);
2026-03-16T22:58:15.4211153Z       |                             ~~~~~~~^~~~~~~~~~~~
```
Only allocate INT32_MAX+2 bytes when sizeof(size_t) >= 8 (64-bit). On 32-bit MinGW the max object size is INT_MAX, so skip the oversized-string rejection test to avoid the warning.

Note that we need to use `__SIZEOF_SIZE_T__` rather than `sizeof(size_t)` to suppress the MinGW warning, since it happens at compile time.

Made with the help of Cursor / Claude Opus 4.5