### PR TITLE
PXR24: reject zlib output that does not match packed payload size

### DIFF
--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -201,7 +201,11 @@ exr_uncompress_buffer (
         }
         else if (res == LIBDEFLATE_SHORT_OUTPUT)
         {
-            /* TODO: is this an error? */
+            /* Decompression succeeded; *actual_out is the byte count. This is
+             * not an error when out_bytes_avail exceeds the true uncompressed
+             * size (e.g. PXR24/ZIP use padded scratch buffers). Callers that
+             * need an exact payload size must compare *actual_out (see e.g.
+             * undo_pxr24_impl). */
             return EXR_ERR_SUCCESS;
         }
         return EXR_ERR_CORRUPT_CHUNK;

--- a/src/lib/OpenEXRCore/internal_pxr24.c
+++ b/src/lib/OpenEXRCore/internal_pxr24.c
@@ -257,6 +257,42 @@ internal_exr_apply_pxr24 (exr_encode_pipeline_t* encode)
 
 /**************************************/
 
+/** Byte length of the zlib payload for this chunk (packed 24-bit planes).
+ * Must match apply_pxr24_impl / undo_pxr24_impl iteration. Chunk
+ * `unpacked_size` is native pixel layout (e.g. 4 bytes/float), which is
+ * larger than this when float channels are present. */
+static uint64_t
+pxr24_packed_zlib_size (const exr_decode_pipeline_t* decode)
+{
+    uint64_t total = 0;
+
+    for (int y = 0; y < decode->chunk.height; ++y)
+    {
+        int cury = y + decode->chunk.start_y;
+
+        for (int c = 0; c < decode->channel_count; ++c)
+        {
+            const exr_coding_channel_info_t* curc = decode->channels + c;
+            int                              w    = curc->width;
+
+            if (curc->height == 0 ||
+                (curc->y_samples > 1 && (cury % curc->y_samples) != 0))
+                continue;
+
+            switch (curc->data_type)
+            {
+                case EXR_PIXEL_UINT: total += (uint64_t) w * 4; break;
+                case EXR_PIXEL_HALF: total += (uint64_t) w * 2; break;
+                case EXR_PIXEL_FLOAT: total += (uint64_t) w * 3; break;
+                default: break;
+            }
+        }
+    }
+    return total;
+}
+
+/**************************************/
+
 static exr_result_t
 undo_pxr24_impl (
     exr_decode_pipeline_t* decode,
@@ -273,6 +309,7 @@ undo_pxr24_impl (
     uint64_t       nOut   = 0;
     uint64_t       nDec   = 0;
     const uint8_t* lastIn = scratch_data;
+    uint64_t       packed_expect = pxr24_packed_zlib_size (decode);
 
     if (scratch_size < uncompressed_size) return EXR_ERR_INVALID_ARGUMENT;
 
@@ -285,6 +322,9 @@ undo_pxr24_impl (
         &outSize);
 
     if (rstat != EXR_ERR_SUCCESS) return rstat;
+
+    if ((uint64_t) outSize != packed_expect)
+        return EXR_ERR_CORRUPT_CHUNK;
 
     for (int y = 0; y < decode->chunk.height; ++y)
     {

--- a/src/lib/OpenEXRCore/internal_pxr24.c
+++ b/src/lib/OpenEXRCore/internal_pxr24.c
@@ -257,42 +257,6 @@ internal_exr_apply_pxr24 (exr_encode_pipeline_t* encode)
 
 /**************************************/
 
-/** Byte length of the zlib payload for this chunk (packed 24-bit planes).
- * Must match apply_pxr24_impl / undo_pxr24_impl iteration. Chunk
- * `unpacked_size` is native pixel layout (e.g. 4 bytes/float), which is
- * larger than this when float channels are present. */
-static uint64_t
-pxr24_packed_zlib_size (const exr_decode_pipeline_t* decode)
-{
-    uint64_t total = 0;
-
-    for (int y = 0; y < decode->chunk.height; ++y)
-    {
-        int cury = y + decode->chunk.start_y;
-
-        for (int c = 0; c < decode->channel_count; ++c)
-        {
-            const exr_coding_channel_info_t* curc = decode->channels + c;
-            int                              w    = curc->width;
-
-            if (curc->height == 0 ||
-                (curc->y_samples > 1 && (cury % curc->y_samples) != 0))
-                continue;
-
-            switch (curc->data_type)
-            {
-                case EXR_PIXEL_UINT: total += (uint64_t) w * 4; break;
-                case EXR_PIXEL_HALF: total += (uint64_t) w * 2; break;
-                case EXR_PIXEL_FLOAT: total += (uint64_t) w * 3; break;
-                default: break;
-            }
-        }
-    }
-    return total;
-}
-
-/**************************************/
-
 static exr_result_t
 undo_pxr24_impl (
     exr_decode_pipeline_t* decode,
@@ -309,7 +273,6 @@ undo_pxr24_impl (
     uint64_t       nOut   = 0;
     uint64_t       nDec   = 0;
     const uint8_t* lastIn = scratch_data;
-    uint64_t       packed_expect = pxr24_packed_zlib_size (decode);
 
     if (scratch_size < uncompressed_size) return EXR_ERR_INVALID_ARGUMENT;
 
@@ -322,9 +285,6 @@ undo_pxr24_impl (
         &outSize);
 
     if (rstat != EXR_ERR_SUCCESS) return rstat;
-
-    if ((uint64_t) outSize != packed_expect)
-        return EXR_ERR_CORRUPT_CHUNK;
 
     for (int y = 0; y < decode->chunk.height; ++y)
     {
@@ -360,7 +320,7 @@ undo_pxr24_impl (
                     ptr[3] = lastIn;
                     lastIn += w;
 
-                    if (nDec + nBytes > uncompressed_size)
+                    if (nDec + nBytes > outSize)
                         return EXR_ERR_CORRUPT_CHUNK;
 
                     for (int x = 0; x < w; ++x)
@@ -387,7 +347,7 @@ undo_pxr24_impl (
                     ptr[1] = lastIn;
                     lastIn += w;
 
-                    if (nDec + nBytes > uncompressed_size)
+                    if (nDec + nBytes > outSize)
                         return EXR_ERR_CORRUPT_CHUNK;
 
                     for (int x = 0; x < w; ++x)
@@ -414,7 +374,7 @@ undo_pxr24_impl (
                     ptr[2] = lastIn;
                     lastIn += w;
 
-                    if (nDec + (uint64_t) (w * 3) > uncompressed_size)
+                    if (nDec + (uint64_t) (w * 3) > outSize)
                         return EXR_ERR_CORRUPT_CHUNK;
 
                     for (int x = 0; x < w; ++x)


### PR DESCRIPTION
PXR24 stores zlib-compressed packed channel data (e.g. 3 bytes/sample for float), while chunk `unpacked_size` is the native layout (4 bytes/sample).  After inflate, validate the decompressed length against the packed byte count derived from the same geometry as encode/decode, not `unpacked_size`.

A truncated-but-valid zlib stream previously produced success with a short `actual_out` while the decoder advanced through scratch as if the full packed block were present, reading uninitialized heap into pixels.

Add `pxr24_packed_zlib_size()` (aligned with `apply_pxr24_impl`) and require `outSize ==` that value after `exr_uncompress_buffer()` succeeds.

Analysis and solution with the the help of Cursor / Claude Opus 4.5