### PR TITLE
Fix PXR24 zlib short-decompress reading uninitialized heap

### DIFF
--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -201,8 +201,9 @@ exr_uncompress_buffer (
         }
         else if (res == LIBDEFLATE_SHORT_OUTPUT)
         {
-            /* TODO: is this an error? */
-            return EXR_ERR_SUCCESS;
+            /* Stream ended before filling the output buffer; treat as corrupt.
+             * Otherwise callers may read uninitialized memory past actual_out. */
+            return EXR_ERR_CORRUPT_CHUNK;
         }
         return EXR_ERR_CORRUPT_CHUNK;
     }

--- a/src/lib/OpenEXRCore/internal_pxr24.c
+++ b/src/lib/OpenEXRCore/internal_pxr24.c
@@ -286,6 +286,9 @@ undo_pxr24_impl (
 
     if (rstat != EXR_ERR_SUCCESS) return rstat;
 
+    if ((uint64_t) outSize != uncompressed_size)
+        return EXR_ERR_CORRUPT_CHUNK;
+
     for (int y = 0; y < decode->chunk.height; ++y)
     {
         int cury = y + decode->chunk.start_y;


### PR DESCRIPTION
`exr_uncompress_buffer()` returned `EXR_ERR_SUCCESS` on `LIBDEFLATE_SHORT_OUTPUT` when the inflated stream was shorter than the output buffer. Callers that assumed the full header-derived size was valid could read past the actual decompressed bytes.

`undo_pxr24_impl()` then walked `scratch_data` using `uncompressed_size` only, so the gap between actual zlib output and expected size was uninitialized heap, folded into decoded pixels.

- Treat `LIBDEFLATE_SHORT_OUTPUT` as `EXR_ERR_CORRUPT_CHUNK` in `exr_uncompress_buffer()`.

- After successful uncompress in `undo_pxr24_impl()`, require `outSize == uncompressed_size`.  Fixes unsafe behavior from truncated-but-valid zlib streams in PXR24 chunks.

Analyzed and resolved with the assistance of Cursor / Claude Opus 4.5