### PR TITLE
Remove WidenFilename() from public API

### DIFF
--- a/src/lib/OpenEXR/ImfMisc.cpp
+++ b/src/lib/OpenEXR/ImfMisc.cpp
@@ -23,9 +23,6 @@
 #include <ImfTileDescription.h>
 #include <ImfXdr.h>
 
-#include <codecvt>
-#include <locale>
-
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 using IMATH_NAMESPACE::Box2i;
@@ -1994,13 +1991,6 @@ getChunkOffsetTableSize (const Header& header)
         return getScanlineChunkOffsetTableSize (header);
     else
         return getTiledChunkOffsetTableSize (header);
-}
-
-std::wstring
-WidenFilename (const char* filename)
-{
-    std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
-    return converter.from_bytes (filename);
 }
 
 const char*

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -435,14 +435,6 @@ IMF_EXPORT
 int getChunkOffsetTableSize (const Header& header);
 
 //
-// Convert a filename to a wide string.  This is useful for working with
-// filenames on Windows.
-//
-
-IMF_EXPORT
-std::wstring WidenFilename (const char* filename);
-
-//
 // Return the string that describes the major.minor.patch release version
 //
 

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -6,8 +6,6 @@
 #ifndef INCLUDE_TestUtilFStream_h_
 #    define INCLUDE_TestUtilFStream_h_ 1
 
-#    include <ImfMisc.h>
-
 #    include <fstream>
 #    include <string>
 
@@ -28,6 +26,18 @@
 namespace testutil
 {
 #    ifdef _WIN32
+// Convert UTF-8 filename to wide string for Windows APIs. Test-only; uses
+// MultiByteToWideChar to avoid deprecated std::codecvt_utf8.
+inline std::wstring
+WidenFilename (const char* filename)
+{
+    if (!filename || !*filename) return std::wstring ();
+    int len = MultiByteToWideChar (CP_UTF8, 0, filename, -1, nullptr, 0);
+    if (len <= 0) return std::wstring ();
+    std::wstring result (static_cast<size_t> (len) - 1, L'\0');
+    MultiByteToWideChar (CP_UTF8, 0, filename, -1, &result[0], len);
+    return result;
+}
 // This is a big work around mechanism for compiling using mingw / gcc under windows
 // until mingw 9 where they add the wide filename version of open
 #        if (                                                                  \
@@ -104,7 +114,7 @@ OpenStreamWithUTF8Name (
     StreamType& is, const char* filename, std::ios_base::openmode mode)
 {
 #    ifdef _WIN32
-    std::wstring wfn = OPENEXR_IMF_INTERNAL_NAMESPACE::WidenFilename (filename);
+    std::wstring wfn = WidenFilename (filename);
 #        ifdef USE_WIDEN_FILEBUF
     using CharT   = typename StreamType::char_type;
     using TraitsT = typename StreamType::traits_type;

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -10,7 +10,6 @@
 #include <ImfArray.h>
 #include <ImfCompressor.h>
 #include <ImfInputPart.h>
-#include <ImfMisc.h>
 #include <ImfMultiPartInputFile.h>
 #include <ImfMultiPartOutputFile.h>
 #include <ImfOutputPart.h>
@@ -127,7 +126,7 @@ MMIFStream::MMIFStream (const char fileName[])
     , _length (0)
 {
 #ifdef _WIN32
-    const std::wstring fileNameWide = WidenFilename (fileName);
+    const std::wstring fileNameWide = testutil::WidenFilename (fileName);
     try
     {
         _f = CreateFileW (
@@ -1093,7 +1092,7 @@ testExistingStreamsUTF8 (const std::string& tempDir)
     {
         cout << "writing";
 #ifdef _WIN32
-        _wremove (WidenFilename (outfn.c_str ()).c_str ());
+        _wremove (testutil::WidenFilename (outfn.c_str ()).c_str ());
 #else
         remove (outfn.c_str ());
 #endif
@@ -1144,7 +1143,7 @@ testExistingStreamsUTF8 (const std::string& tempDir)
     cout << endl;
 
 #ifdef _WIN32
-    _wremove (WidenFilename (outfn.c_str ()).c_str ());
+    _wremove (testutil::WidenFilename (outfn.c_str ()).c_str ());
 #else
     remove (outfn.c_str ());
 #endif


### PR DESCRIPTION
This utility function is only used internally in the test suite, and only necessary on Windows. The implementation has been removed from the public API and a windows-specific version provided locally for the tests.

The motivation for this is to eliminate the compiler warning that the implementation generated.

Note that because this is an API change, it needs to wait for the next major release.