### PR TITLE
Add HTJ2K256 and HTJ2K32 to data compression scheme list

### DIFF
--- a/website/TechnicalIntroduction.rst
+++ b/website/TechnicalIntroduction.rst
@@ -865,6 +865,17 @@ Supported compression schemes:
        efficient space wise and faster to decode full frames than DWAA
        access.
 
+   * - HTJ2K256 (lossless)
+ 
+     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 256 scanlines, 
+       using `JPEG 2000 Part 15 (High-throughput JPEG 2000) <https://www.itu.int/rec/T-REC-T.814>`_, 
+
+   * - HTJ2K32 (lossless)
+ 
+     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 32 scanlines, 
+       using `JPEG 2000 Part 15 (High-throughput JPEG 2000) <https://www.itu.int/rec/T-REC-T.814>`_, 
+       
+
 Luminance/Chroma Images
 =======================
 


### PR DESCRIPTION
- add HTJ2K256 and HTJ2K32 to data compression scheme list on TechnicalIntroduction website
- closes #2415 