### PR TITLE
Add "cherry" and "changes" options to release.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -548,26 +548,56 @@ The preferred workflow is:
 1. Cherry-pick commits from the main branch to the release branch,
    compose release notes, and bump the version number.
 
-   a. Create a new PR label for the new release, identify all PRs to
-      be included, and assign the label to them.
+   a. Create a new PR label for the new release (on the GitHub "Pull
+      Request" page), identify all PRs to be included, and assign the
+      label to them.  Run:
+
+          % share/util/release.py log
+
+      to print recent commits and their associated PRs and release
+      labels. The best practice is to ensure that every PR is labeled
+      with the release it should go into, even if that is the next
+      major release.
    
-   b. Run `share/util/release.py cherry <tag>`. This will print the
-      SHAs for the commits associated with the labeled PRs. This will
-      print something like:
+      Note that this relies on the commit message having the PR number
+      appended to the end, which GitHub adds on "Squash and
+      merge". PRs merged via "Rebase and merge" do *not* get this PR
+      number, which leaves you to manually decipher the PRs to report
+      in the release notes. Our project policy is to "Squash and
+      merge" whenever possible, unless the PR's individual commits
+      really do need to be preserved in the history.
+
+   b. Identify the main branch commits to cherry pick to the release
+      branch:
+   
+          % share/util/release.py cherry <tag>
+
+      This will print the SHAs for the commits associated with the
+      labeled PRs. The output will look something like:
       
           git cherry-pick 2e32c6b # Bump actions/cache from 5.0.3 to 5.0.4 (#2311)
           git cherry-pick 3df0122 # Pin pypa/cibuildwheel actions to release sha (#2294)
           git cherry-pick 6155271 # Force macos cibuildwheel to use Xcode clang (#2315)
+          share/util/release.py changes v3.4.8 2311 2294 2315
+          
+   c. Cherry-pick the commits (copy & execute output from `release.py cherry`):
 
-   c. Cherry-pick the commits (copy & execute output from `release.py`):
+          % git checkout RB-3.4
+          % git cherry-pick 2e32c6b
+          % git cherry-pick 3df0122
+          % git cherry-pick 6155271
 
-          git checkout RB-3.4
-          git cherry-pick 2e32c6b
-          git cherry-pick 3df0122
-          git cherry-pick 6155271
+      This may involve resolving conflicts along the way. Confirm the
+      updated branch builds successfully.
 
-   d. Run `share/util/release.py changes <tag> <pr>`. This will add a
-      new section to `CHANGES.md` and add an entry to the PR list.
+   d. Create a new section in the `CHANGES.md` release notes file:
+   
+          % share/util/release.py changes <tag> <pr list>
+
+      This is the command as printed at the end of the output of the
+      "cherry" command. This will add a new section to `CHANGES.md`
+      and add entries to the PR lists. Run this from the release
+      branch, since it's preparing a commit for there.
    
    e. Edit `CHANGES.md` and compose a release notes summary. Commit
       this change.
@@ -593,9 +623,9 @@ The preferred workflow is:
    of the release with link to the release candidate tag. Include the
    release notes from [CHANGES.md](CHANGES.md) for review.
 
-5. Draft the release via:
+5. Draft the GitHub release via:
 
-        share/util/release.py draft <tag>
+        % share/util/release.py draft <tag>
        
    Verify the notes look correct on the
    [Releases](https://github.com/AcademySoftwareFoundation/openexr/releases)
@@ -626,9 +656,13 @@ The preferred workflow is:
       [registered](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
       with your GitHub account and git config.
 
-   b. Create a signed tag with the release name via `git tag -s v3.1.9`.
+   b. Create a signed tag with the release name via:
+   
+          git tag -s v3.1.9
 
-   c. Push the tag via `git push --tags`
+   c. Push the tag via:
+
+          git push --tags
 
 8. Publish the release
 
@@ -646,9 +680,9 @@ The preferred workflow is:
 
    From a clone of the main repo:
 
-       % git checkout release
-       % git merge RB-3.1
-       % git push
+        % git checkout release
+        % git merge RB-3.1
+        % git push
          
 10. Submit a PR that adds the release notes to [CHANGES.md](CHANGES.md)
     on the main branch. Cherry-pick the release notes commit from
@@ -658,18 +692,25 @@ The preferred workflow is:
       the associated commit as well.
 
     - Also include in this PR edits to [``website/news.rst``](website/news.rst)
-      that add an announcement of the release.
+      that add an announcement of the release:
 
-11. After review/merge of the updates to ``website/news.rst``, build the
-    website at https://readthedocs.org/projects/openexr.
+            share/util/release.py news v3.4.8
 
+      This will edit the website source files to add the news item.
+
+    - Get the PR approved and merged promptly so the news item appears
+      on the website. The website rebuilds automatically at
+      https://readthedocs.org/projects/openexr on changes to the main
+      branch, so no action is required.
+      
 12. If the release has resolved any OSS-Fuzz issues, update the
     associated pages at https://bugs.chromium.org/p/oss-fuzz with a
     reference to the release.
 
-13. If the release has resolved any public CVE's, request an update
+13. If the release has resolved any public CVEs, request an update
     from the registry service providing the release and a link to the
-    release notes.
+    release notes.  Add a reference to resolved public CVEs to
+    `SECURITY.md` and submit as a PR.
 
 ## Creating a Major/Minor Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -545,83 +545,41 @@ access on the GitHub repo.
 
 The preferred workflow is:
 
-1. Make a PR that merges appropriate changes from the main branch to
-   the release branch:
+1. Cherry-pick commits from the main branch to the release branch,
+   compose release notes, and bump the version number.
 
-   a. In a forked clone, create a branch to hold the patch commits,
-      e.g. ``v3.1.9-fixes``.
+   a. Create a new PR label for the new release, identify all PRs to
+      be included, and assign the label to them.
+   
+   b. Run `share/util/release.py cherry <tag>`. This will print the
+      SHAs for the commits associated with the labeled PRs. This will
+      print something like:
+      
+          git cherry-pick 2e32c6b # Bump actions/cache from 5.0.3 to 5.0.4 (#2311)
+          git cherry-pick 3df0122 # Pin pypa/cibuildwheel actions to release sha (#2294)
+          git cherry-pick 6155271 # Force macos cibuildwheel to use Xcode clang (#2315)
 
-   b. Cherry-pick the appropriate commits from ``main``, resolving any
-      merge conflicts.
+   c. Cherry-pick the commits (copy & execute output from `release.py`):
 
-   c. Increment ``OPENEXR_VERSION_PATCH`` in
-      [src/lib/OpenEXRCore/openexr_version.h](src/lib/OpenEXRCore/openexr_version.h)
+          git checkout RB-3.4
+          git cherry-pick 2e32c6b
+          git cherry-pick 3df0122
+          git cherry-pick 6155271
 
-   d. Update the ``IMATH_TAG`` setting in
-      [cmake/OpenEXRSetup.cmake](cmake/OpenEXRSetup.cmake) to
-      correspond to the proper Imath release.
+   d. Run `share/util/release.py changes <tag> <pr>`. This will add a
+      new section to `CHANGES.md` and add an entry to the PR list.
+   
+   e. Edit `CHANGES.md` and compose a release notes summary. Commit
+      this change.
 
-   e. Add release notes to [CHANGES.md](CHANGES.md):
+   f. Bump the version number in
+      `src/lib/OpenEXRCore/openexr_version.h`. Commit this change.
 
-      - Generate a list of links to merged pull requests.
-
-        Use ``git log`` to identify the merged commits, and for each
-        commit, and add a link in the notes to the corresponding PR
-        that merged it to ``main``. Citing PR's in the release notes
-        is preferable to citing raw commits because the PR's often
-        have helpful information and discussion missing from the
-        commit descriptions, and the commit history is readily
-        accessible via ``git log`` anyway.
-
-        The typical OpenEXR project workflow uses "squash and merge"
-        to merge PR's into ``main``, so the changes involved in each
-        PR end up on ``main`` as a single commit. This is preferable
-        because a raw PR often includes numerous commits that address
-        comments and feedback or fix typos or mistakes, intermediate
-        steps not helpful to the preserved history of the main
-        development thread. Note that GitHub's "squash and merge"
-        helpfully appends the PR number to the commit subject line.
-
-        Note that when this PR is merged to the release branch, it
-        should go in via "rebase and merge" that the release branch
-        retains the granular changes, described below.
-
-      - Generate a list of OSS-Fuzz issues addressed.
-
-        These are security concerns, so they deserve special
-        attention. Provide a link in the notes to the issue at
-        https://bugs.chromium.org/p/oss-fuzz, including the issue id
-        number and description.
-
-      - If there are any public CVE's, mention them explicitly with a
-        link to the CVE registry item.
-
-      - Provide an executive summary of the patch changes, in a few
-        sentences as well as bullet points if appropriate.
-
-      - Choose a proposed release date at least several days in
-        advance.
-
-   f. If there are any public CVE's, reference them in
-      [SECURITY.md](SECURITY.md).
-
-   g. Submit the PR for others to review. The PR should go *to the
-      release branch, not ``main``*, obviously.
-
-   h. After others have had a chance to sanity-check the changes,
-      merge the PR *with "rebase and merge"*.  Unlike with the usual
-      PR's merged to main, it is essential to retain the individual
-      commits on the release branch. That way, the release branch
-      commit history retains the details of the changes.
-
-   i. If further fixes come in that need to go into the release, push
-      them to the PR branch. It's not absolutely essential that all
-      changes to the release branch go in via a PR. The PR is simply a
-      convenient forum for publicly discussing and reviewing the
-      composition of the release.
-
+   g. Push the release branch and confirm the CI passes.
+   
 2. Tag the release with a ``-rc`` "release candidate" tag,
-   e.g. ``v3.1.9-rc``.
+   e.g. ``v3.1.9-rc``.  Push the tag via `git push --tags`. This will
+   trigger the release candidate workflow.
 
 3. Validate ABI compatibility. Build at the release candidate tag and
    run
@@ -635,15 +593,13 @@ The preferred workflow is:
    of the release with link to the release candidate tag. Include the
    release notes from [CHANGES.md](CHANGES.md) for review.
 
-5. Draft the release on the GitHub
+5. Draft the release via:
+
+        share/util/release.py draft <tag>
+       
+   Verify the notes look correct on the
    [Releases](https://github.com/AcademySoftwareFoundation/openexr/releases)
-   page.  Include the summary from the notes in
-   [CHANGES.md](CHANGES.md), but don't include the list of PR's.
-
-   Create the release from the latest ``--rc`` tag, and give it a name
-   that begins with ``v``, i.e. ``v3.1.9``.
-
-   Save the release as a "draft".
+   page and edit as appropriate. Save as a "draft".
 
 6. Wait at least 48 hours, to give the community time to discover and
    report any obvious problems. Avoid the temptation to rush changes
@@ -652,13 +608,12 @@ The preferred workflow is:
 
    If additional fixes need to go in before release:
 
-   a. Merge commits to the release branch. Push them directly, no need
-      for a pull request.
+   a. Merge commits to the release branch. Push them directly.
 
    b. Update the release notes in a separate commit.
 
    c. Re-tag with a incremented "release candidate" number,
-      e.g. ``v3.1.9-rc2``.  
+      e.g. ``v3.1.9-rc2``.
 
    d. Send an email update to ``openexr-dev@lists.aswf.io`` notifying
       the community of the addition and the new tag.
@@ -677,9 +632,12 @@ The preferred workflow is:
 
 8. Publish the release
 
-   a. Click the "Publish release" button on the GitHub release draft
+   a. Set the release to correspond to the latest release candidate
+      tag.
+   
+   b. Click the "Publish release" button on the GitHub release draft
 
-   b. Send an email to ``openexr-dev@lists.aswf.io`` officially
+   c. Send an email to ``openexr-dev@lists.aswf.io`` officially
       announcing the release.
 
 9. Update the ``release`` branch, which should always point to the

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -187,11 +187,14 @@ def cmd_cherry(label):
 
     merged.sort(key=lambda x: x[0])
 
+    changes_prs = []
     for _merged_at, oid, title, id in merged:
         abbrev = oid[:7]
         title_one_line = " ".join(title.split())
         print(f"git cherry-pick {abbrev} # {title_one_line} (#{id})")
+        changes_prs += f" {id}" 
 
+    print(f"share/util/release.py changes {label} {changes_prs}")
 
 def prev_patch_version(base_tag):
     """
@@ -310,7 +313,7 @@ def parse_section(lines):
     return heading, merged_prs, merged_workflow_prs
 
 
-def cmd_changes(tag, pr_number):
+def cmd_changes(tag, prs):
     """
     Add a section to CHANGES.md for the given release if one doesn't already exist, and add the given PR 
     to the list if it's not already there.
@@ -381,21 +384,22 @@ def cmd_changes(tag, pr_number):
             prev_toc = i
             break
 
-    # Format the list entry for the new PR:
+    # Format the list entry for each new PR:
     # * [number](url)
     # title
-    info = gh_pr_view(pr_number)
-    title = info.get("title") or ""
-    author = (info.get("author") or {}).get("login") or ""
-    is_workflow = "dependabot" in author
-    url = get_repo_url()
-    title_one_line = " ".join(title.split())
-    pr_block = f"* [{pr_number}]({url}/pull/{pr_number})\n{title_one_line}"
-    # Add it to the appropriate section
-    if is_workflow:
-        merged_workflow_prs[pr_number] = pr_block
-    else:
-        merged_prs[pr_number] = pr_block
+    for pr_number in prs:
+        info = gh_pr_view(pr_number)
+        title = info.get("title") or ""
+        author = (info.get("author") or {}).get("login") or ""
+        is_workflow = "dependabot" in author
+        url = get_repo_url()
+        title_one_line = " ".join(title.split())
+        pr_block = f"* [{pr_number}]({url}/pull/{pr_number})\n{title_one_line}"
+        # Add it to the appropriate section
+        if is_workflow:
+            merged_workflow_prs[pr_number] = pr_block
+        else:
+            merged_prs[pr_number] = pr_block
 
     with open("CHANGES.md", "w", encoding="utf-8", newline="\n") as f:
         if toc is None:
@@ -497,7 +501,72 @@ def convert_to_html(release_notes):
     html_content = f"<h2>Release Notes</h2><p>{notes}</p>"
     return html_content
 
+def pr_labels(line):
+    """line is from `git log --pretty:format='%h %s'`, so for
+    squash/merge commits, it ends in (#<pr>).
+
+    Return the release-related labels for the identified PR, i.e.
+    labels of the form 'v<major>.<minor>.<patch>'
+    """
+
+    LOG_PR_SUFFIX_RE = re.compile(r"\(#(\d+)\)\s*$")
+    m = LOG_PR_SUFFIX_RE.search(line)
+    if not m:
+        return ""
+    pr_number = m.group(1)
+    result = run(
+        ["gh", "pr", "view", pr_number, "--json", "labels"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return ""
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return ""
+    out = []
+    for lab in data.get("labels") or []:
+        name = lab.get("name") or ""
+        if name.startswith("v"):
+            out.append(name)
+    return " ".join(out)
+
+def cmd_log():
+    """
+    Run ``git log`` and print commits annotated with the release labels for the associated PRs
+    """
+
+    # Output looks like:
+    # v3.4.7  3978976a Bump pypa/cibuildwheel from 3.3 to 3.4 (#2287)
+    #         b19cfec2 Bump github/codeql-action from 4.32.4 to 4.32.5 (#2286)
+    # v3.4.7  50ea61bd Fix build failure with glibc 2.43 due to C11 threads.h conflicts (#2262)
+
+    result = run(
+        ["git", "log", "--pretty=format:%h %s"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "git log failed\n")
+        sys.exit(1)
+
+    for line in result.stdout.splitlines():
+        l = pr_labels(line)
+        print(f"{l:7} {line}")
+
 def main():
+
+    if len(sys.argv) > 1:
+        action = sys.argv[1]
+        if action == "log":
+            cmd_log()
+            return
+
     if len(sys.argv) < 2:
         print(
             "Usage: python release.py "
@@ -527,12 +596,8 @@ def main():
             )
             sys.exit(1)
         tag = sys.argv[2]
-        try:
-            pr_number = int(sys.argv[3])
-        except ValueError:
-            print("PR number must be an integer.", file=sys.stderr)
-            sys.exit(1)
-        cmd_changes(tag, pr_number)
+        prs = sys.argv[3:]
+        cmd_changes(tag, prs)
         return
 
     if len(sys.argv) < 3:

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -312,7 +312,18 @@ def parse_section(lines):
 
     return heading, merged_prs, merged_workflow_prs
 
-
+def pr_is_workflow_only(pr_number: int) -> bool:
+    """Return True if every file changed by the PR is under .github/workflows/."""
+    result = run(
+        ["gh", "pr", "view", str(pr_number), "--json", "files",
+         "--jq", "[.files[].path]"],
+        stdout=PIPE, stderr=PIPE, universal_newlines=True, check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    paths = json.loads(result.stdout or "[]")
+    return bool(paths) and all(p.startswith(".github/workflows/") for p in paths)
 def cmd_changes(tag, prs):
     """
     Add a section to CHANGES.md for the given release if one doesn't already exist, and add the given PR 
@@ -391,7 +402,7 @@ def cmd_changes(tag, prs):
         info = gh_pr_view(pr_number)
         title = info.get("title") or ""
         author = (info.get("author") or {}).get("login") or ""
-        is_workflow = "dependabot" in author
+        is_workflow = "dependabot" in author or pr_is_workflow_only(pr_number)
         url = get_repo_url()
         title_one_line = " ".join(title.split())
         pr_block = f"* [{pr_number}]({url}/pull/{pr_number})\n{title_one_line}"

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -187,7 +187,7 @@ def cmd_cherry(label):
 
     merged.sort(key=lambda x: x[0])
 
-    changes_prs = []
+    changes_prs = ""
     for _merged_at, oid, title, id in merged:
         abbrev = oid[:7]
         title_one_line = " ".join(title.split())

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -9,8 +9,8 @@
 # `release.py draft <tag>` - create a draft release on GitHub
 # `release.py candidate <tag>` - format a message about the upcoming release, print to stdout
 # `release.py cherry <label>` - list merged PRs with the given label, print cherry-pick lines (oldest merge first)
-# `release.py changes <tag> <pr#>` - preview CHANGES.md update for a merged PR (prints to stdout)
-
+# `release.py changes <tag> [pr#> ... ]` - add section to CHANGES.md with given PRs
+# `release.py log` - print a `git log` annotated with the labels from each commit's associated PR, if there is one.
 #
 # The file `CHANGES.md` is assumed to old the release notes. When
 # preparing a release, edit this file by hand to add a description of

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -8,6 +8,8 @@
 # `release.py news <tag>` - edit the website/news.rst file to add reference to the tagged release
 # `release.py draft <tag>` - create a draft release on GitHub
 # `release.py candidate <tag>` - format a message about the upcoming release, print to stdout
+# `release.py cherry <label>` - list merged PRs with the given label, print cherry-pick lines (oldest merge first)
+# `release.py changes <tag> <pr#>` - preview CHANGES.md update for a merged PR (prints to stdout)
 
 #
 # The file `CHANGES.md` is assumed to old the release notes. When
@@ -22,10 +24,13 @@
 # main website landing page to reproduce the text.
 #
 
+import json
 import sys
 import re
+import subprocess
+from pathlib import Path
 from subprocess import PIPE, run
-from datetime import datetime
+from datetime import datetime, timedelta
 import markdown
 
 def extract_section(content, version_tag):
@@ -120,12 +125,301 @@ def create_draft_release(tag, release_notes):
 
 def get_repo_url():
     try:
+        # Return the upstream if this is in a fork
+        result = run(['git', 'config', '--get', 'remote.upstream.url'],
+                     stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        url = result.stdout.strip().rstrip(".git")
+        if url:
+            return url
+        
         result = run(['git', 'config', '--get', 'remote.origin.url'],
                      stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        url = result.stdout.strip()
+        url = result.stdout.strip().rstrip(".git")
         return url
     except subprocess.CalledProcessError:
         return None  # Not a git repo or no origin remote
+
+
+def cmd_cherry(label):
+    """
+    List merged PRs with the given GitHub label, ordered by merge time
+    (oldest first). Print one line per merge commit suitable for cherry-picking.
+    """
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--label",
+            label,
+            "--state",
+            "merged",
+            "--limit",
+            "500",
+            "--json",
+            "mergedAt,mergeCommit,title,number",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr list failed\n")
+        sys.exit(1)
+
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON from gh: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    merged = []
+    for pr in prs:
+        id = pr.get("number") or "?"
+        mc = pr.get("mergeCommit") or {}
+        oid = mc.get("oid")
+        merged_at = pr.get("mergedAt")
+        title = pr.get("title") or ""
+        if not oid or not merged_at:
+            continue
+        merged.append((merged_at, oid, title, id))
+
+    merged.sort(key=lambda x: x[0])
+
+    for _merged_at, oid, title, id in merged:
+        abbrev = oid[:7]
+        title_one_line = " ".join(title.split())
+        print(f"git cherry-pick {abbrev} # {title_one_line} (#{id})")
+
+
+def prev_patch_version(base_tag):
+    """
+    Previous release in the same major.minor line, e.g. 3.4.5 -> 3.4.4.
+    Returns None if the patch segment is missing, non-numeric, or already 0.
+    """
+    parts = base_tag.split(".")
+    if not parts or not parts[-1].isdigit():
+        return None
+    patch = int(parts[-1])
+    if patch <= 0:
+        return None
+    parts[-1] = str(patch - 1)
+    return ".".join(parts)
+
+
+def gh_pr_view(pr_number):
+    result = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "title,author",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+MERGED_PR_HEADING_RE = re.compile(
+    r"^###\s+Merged Pull Requests\s*:?\s*$", re.IGNORECASE
+)
+MERGED_WORKFLOW_HEADING_RE = re.compile(
+    r"^###\s+Merged Workflow Pull Requests\s*:?\s*$", re.IGNORECASE
+)
+PR_BULLET_RE = re.compile(r"^\*\s*\[(\d+)\]\(")
+
+
+def parse_pr_blocks_dict(lines, i, stop_at_workflow_heading):
+    """
+    From index *i*, read ``* [pr](url)`` entries. Each value is the bullet line and
+    the following line joined with ``\\n`` when that following line is not another
+    bullet or (if applicable) the workflow subsection heading.
+
+    If *stop_at_workflow_heading* is true, stop before ``### Merged Workflow Pull Requests``.
+    Returns ``(dict pr -> str, next_index)``.
+    """
+    out = {}
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if stop_at_workflow_heading and MERGED_WORKFLOW_HEADING_RE.match(line.strip()):
+            break
+        mo = PR_BULLET_RE.match(line.strip())
+        if mo:
+            pr = int(mo.group(1))
+            bullet = line
+            if i + 1 < n:
+                nxt = lines[i + 1]
+                if stop_at_workflow_heading and MERGED_WORKFLOW_HEADING_RE.match(
+                    nxt.strip()
+                ):
+                    out[pr] = bullet
+                    i += 1
+                    continue
+                if PR_BULLET_RE.match(nxt.strip()):
+                    out[pr] = bullet
+                    i += 1
+                    continue
+                out[pr] = "\n".join([bullet, nxt])
+                i += 2
+                continue
+            out[pr] = bullet
+            i += 1
+            continue
+        i += 1
+    return out, i
+
+
+def parse_section(lines):
+    """
+    Parse a version slice of CHANGES.md (list of line strings, no trailing newlines).
+
+    Returns ``heading`` (lines before ``### Merged Pull Requests``), and two dicts
+    mapping PR number -> two-line bullet+title string for each subsection.
+    """
+    heading = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        if MERGED_PR_HEADING_RE.match(line.strip()):
+            break
+        heading.append(line)
+        i += 1
+
+    merged_prs = {}
+    if i < n and MERGED_PR_HEADING_RE.match(lines[i].strip()):
+        i += 1
+        merged_prs, i = _parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=True)
+
+    merged_workflow_prs = {}
+    if i < n and MERGED_WORKFLOW_HEADING_RE.match(lines[i].strip()):
+        i += 1
+        merged_workflow_prs, i = _parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=False)
+
+    return heading, merged_prs, merged_workflow_prs
+
+
+def cmd_changes(tag, pr_number):
+    """
+    Add a section to CHANGES.md for the given release if one doesn't already exist, and add the given PR 
+    to the list if it's not already there.
+    """
+
+    with open("CHANGES.md", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    base_tag = tag.lstrip("v").split("-rc")[0] # i.e. "3.4.7"
+    prev_tag = prev_patch_version(base_tag) # i.e.e "3.4.6"
+
+    section_re = re.compile(rf"^##\s+Version\s+{re.escape(base_tag)}\b", re.IGNORECASE)
+    prev_re = re.compile(rf"^##\s+Version\s+{re.escape(prev_tag)}\b", re.IGNORECASE)
+
+    #
+    # Terminology:
+    #  "header" = everything from the beginning of the file up to the new section
+    #  "footer" = everything afer the new section
+    #
+    
+    # Find the line index of the existing section if there is one, and
+    # to the previous release section, i.e. the release before, which
+    # comes after it in the file.
+    
+    section_index = None
+    footer_index = None # line of the following section, i.e. the remainder of the file.
+    for i, line in enumerate(lines):
+        if section_index is None and section_re.match(line):
+            section_index = i
+        if prev_re is not None and footer_index is None and prev_re.match(line):
+            footer_index = i
+
+    # header_index is the last line of content before the new section
+    header_index = ( 
+        section_index if section_index is not None else footer_index
+    )
+    if header_index is None:
+        print(
+            "Could not locate insertion point (no matching version section and no "
+            "previous patch release heading in CHANGES.md).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    release_date = datetime.now() + timedelta(days=3)
+    date_str = release_date.strftime("%B %e, %Y")
+
+    if section_index is not None:
+        # Parse the existing section into the heading (section heading
+        # and existing notes), the dict of merged PRs, and the dict of merge workflow PRs
+        section_heading, merged_prs, merged_workflow_prs = parse_section(
+            lines[section_index:footer_index]
+        )
+    else:
+        # The section does not exist, so create the stub of a new one
+        section_heading = [f"## Version {base_tag} ({date_str})\n"]
+        merged_prs = {}
+        merged_workflow_prs = {}
+
+    # Find the index of the table of contents entry, if there is one.
+    toc, prev_toc = None, None
+    toc_re = re.compile(rf"^\*\s+\[Version\s+{re.escape(base_tag)}\]", re.IGNORECASE)
+    prev_toc_re = re.compile(rf"^\*\s+\[Version\s+{re.escape(prev_tag)}\]", re.IGNORECASE)
+    for i, line in enumerate(lines[:footer_index]):
+        if toc is None and toc_re.match(line):
+            toc = i
+        elif prev_toc is None and prev_toc_re.match(line):
+            prev_toc = i
+            break
+
+    # Format the list entry for the new PR:
+    # * [number](url)
+    # title
+    info = gh_pr_view(pr_number)
+    title = info.get("title") or ""
+    author = (info.get("author") or {}).get("login") or ""
+    is_workflow = "dependabot" in author
+    url = get_repo_url()
+    title_one_line = " ".join(title.split())
+    pr_block = f"* [{pr_number}]({url}/pull/{pr_number})\n{title_one_line}"
+    # Add it to the appropriate section
+    if is_workflow:
+        merged_workflow_prs[pr_number] = pr_block
+    else:
+        merged_prs[pr_number] = pr_block
+
+    with open("CHANGES.md", "w", encoding="utf-8", newline="\n") as f:
+        if toc is None:
+            # No table of contents entry for this release, so add one.
+            f.write("\n".join(lines[:prev_toc]) + "\n")  # everything up to the previous release entry
+            # Write new entry
+            base_tag_nonum = base_tag.replace(".","")
+            date_str_lower = date_str.lower().replace(",","").replace(" ","-")
+            f.write(f"* [Version {base_tag}](#version-{base_tag_nonum}-{date_str_lower}) {date_str}\n")
+            # Write the rest of the table of contents and everything up to the new release section
+            f.write("\n".join(lines[prev_toc:header_index]) + "\n")  
+        else:
+            # Table of contents already has an entry, so just write the header
+            f.write("\n".join(lines[:header_index]) + "\n")
+        # Write the release section
+        f.write("\n".join(section_heading))
+        f.write("\n### Merged Pull Requests\n\n")
+        for pr, value in sorted(merged_prs.items(), reverse=True):
+            f.write(value + "\n")
+        f.write("\n### Merged Workflow Pull Requests\n\n")
+        for pr, value in sorted(merged_workflow_prs.items(), reverse=True):
+            f.write(value + "\n")
+        # Write the rest of the file
+        f.write("\n" + "\n".join(lines[footer_index:]))
 
 def update_news_file(release_notes, tag, release_date):
     """
@@ -204,11 +498,50 @@ def convert_to_html(release_notes):
     return html_content
 
 def main():
-    if len(sys.argv) < 3:
-        print("Usage: python release.py <notes|news|draft|candidate> <tag> [date]")
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python release.py "
+            "<notes|news|draft|candidate|cherry|changes> ...\n"
+            "  release.py changes <tag> <pr-number>   e.g. release.py changes v3.4.7 1234"
+        )
         sys.exit(1)
 
     action = sys.argv[1]
+
+    if action == "cherry":
+        if len(sys.argv) < 3:
+            print(
+                "Usage: python release.py cherry <label>",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        cmd_cherry(sys.argv[2])
+        return
+
+    if action == "changes":
+        if len(sys.argv) < 4:
+            print(
+                "Usage: python release.py changes <tag> <pr-number>\n"
+                "Example: python release.py changes v3.4.7 1234",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        tag = sys.argv[2]
+        try:
+            pr_number = int(sys.argv[3])
+        except ValueError:
+            print("PR number must be an integer.", file=sys.stderr)
+            sys.exit(1)
+        cmd_changes(tag, pr_number)
+        return
+
+    if len(sys.argv) < 3:
+        print(
+            "Usage: python release.py "
+            "<notes|news|draft|candidate|cherry|changes> <tag-or-label> [date]"
+        )
+        sys.exit(1)
+
     tag = sys.argv[2]
 
     # Strip leading 'v' and trailing '-rc<candidate>' if necessary


### PR DESCRIPTION
The "cherry" and "changes" options help with staging a release candidate.

Print the SHAs of commits from PRs with the given label:
`   share/util/release.py cherry v3.4.7`

Add section and PR list entry to CHANGES.md:
`   share/util/release.py changes v3.4.7 2313`

These options help automate the release process, although they still leave theactual cherry-picking to be done by hand.

The release process:
1. Label PRs with the new release label
2. Run "release.py cherry" to print the commits
3. For each PR/commit: a. cherry pick it onto the release branch b. run "release.py changes" to add to the release notes