### PR TITLE
news and release notes for v3.4.8 and v3.4.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,31 +153,31 @@ Patch release bug/build fixes:
 
 ### Merged Pull Requests:
 
-* [2292](https://github.com/AcademySoftwareFoundation/openexr/pulls/2292)
+* [2292](https://github.com/AcademySoftwareFoundation/openexr/pull/2292)
 Bump actions/download-artifact from 8.0.0 to 8.0.1
 
-* [2291](https://github.com/AcademySoftwareFoundation/openexr/pulls/2291)
+* [2291](https://github.com/AcademySoftwareFoundation/openexr/pull/2291)
 Fix integer overflow in htj2k decode with width > 32767
 
-* [2289](https://github.com/AcademySoftwareFoundation/openexr/pulls/2289)
+* [2289](https://github.com/AcademySoftwareFoundation/openexr/pull/2289)
 Bump scikit-build-core from 0.12.1 to 0.12.2
 
-* [2288](https://github.com/AcademySoftwareFoundation/openexr/pulls/2288)
+* [2288](https://github.com/AcademySoftwareFoundation/openexr/pull/2288)
 Bump jmertic/slack-release-notifier from 6fa159048d5313ff1177d248ad84beb627571670 to 35fad060af5559c24decdec0f701e6ba93566704
 
-* [2287](https://github.com/AcademySoftwareFoundation/openexr/pulls/2287)
+* [2287](https://github.com/AcademySoftwareFoundation/openexr/pull/2287)
 Bump pypa/cibuildwheel from 3.3 to 3.4
 
-* [2283](https://github.com/AcademySoftwareFoundation/openexr/pulls/2283)
+* [2283](https://github.com/AcademySoftwareFoundation/openexr/pull/2283)
 update SECURITY with CVE info for PR #2256
 
-* [2282](https://github.com/AcademySoftwareFoundation/openexr/pulls/2282)
+* [2282](https://github.com/AcademySoftwareFoundation/openexr/pull/2282)
 Remove website_preview_link workflow
 
-* [2281](https://github.com/AcademySoftwareFoundation/openexr/pulls/2281)
+* [2281](https://github.com/AcademySoftwareFoundation/openexr/pull/2281)
 Disable visibility attributes on Windows to fix msys2 -Wattributes warning
 
-* [2262](https://github.com/AcademySoftwareFoundation/openexr/pulls/2262)
+* [2262](https://github.com/AcademySoftwareFoundation/openexr/pull/2262)
 Fix build failure with glibc 2.43 due to C11 threads.h conflicts
 
 ## Version 3.4.6 (March 1, 2026)
@@ -187,8 +187,6 @@ Patch release with several bug fixes, enhancements, and build improvements.
 * :bug: A limit of ``UINT_MAX`` deep samples per pixel is now
   enforced, which prevents an integer overflow when using the
   `CompositeDeepScanLine` API to combine multiple deep parts.
-
-* :bug: `IlmThread` now builds properl with glibc 2.43.
 
 * :wrench: In `IlmThreadPool`, replace deprecated `std::atomic_load /
   std::atomic_exchange` overloads for `std::shared_ptr` with the C++20
@@ -239,99 +237,99 @@ Also, this release bumps the vendered version of `libdeflate` to 1.25.
 
 ### Merged Pull Requests:
 
-* [2274](https://github.com/AcademySoftwareFoundation/openexr/pulls/2274)
+* [2274](https://github.com/AcademySoftwareFoundation/openexr/pull/2274)
 Update the vendored libdeflate to 1.25
-* [2273](https://github.com/AcademySoftwareFoundation/openexr/pulls/2273)
+* [2273](https://github.com/AcademySoftwareFoundation/openexr/pull/2273)
 Release Python GIL during I/O operations in bindings
-* [2272](https://github.com/AcademySoftwareFoundation/openexr/pulls/2272)
+* [2272](https://github.com/AcademySoftwareFoundation/openexr/pull/2272)
 Fix build failure with -march=sandybridge (#2231)
-* [2271](https://github.com/AcademySoftwareFoundation/openexr/pulls/2271)
+* [2271](https://github.com/AcademySoftwareFoundation/openexr/pull/2271)
 Enable SSE2 on 32-bit x86 builds to fix test failures
-* [2269](https://github.com/AcademySoftwareFoundation/openexr/pulls/2269)
+* [2269](https://github.com/AcademySoftwareFoundation/openexr/pull/2269)
 Mention OpenEXR dependencies on README
-* [2268](https://github.com/AcademySoftwareFoundation/openexr/pulls/2268)
+* [2268](https://github.com/AcademySoftwareFoundation/openexr/pull/2268)
 Bazel: Use openjph 0.26.3
-* [2267](https://github.com/AcademySoftwareFoundation/openexr/pulls/2267)
+* [2267](https://github.com/AcademySoftwareFoundation/openexr/pull/2267)
 Bump rules_cc from 0.2.16 to 0.2.17
-* [2265](https://github.com/AcademySoftwareFoundation/openexr/pulls/2265)
+* [2265](https://github.com/AcademySoftwareFoundation/openexr/pull/2265)
 Bump jmertic/slack-release-notifier
-* [2264](https://github.com/AcademySoftwareFoundation/openexr/pulls/2264)
+* [2264](https://github.com/AcademySoftwareFoundation/openexr/pull/2264)
 Bump github/codeql-action from 4.32.3 to 4.32.4
-* [2263](https://github.com/AcademySoftwareFoundation/openexr/pulls/2263)
+* [2263](https://github.com/AcademySoftwareFoundation/openexr/pull/2263)
 Add sanity check for correct arguments to exrstdattr
-* [2261](https://github.com/AcademySoftwareFoundation/openexr/pulls/2261)
+* [2261](https://github.com/AcademySoftwareFoundation/openexr/pull/2261)
 Fix sentence fragment typo in website python docs
-* [2260](https://github.com/AcademySoftwareFoundation/openexr/pulls/2260)
+* [2260](https://github.com/AcademySoftwareFoundation/openexr/pull/2260)
 Add reference to `OPENEXR_FORCE_EMBEDDED_CORE` on install page
-* [2259](https://github.com/AcademySoftwareFoundation/openexr/pulls/2259)
+* [2259](https://github.com/AcademySoftwareFoundation/openexr/pull/2259)
 Fix ZipCompressor to initialize compresson type correctly
-* [2258](https://github.com/AcademySoftwareFoundation/openexr/pulls/2258)
+* [2258](https://github.com/AcademySoftwareFoundation/openexr/pull/2258)
 Bazel: Remove WORKSPACE.bazel file
-* [2256](https://github.com/AcademySoftwareFoundation/openexr/pulls/2256)
+* [2256](https://github.com/AcademySoftwareFoundation/openexr/pull/2256)
 Report an error if a deep pixel as more than `UINT_MAX` samples
-* [2253](https://github.com/AcademySoftwareFoundation/openexr/pulls/2253)
+* [2253](https://github.com/AcademySoftwareFoundation/openexr/pull/2253)
 Add CVE-2025-64181 to SECURITY.md
-* [2252](https://github.com/AcademySoftwareFoundation/openexr/pulls/2252)
+* [2252](https://github.com/AcademySoftwareFoundation/openexr/pull/2252)
 Add news and release notes for v3.4.5 and v3.3.7
-* [2250](https://github.com/AcademySoftwareFoundation/openexr/pulls/2250)
+* [2250](https://github.com/AcademySoftwareFoundation/openexr/pull/2250)
 Vendor OpenJPH v0.26.3
-* [2249](https://github.com/AcademySoftwareFoundation/openexr/pulls/2249)
+* [2249](https://github.com/AcademySoftwareFoundation/openexr/pull/2249)
 Add python support for Opaque Attributes
-* [2248](https://github.com/AcademySoftwareFoundation/openexr/pulls/2248)
+* [2248](https://github.com/AcademySoftwareFoundation/openexr/pull/2248)
 Fix tag check, git rm, and sed calls in vendor_openjph.sh
-* [2247](https://github.com/AcademySoftwareFoundation/openexr/pulls/2247)
+* [2247](https://github.com/AcademySoftwareFoundation/openexr/pull/2247)
 Bump github/codeql-action from 4.31.9 to 4.32.3
-* [2243](https://github.com/AcademySoftwareFoundation/openexr/pulls/2243)
+* [2243](https://github.com/AcademySoftwareFoundation/openexr/pull/2243)
 IlmThread: fix deprecated atomic `shared_ptr` ops for `shared_ptr` (GCC 15)
-* [2240](https://github.com/AcademySoftwareFoundation/openexr/pulls/2240)
+* [2240](https://github.com/AcademySoftwareFoundation/openexr/pull/2240)
 Bump actions/cache from 5.0.1 to 5.0.3
-* [2239](https://github.com/AcademySoftwareFoundation/openexr/pulls/2239)
+* [2239](https://github.com/AcademySoftwareFoundation/openexr/pull/2239)
 Fix links and formatting in CONTRIBUTING.md
-* [2236](https://github.com/AcademySoftwareFoundation/openexr/pulls/2236)
+* [2236](https://github.com/AcademySoftwareFoundation/openexr/pull/2236)
 Bump actions/checkout from 6.0.1 to 6.0.2
-* [2235](https://github.com/AcademySoftwareFoundation/openexr/pulls/2235)
+* [2235](https://github.com/AcademySoftwareFoundation/openexr/pull/2235)
 Bump actions/setup-python from 6.1.0 to 6.2.0
-* [2227](https://github.com/AcademySoftwareFoundation/openexr/pulls/2227)
+* [2227](https://github.com/AcademySoftwareFoundation/openexr/pull/2227)
 Bump rules_cc from 0.2.14 to 0.2.16
-* [2226](https://github.com/AcademySoftwareFoundation/openexr/pulls/2226)
+* [2226](https://github.com/AcademySoftwareFoundation/openexr/pull/2226)
 Bump bazel_skylib from 1.8.2 to 1.9.0
-* [2225](https://github.com/AcademySoftwareFoundation/openexr/pulls/2225)
+* [2225](https://github.com/AcademySoftwareFoundation/openexr/pull/2225)
 Rename external/OpenJPH/src/core/common to openjph, instead of using a symlink
-* [2224](https://github.com/AcademySoftwareFoundation/openexr/pulls/2224)
+* [2224](https://github.com/AcademySoftwareFoundation/openexr/pull/2224)
 Bump github/codeql-action from 4.31.8 to 4.31.9
-* [2222](https://github.com/AcademySoftwareFoundation/openexr/pulls/2222)
+* [2222](https://github.com/AcademySoftwareFoundation/openexr/pull/2222)
 Bump actions/upload-artifact from 5 to 6
-* [2221](https://github.com/AcademySoftwareFoundation/openexr/pulls/2221)
+* [2221](https://github.com/AcademySoftwareFoundation/openexr/pull/2221)
 Bump actions/cache from 4.3.0 to 5.0.1
-* [2220](https://github.com/AcademySoftwareFoundation/openexr/pulls/2220)
+* [2220](https://github.com/AcademySoftwareFoundation/openexr/pull/2220)
 Bump msys2/setup-msys2 from 2.29.0 to 2.30.0
-* [2219](https://github.com/AcademySoftwareFoundation/openexr/pulls/2219)
+* [2219](https://github.com/AcademySoftwareFoundation/openexr/pull/2219)
 Bump actions/download-artifact from 6.0.0 to 7.0.0
-* [2218](https://github.com/AcademySoftwareFoundation/openexr/pulls/2218)
+* [2218](https://github.com/AcademySoftwareFoundation/openexr/pull/2218)
 Bump github/codeql-action from 4.31.7 to 4.31.8
-* [2216](https://github.com/AcademySoftwareFoundation/openexr/pulls/2216)
+* [2216](https://github.com/AcademySoftwareFoundation/openexr/pull/2216)
 Add option to compile c++ libraries with an embedded core library
-* [2215](https://github.com/AcademySoftwareFoundation/openexr/pulls/2215)
+* [2215](https://github.com/AcademySoftwareFoundation/openexr/pull/2215)
 Bump imath from 3.2.2 to 3.2.2.bcr.1
-* [2214](https://github.com/AcademySoftwareFoundation/openexr/pulls/2214)
+* [2214](https://github.com/AcademySoftwareFoundation/openexr/pull/2214)
 Bump github/codeql-action from 4.31.5 to 4.31.7
-* [2213](https://github.com/AcademySoftwareFoundation/openexr/pulls/2213)
+* [2213](https://github.com/AcademySoftwareFoundation/openexr/pull/2213)
 Bump sigstore/gh-action-sigstore-python from 3.1.0 to 3.2.0
-* [2212](https://github.com/AcademySoftwareFoundation/openexr/pulls/2212)
+* [2212](https://github.com/AcademySoftwareFoundation/openexr/pull/2212)
 Bump actions/checkout from 6.0.0 to 6.0.1
-* [2210](https://github.com/AcademySoftwareFoundation/openexr/pulls/2210)
+* [2210](https://github.com/AcademySoftwareFoundation/openexr/pull/2210)
 Bump actions/setup-python from 6.0.0 to 6.1.0
-* [2209](https://github.com/AcademySoftwareFoundation/openexr/pulls/2209)
+* [2209](https://github.com/AcademySoftwareFoundation/openexr/pull/2209)
 Bump github/codeql-action from 4.31.4 to 4.31.5
-* [2208](https://github.com/AcademySoftwareFoundation/openexr/pulls/2208)
+* [2208](https://github.com/AcademySoftwareFoundation/openexr/pull/2208)
 Remove enable-beta-ecosystem since Bazel is no officially supported
-* [2204](https://github.com/AcademySoftwareFoundation/openexr/pulls/2204)
+* [2204](https://github.com/AcademySoftwareFoundation/openexr/pull/2204)
 Bump actions/checkout from 3.6.0 to 6.0.0
-* [2202](https://github.com/AcademySoftwareFoundation/openexr/pulls/2202)
+* [2202](https://github.com/AcademySoftwareFoundation/openexr/pull/2202)
 Bump github/codeql-action from 4.31.3 to 4.31.4
-* [2193](https://github.com/AcademySoftwareFoundation/openexr/pulls/2193)
+* [2193](https://github.com/AcademySoftwareFoundation/openexr/pull/2193)
 Vendor in an internal version of OpenJPH
-* [2167](https://github.com/AcademySoftwareFoundation/openexr/pulls/2167)
+* [2167](https://github.com/AcademySoftwareFoundation/openexr/pull/2167)
 Bazel build: Bump openjph to 0.25.0 and libdeflate to 1.25
 
 ## Version 3.4.5 (February 21, 2026)
@@ -342,7 +340,7 @@ invalid input data.
 
 ### Merged Pull Requests:
 
-* [2244](https://github.com/AcademySoftwareFoundation/pulls/2244)
+* [2244](https://github.com/AcademySoftwareFoundation/openexr/pull/2244)
 Fix incorrect size check in `istream_nonparallel_read`
 
 ## Version 3.4.4 (November 19, 2025)
@@ -363,53 +361,53 @@ directory would fail.
 
 ### Merged Pull Requests:
 
-* [2199](https://github.com/AcademySoftwareFoundation/pulls/2199)
+* [2199](https://github.com/AcademySoftwareFoundation/openexr/pull/2199)
 OpenEXRCore: fix `ILMTHREAD_THREADING_ENABLED` checks
-* [2198](https://github.com/AcademySoftwareFoundation/pulls/2198)
+* [2198](https://github.com/AcademySoftwareFoundation/openexr/pull/2198)
 OpenEXRCore: avoid direct dependency on imath
-* [2196](https://github.com/AcademySoftwareFoundation/pulls/2196)
+* [2196](https://github.com/AcademySoftwareFoundation/openexr/pull/2196)
 Bump github/codeql-action from 4.31.2 to 4.31.3
-* [2194](https://github.com/AcademySoftwareFoundation/pulls/2194)
+* [2194](https://github.com/AcademySoftwareFoundation/openexr/pull/2194)
 Add missing copywrite comments
-* [2192](https://github.com/AcademySoftwareFoundation/pulls/2192)
+* [2192](https://github.com/AcademySoftwareFoundation/openexr/pull/2192)
 Bump pypa/cibuildwheel from 3.2 to 3.3
-* [2190](https://github.com/AcademySoftwareFoundation/pulls/2190)
+* [2190](https://github.com/AcademySoftwareFoundation/openexr/pull/2190)
 Bump github/codeql-action from 3.27.9 to 4.31.2
-* [2189](https://github.com/AcademySoftwareFoundation/pulls/2189)
+* [2189](https://github.com/AcademySoftwareFoundation/openexr/pull/2189)
 Bump msys2/setup-msys2 from 2.27.0 to 2.29.0
-* [2188](https://github.com/AcademySoftwareFoundation/pulls/2188)
+* [2188](https://github.com/AcademySoftwareFoundation/openexr/pull/2188)
 Bump actions/download-artifact from 4.1.8 to 6.0.0
-* [2187](https://github.com/AcademySoftwareFoundation/pulls/2187)
+* [2187](https://github.com/AcademySoftwareFoundation/openexr/pull/2187)
 Bump ossf/scorecard-action from 2.4.0 to 2.4.3
-* [2186](https://github.com/AcademySoftwareFoundation/pulls/2186)
+* [2186](https://github.com/AcademySoftwareFoundation/openexr/pull/2186)
 Bump pypa/cibuildwheel from 2.23 to 3.2
-* [2185](https://github.com/AcademySoftwareFoundation/pulls/2185)
+* [2185](https://github.com/AcademySoftwareFoundation/openexr/pull/2185)
 Bump actions/cache from 4.2.0 to 4.3.0
-* [2184](https://github.com/AcademySoftwareFoundation/pulls/2184)
+* [2184](https://github.com/AcademySoftwareFoundation/openexr/pull/2184)
 Bump actions/upload-artifact from 4 to 5
-* [2183](https://github.com/AcademySoftwareFoundation/pulls/2183)
+* [2183](https://github.com/AcademySoftwareFoundation/openexr/pull/2183)
 Bump actions/checkout from 2.7.0 to 5.0.0
-* [2182](https://github.com/AcademySoftwareFoundation/pulls/2182)
+* [2182](https://github.com/AcademySoftwareFoundation/openexr/pull/2182)
 Add recent CVEs to SECURITY.md
-* [2181](https://github.com/AcademySoftwareFoundation/pulls/2181)
+* [2181](https://github.com/AcademySoftwareFoundation/openexr/pull/2181)
 Bump sigstore/gh-action-sigstore-python from 3.0.0 to 3.1.0
-* [2180](https://github.com/AcademySoftwareFoundation/pulls/2180)
+* [2180](https://github.com/AcademySoftwareFoundation/openexr/pull/2180)
 Bump actions/setup-python from 5.3.0 to 6.0.0
-* [2178](https://github.com/AcademySoftwareFoundation/pulls/2178)
+* [2178](https://github.com/AcademySoftwareFoundation/openexr/pull/2178)
 Bump snyk/actions from 0.4.0 to 1.0.0
-* [2177](https://github.com/AcademySoftwareFoundation/pulls/2177)
+* [2177](https://github.com/AcademySoftwareFoundation/openexr/pull/2177)
 Bump pypa/gh-action-pypi-publish from 1.12.3 to 1.13.0
-* [2176](https://github.com/AcademySoftwareFoundation/pulls/2176)
+* [2176](https://github.com/AcademySoftwareFoundation/openexr/pull/2176)
 Imporve Bazel support
-* [2175](https://github.com/AcademySoftwareFoundation/pulls/2175)
+* [2175](https://github.com/AcademySoftwareFoundation/openexr/pull/2175)
 Converts asserts in internal_ht.cpp to if statement that throws an exception.
-* [2174](https://github.com/AcademySoftwareFoundation/pulls/2174)
+* [2174](https://github.com/AcademySoftwareFoundation/openexr/pull/2174)
 DWA: initialize linear/nonlinear tables at runtime
-* [2173](https://github.com/AcademySoftwareFoundation/pulls/2173)
+* [2173](https://github.com/AcademySoftwareFoundation/openexr/pull/2173)
 Update macos-13 to macos-15-intel
-* [2171](https://github.com/AcademySoftwareFoundation/pulls/2171)
+* [2171](https://github.com/AcademySoftwareFoundation/openexr/pull/2171)
 Properly set `OpenEXR_error` in legacy python API
-* [2126](https://github.com/AcademySoftwareFoundation/pulls/2126)
+* [2126](https://github.com/AcademySoftwareFoundation/openexr/pull/2126)
 B44: initialize exp/log tables at runtime
 
 
@@ -745,7 +743,7 @@ Patch release that prevents an integer overflow when using the
 
 ### Merged Pull Requests:
 
-* [2256](https://github.com/AcademySoftwareFoundation/pulls/2256)
+* [2256](https://github.com/AcademySoftwareFoundation/openexr/pull/2256)
 Report an error if a deep pixel as more than UINT_MAX samples
 
 ## Version 3.3.7 (February 19, 2026)
@@ -756,7 +754,7 @@ invalid input data.
 
 ### Merged Pull Requests:
 
-* [2244](https://github.com/AcademySoftwareFoundation/pulls/2244)
+* [2244](https://github.com/AcademySoftwareFoundation/openexr/pull/2244)
 Fix incorrect size check in `istream_nonparallel_read`
 
 ## Version 3.3.6 (November 4, 2025)
@@ -1378,7 +1376,7 @@ Patch release that prevents an integer overflow when using the
 
 ### Merged Pull Requests:
 
-* [2256](https://github.com/AcademySoftwareFoundation/pulls/2256)
+* [2256](https://github.com/AcademySoftwareFoundation/openexr/pull/2256)
 
 ## Version 3.2.5 (November 4, 2025)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,8 @@ Patch release with several bug fixes, enhancements, and build improvements.
   enforced, which prevents an integer overflow when using the
   `CompositeDeepScanLine` API to combine multiple deep parts.
 
+* :bug: `IlmThread` now builds properl with glibc 2.43.
+
 * :wrench: In `IlmThreadPool`, replace deprecated `std::atomic_load /
   std::atomic_exchange` overloads for `std::shared_ptr` with the C++20
   `std::atomic<std::shared_ptr<T>>` interface when available.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 # OpenEXR Release Notes
 
+* [Version 3.4.8](#version-348-march-26-2026) March 26, 2026
 * [Version 3.4.7](#version-347-march-15-2026) March 15, 2026
 * [Version 3.4.6](#version-346-march-1-2026) March 1, 2026
 * [Version 3.4.5](#version-345-february-21-2026) February 21, 2026
@@ -93,6 +94,54 @@
 * [Version 1.0.1](#version-101)
 * [Version 1.0](#version-10)
 
+## Version 3.4.8 (March 26, 2026)
+
+Patch release with several bug/build fixes:
+
+- Fix an integer-overflow bug reading malformed files compressed with
+  B44A/B44B 
+- Fix a buffer-overrun bug reading malformed files compressed with PXR24
+- Fix a bug compressing half data with ZIPS/ZIP data when the
+  compressed size equals packed size
+- Single part files no longer get assigned a part name when writing
+  via the python module
+- Fix a build failure on FreeBSD involving `threads.h`
+
+This also eliminates several compiler warnings, particularly about the
+deprecated `isOptimizationEnabled()` API and deprecates standard
+attributes. 
+
+### Merged Pull Requests
+
+* [2312](https://github.com/AcademySoftwareFoundation/openexr/pull/2312)
+Fix B44/B44A integer overflow: use uint64_t for row offset
+* [2310](https://github.com/AcademySoftwareFoundation/openexr/pull/2310)
+PXR24: reject zlib output that does not match packed payload size
+* [2307](https://github.com/AcademySoftwareFoundation/openexr/pull/2307)
+Fix ZIPS/ZIP encoder corruption when compressed size equals packed size
+* [2303](https://github.com/AcademySoftwareFoundation/openexr/pull/2303)
+Fix MinGW -Walloc-size-larger-than= in general_attr string test
+* [2301](https://github.com/AcademySoftwareFoundation/openexr/pull/2301)
+don't insert name attributes into single part files
+* [2300](https://github.com/AcademySoftwareFoundation/openexr/pull/2300)
+Fix FreeBSD build failure involving threads.h, and add FreeBSD CI build
+* [2124](https://github.com/AcademySoftwareFoundation/openexr/pull/2124)
+Suppress deprecation warnings for isOptimizationEnabled and standard attributes
+
+### Merged Workflow Pull Requests
+
+* [2315](https://github.com/AcademySoftwareFoundation/openexr/pull/2315)
+Force macos cibuildwheel to use Xcode clang
+* [2311](https://github.com/AcademySoftwareFoundation/openexr/pull/2311)
+Bump actions/cache from 5.0.3 to 5.0.4
+* [2304](https://github.com/AcademySoftwareFoundation/openexr/pull/2304)
+Bump github/codeql-action from 4.32.6 to 4.33.0
+* [2297](https://github.com/AcademySoftwareFoundation/openexr/pull/2297)
+Restore Analysis build
+* [2295](https://github.com/AcademySoftwareFoundation/openexr/pull/2295)
+Restrict workflow permissions for ci_steps, release-sign, and codeql
+* [2294](https://github.com/AcademySoftwareFoundation/openexr/pull/2294)
+Pin pypa/cibuildwheel actions to release sha
 
 ## Version 3.4.7 (March 15, 2026)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 
 # OpenEXR Release Notes
 
+* [Version 3.4.7](#version-347-march-15-2026) March 15, 2026
 * [Version 3.4.6](#version-346-march-1-2026) March 1, 2026
 * [Version 3.4.5](#version-345-february-21-2026) February 21, 2026
 * [Version 3.4.4](#version-344-november-19-2025) November 19, 2025
@@ -91,6 +92,44 @@
 * [Version 1.0.2](#version-102)
 * [Version 1.0.1](#version-101)
 * [Version 1.0](#version-10)
+
+
+## Version 3.4.7 (March 15, 2026)
+
+Patch release bug/build fixes:
+
+* Fix an integer overflow decoding very wide htj2k images
+* Fix build failure with glibc 2.43
+* Fix Windows symbol visibility warnings
+
+### Merged Pull Requests:
+
+* [2292](https://github.com/AcademySoftwareFoundation/openexr/pulls/2292)
+Bump actions/download-artifact from 8.0.0 to 8.0.1
+
+* [2291](https://github.com/AcademySoftwareFoundation/openexr/pulls/2291)
+Fix integer overflow in htj2k decode with width > 32767
+
+* [2289](https://github.com/AcademySoftwareFoundation/openexr/pulls/2289)
+Bump scikit-build-core from 0.12.1 to 0.12.2
+
+* [2288](https://github.com/AcademySoftwareFoundation/openexr/pulls/2288)
+Bump jmertic/slack-release-notifier from 6fa159048d5313ff1177d248ad84beb627571670 to 35fad060af5559c24decdec0f701e6ba93566704
+
+* [2287](https://github.com/AcademySoftwareFoundation/openexr/pulls/2287)
+Bump pypa/cibuildwheel from 3.3 to 3.4
+
+* [2283](https://github.com/AcademySoftwareFoundation/openexr/pulls/2283)
+update SECURITY with CVE info for PR #2256
+
+* [2282](https://github.com/AcademySoftwareFoundation/openexr/pulls/2282)
+Remove website_preview_link workflow
+
+* [2281](https://github.com/AcademySoftwareFoundation/openexr/pulls/2281)
+Disable visibility attributes on Windows to fix msys2 -Wattributes warning
+
+* [2262](https://github.com/AcademySoftwareFoundation/openexr/pulls/2262)
+Fix build failure with glibc 2.43 due to C11 threads.h conflicts
 
 ## Version 3.4.6 (March 1, 2026)
 

--- a/website/latest_news_title.rst
+++ b/website/latest_news_title.rst
@@ -1,4 +1,4 @@
 ..
   SPDX-License-Identifier: BSD-3-Clause
   Copyright (c) Contributors to the OpenEXR Project.
-.. |latest-news-title| replace:: **March  1, 2026 - OpenEXR 3.4.6 Released**
+.. |latest-news-title| replace:: **March 26, 2026 - OpenEXR 3.4.8 Released**

--- a/website/news.rst
+++ b/website/news.rst
@@ -21,6 +21,37 @@ News
 
 .. _LatestNewsStart:
 
+Patch release with several bug/build fixes:
+
+* Fix an integer-overflow bug reading malformed files compressed with
+  B44A/B44B 
+* Fix a buffer-overrun bug reading malformed files compressed with PXR24
+* Fix a bug compressing half data with ZIPS/ZIP data when the
+  compressed size equals packed size
+* Single part files no longer get assigned a part name when writing
+  via the python module
+* Fix a build failure on FreeBSD involving ``threads.h``
+
+This also eliminates several compiler warnings, particularly about the
+deprecated ``isOptimizationEnabled()`` API and deprecates standard
+attributes.
+
+.. _LatestNewsEnd:
+
+March  15, 2026 - OpenEXR 3.4.7 Released
+========================================
+
+Patch release bug/build fixes:
+
+* Fix an integer overflow decoding very wide htj2k images
+* Fix build failure with glibc 2.43
+* Fix Windows symbol visibility warnings
+
+Full changelog: ``v3.4.6..v3.4.7 <https://github.com/AcademySoftwareFoundation/openexr/compare/v3.4.6..v3.4.7>``_
+
+March  1, 2026 - OpenEXR 3.4.6 Released
+=======================================
+
 Patch release with several bug fixes, enhancements, and build improvements.
 
 * 🐛 A limit of ``UINT_MAX`` deep samples per pixel is now
@@ -76,7 +107,6 @@ Tools:
 
 Also, this release bumps the vendered version of ``libdeflate`` to 1.25.
 
-.. _LatestNewsEnd:
 
 March 1, 2026 - OpenEXR 3.3.8 Released
 ======================================


### PR DESCRIPTION
v3.4.7 never got updated. 

Also, some of the links in CHANGES.md were incorrect.