### PR TITLE
Force macos cibuildwheel to use Xcode clang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,6 @@ manylinux-aarch64-image = "manylinux2014"
 # Needed for full C++17 support
 [tool.cibuildwheel.macos.environment]
 MACOSX_DEPLOYMENT_TARGET = "10.15"
+# pass compilers directly to avoid Homebrew LLVM libunwind
+CMAKE_ARGS = "-DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++"
+


### PR DESCRIPTION
On GitHub’s macOS runners, clang on PATH often points to Homebrew’s LLVM (e.g. /usr/local/opt/llvm@18/bin/clang) instead of Xcode’s clang.

That LLVM build pulls in Homebrew’s libunwind, which is built with minimum macOS 14.0. When the OpenEXR extension is built with that toolchain, it ends up depending on that libunwind.

During wheel repair, delocate copies all non-system dependencies into the wheel. It then checks that each bundled library’s minimum macOS version matches the wheel’s target. Homebrew’s libunwind requires 14.0, so if the wheel claims 11.0 (or 10.15), delocate fails.

Xcode’s clang lives at /usr/bin/clang and uses the system C++ runtime and unwinder. Those are part of macOS and don’t bring in a separate libunwind dylib with a higher minimum version.

Assisted-with: Cursor / Claude Opus 4.5