### PR TITLE
Fix CodeQL SARIF upload ref for pull_request workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,3 +102,8 @@ jobs:
       uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         category: "/language:${{matrix.language}}"
+        # For pull_request, upload against refs/pull/<n>/head + head SHA so the Code
+        # Scanning API does not require refs/heads/<branch> (e.g. Dependabot branches
+        # can trigger "ref ... not found"). Ignored for fork PRs by the action.
+        ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
+        sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
Use refs/pull/<n>/head and the PR head SHA when uploading results so Dependabot and other branch refs are not required by the Code Scanning API (avoids ref not found errors).

Made-with: Cursor