### PR TITLE
Python: reject dataWindow size mismatch before write

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -55,6 +55,7 @@
 #include "ImfTimeCodeAttribute.h"
 #include "ImfVecAttribute.h"
 
+#include <algorithm>
 #include <typeinfo>
 #include <sys/types.h>
 
@@ -1189,7 +1190,44 @@ PyFile::write(const char* outfilename)
                                                                C.pLinear));
             }
         }
-        
+
+        //
+        // When writing from numpy channel buffers, the dataWindow size must
+        // match the pixel array extent (shape[0] = height, shape[1] = width).
+        // Otherwise Slice setup disagrees with the buffer and native code can
+        // fault. Skip when copying pixels from an input file, when there are
+        // no channel buffers, or when any channel uses subsampling (different
+        // size rule than full-res arrays).
+        //
+        if (!(_header_only && _inputFile) && !P.channels.empty())
+        {
+            const bool anySubsampling =
+                std::any_of (P.channels.begin(),
+                             P.channels.end(),
+                             [] (const auto& kv)
+                             {
+                                 const auto& ch = kv.second.template cast<const PyChannel&>();
+                                 return ch.xSampling != 1 || ch.ySampling != 1;
+                             });
+
+            if (!anySubsampling)
+            {
+                const Box2i& dw = header.dataWindow();
+                const int dwW  = dw.max.x - dw.min.x + 1;
+                const int dwH = dw.max.y - dw.min.y + 1;
+
+                const V2i dims = P.shape();
+                if (dims[0] != dwH || dims[1] != dwW)
+                {
+                    std::stringstream err;
+                    err << "dataWindow size (" << dwW << " x " << dwH
+                        << ") does not match pixel array size (" << dims[1]
+                        << " x " << dims[0] << ")";
+                    throw std::invalid_argument(err.str());
+                }
+            }
+        }
+
         headers.push_back (header);
     }
     

--- a/src/wrappers/python/tests/test_exceptions.py
+++ b/src/wrappers/python/tests/test_exceptions.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import sys
 import os
 import numpy as np
+import tempfile
 import unittest
 
 import OpenEXR
@@ -152,6 +153,25 @@ class TestExceptions(unittest.TestCase):
             OpenEXR.Channel(np.array([0,0,0,0], dtype='uint8').reshape((height, width)), 2, 2)
         with self.assertRaises(Exception):
             OpenEXR.Channel("C", np.array([0,0,0,0], dtype='uint8').reshape((height, width)), 2, 2)
+
+    def test_dataWindow_mismatch_numpy_pixels(self):
+
+        w, h = 640, 480
+        rgb = np.zeros((w, h, 3), dtype=np.float32)
+
+        header = {
+            "type": OpenEXR.scanlineimage,
+            "compression": OpenEXR.ZIP_COMPRESSION,
+            "displayWindow": ((0, 0), (w - 1, h - 1)),
+            "dataWindow": ((0, 0), (50, 100)),
+        }
+
+        part = OpenEXR.Part(header, {"RGB": rgb})
+        f = OpenEXR.File([part])
+
+        with tempfile.NamedTemporaryFile(suffix=".exr", delete=True) as tmp:
+            with self.assertRaises(ValueError):
+                f.write(tmp.name)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #2023

Summary:
if datawindow != the size of the numpy buffers, the library could still try to write. That put native code in a bad state and could crash the process instead of reporting a normal Python error.

This change adds a safety check before writing: when we are writing those numpy buffers under the simple case where channels are not subsampled, we verify that the dataWindow width and height line up with the array dimensions. If they do not, we fail immediately with a clear error so callers can fix the header or the array shape.

Added unit test

Collaborated-with: Cursor
Signed-off-by: Moira Shooter [mshooter@ilm.com](mailto:mshooter@ilm.com)