### PR TITLE
fix link formatting typo

### DIFF
--- a/share/util/release.py
+++ b/share/util/release.py
@@ -75,15 +75,16 @@ def markdown_to_rst(markdown_text):
     """
     Convert simple Markdown text to reStructuredText (reST) manually.
     """
+
+    # Convert `text` to ``text`` (but skip existing ``)
+    markdown_text = re.sub(r'(?<!`)`([^`]+)`(?!`)', r'``\1``', markdown_text)
+
     # Replace markdown links [text](url) with reST format `text <url>`_
     markdown_text = re.sub(
         r'\[([\s\S]*?)\]\(([\s\S]*?)\)',
         r'`\1 <\2>`_',
         markdown_text
     )
-
-    # Convert `text to ``text`` (but skip existing ``)
-    markdown_text = re.sub(r'(?<!`)`([^`]+)`(?!`)', r'``\1``', markdown_text)
 
     # Convert the special symbols
     markdown_text = re.sub(r':bug:', "🐛", markdown_text, flags=re.DOTALL)

--- a/website/news.rst
+++ b/website/news.rst
@@ -28,11 +28,11 @@ get installed in the incorrect location when overriding the cached
 install prefix path.
 
 This release addresses the following CVEs:
-* ``CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>``_ DWA Lossy Decoder Heap Out-of-Bounds Write
-* ``CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>``_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
-* ``CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>``_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
-* ``CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>``_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
-* ``CVE-2026-34378 <https://www.cve.org/CVERecord?id=CVE-2026-34378>``_ Signed integer overflow in generic_unpack() when parsing EXR files with crafted negative dataWindow.min.x
+* `CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>`_ DWA Lossy Decoder Heap Out-of-Bounds Write
+* `CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>`_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
+* `CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>`_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
+* `CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>`_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
+* `CVE-2026-34378 <https://www.cve.org/CVERecord?id=CVE-2026-34378>`_ Signed integer overflow in generic_unpack() when parsing EXR files with crafted negative dataWindow.min.x
 
 .. _LatestNewsEnd:
 
@@ -41,13 +41,13 @@ April  3, 2026 - OpenEXR 3.3.9 Released
 
 Patch release for v3.3 that addresses the following security vulnerabilities:
 
-* ``CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>``_ DWA Lossy Decoder Heap Out-of-Bounds Write
-* ``CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>``_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
-* ``CVE-2026-34544 <https://www.cve.org/CVERecord?id=CVE-2026-34544>``_ integer overflow to OOB write in uncompress_b44_impl()
-* ``CVE-2026-34543 <https://www.cve.org/CVERecord?id=CVE-2026-34543>``_ Heap information disclosure in PXR24 decompression via unchecked decompressed size (undo_pxr24_impl)
-* ``CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>``_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
-* ``CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>``_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
-* ``CVE-2026-34378 <https://www.cve.org/CVERecord?id=CVE-2026-34378>``_ Signed integer overflow in generic_unpack() when parsing EXR files with crafted negative dataWindow.min.x
+* `CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>`_ DWA Lossy Decoder Heap Out-of-Bounds Write
+* `CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>`_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
+* `CVE-2026-34544 <https://www.cve.org/CVERecord?id=CVE-2026-34544>`_ integer overflow to OOB write in uncompress_b44_impl()
+* `CVE-2026-34543 <https://www.cve.org/CVERecord?id=CVE-2026-34543>`_ Heap information disclosure in PXR24 decompression via unchecked decompressed size (undo_pxr24_impl)
+* `CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>`_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
+* `CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>`_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
+* `CVE-2026-34378 <https://www.cve.org/CVERecord?id=CVE-2026-34378>`_ Signed integer overflow in generic_unpack() when parsing EXR files with crafted negative dataWindow.min.x
 
 
 April  3, 2026 - OpenEXR 3.2.7 Released
@@ -55,12 +55,12 @@ April  3, 2026 - OpenEXR 3.2.7 Released
 
 Patch release for v3.2 that addresses the following security vulnerabilities:
 
-* ``CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>``_ DWA Lossy Decoder Heap Out-of-Bounds Write
-* ``CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>``_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
-* ``CVE-2026-34544 <https://www.cve.org/CVERecord?id=CVE-2026-34544>``_ integer overflow to OOB write in uncompress_b44_impl()
-* ``CVE-2026-34543 <https://www.cve.org/CVERecord?id=CVE-2026-34543>``_ Heap information disclosure in PXR24 decompression via unchecked decompressed size (undo_pxr24_impl)
-* ``CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>``_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
-* ``CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>``_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
+* `CVE-2026-34589 <https://www.cve.org/CVERecord?id=CVE-2026-34589>`_ DWA Lossy Decoder Heap Out-of-Bounds Write
+* `CVE-2026-34588 <https://www.cve.org/CVERecord?id=CVE-2026-34588>`_ Signed 32-bit Overflow in PIZ Decoder Leads to OOB Read/Write
+* `CVE-2026-34544 <https://www.cve.org/CVERecord?id=CVE-2026-34544>`_ integer overflow to OOB write in uncompress_b44_impl()
+* `CVE-2026-34543 <https://www.cve.org/CVERecord?id=CVE-2026-34543>`_ Heap information disclosure in PXR24 decompression via unchecked decompressed size (undo_pxr24_impl)
+* `CVE-2026-34380 <https://www.cve.org/CVERecord?id=CVE-2026-34380>`_ Signed integer overflow (undefined behavior) in undo_pxr24_impl may allow bounds-check bypass in PXR24 decompression
+* `CVE-2026-34379 <https://www.cve.org/CVERecord?id=CVE-2026-34379>`_ Misaligned write in LossyDctDecoder_execute leading to undefined behavior (DWA/DWAB decompression)
 
 
 March 26, 2026 - OpenEXR 3.4.8 Released


### PR DESCRIPTION
Also, in release.py, convert `text` to ``text`` *before* converting links, so gthe links don't get doubly-converted.