### PR TITLE
Add Linux i686 (-m32) CI and fix 32-bit test failures

### DIFF
--- a/.github/workflows/ci_linux_i686.yml
+++ b/.github/workflows/ci_linux_i686.yml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+#
+# Build and test OpenEXR as 32-bit x86 (i686) ELF on an amd64 GitHub runner
+# using GCC multilib (-m32). Catches regressions that only show up on 32-bit
+# Linux (e.g. issue #1284 / testOptimizedInterleavePatterns).
+#
+# Pattern: standalone workflow, same path filters as ci_freebsd.yml.
+
+name: CI (Linux i686)
+
+on:
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!website/**'
+      - '!bazel/**'
+      - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ci_linux_i686.yml'
+  pull_request:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!website/**'
+      - '!bazel/**'
+      - '!src/wrappers/**'
+      - '!.github/workflows/**'
+      - '.github/workflows/ci_linux_i686.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  linux-i686:
+    name: Linux i686 (-m32)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install multilib toolchain
+        run: |
+          set -ex
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build \
+            gcc-multilib g++-multilib libc6-dev-i386
+
+      - name: Configure
+        run: |
+          set -ex
+          cmake -B _build -S . -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_FLAGS=-m32 \
+            -DCMAKE_CXX_FLAGS=-m32 \
+            -DCMAKE_EXE_LINKER_FLAGS=-m32 \
+            -DCMAKE_SHARED_LINKER_FLAGS=-m32 \
+            -DOPENEXR_FORCE_INTERNAL_IMATH=ON \
+            -DOPENEXR_FORCE_INTERNAL_DEFLATE=ON \
+            -DOPENEXR_FORCE_INTERNAL_OPENJPH=ON \
+            -DBUILD_TESTING=ON
+        shell: bash
+
+      - name: Build
+        run: |
+          set -ex
+          cmake --build _build --parallel "$(nproc)"
+        shell: bash
+
+      - name: Test
+        run: |
+          set -ex
+          ctest --test-dir _build --output-on-failure --timeout 7200
+        shell: bash

--- a/src/lib/OpenEXR/ImfSystemSpecific.cpp
+++ b/src/lib/OpenEXR/ImfSystemSpecific.cpp
@@ -12,21 +12,33 @@
 #    include <intrin.h>
 #endif
 
+// Runtime CPUID must not depend on IMF_HAVE_SSE2 (__SSE2__). For example,
+// gcc -m32 often omits __SSE2__ while the hardware still supports SSE2; the
+// OpenEXRCore helpers use <cpuid.h> regardless, and CpuId must match.
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__e2k__) &&           \
+    (defined(__i386__) || defined(__x86_64__) || defined(__amd64__)) &&      \
+    (!defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__))
+#    include <cpuid.h>
+#endif
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 namespace
 {
-#if defined(IMF_HAVE_SSE2) && defined(__GNUC__) && !defined(__e2k__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__e2k__) &&           \
+    (defined(__i386__) || defined(__x86_64__) || defined(__amd64__)) &&      \
+    (!defined(_WIN32) || defined(__MINGW32__) || defined(__MINGW64__))
 
-// Helper functions for gcc + SSE enabled
 void
 cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
 {
-    __asm__ __volatile__ (
-        "cpuid"
-        : /* Output  */ "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
-        : /* Input   */ "a"(n)
-        : /* Clobber */);
+    unsigned int r0 = 0, r1 = 0, r2 = 0, r3 = 0;
+    if (!__get_cpuid (static_cast<unsigned int> (n), &r0, &r1, &r2, &r3))
+        r0 = r1 = r2 = r3 = 0;
+    eax = static_cast<int> (r0);
+    ebx = static_cast<int> (r1);
+    ecx = static_cast<int> (r2);
+    edx = static_cast<int> (r3);
 }
 
 #elif defined(_MSC_VER) &&                                                     \
@@ -44,7 +56,20 @@ cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
     edx = cpuInfo[3];
 }
 
-#else // IMF_HAVE_SSE2 && __GNUC__ && !__e2k__
+#elif defined(IMF_HAVE_SSE2) && defined(__GNUC__) && !defined(__e2k__)
+
+// Fallback when <cpuid.h> is unavailable (e.g. unusual Windows GCC toolchains).
+void
+cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
+{
+    __asm__ __volatile__ (
+        "cpuid"
+        : /* Output  */ "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+        : /* Input   */ "a"(n)
+        : /* Clobber */);
+}
+
+#else
 
 // Helper functions for generic compiler - all disabled
 void
@@ -53,7 +78,7 @@ cpuid (int n, int& eax, int& ebx, int& ecx, int& edx)
     eax = ebx = ecx = edx = 0;
 }
 
-#endif // IMF_HAVE_SSE2 && __GNUC__ && !__e2k__
+#endif
 
 #ifdef IMF_HAVE_GCC_INLINEASM_X86
 

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -525,7 +525,10 @@ struct pixels
         } a, b;
         a.fv = af;
         b.fv = bf;
-        if (a.iv != b.iv)
+        // C vs C++ EXR paths can preserve NaN while changing quiet-NaN payload;
+        // bit-identical compare is too strict (see half test hardening, issue #1284).
+        const bool bothNan = std::isnan (af) && std::isnan (bf);
+        if (!bothNan && a.iv != b.iv)
         {
             std::cout << chan << " float at " << x << ", " << y
                       << " not equal: " << taga << " 0x" << std::hex << a.iv
@@ -533,7 +536,7 @@ struct pixels
                       << std::hex << b.iv << std::dec << " (" << bf << ")"
                       << std::endl;
         }
-        EXRCORE_TEST (a.iv == b.iv);
+        EXRCORE_TEST (bothNan || a.iv == b.iv);
     }
     void
     compareExact (const pixels& o, const char* otag, const char* selftag) const

--- a/src/test/OpenEXRCoreTest/compressionTables.cpp
+++ b/src/test/OpenEXRCoreTest/compressionTables.cpp
@@ -32,6 +32,7 @@
 #include "IlmThreadSemaphore.h"
 
 #include <cstddef>
+#include <cmath>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,6 +68,19 @@ using namespace OPENEXR_IMF_NAMESPACE;
 
 namespace
 {
+
+// Absolute |float(a)-float(b)| for half values, using volatile intermediates so
+// each step rounds to IEEE binary32. Without this, i686 defaults (387 stack) can
+// keep extra precision and change which candidate "wins" vs tables built with
+// SSE float math — no special compile flags required for users running tests.
+static inline float
+ieeeFloatAbsDiffHalf (const half& a, const half& b)
+{
+    volatile float af = static_cast<float> (a);
+    volatile float bf = static_cast<float> (b);
+    volatile float d  = af - bf;
+    return std::fabs (static_cast<float> (d));
+}
 
 class LutHeaderWorker
 {
@@ -160,8 +174,8 @@ public:
 
                         tmpHalf.setBits (i);
 
-                        if (fabs ((float) inputHalf - (float) tmpHalf) <
-                            fabs ((float) inputHalf - (float) closestHalf))
+                        if (ieeeFloatAbsDiffHalf (inputHalf, tmpHalf) <
+                            ieeeFloatAbsDiffHalf (inputHalf, closestHalf))
                         {
                             closestHalf = tmpHalf;
                         }

--- a/src/test/OpenEXRCoreTest/compressionTables.cpp
+++ b/src/test/OpenEXRCoreTest/compressionTables.cpp
@@ -84,8 +84,10 @@ public:
 
         virtual void run ()
         {
-            _semaphore.post ();
             _worker.run (_output);
+            // Signal completion: ~Runner() waits so the main thread does not read
+            // worker buffers until this thread finishes (post-before-work was a race).
+            _semaphore.post ();
         }
 
     private:


### PR DESCRIPTION
This consists of several changes to resolve the i686/32-bit test failures described in #1281 and #1284:

* Stabilize DWA LUT test half-distance compare on i686
    
Add `ieeeFloatAbsDiffHalf()` using volatile float steps so each half→float conversion and subtraction rounds to IEEE binary32 before fabs. Without this, i686 387 FPU extended precision can pick a different closest candidate than `dwaQuantTables.h` (built with typical SSE float math), breaking `testLutHeader`.
    
* Relax float compareExact for NaN payload differences in compression tests
    
`compareExact(float)` required bitwise equality, but C vs C++ EXR round-trips can preserve NaN while changing quiet-NaN encodings (common on i686 with x87 vs SSE). Treat two NaNs as equal; still require identical bits for non-NaN values.
    
* Fix race in OpenEXRCore DWA LUT header test threading
    
`LutHeaderWorker::Runner` posted its semaphore before `_worker.run()` finished, so `~Runner() wait()` returned while work was still in progress and the main thread could read worker buffers concurrently. Move `post()` to after `run()` completes so `testLutHeader()` compares `closestData[]` only after all workers finish.

* Fix CpuId runtime detection when __SSE2__ is not defined
    
CpuId used a no-op cpuid stub unless `IMF_HAVE_SSE2` was set, which comes from `__SSE2__`. `gcc -m32` often omits that macro while the CPU still supports SSE2, so CpuId reported sse2=false while OpenEXRCore's `check_for_x86_simd()` (via `<cpuid.h>`) reported true, breaking `testCPUIdent` and risking inconsistent SIMD paths.
    
Use `__get_cpuid` from `<cpuid.h>` for GCC/Clang on x86/x86_64 (non-MSVC Windows via MinGW), matching the core library and avoiding i386 PIC issues with raw cpuid asm. Keep the MSVC `__cpuid` path and an `IMF_HAVE_SSE2` asm fallback for unusual toolchains.
    
* Add ci_linux_i686.yml workflow
    
On ubuntu-latest, install gcc/g++ multilib + libc6-dev-i386 and build with -m32. This validates 32-bit x86 behavior that x86_64 CI does not cover.
    
This helped reproduce and diagnose the test failures described in #1281.

Made with Cursor