### PR TITLE
docs: add openexr_enable_threading to install.rst cmake options

### DIFF
--- a/website/install.rst
+++ b/website/install.rst
@@ -540,7 +540,14 @@ Component Options
   ``OpenEXRCore`` library with symbols hidden. This allows the ``OpenEXR``
   library to be linked into an executable that already links against
   another version of OpenEXR.  See :ref:`embedded-core-label` for more details.
-  
+
+* ``OPENEXR_ENABLE_THREADING``
+
+  Enables threaded processing of requests, using the threading library
+  found at configure time. Default is ``ON``. Disable with
+  ``-DOPENEXR_ENABLE_THREADING=OFF`` for builds on platforms where no
+  threading library is available, or to force single-threaded operation.
+
 * ``BUILD_TESTING``
 
   Build the testing tree. Default is ``ON``.  Note that


### PR DESCRIPTION
hey, saw #2351 — the threading cmake option wasnt listed in the component options section on install.rst so added an entry for it.

kept the wording short and matching the format of the other entries (force_embedded_core, build_testing, etc). verified in cmake/OpenEXRSetup.cmake that the option exists with default ON and is used to gate the threading library lookup.

placed it right after force_embedded_core since both are core library behaviour options.

fixes #2351