### PR TITLE
Arcmantis/warning deprecate WidenFilename

### DIFF
--- a/src/lib/OpenEXR/ImfMisc.h
+++ b/src/lib/OpenEXR/ImfMisc.h
@@ -438,6 +438,7 @@ int getChunkOffsetTableSize (const Header& header);
 // Convert a UTF-8 filename to a wide string (for example for Windows APIs).
 //
 
+OPENEXR_DEPRECATED ("To be removed in future releases.")
 IMF_EXPORT
 std::wstring WidenFilename (const char* filename);
 

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -103,8 +103,12 @@ inline void
 OpenStreamWithUTF8Name (
     StreamType& is, const char* filename, std::ios_base::openmode mode)
 {
-#    ifdef _WIN32
+#   ifdef _WIN32
+#   pragma warning(push)
+#   pragma warning(disable: 4996)
+
     std::wstring wfn = OPENEXR_IMF_INTERNAL_NAMESPACE::WidenFilename (filename);
+
 #        ifdef USE_WIDEN_FILEBUF
     using CharT   = typename StreamType::char_type;
     using TraitsT = typename StreamType::traits_type;
@@ -119,6 +123,10 @@ OpenStreamWithUTF8Name (
 #    else
     is.rdbuf ()->open (filename, mode);
 #    endif
+
+#   ifdef _WIN32
+#   pragma warning(pop)
+#   endif
 }
 
 } // namespace testutil

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -103,9 +103,15 @@ inline void
 OpenStreamWithUTF8Name (
     StreamType& is, const char* filename, std::ios_base::openmode mode)
 {
+#   ifdef _MSC_VER
+#       pragma warning(push)
+#       pragma warning(disable: 4996)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic push
+#       pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#   endif
+
 #   ifdef _WIN32
-#   pragma warning(push)
-#   pragma warning(disable: 4996)
 
     std::wstring wfn = OPENEXR_IMF_INTERNAL_NAMESPACE::WidenFilename (filename);
 
@@ -124,8 +130,10 @@ OpenStreamWithUTF8Name (
     is.rdbuf ()->open (filename, mode);
 #    endif
 
-#   ifdef _WIN32
-#   pragma warning(pop)
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic pop
 #   endif
 }
 

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -103,6 +103,8 @@ inline void
 OpenStreamWithUTF8Name (
     StreamType& is, const char* filename, std::ios_base::openmode mode)
 {
+
+// TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
 #   ifdef _MSC_VER
 #       pragma warning(push)
 #       pragma warning(disable: 4996)

--- a/src/test/OpenEXRTest/TestUtilFStream.h
+++ b/src/test/OpenEXRTest/TestUtilFStream.h
@@ -104,6 +104,8 @@ OpenStreamWithUTF8Name (
     StreamType& is, const char* filename, std::ios_base::openmode mode)
 {
 
+#   ifdef _WIN32
+
 // TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
 #   ifdef _MSC_VER
 #       pragma warning(push)
@@ -113,9 +115,13 @@ OpenStreamWithUTF8Name (
 #       pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #   endif
 
-#   ifdef _WIN32
-
     std::wstring wfn = OPENEXR_IMF_INTERNAL_NAMESPACE::WidenFilename (filename);
+
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic pop
+#   endif
 
 #        ifdef USE_WIDEN_FILEBUF
     using CharT   = typename StreamType::char_type;
@@ -131,12 +137,6 @@ OpenStreamWithUTF8Name (
 #    else
     is.rdbuf ()->open (filename, mode);
 #    endif
-
-#   ifdef _MSC_VER
-#       pragma warning(pop)
-#   elif defined(__clang__) || defined(__GNUC__)
-#       pragma GCC diagnostic pop
-#   endif
 }
 
 } // namespace testutil

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -41,6 +41,11 @@ using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;
 
+#ifdef _WIN32
+#pragma warning(push,0)
+#pragma warning(disable: 4996)
+#endif
+
 namespace
 {
 
@@ -1145,6 +1150,7 @@ testExistingStreamsUTF8 (const std::string& tempDir)
 
 #ifdef _WIN32
     _wremove (WidenFilename (outfn.c_str ()).c_str ());
+#   pragma warning(pop)
 #else
     remove (outfn.c_str ());
 #endif

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -41,9 +41,12 @@ using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;
 
-#ifdef _WIN32
-#pragma warning(push,0)
-#pragma warning(disable: 4996)
+#ifdef _MSC_VER
+#   pragma warning(push,0)
+#   pragma warning(disable: 4996)
+#elif defined(__clang__) || defined(__GNUC__)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 namespace
@@ -1150,8 +1153,12 @@ testExistingStreamsUTF8 (const std::string& tempDir)
 
 #ifdef _WIN32
     _wremove (WidenFilename (outfn.c_str ()).c_str ());
-#   pragma warning(pop)
 #else
     remove (outfn.c_str ());
+#endif
+#ifdef _MSC_VER
+#   pragma warning(pop)
+#elif defined(__clang__) || defined(__GNUC__)
+#   pragma GCC diagnostic pop
 #endif
 }

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -41,6 +41,7 @@ using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;
 
+// TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
 #ifdef _MSC_VER
 #   pragma warning(push,0)
 #   pragma warning(disable: 4996)

--- a/src/test/OpenEXRTest/testExistingStreams.cpp
+++ b/src/test/OpenEXRTest/testExistingStreams.cpp
@@ -41,15 +41,6 @@ using namespace OPENEXR_IMF_NAMESPACE;
 using namespace std;
 using namespace IMATH_NAMESPACE;
 
-// TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
-#ifdef _MSC_VER
-#   pragma warning(push,0)
-#   pragma warning(disable: 4996)
-#elif defined(__clang__) || defined(__GNUC__)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 namespace
 {
 
@@ -136,7 +127,24 @@ MMIFStream::MMIFStream (const char fileName[])
     , _length (0)
 {
 #ifdef _WIN32
+
+    // TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
+#   ifdef _MSC_VER
+#       pragma warning(push,0)
+#       pragma warning(disable: 4996)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic push
+#       pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#   endif
+
     const std::wstring fileNameWide = WidenFilename (fileName);
+
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic pop
+#   endif
+
     try
     {
         _f = CreateFileW (
@@ -1102,7 +1110,23 @@ testExistingStreamsUTF8 (const std::string& tempDir)
     {
         cout << "writing";
 #ifdef _WIN32
+
+    // TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
+#   ifdef _MSC_VER
+#       pragma warning(push,0)
+#       pragma warning(disable: 4996)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic push
+#       pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#   endif
+
         _wremove (WidenFilename (outfn.c_str ()).c_str ());
+
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic pop
+#   endif
 #else
         remove (outfn.c_str ());
 #endif
@@ -1153,13 +1177,24 @@ testExistingStreamsUTF8 (const std::string& tempDir)
     cout << endl;
 
 #ifdef _WIN32
+
+    // TODO: Remove pragmas for pushing/popping deprecation warnings when WidenFilename is removed from API
+#   ifdef _MSC_VER
+#       pragma warning(push,0)
+#       pragma warning(disable: 4996)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic push
+#       pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#   endif
+
     _wremove (WidenFilename (outfn.c_str ()).c_str ());
+
+#   ifdef _MSC_VER
+#       pragma warning(pop)
+#   elif defined(__clang__) || defined(__GNUC__)
+#       pragma GCC diagnostic pop
+#   endif
 #else
     remove (outfn.c_str ());
-#endif
-#ifdef _MSC_VER
-#   pragma warning(pop)
-#elif defined(__clang__) || defined(__GNUC__)
-#   pragma GCC diagnostic pop
 #endif
 }


### PR DESCRIPTION
Marked WidenFilename as deprecated. Suppressed deprecation warnings in unit-tests. Addresses issue #2349  