### PR TITLE
Fix leak in internal_exr_revert_add_part; test duplicate exr_add_part

### DIFF
--- a/src/lib/OpenEXRCore/internal_structs.c
+++ b/src/lib/OpenEXRCore/internal_structs.c
@@ -264,6 +264,8 @@ internal_exr_revert_add_part (
     *new_index = -1;
 
     internal_exr_destroy_part (ctxt, part);
+    if (part != &(ctxt->first_part)) ctxt->free_fn (part);
+
     if (ncount == 0)
     {
         ctxt->num_parts = 0;

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -88,6 +88,9 @@ testStartWriteScan (const std::string& tempdir)
     EXRCORE_TEST_RVAL (
         exr_add_part (outf, "beauty", EXR_STORAGE_SCANLINE, &partidx));
     EXRCORE_TEST (partidx == 0);
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_add_part (outf, "beauty", EXR_STORAGE_SCANLINE, &partidx));
     EXRCORE_TEST_RVAL (exr_get_count (outf, &partidx));
     EXRCORE_TEST (partidx == 1);
     partidx = 0;


### PR DESCRIPTION
Free heap-allocated part storage after destroy when reverting a failed exr_add_part (skip embedded first_part).

OpenEXRCoreTest: expect EXR_ERR_INVALID_ARGUMENT when adding a second part with the same name as an existing part.

Addresses https://issues.oss-fuzz.com/issues/512314697