### PR TITLE
Fix signed integer overflow in `LossyDctDecoder_execute()` pointer arithmatic

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_decoder.h
+++ b/src/lib/OpenEXRCore/internal_dwa_decoder.h
@@ -328,7 +328,7 @@ LossyDctDecoder_execute (
     rowBlock[0] = (uint16_t*) simd_align_pointer (rowBlockHandle);
 
     for (int comp = 1; comp < numComp; ++comp)
-        rowBlock[comp] = rowBlock[comp - 1] + numBlocksX * 64;
+        rowBlock[comp] = rowBlock[comp - 1] + (size_t) numBlocksX * 64;
 
     //
     // Pack DC components together by common plane, so we can get
@@ -338,7 +338,7 @@ LossyDctDecoder_execute (
 
     currDcComp[0] = (uint16_t*) d->_packedDc;
     for (int comp = 1; comp < numComp; ++comp)
-        currDcComp[comp] = currDcComp[comp - 1] + numBlocksX * numBlocksY;
+        currDcComp[comp] = currDcComp[comp - 1] + (size_t) numBlocksX * numBlocksY;
 
     for (int blocky = 0; blocky < numBlocksY; ++blocky)
     {


### PR DESCRIPTION
`numBlocksX` and `numBlocksY` are declared as `int`. Two pointer-offset expressions in `LossyDctDecoder_execute()` multiplied them as signed 32-bit integers before using the result as a pointer offset:

    rowBlock[comp]   = rowBlock[comp - 1]   + numBlocksX * 64;
    currDcComp[comp] = currDcComp[comp - 1] + numBlocksX * numBlocksY;

`dataWindow.max.x` is a signed 32-bit value in the EXR file format, so `numBlocksX` can reach `(INT32_MAX + 7) / 8 = 268,435,456`. At that point `numBlocksX * 64 = 17,179,869,184` overflows `int32`, and `numBlocksX * numBlocksY` overflows even sooner. The wraparound produces a small or negative pointer offset, causing `rowBlock[comp]` and `currDcComp[comp]` to point into already-used or pre-buffer memory rather than the intended component stride.

Fix: cast `numBlocksX` to `size_t` before multiplying so the arithmetic is performed in pointer-sized unsigned arithmetic:

    rowBlock[comp]   = rowBlock[comp - 1]   + (size_t) numBlocksX * 64;
    currDcComp[comp] = currDcComp[comp - 1] + (size_t) numBlocksX * numBlocksY;

This is consistent with the allocation on the line above, which already uses `(size_t) numComp * (size_t) numBlocksX * 64 * sizeof(uint16_t)`, and with the packed-DC count check, which uses explicit `uint64_t` casts.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-p8xc-w3q4-h64x
Made-with: Cursor