### PR TITLE
Check for invalid Slice base and type in TileProcess::copy_sample_count

### DIFF
--- a/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineInputFile.cpp
@@ -617,6 +617,21 @@ DeepScanLineInputFile::Data::readMemData (
     std::vector<DeepSlice> fills;
     ScanLineProcess proc;
 
+    if (countsOnly)
+    {
+        const Slice& scslice = fb.getSampleCountSlice ();
+        if (!scslice.base)
+        {
+            throw IEX_NAMESPACE::ArgExc (
+                "Invalid base pointer, please set a proper sample count slice.");
+        }
+        if (scslice.type != OPENEXR_IMF_INTERNAL_NAMESPACE::UINT)
+        {
+            throw IEX_NAMESPACE::ArgExc (
+                "The type of sample count slice should be UINT.");
+        }
+    }
+
     if (!countsOnly)
         prepFillList(fb, fills);
 
@@ -985,6 +1000,17 @@ void ScanLineProcess::copy_sample_count (
     int fbY)
 {
     const Slice& scslice = outfb->getSampleCountSlice ();
+
+    if (!scslice.base)
+    {
+        throw IEX_NAMESPACE::ArgExc (
+            "Invalid base pointer, please set a proper sample count slice.");
+    }
+    if (scslice.type != OPENEXR_IMF_INTERNAL_NAMESPACE::UINT)
+    {
+        throw IEX_NAMESPACE::ArgExc (
+            "The type of sample count slice should be UINT.");
+    }
 
     int     end = cinfo.height - decoder.user_line_end_ignore;
     int64_t xS = int64_t (scslice.xStride);

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -1199,6 +1199,14 @@ void TileProcess::copy_sample_count (
     if (s.xSampling != 1 || s.ySampling != 1)
         throw IEX_NAMESPACE::ArgExc ("Tiled data should not have subsampling.");
 
+    if (s.base == nullptr)
+        throw IEX_NAMESPACE::ArgExc (
+            "Deep frame buffer is missing sample counts; call insertSampleCountSlice before reading.");
+
+    if (s.type != UINT)
+        throw IEX_NAMESPACE::ArgExc (
+            "The type of sample count slice should be UINT.");
+
     int xOffset = s.xTileCoords ? 0 : t_absX;
     int yOffset = s.yTileCoords ? 0 : t_absY;
 

--- a/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledInputFile.cpp
@@ -279,6 +279,18 @@ DeepTiledInputFile::setFrameBuffer (const DeepFrameBuffer& frameBuffer)
                        "subsampling factors.");
     }
 
+    const Slice& sampleCountSlice = frameBuffer.getSampleCountSlice ();
+    if (!sampleCountSlice.base)
+    {
+        throw IEX_NAMESPACE::ArgExc (
+            "Invalid base pointer, please set a proper sample count slice.");
+    }
+    if (sampleCountSlice.type != UINT)
+    {
+        throw IEX_NAMESPACE::ArgExc (
+            "The type of sample count slice should be UINT.");
+    }
+
     _data->frameBuffer = frameBuffer;
     _data->frameBufferValid = true;
 }


### PR DESCRIPTION
Reject as invalid if the framebuffer has no sample counts, or they're not UINTs.

Addresses https://issues.oss-fuzz.com/issues/512895184

Made-with: Cursor