### PR TITLE
Fix ZIPS/ZIP encoder corruption when compressed size equals packed size

### DIFF
--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -374,7 +374,7 @@ apply_zip_impl (exr_encode_pipeline_t* encode)
 
     if (rv == EXR_ERR_SUCCESS)
     {
-        if (compbufsz > encode->packed_bytes)
+        if (compbufsz >= encode->packed_bytes)
         {
             memcpy (
                 encode->compressed_buffer,


### PR DESCRIPTION
Fixes #2306