### PR TITLE
Fix B44/B44A integer overflow: use uint64_t for row offset

### DIFF
--- a/src/lib/OpenEXRCore/internal_b44.c
+++ b/src/lib/OpenEXRCore/internal_b44.c
@@ -427,13 +427,13 @@ compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
             // rightmost column and the bottom row.
             //
             uint16_t *row0, *row1, *row2, *row3;
+            /* row offset in elements: use uint64_t so y*nx cannot overflow int */
+            uint64_t row_off = (uint64_t) (y) * (uint64_t) (nx);
 
-            row0 = (uint16_t*) scratch;
-            row0 += y * nx;
-
-            row1 = row0 + nx;
-            row2 = row1 + nx;
-            row3 = row2 + nx;
+            row0 = (uint16_t*) scratch + row_off;
+            row1 = row0 + (uint64_t) nx;
+            row2 = row1 + (uint64_t) nx;
+            row3 = row2 + (uint64_t) nx;
 
             if (y + 3 >= ny)
             {
@@ -557,11 +557,12 @@ uncompress_b44_impl (
 
         for (int y = 0; y < ny; y += 4)
         {
-            row0 = (uint16_t*) scratch;
-            row0 += y * nx;
-            row1 = row0 + nx;
-            row2 = row1 + nx;
-            row3 = row2 + nx;
+            /* row offset in elements: use uint64_t so y*nx cannot overflow int */
+            uint64_t row_off = (uint64_t) (y) * (uint64_t) (nx);
+            row0 = (uint16_t*) scratch + row_off;
+            row1 = row0 + (uint64_t) nx;
+            row2 = row1 + (uint64_t) nx;
+            row3 = row2 + (uint64_t) nx;
             for (int x = 0; x < nx; x += 4)
             {
                 if (bIn + 3 > comp_buf_size) return EXR_ERR_OUT_OF_MEMORY;


### PR DESCRIPTION
The B44 and B44A decoder and encoder use channel width (`nx`) and height (`ny`) in row pointer math. `nx` and `ny` are `int`; the scratch buffer is correctly sized with `(uint64_t)ny * (uint64_t)nx * bytes_per_element`, but row bases were computed as:

```
  row0 = (uint16_t*)scratch;
  row0 += y * nx;   // int * int -> signed overflow when y*nx > INT_MAX
```

For large `nx` (e.g. 268435456), `y*nx` overflows, so `row0`/`row1`/`row2`/`row3` point before the scratch buffer.

Fix: compute the row offset in `uint64_t` before pointer arithmetic in both `uncompress_b44_impl` (decoder) and `compress_b44_impl` (encoder).

Analysis and solution with the help of Curor / Claude Opus 4.5