### PR TITLE
Add documentation and test for UTF-8 file paths

### DIFF
--- a/src/lib/OpenEXR/ImfAcesFile.h
+++ b/src/lib/OpenEXR/ImfAcesFile.h
@@ -43,6 +43,8 @@
 //	converted to CIE XYZ, a color adaptation transform shifts the
 //	white point, and the result is converted to ACES RGB.
 //
+//	String parameters that name a file to open are UTF-8 paths; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImathBox.h"

--- a/src/lib/OpenEXR/ImfCRgbaFile.h
+++ b/src/lib/OpenEXR/ImfCRgbaFile.h
@@ -15,6 +15,11 @@ extern "C" {
 #endif
 
 /*
+** File names passed to ImfOpen* functions are UTF-8 encoded (see ImfIO.h in the
+** C++ API).
+*/
+
+/*
 ** Interpreting unsigned shorts as 16-bit floating point numbers
 */
 

--- a/src/lib/OpenEXR/ImfContext.h
+++ b/src/lib/OpenEXR/ImfContext.h
@@ -27,6 +27,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 /// the main entrypoint for querying any of the metadata for all the
 /// component parts of the file, along with the global header
 /// information.
+///
+/// Constructors that take a filename expect a UTF-8 encoded path; see ImfIO.h.
 class IMF_EXPORT_TYPE Context
 {
 public:

--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.h
@@ -10,6 +10,8 @@
 //
 //      class DeepScanLineInputFile
 //
+//      Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfDeepScanLineOutputFile.h
+++ b/src/lib/OpenEXR/ImfDeepScanLineOutputFile.h
@@ -10,6 +10,8 @@
 //
 //      class DeepScanLineOutputFile
 //
+//      Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfExport.h"

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.h
@@ -10,6 +10,8 @@
 //
 //      class DeepTiledInputFile
 //
+//      Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.h
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.h
@@ -10,6 +10,8 @@
 //
 //      class DeepTiledOutputFile
 //
+//      Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfIO.h
+++ b/src/lib/OpenEXR/ImfIO.h
@@ -12,6 +12,16 @@
 //
 //-----------------------------------------------------------------------------
 
+//
+// File path encoding: Any const char* string that names or opens a file,
+// including the strings passed to the protected IStream(const char*) and
+// OStream(const char*) constructors, and the value returned by fileName(),
+// is interpreted as UTF-8 on all platforms, including Microsoft
+// Windows. Callers must not pass legacy ANSI/code-page paths. This matches
+// StdIFStream/StdOFStream (via std::filesystem::u8path) and the OpenEXRCore
+// C API.
+//
+
 #include "ImfForward.h"
 
 #include <cstdint>

--- a/src/lib/OpenEXR/ImfInputFile.h
+++ b/src/lib/OpenEXR/ImfInputFile.h
@@ -11,6 +11,8 @@
 //	class InputFile -- a scanline-based interface that can be used
 //	to read both scanline-based and tiled OpenEXR image files.
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -435,8 +435,7 @@ IMF_EXPORT
 int getChunkOffsetTableSize (const Header& header);
 
 //
-// Convert a filename to a wide string.  This is useful for working with
-// filenames on Windows.
+// Convert a UTF-8 filename to a wide string (for example for Windows APIs).
 //
 
 IMF_EXPORT

--- a/src/lib/OpenEXR/ImfMultiPartInputFile.h
+++ b/src/lib/OpenEXR/ImfMultiPartInputFile.h
@@ -14,6 +14,10 @@
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
+//
+// Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
+
 /// \brief
 ///
 /// TODO: Document this

--- a/src/lib/OpenEXR/ImfMultiPartOutputFile.h
+++ b/src/lib/OpenEXR/ImfMultiPartOutputFile.h
@@ -32,6 +32,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 //                             to copy the values over from the first header.
 //  numThreads - number of threads that should be used in encoding the data.
 //
+// Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 
 class IMF_EXPORT_TYPE MultiPartOutputFile : public GenericOutputFile
 {

--- a/src/lib/OpenEXR/ImfOutputFile.h
+++ b/src/lib/OpenEXR/ImfOutputFile.h
@@ -10,6 +10,8 @@
 //
 //	class OutputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfRgbaFile.h
+++ b/src/lib/OpenEXR/ImfRgbaFile.h
@@ -13,6 +13,8 @@
 //	class RgbaOutputFile
 //	class RgbaInputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfExport.h"

--- a/src/lib/OpenEXR/ImfScanLineInputFile.h
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.h
@@ -10,6 +10,8 @@
 //
 //	class ScanLineInputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfStdIO.h
+++ b/src/lib/OpenEXR/ImfStdIO.h
@@ -13,6 +13,10 @@
 //
 //-----------------------------------------------------------------------------
 
+//
+// Constructors taking const char fileName[] expect a UTF-8 path; see ImfIO.h.
+//
+
 #include "ImfExport.h"
 #include "ImfNamespace.h"
 

--- a/src/lib/OpenEXR/ImfTestFile.h
+++ b/src/lib/OpenEXR/ImfTestFile.h
@@ -18,6 +18,10 @@
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
+//
+// Filename parameters are UTF-8 encoded (including on Windows). See ImfIO.h.
+//
+
 IMF_EXPORT bool isOpenExrFile (const char fileName[]);
 
 IMF_EXPORT bool isOpenExrFile (const char fileName[], bool& isTiled);

--- a/src/lib/OpenEXR/ImfTiledInputFile.h
+++ b/src/lib/OpenEXR/ImfTiledInputFile.h
@@ -10,6 +10,8 @@
 //
 //	class TiledInputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfTiledOutputFile.h
+++ b/src/lib/OpenEXR/ImfTiledOutputFile.h
@@ -10,6 +10,8 @@
 //
 //	class TiledOutputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXR/ImfTiledRgbaFile.h
+++ b/src/lib/OpenEXR/ImfTiledRgbaFile.h
@@ -13,6 +13,8 @@
 //	class TiledRgbaOutputFile
 //	class TiledRgbaInputFile
 //
+//	Constructors that open a file by path expect UTF-8; see ImfIO.h.
+//
 //-----------------------------------------------------------------------------
 
 #include "ImfForward.h"

--- a/src/lib/OpenEXRUtil/ImfCheckFile.h
+++ b/src/lib/OpenEXRUtil/ImfCheckFile.h
@@ -27,6 +27,8 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 //
 // if runCoreCheck is true, only uses the OpenEXRCore (C) API, otherwise uses the OpenEXR (C++) API
 //
+// fileName is a UTF-8 encoded path; see ImfIO.h.
+//
 
 IMFUTIL_EXPORT bool checkOpenEXRFile (
     const char* fileName,

--- a/src/lib/OpenEXRUtil/ImfDeepImageIO.h
+++ b/src/lib/OpenEXRUtil/ImfDeepImageIO.h
@@ -11,6 +11,8 @@
 //      Functions to load deep images from OpenEXR files
 //      and to save deep images in OpenEXR files.
 //
+//      File name parameters are UTF-8 paths; see ImfIO.h.
+//
 //----------------------------------------------------------------------------
 
 #include "ImfNamespace.h"

--- a/src/lib/OpenEXRUtil/ImfFlatImageIO.h
+++ b/src/lib/OpenEXRUtil/ImfFlatImageIO.h
@@ -11,6 +11,8 @@
 //      Functions to load flat images from OpenEXR files
 //      and to save flat images in OpenEXR files.
 //
+//      File name parameters are UTF-8 paths; see ImfIO.h.
+//
 //----------------------------------------------------------------------------
 
 #include "ImfFlatImage.h"

--- a/src/lib/OpenEXRUtil/ImfImageIO.h
+++ b/src/lib/OpenEXRUtil/ImfImageIO.h
@@ -11,6 +11,8 @@
 //      Functions to load flat or deep images from OpenEXR files
 //      and to save flat or deep images in OpenEXR files.
 //
+//      File name parameters are UTF-8 paths; see ImfIO.h.
+//
 //----------------------------------------------------------------------------
 
 #include "ImfUtilExport.h"

--- a/src/test/OpenEXRTest/testMagic.cpp
+++ b/src/test/OpenEXRTest/testMagic.cpp
@@ -12,8 +12,15 @@
 #include <ImfVersion.h>
 #include <assert.h>
 #include <exception>
+#include <filesystem>
 #include <iostream>
 #include <stdio.h>
+#include <string>
+
+#if (defined(__cplusplus) && __cplusplus >= 202002L) \
+    || (defined(_MSVC_LANG) && _MSVC_LANG >= 202004L)
+#    include <string_view>
+#endif
 
 #include "TestUtilFStream.h"
 
@@ -85,10 +92,91 @@ testFile2 (const char fileName[], bool exists, bool exrFile, bool tiledFile)
          << (tiledFile ? "is tiled" : "is not tiled") << endl;
 }
 
+void
+testUtf8Filename (const std::string& tempDir)
+{
+    namespace fs = std::filesystem;
+
+    // Test isOpenExrFile on an image with a UTF-8 filename (copy a known-good
+    // .exr under a name containing non-ASCII UTF-8 bytes).
+    //
+    // isOpenExrFile() takes a const char* argument that is expected to point
+    // to a null-terminated sequence of potentially non-ASCII UTF-8 bytes.
+    // We build a std::filesystem::path from a UTF-8 file name, join it with
+    // tempDir, copy a known-good .exr to that destination, then call
+    // isOpenExrFile() with the full UTF-8 path obtained from that path
+    // object (see below).
+    //
+    // This is complicated because of how std::filesystem and UTF-8 interact
+    // across C++17 and C++20, and because isOpenExrFile takes const char*,
+    // not char8_t*.
+    //
+    // - Building fs::path from a UTF-8 std::string: In C++20, treating a
+    //   char buffer as UTF-8 for path construction is spelled with char8_t
+    //   (std::u8string_view). A reinterpret_cast from const char* to const
+    //   char8_t* is the standard way to attach that meaning to the same byte
+    //   sequence without transcoding. Pre-C++20 we use the narrow-string
+    //   constructor directly.
+    //
+    // - Getting a string for isOpenExrFile: We ask the path for its UTF-8
+    //   form via u8string() so we match the actual on-disk name the library
+    //   will open. In C++20, u8string() returns std::u8string (char8_t), but
+    //   OpenEXR's API still expects a NUL-terminated const char* UTF-8 path,
+    //   so we copy those bytes into a std::string (again via reinterpret_cast
+    //   of the data pointer) and pass c_str(). In C++17, u8string() already
+    //   returns std::string, so no second cast is needed there.
+    
+    const std::string utf8Name (
+        "openexr_isOpenExrFile_\xc3\xa9\xe6\x97\xa5_\xd1\x84.exr");
+    const fs::path src = fs::path (ILM_IMF_TEST_IMAGEDIR) / "comp_none.exr";
+#if (defined(__cplusplus) && __cplusplus >= 202002L) \
+    || (defined(_MSVC_LANG) && _MSVC_LANG >= 202004L)
+    // C++20+: interpret UTF-8 bytes as char8_t.
+    fs::path utf8Path (std::u8string_view (reinterpret_cast<const char8_t*> (utf8Name.data ()),
+                                           utf8Name.size ()));
+#else
+    fs::path utf8Path (utf8Name);
+#endif
+    const fs::path dst = fs::path (tempDir) / utf8Path;
+
+    std::error_code ec;
+    fs::copy_file (src, dst, fs::copy_options::overwrite_existing, ec);
+    if (ec)
+    {
+        cout << "skipping UTF-8 path test (could not copy " << src << " to " << dst << "): "
+             << ec.message () << endl;
+        assert(false);
+    }
+
+    // remove the temp copy on exit
+    struct Cleanup
+    {
+        fs::path p;
+        ~Cleanup ()
+        {
+            std::error_code e;
+            std::filesystem::remove (p, e);
+        }
+    } cleanup{dst};
+
+    const auto u = dst.u8string ();
+    const std::string dstUtf8 (reinterpret_cast<const char*> (u.data ()), u.size ());
+
+    bool tiled = false, deep = false, multiPart = false;
+
+    bool ok = isOpenExrFile (dstUtf8.c_str (), tiled, deep, multiPart);
+    assert (ok);
+    assert (!tiled && !deep && !multiPart);
+
+    assert (isOpenExrFile (dstUtf8.c_str ()));
+
+    cout << "UTF-8 filename isOpenExrFile ok\n";
+}
+
 } // namespace
 
 void
-testMagic (const std::string&)
+testMagic (const std::string& tempDir)
 {
     try
     {
@@ -102,6 +190,8 @@ testMagic (const std::string&)
         testFile2 (ILM_IMF_TEST_IMAGEDIR "invalid.exr", true, false, false);
         testFile2 (
             ILM_IMF_TEST_IMAGEDIR "does_not_exist.exr", false, false, false);
+
+        testUtf8Filename (tempDir);
 
         cout << "ok\n" << endl;
     }

--- a/website/ReadingAndWritingImageFiles.rst
+++ b/website/ReadingAndWritingImageFiles.rst
@@ -72,6 +72,19 @@ worrying about complications related to tiling and multiple resolutions.
 When a multi-resolution file is read via a scan line interface, only the
 highest-resolution version of the image is accessible.
 
+File Paths and UTF-8
+--------------------
+
+File path arguments passed as ``const char*`` to the OpenEXR C++ API
+(when constructing ``InputFile``, ``OutputFile``, ``RgbaInputFile``,
+or when calling ``isOpenExrFile``) must use **UTF-8** encoding.  This
+is true on all platforms, including Microsoft Windows.  Under the
+hood, the library opens files named as ``const char*`` through
+``std::filesystem::u8path``.
+
+Note that the OpenEXRCore C layer documents the same assumption of
+**UTF-8** encoding.
+
 Multi-Part and Deep Data
 ------------------------
 


### PR DESCRIPTION
This is in response to #292 from 2018. There's no actual new code here, just clarified comments and a new CI test.

This adds a note to the source code and the website documentation that clarifies that `const char*` filename arguments are assumed to be UTF-8 encoded.

It also adds a test to validate the handling of non-ascii filenames by isOpenExrFile().

We may want to consider adding an overloaded `isOpenExrFile(const std::filesystem::path& path)` in a future release, which I think was the substance of #292.

Assisted by Cursor.