### PR TITLE
Fix OOB read when expanding IDManifest prefix-compressed strings

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -337,6 +337,13 @@ IDManifest::init (const char* data, const char* endOfData)
         //
         // previous string had more than 255 characters?
         //
+        const size_t minPrefixLen =
+            stringList[i - 1].size () > 255 ? size_t (2) : size_t (1);
+        if (stringList[i].size () < minPrefixLen)
+        {
+            throw IEX_NAMESPACE::InputExc (
+                "IDManifest string too small for common prefix length");
+        }
         if (stringList[i - 1].size () > 255)
         {
             common = size_t (((unsigned char) (stringList[i][0])) << 8) +


### PR DESCRIPTION
Validate each string has enough bytes for the 1- or 2-byte common-prefix encoding before indexing. Prevents heap OOB read when the previous string is long and the current entry is empty or too short.

Made with Cursor