### PR TITLE
Fix integer overflow in `srcbuffer` pointer arithmetic in `unpack_*`

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -232,7 +232,7 @@ unpack_16bit_3chan_interleave (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -243,7 +243,7 @@ unpack_16bit_3chan_interleave (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = one_to_native16 (in0[x]);
@@ -278,7 +278,7 @@ unpack_16bit_3chan_interleave_rev (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -289,7 +289,7 @@ unpack_16bit_3chan_interleave_rev (exr_decode_pipeline_t* decode)
         in1 = in0 + w;                     // G
         in2 = in1 + w;                     // R
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = one_to_native16 (in2[x]);
@@ -324,7 +324,7 @@ unpack_half_to_float_3chan_interleave (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -335,7 +335,7 @@ unpack_half_to_float_3chan_interleave (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in0[x]));
@@ -370,7 +370,7 @@ unpack_half_to_float_3chan_interleave_rev (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -381,7 +381,7 @@ unpack_half_to_float_3chan_interleave_rev (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in2[x]));
@@ -420,7 +420,7 @@ unpack_16bit_3chan_planar (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     // planar output
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -428,7 +428,7 @@ unpack_16bit_3chan_planar (exr_decode_pipeline_t* decode)
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
 #if EXR_HOST_IS_NOT_LITTLE_ENDIAN
         for (int x = 0; x < w; ++x)
@@ -476,7 +476,7 @@ unpack_half_to_float_3chan_planar (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     // planar output
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -484,7 +484,7 @@ unpack_half_to_float_3chan_planar (exr_decode_pipeline_t* decode)
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
         half_to_float_buffer ((float*) out0, in0, w);
         half_to_float_buffer ((float*) out1, in1, w);
@@ -528,14 +528,14 @@ unpack_16bit_3chan (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 6;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 6;
 
     for (int y = decode->user_line_begin_skip; y < h; ++y)
     {
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
             *((uint16_t*) (out0 + x * inc0)) = one_to_native16 (in0[x]);
         for (int x = 0; x < w; ++x)
@@ -584,7 +584,7 @@ unpack_16bit_4chan_interleave (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -595,7 +595,7 @@ unpack_16bit_4chan_interleave (exr_decode_pipeline_t* decode)
         in2              = in1 + w;
         in3              = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             combined.a = one_to_native16 (in0[x]);
@@ -643,7 +643,7 @@ unpack_16bit_4chan_interleave_rev (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -654,7 +654,7 @@ unpack_16bit_4chan_interleave_rev (exr_decode_pipeline_t* decode)
         in2              = in1 + w;
         in3              = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             combined.a = one_to_native16 (in0[x]);
@@ -690,7 +690,7 @@ unpack_half_to_float_4chan_interleave (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -701,7 +701,7 @@ unpack_half_to_float_4chan_interleave (exr_decode_pipeline_t* decode)
         in2        = in1 + w;
         in3        = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in0[x]));
@@ -737,7 +737,7 @@ unpack_half_to_float_4chan_interleave_rev (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     /* interleaving case, we can do this! */
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -748,7 +748,7 @@ unpack_half_to_float_4chan_interleave_rev (exr_decode_pipeline_t* decode)
         in2        = in1 + w;
         in3        = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in3[x]));
@@ -790,7 +790,7 @@ unpack_16bit_4chan_planar (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     // planar output
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -799,7 +799,7 @@ unpack_16bit_4chan_planar (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
                             /* specialize to memcpy if we can */
 #if EXR_HOST_IS_NOT_LITTLE_ENDIAN
         for (int x = 0; x < w; ++x)
@@ -852,7 +852,7 @@ unpack_half_to_float_4chan_planar (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += decode->user_line_begin_skip * w * 8;
+    srcbuffer += (int64_t) decode->user_line_begin_skip * w * 8;
 
     // planar output
     for (int y = decode->user_line_begin_skip; y < h; ++y)
@@ -861,7 +861,7 @@ unpack_half_to_float_4chan_planar (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
 
         half_to_float_buffer ((float*) out0, in0, w);
         half_to_float_buffer ((float*) out1, in1, w);
@@ -909,7 +909,7 @@ unpack_16bit_4chan (exr_decode_pipeline_t* decode)
      * not actually using y in the loop, so just pre-increment
      * the srcbuffer for any skip
      */
-    srcbuffer += w * decode->user_line_begin_skip * 8;
+    srcbuffer += (int64_t) w * decode->user_line_begin_skip * 8;
 
     for (int y = decode->user_line_begin_skip; y < h; ++y)
     {
@@ -917,7 +917,7 @@ unpack_16bit_4chan (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
             *((uint16_t*) (out0 + x * inc0)) = one_to_native16 (in0[x]);
         for (int x = 0; x < w; ++x)
@@ -952,7 +952,7 @@ unpack_16bit (exr_decode_pipeline_t* decode)
     for (int c = 0; c < decode->channel_count; ++c)
     {
         exr_coding_channel_info_t* decc = (decode->channels + c);
-        srcbuffer += decc->width * decode->user_line_begin_skip * 2;
+        srcbuffer += (int64_t) decc->width * decode->user_line_begin_skip * 2;
     }
     h -= decode->user_line_begin_skip;
 
@@ -1001,7 +1001,7 @@ unpack_16bit (exr_decode_pipeline_t* decode)
                 }
             }
 #endif
-            srcbuffer += w * 2;
+            srcbuffer += (int64_t) w * 2;
         }
     }
     return EXR_ERR_SUCCESS;
@@ -1027,7 +1027,7 @@ unpack_32bit (exr_decode_pipeline_t* decode)
     for (int c = 0; c < decode->channel_count; ++c)
     {
         exr_coding_channel_info_t* decc = (decode->channels + c);
-        srcbuffer += decc->width * decode->user_line_begin_skip * 4;
+        srcbuffer += (int64_t) decc->width * decode->user_line_begin_skip * 4;
     }
     h -= decode->user_line_begin_skip;
 
@@ -1076,7 +1076,7 @@ unpack_32bit (exr_decode_pipeline_t* decode)
                 }
             }
 #endif
-            srcbuffer += w * 4;
+            srcbuffer += (int64_t) w * 4;
         }
     }
     return EXR_ERR_SUCCESS;
@@ -1263,7 +1263,7 @@ generic_unpack (exr_decode_pipeline_t* decode)
                 if ((cury % decc->y_samples) != 0) continue;
                 if (y < uls || !cdata)
                 {
-                    srcbuffer += w * bpc;
+                    srcbuffer += (int64_t) w * bpc;
                     continue;
                 }
 
@@ -1275,7 +1275,7 @@ generic_unpack (exr_decode_pipeline_t* decode)
             {
                 if (y < uls || !cdata)
                 {
-                    srcbuffer += w * bpc;
+                    srcbuffer += (int64_t) w * bpc;
                     continue;
                 }
 
@@ -1283,7 +1283,7 @@ generic_unpack (exr_decode_pipeline_t* decode)
             }
 
             UNPACK_SAMPLES (w)
-            srcbuffer += w * bpc;
+            srcbuffer += (int64_t) w * bpc;
         }
     }
     return EXR_ERR_SUCCESS;


### PR DESCRIPTION
Pointer arithmetic involving `srcbuffer` in the `unpack_*` functions can overflow for very wide images.

Multiplying `int w` by a bytes-per-element constant (2, 4, 6, or 8) in `srcbuffer +=` expressions causes signed integer overflow when the image width is large.

Promote the leading operand to `int64_t` at every affected multiplication so pointer arithmetic is performed in 64-bit signed arithmetic throughout, eliminating the undefined behavior without imposing any image size limit.

Affected sites: `generic_unpack`, `unpack_16bit`, `unpack_32bit`, and all 3- and 4-channel interleave/planar specializations.

Made-with: Cursor