### PR TITLE
Python: fix docstring indentation

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -2583,383 +2583,312 @@ PYBIND11_MODULE(OpenEXR, m)
     // The File API: Channel, Part, and File
     //
     
-    py::class_<PyChannel>(m, "Channel", R"pbdoc(
-         The class object representing a channel in an EXR image file.
-         Example
-         -------  
-         >>> import OpenEXR
-         >>> f = OpenEXR.File("image.exr")
-         >>> f.channels()['A']
-         Channel("A", xSampling=1, ySampling=1)
-    )pbdoc")
+    py::class_<PyChannel>(m, "Channel", "The class object representing a channel in an EXR image file.\n"
+                                        "Example\n"
+                                        "-------  \n"
+                                        ">>> import OpenEXR\n"
+                                        ">>> f = OpenEXR.File(\"image.exr\")\n"
+                                        ">>> f.channels()['A']\n"
+                                        "Channel(\"A\", xSampling=1, ySampling=1)")
         .def(py::init(),
-             R"pbdoc(
-             Construct an empty Channel object.
-             )pbdoc")
+             "Construct an empty Channel object.")
         .def(py::init<int,int,bool>(),
              py::arg("xSampling"),
              py::arg("ySampling"),
              py::arg("pLinear")=false,
-             R"pbdoc(
-             Construct Channel object with the given parameters.
-
-             Parameters:
-                 int : xSampling
-                     The x subsampling value
-                 int : ySampling
-                     The y subsampling value
-                 int : pLinear
-                     The pLinear value
-             )pbdoc")
+             "Construct Channel object with the given parameters.\n"
+             "\n"
+             "Parameters:\n"
+             "    int : xSampling\n"
+             "        The x subsampling value\n"
+             "    int : ySampling\n"
+             "        The y subsampling value\n"
+             "    int : pLinear\n"
+             "        The pLinear value")
         .def(py::init<py::array>(),
              py::arg("pixels"),
-             R"pbdoc(
-             Construct Channel object with the given pixel array
-
-             Parameters:
-                 np.array : pixels
-                     The numpy array of pixels. Supported types are uin32, float16, float32
-             )pbdoc")
+             "Construct Channel object with the given pixel array\n"
+             "\n"
+             "Parameters:\n"
+             "    np.array : pixels\n"
+             "        The numpy array of pixels. Supported types are uin32, float16, float32")
         .def(py::init<py::array,int,int,bool>(),
              py::arg("pixels"),
              py::arg("xSampling"),
              py::arg("ySampling"),
              py::arg("pLinear")=false,
-             R"pbdoc(
-             Construct Channel object with the given parameters.
-
-             Parameters:
-             -----------
-             np.array : pixels
-                 The numpy array of pixels. Supported types are uin32, float16, float32
-             int : xSampling
-                 The x subsampling value
-             int : ySampling
-                 The y subsampling value
-             int : pLinear
-                 The pLinear value
-             )pbdoc")
+             "Construct Channel object with the given parameters.\n"
+             "\n"
+             "Parameters:\n"
+             "-----------\n"
+             "np.array : pixels\n"
+             "    The numpy array of pixels. Supported types are uin32, float16, float32\n"
+             "int : xSampling\n"
+             "    The x subsampling value\n"
+             "int : ySampling\n"
+             "    The y subsampling value\n"
+             "int : pLinear\n"
+             "    The pLinear value")
         .def(py::init<const char*>(),
              py::arg("name"),
-             R"pbdoc(
-             Construct Channel object with the given name.
-
-             Parameters:
-             -----------
-             str : name
-                 The name of the channel.
-             )pbdoc")
+             "Construct Channel object with the given name.\n"
+             "\n"
+             "Parameters:\n"
+             "-----------\n"
+             "str : name\n"
+             "    The name of the channel.")
         .def(py::init<const char*,int,int,bool>(),
              py::arg("name"),
              py::arg("xSampling"),
              py::arg("ySampling"),
              py::arg("pLinear")=false,
-             R"pbdoc(
-             Construct Channel object with the given parameters.
-
-             Parameters:
-             -----------
-             str : name
-                 The name of the channel.
-             int : xSampling
-                 The x subsampling value
-             int : ySampling
-                 The y subsampling value
-             int : pLinear
-                 The pLinear value
-             )pbdoc")
+             "Construct Channel object with the given parameters.\n"
+             "\n"
+             "Parameters:\n"
+             "-----------\n"
+             "str : name\n"
+             "    The name of the channel.\n"
+             "int : xSampling\n"
+             "    The x subsampling value\n"
+             "int : ySampling\n"
+             "    The y subsampling value\n"
+             "int : pLinear\n"
+             "    The pLinear value")
         .def(py::init<const char*,py::array>(),
              py::arg("name"),
              py::arg("pixels"),
-             R"pbdoc(
-             Construct Channel object with the given parameters.
-
-             Parameters:
-             -----------
-             str : name
-                 The name of the channel.
-             np.array : pixels
-                 The numpy array of pixels. Supported types are uin32, float16, float32
-             )pbdoc")
+             "Construct Channel object with the given parameters.\n"
+             "\n"
+             "Parameters:\n"
+             "-----------\n"
+             "str : name\n"
+             "    The name of the channel.\n"
+             "np.array : pixels\n"
+             "    The numpy array of pixels. Supported types are uin32, float16, float32")
         .def(py::init<const char*,py::array,int,int,bool>(),
              py::arg("name"),
              py::arg("pixels"),
              py::arg("xSampling"),
              py::arg("ySampling"),
              py::arg("pLinear")=false,
-             R"pbdoc(
-             Construct Channel object with the given parameters.
-
-             Parameters:
-             -----------
-             str : name
-                 The name of the channel.
-             np.array : pixels
-                 The numpy array of pixels. Supported types are uin32, float16, float32
-             int : xSampling
-                 The x subsampling value
-             int : ySampling
-                 The y subsampling value
-             int : pLinear
-                 The pLinear value
-             )pbdoc")
+             "Construct Channel object with the given parameters.\n"
+             "\n"
+             "Parameters:\n"
+             "-----------\n"
+             "str : name\n"
+             "    The name of the channel.\n"
+             "np.array : pixels\n"
+             "    The numpy array of pixels. Supported types are uin32, float16, float32\n"
+             "int : xSampling\n"
+             "    The x subsampling value\n"
+             "int : ySampling\n"
+             "    The y subsampling value\n"
+             "int : pLinear\n"
+             "    The pLinear value")
         .def("__repr__", [](const PyChannel& c) { return repr(c); })
         .def_readwrite("name", &PyChannel::name,
-             R"pbdoc(
-              str : The channel name.
-             )pbdoc")
+             "str : The channel name.")
         .def("type", &PyChannel::pixelType,
-             R"pbdoc(
-              OpenEXR.PixelType : The pixel type (UINT, HALF, FLOAT)
-             )pbdoc")
+             "OpenEXR.PixelType : The pixel type (UINT, HALF, FLOAT)")
         .def_readwrite("xSampling", &PyChannel::xSampling,
-             R"pbdoc(
-             int : The x subsampling value
-             )pbdoc")
+             "int : The x subsampling value")
         .def_readwrite("ySampling", &PyChannel::ySampling,
-             R"pbdoc(
-             int : The y subsampling value
-             )pbdoc")
+             "int : The y subsampling value")
         .def_readwrite("pLinear", &PyChannel::pLinear,
-             R"pbdoc(
-             bool : The pLinear value, used for DWA compression.
-             )pbdoc")
+             "bool : The pLinear value, used for DWA compression.")
         .def_readwrite("pixels", &PyChannel::pixels,
-             R"pbdoc(
-             np.array : The channel pixel array.
-             )pbdoc")
+             "np.array : The channel pixel array.")
         .def_readonly("channel_index", &PyChannel::channel_index,
-             R"pbdoc(
-             int : The index of the channel.
-             )pbdoc")
+             "int : The index of the channel.")
         ;
     
-    py::class_<PyPart>(m, "Part", R"pbdoc(
-         The class object representing a part in a EXR image file.
-
-         Example
-         -------  
-         >>> import OpenEXR
-         >>> Z = np.zeros((200,100), dtype='f')
-         >>> P = OpenEXR.Part({}, {"Z" : Z })
-         >>> f = OpenEXR.File([P])
-         >>> f.parts()
-         [Part("Part0", Compression.ZIPS_COMPRESSION, width=100, height=200)] 
-    )pbdoc")
+    py::class_<PyPart>(m, "Part", "The class object representing a part in a EXR image file.\n"
+                                  "\n"
+                                  "Example\n"
+                                  "-------  \n"
+                                  ">>> import OpenEXR\n"
+                                  ">>> Z = np.zeros((200,100), dtype='f')\n"
+                                  ">>> P = OpenEXR.Part({}, {\"Z\" : Z })\n"
+                                  ">>> f = OpenEXR.File([P])\n"
+                                  ">>> f.parts()\n"
+                                  "[Part(\"Part0\", Compression.ZIPS_COMPRESSION, width=100, height=200)] ")
         .def(py::init(),
-             R"pbdoc(
-             Create an empty Part object
-             )pbdoc")
+             "Create an empty Part object")
         .def(py::init<py::dict,py::dict,std::string>(),
              py::arg("header"),
              py::arg("channels"),
              py::arg("name")="",
-             R"pbdoc(
-             Create a Part object from dicts for the header and channels.
-
-             Parameters
-             ----------
-             header : dict
-                 Dict of header metadata, with attribute name as key.
-             channels : list
-                 List of `Channel` objects, which hold pixel numpy arrays.
-             name : str
-                 The name of the part
-
-             Example
-             -------
-             >>> Z = np.zeros((200,100), dtype='f')
-             >>> P = OpenEXR.Part({}, {"Z" : Z }, "left")
-             )pbdoc")
+             "Create a Part object from dicts for the header and channels.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "header : dict\n"
+             "    Dict of header metadata, with attribute name as key.\n"
+             "channels : list\n"
+             "    List of `Channel` objects, which hold pixel numpy arrays.\n"
+             "name : str\n"
+             "    The name of the part\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> Z = np.zeros((200,100), dtype='f')\n"
+             ">>> P = OpenEXR.Part({}, {\"Z\" : Z }, \"left\")")
         .def("__repr__", [](const PyPart& p) { return repr(p); })
         .def("name", &PyPart::name,
-             R"pbdoc(
-              str : The part name.
-             )pbdoc")
+             "str : The part name.")
         .def("type", &PyPart::type,
-             R"pbdoc(
-              OpenEXR.Storage : The type of the part: scanlineimage, tiledimage, deepscanline, deeptile
-             )pbdoc")
+             "OpenEXR.Storage : The type of the part: scanlineimage, tiledimage, deepscanline, deeptile")
         .def("width", &PyPart::width,
-             R"pbdoc(
-             int : The width of the image, in pixels.
-             )pbdoc")
+             "int : The width of the image, in pixels.")
         .def("height", &PyPart::height,
-             R"pbdoc(
-             int : The height of the image, in pixels.
-             )pbdoc")
+             "int : The height of the image, in pixels.")
         .def("compression", &PyPart::compression,
-             R"pbdoc(
-             OpenEXR.Compression : The compression method:
-                 NO_COMPRESSION
-                 RLE_COMPRESSION
-                 ZIPS_COMPRESSION
-                 ZIP_COMPRESSION
-                 PIZ_COMPRESSION
-                 PXR24_COMPRESSION
-                 B44_COMPRESSION
-                 B44A_COMPRESSION
-                 DWAA_COMPRESSION
-                 DWAB_COMPRESSION
-                 HTJ2K256_COMPRESSION
-                 HTJ2K32_COMPRESSION
-             )pbdoc")
+             "OpenEXR.Compression : The compression method:\n"
+             "    NO_COMPRESSION\n"
+             "    RLE_COMPRESSION\n"
+             "    ZIPS_COMPRESSION\n"
+             "    ZIP_COMPRESSION\n"
+             "    PIZ_COMPRESSION\n"
+             "    PXR24_COMPRESSION\n"
+             "    B44_COMPRESSION\n"
+             "    B44A_COMPRESSION\n"
+             "    DWAA_COMPRESSION\n"
+             "    DWAB_COMPRESSION\n"
+             "    HTJ2K256_COMPRESSION\n"
+             "    HTJ2K32_COMPRESSION")
         .def_readwrite("header", &PyPart::header,
-             R"pbdoc(
-             dict : The header metadata.
-             )pbdoc")
+             "dict : The header metadata.")
         .def_readwrite("channels", &PyPart::channels,
-             R"pbdoc(
-             dict : The channels.
-             )pbdoc")
+             "dict : The channels.")
         .def_readonly("part_index", &PyPart::part_index,
-             R"pbdoc(
-             int : The index of the part.
-             )pbdoc")
+             "int : The index of the part.")
         ;
 
-    py::class_<PyFile>(m, "File", R"pbdoc(
-         The class object representing an EXR image file.
-
-         This class is the interface for reading and writing image
-         header and pixel data.
-
-         Example
-         -------  
-         >>> import OpenEXR
-         >>> f = OpenEXR.File("image.exr")
-         >>> f.header()["comment"] = "Hello, image."
-         >>> f.write("out.exr")
-    )pbdoc")
+    py::class_<PyFile>(m, "File", "The class object representing an EXR image file.\n"
+                                  "\n"
+                                  "This class is the interface for reading and writing image\n"
+                                  "header and pixel data.\n"
+                                  "\n"
+                                  "Example\n"
+                                  "-------  \n"
+                                  ">>> import OpenEXR\n"
+                                  ">>> f = OpenEXR.File(\"image.exr\")\n"
+                                  ">>> f.header()[\"comment\"] = \"Hello, image.\"\n"
+                                  ">>> f.write(\"out.exr\")")
         .def(py::init<>())
         .def(py::init<std::string,bool,bool>(),
              py::arg("filename"),
              py::arg("separate_channels")=false,
              py::arg("header_only")=false,
-             R"pbdoc(
-             Initialize a File by reading the image from the given filename.
-
-             Parameters
-             ----------
-             filename : str
-                 The path to the image file on disk.
-             separate_channels : bool
-                 If True, read each channel into a separate 2D numpy array
-                 if False (default), read pixel data into a single "RGB" or "RGBA" numpy array of dimension (height,width,3) or (height,width,4);
-             header_only : bool
-                 If True, read only the header metadata, not the image pixel data.
-
-             Example
-             -------  
-             >>> f = OpenEXR.File("image.exr", separate_channels=False, header_only=False)
-             )pbdoc")
+             "Initialize a File by reading the image from the given filename.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "filename : str\n"
+             "    The path to the image file on disk.\n"
+             "separate_channels : bool\n"
+             "    If True, read each channel into a separate 2D numpy array\n"
+             "    if False (default), read pixel data into a single \"RGB\" or \"RGBA\" numpy array of dimension (height,width,3) or (height,width,4);\n"
+             "header_only : bool\n"
+             "    If True, read only the header metadata, not the image pixel data.\n"
+             "\n"
+             "Example\n"
+             "-------  \n"
+             ">>> f = OpenEXR.File(\"image.exr\", separate_channels=False, header_only=False)")
         .def(py::init<py::dict,py::dict>(),
              py::arg("header"),
              py::arg("channels"),
-             R"pbdoc(
-             Initialize a File with metadata and pixels. Creates a single-part EXR file.
-
-             Parameters
-             ----------
-             header : dict
-                 Dict of header metadata, with attribute name as key.
-             channels : list
-                 List of `Channel` objects, which hold pixel numpy arrays.
-
-             Example
-             -------
-             >>> height, width = (20, 10)
-             >>> R = np.random.rand(height, width).astype('f')
-             >>> G = np.random.rand(height, width).astype('f')
-             >>> B = np.random.rand(height, width).astype('f')
-             >>> channels = { "R" : R, "G" : G, "B" : B }
-             >>> header = { "compression" : OpenEXR.ZIP_COMPRESSION,
-                            "type" : OpenEXR.scanlineimage }
-             >>> f = OpenEXR.File(header, channels)
-        )pbdoc")
+             "Initialize a File with metadata and pixels. Creates a single-part EXR file.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "header : dict\n"
+             "    Dict of header metadata, with attribute name as key.\n"
+             "channels : list\n"
+             "    List of `Channel` objects, which hold pixel numpy arrays.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> height, width = (20, 10)\n"
+             ">>> R = np.random.rand(height, width).astype('f')\n"
+             ">>> G = np.random.rand(height, width).astype('f')\n"
+             ">>> B = np.random.rand(height, width).astype('f')\n"
+             ">>> channels = { \"R\" : R, \"G\" : G, \"B\" : B }\n"
+             ">>> header = { \"compression\" : OpenEXR.ZIP_COMPRESSION,\n"
+             "               \"type\" : OpenEXR.scanlineimage }\n"
+             ">>> f = OpenEXR.File(header, channels)")
         .def(py::init<py::list>(),
              py::arg("parts"),
-             R"pbdoc(
-             Initialize a File with a list of Part objects.
-
-             Parameters
-             ----------
-             parts : list
-                 List of Part objects
-
-             Example
-             -------
-             >>> height, width = (20, 10)
-             >>> Z0 = np.zeros((height, width), dtype='f')
-             >>> Z1 = np.ones((height, width), dtype='f')
-             >>> P0 = OpenEXR.Part({}, {"Z" : Z0 })
-             >>> P1 = OpenEXR.Part({}, {"Z" : Z1 })
-             >>> f = OpenEXR.File([P0, P1])
-            )pbdoc")
+             "Initialize a File with a list of Part objects.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "parts : list\n"
+             "    List of Part objects\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> height, width = (20, 10)\n"
+             ">>> Z0 = np.zeros((height, width), dtype='f')\n"
+             ">>> Z1 = np.ones((height, width), dtype='f')\n"
+             ">>> P0 = OpenEXR.Part({}, {\"Z\" : Z0 })\n"
+             ">>> P1 = OpenEXR.Part({}, {\"Z\" : Z1 })\n"
+             ">>> f = OpenEXR.File([P0, P1])")
         .def("__enter__", &PyFile::__enter__)
         .def("__exit__", &PyFile::__exit__)
         .def_readwrite("filename", &PyFile::filename,
-             R"pbdoc(
-             str : The filename the File was read from.
-
-             Example
-             -------
-             >>> f = OpenEXR.File("image.exr")
-             >>> f.filename
-             'image.exr'
-             )pbdoc")
+             "str : The filename the File was read from.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> f = OpenEXR.File(\"image.exr\")\n"
+             ">>> f.filename\n"
+             "'image.exr'")
         .def_readwrite("parts", &PyFile::parts,
-             R"pbdoc(
-             list : The image parts. The list has a single element for single-part files.
-             Example
-             -------
-             >>> f = OpenEXR.File("image.exr")
-             >>>> f.parts
-             [Part("Part0", Compression.ZIPS_COMPRESSION, width=10, height=20)]         
-             )pbdoc")
+             "list : The image parts. The list has a single element for single-part files.\n"
+             "Example\n"
+             "-------\n"
+             ">>> f = OpenEXR.File(\"image.exr\")\n"
+             ">>>> f.parts\n"
+             "[Part(\"Part0\", Compression.ZIPS_COMPRESSION, width=10, height=20)]         ")
         .def("header", &PyFile::header, py::arg("part_index") = 0,
-             R"pbdoc(
-             dict : The header metadata for the given part if specified, or for the first part if not.
-
-             Parameters
-             ----------
-             part_index : int
-                 The index of the part. Defaults to 0.
-
-             Example
-             -------
-             >>> f = OpenEXR.File("image.exr")
-             >>> f.header()
-             {'dataWindow': (array([0, 0], dtype=int32), array([100, 100], dtype=int32)), 'displayWindow': (array([0, 0], dtype=int32), array([100, 100], dtype=int32))}
-             )pbdoc")
+             "dict : The header metadata for the given part if specified, or for the first part if not.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "part_index : int\n"
+             "    The index of the part. Defaults to 0.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> f = OpenEXR.File(\"image.exr\")\n"
+             ">>> f.header()\n"
+             "{'dataWindow': (array([0, 0], dtype=int32), array([100, 100], dtype=int32)), 'displayWindow': (array([0, 0], dtype=int32), array([100, 100], dtype=int32))}")
         .def("channels", &PyFile::channels, py::arg("part_index") = 0,
-             R"pbdoc(
-             Return a dict of channels given part if specified, or for the first part if not. The dict key is the channel name.
-
-             Parameters
-             ----------
-             part_index : int
-                 The index of the part. Defaults to 0.
-
-             Example
-             -------
-             >>> f = OpenEXR.File("image.exr")
-             >>> f.channels(0)
-             {'A': Channel("A", xSampling=1, ySampling=1), 'B': Channel("B", xSampling=1, ySampling=1), 'G': Channel("G", xSampling=1, ySampling=1), 'R': Channel("R", xSampling=1, ySampling=1)}
-             )pbdoc")
+             "Return a dict of channels given part if specified, or for the first part if not. The dict key is the channel name.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "part_index : int\n"
+             "    The index of the part. Defaults to 0.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> f = OpenEXR.File(\"image.exr\")\n"
+             ">>> f.channels(0)\n"
+             "{'A': Channel(\"A\", xSampling=1, ySampling=1), 'B': Channel(\"B\", xSampling=1, ySampling=1), 'G': Channel(\"G\", xSampling=1, ySampling=1), 'R': Channel(\"R\", xSampling=1, ySampling=1)}")
         .def("write", &PyFile::write,
-             R"pbdoc(
-             Write the File to the give file name.
-
-             Parameters
-             ----------
-             filename : str
-                 The output path name.
-
-             Example
-             -------
-             >>> f = OpenEXR.File("image.exr")
-             >>> f.write("out.exr"))pbdoc")
+             "Write the File to the give file name.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "filename : str\n"
+             "    The output path name.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> f = OpenEXR.File(\"image.exr\")\n"
+             ">>> f.write(\"out.exr\")")
         ;
 }
 


### PR DESCRIPTION
## Summary
- replace indented multiline `pbdoc` raw strings in `PyOpenEXR.cpp` with adjacent C++ string literals
- dedent the Python-facing docs for `Channel`, `Part`, and `File` APIs so `help(OpenEXR)` output does not include source indentation

Fixes #2408.

## Tests
- `uv pip install -v .`
- `.venv/bin/python -m pytest -q src/wrappers/python/tests` -> 47 passed
- `.venv/bin/python` docstring smoke check for `OpenEXR.Channel`, `OpenEXR.Part`, and `OpenEXR.File`
- `git diff --check`