### PR TITLE
Add support for multithreading in Python module

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -31,6 +31,7 @@
 #include "ImfDeepTiledInputPart.h"
 #include "ImfDeepFrameBuffer.h"
 #include "ImfPartType.h"
+#include "ImfThreading.h"
 #include "ImfArray.h"
 
 #include <cstring>
@@ -294,7 +295,8 @@ PythonBinaryOStream::seekp(uint64_t pos)
 }
 
 PyFile::PyFile()
-    : _header_only(false)
+    : _header_only(false),
+      _num_threads(globalThreadCount())
 {
 }
     
@@ -302,9 +304,10 @@ PyFile::PyFile()
 // Create a PyFile out of a list of parts (i.e. a multi-part file)
 //
 
-PyFile::PyFile(const py::list& parts)
+PyFile::PyFile(const py::list& parts, int num_threads)
     : parts(parts),
-      _header_only(false)
+      _header_only(false),
+      _num_threads(num_threads)
 {
     int part_index = 0;
     for (auto p : this->parts)
@@ -322,8 +325,10 @@ PyFile::PyFile(const py::list& parts)
 // type, and compression (i.e. a single-part file)
 //
 
-PyFile::PyFile(const py::dict& header, const py::dict& channels)
-    : _header_only(false)
+PyFile::PyFile(const py::dict& header, const py::dict& channels,
+               int num_threads)
+    : _header_only(false),
+      _num_threads(num_threads)
 {
     parts.append(py::cast<PyPart>(PyPart(header, channels, "")));
 }
@@ -345,16 +350,21 @@ PyFile::PyFile(const py::dict& header, const py::dict& channels)
 // e.g. "left.R", "left.G", etc, the channel key is the prefix.
 //
 
-PyFile::PyFile(const std::string& filename, bool separate_channels, bool header_only)
+PyFile::PyFile(const std::string& filename, bool separate_channels,
+               bool header_only, int num_threads)
     : filename(filename),
       _header_only(header_only),
-      _inputFile(std::make_unique<MultiPartInputFile>(filename.c_str()))
+      _inputFile(std::make_unique<MultiPartInputFile>(filename.c_str(), num_threads)),
+      _num_threads(num_threads)
 {
     readPartsFromOpenInput(separate_channels);
 }
 
-PyFile::PyFile(py::object binary_stream, bool separate_channels, bool header_only)
-    : filename("<buffer>"), _header_only(header_only)
+PyFile::PyFile(py::object binary_stream, bool separate_channels, 
+               bool header_only, int num_threads)
+    : filename("<buffer>"),
+      _header_only(header_only),
+      _num_threads(num_threads)
 {
     if (py::isinstance<py::str>(binary_stream))
     {
@@ -364,7 +374,7 @@ PyFile::PyFile(py::object binary_stream, bool separate_channels, bool header_onl
     }
 
     _readStream = std::make_unique<PythonBinaryIStream>(std::move(binary_stream));
-    _inputFile  = std::make_unique<MultiPartInputFile>(*_readStream);
+    _inputFile  = std::make_unique<MultiPartInputFile>(*_readStream, _num_threads);
     readPartsFromOpenInput(separate_channels);
 }
 
@@ -1212,17 +1222,26 @@ PyFile::__enter__()
 void
 PyFile::__exit__(py::args args)
 {
-    for (auto p : parts)
+    //
+    // Only clear part dicts when this File was populated by reading from
+    // disk. Constructors that take caller-owned header/channels dicts or
+    // a list of PyPart objects alias those Python objects; clearing here
+    // would mutate or empty the caller's dicts (see PyPart ctor).
+    //
+    if (_inputFile)
     {
-        PyPart& P = p.cast<PyPart&>();
-        P.header.clear();
-
-        for (auto c : P.channels)
+        for (auto p : parts)
         {
-            auto C = py::cast<PyChannel&>(c.second);
-            C.pixels = py::none();
+            PyPart& P = p.cast<PyPart&>();
+            P.header.clear();
+
+            for (auto c : P.channels)
+            {
+                auto C = py::cast<PyChannel&>(c.second);
+                C.pixels = py::none();
+            }
+            P.channels.clear();
         }
-        P.channels.clear();
     }
     parts = py::list();
 }
@@ -2648,6 +2667,23 @@ PYBIND11_MODULE(OpenEXR, m)
     m.attr("__version__") = OPENEXR_VERSION_STRING;
     m.attr("OPENEXR_VERSION") = OPENEXR_VERSION_STRING;
 
+    m.def(
+        "set_global_thread_count",
+        &setGlobalThreadCount,
+        py::arg("count"),
+        "Set the number of worker threads in OpenEXR's **process-wide** "
+        "thread pool used for parallel I/O and compression/decompression.\n\n"
+        "``count`` may be any non-negative integer; ``0`` selects single-threaded "
+        "operation. For parallel decode when opening files "
+        "with ``num_threads`` > 1, the global pool must typically be non-zero. "
+        "This setting is shared by all OpenEXR I/O in the process. "
+        "Call this once at startup before reading/writing large images.\n\n");
+
+    m.def(
+        "global_thread_count",
+        &globalThreadCount,
+        "Return the current number of worker threads in OpenEXR's global pool.\n\n");
+
     //
     // Add symbols from the legacy implementation of the bindings for
     // backwards compatibility
@@ -3056,10 +3092,11 @@ PYBIND11_MODULE(OpenEXR, m)
                                   ">>> f.header()[\"comment\"] = \"Hello, image.\"\n"
                                   ">>> f.write(\"out.exr\")")
         .def(py::init<>())
-        .def(py::init<std::string,bool,bool>(),
+        .def(py::init<std::string,bool,bool,int>(),
              py::arg("filename"),
              py::arg("separate_channels")=false,
              py::arg("header_only")=false,
+             py::arg("num_threads")=globalThreadCount(),
              "Initialize a File by reading the image from the given filename.\n"
              "\n"
              "Parameters\n"
@@ -3071,40 +3108,28 @@ PYBIND11_MODULE(OpenEXR, m)
              "    if False (default), read pixel data into a single \"RGB\" or \"RGBA\" numpy array of dimension (height,width,3) or (height,width,4);\n"
              "header_only : bool\n"
              "    If True, read only the header metadata, not the image pixel data.\n"
+             "num_threads : int\n"
+             "    Number of threads for multithreaded I/O and encode/decode.\n"
              "\n"
              "Example\n"
              "-------  \n"
              ">>> f = OpenEXR.File(\"image.exr\", separate_channels=False, header_only=False)")
-        .def(py::init<py::dict,py::dict>(),
-             py::arg("header"),
-             py::arg("channels"),
-             "Initialize a File with metadata and pixels. Creates a single-part EXR file.\n"
-             "\n"
-             "Parameters\n"
-             "----------\n"
-             "header : dict\n"
-             "    Dict of header metadata, with attribute name as key.\n"
-             "channels : list\n"
-             "    List of `Channel` objects, which hold pixel numpy arrays.\n"
-             "\n"
-             "Example\n"
-             "-------\n"
-             ">>> height, width = (20, 10)\n"
-             ">>> R = np.random.rand(height, width).astype('f')\n"
-             ">>> G = np.random.rand(height, width).astype('f')\n"
-             ">>> B = np.random.rand(height, width).astype('f')\n"
-             ">>> channels = { \"R\" : R, \"G\" : G, \"B\" : B }\n"
-             ">>> header = { \"compression\" : OpenEXR.ZIP_COMPRESSION,\n"
-             "               \"type\" : OpenEXR.scanlineimage }\n"
-             ">>> f = OpenEXR.File(header, channels)")
-        .def(py::init<py::list>(),
+        //
+        // Single-arg py::object (binary stream) matches any Python object, so
+        // register list-of-parts BEFORE stream so File([Part, ...]) is not
+        // mistaken for File(BytesIO(...)).
+        //
+        .def(py::init<py::list,int>(),
              py::arg("parts"),
+             py::arg("num_threads")=globalThreadCount(),
              "Initialize a File with a list of Part objects.\n"
              "\n"
              "Parameters\n"
              "----------\n"
              "parts : list\n"
              "    List of Part objects\n"
+             "num_threads : int\n"
+             "    Number of threads for multithreaded I/O and encode/decode.\n"
              "\n"
              "Example\n"
              "-------\n"
@@ -3114,10 +3139,11 @@ PYBIND11_MODULE(OpenEXR, m)
              ">>> P0 = OpenEXR.Part({}, {\"Z\" : Z0 })\n"
              ">>> P1 = OpenEXR.Part({}, {\"Z\" : Z1 })\n"
              ">>> f = OpenEXR.File([P0, P1])")
-        .def(py::init<py::object, bool, bool>(),
+        .def(py::init<py::object, bool, bool, int>(),
              py::arg("stream"),
              py::arg("separate_channels") = false,
              py::arg("header_only") = false,
+             py::arg("num_threads")=globalThreadCount(),
              "Initialize a File by reading from a binary stream.\n"
              "\n"
              "The stream must implement read(), tell(), and seek() and contain a\n"
@@ -3131,7 +3157,34 @@ PYBIND11_MODULE(OpenEXR, m)
              "separate_channels : bool\n"
              "    Same as for the filename constructor.\n"
              "header_only : bool\n"
-             "    Same as for the filename constructor.\n")
+             "    Same as for the filename constructor.\n"
+             "num_threads : int\n"
+             "    Number of threads for multithreaded I/O and encode/decode.\n")
+        .def(py::init<py::dict,py::dict,int>(),
+             py::arg("header"),
+             py::arg("channels"),
+             py::arg("num_threads")=globalThreadCount(),
+             "Initialize a File with metadata and pixels. Creates a single-part EXR file.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "header : dict\n"
+             "    Dict of header metadata, with attribute name as key.\n"
+             "channels : list\n"
+             "    List of `Channel` objects, which hold pixel numpy arrays.\n"
+             "num_threads : int\n"
+             "    Number of threads for multithreaded I/O and encode/decode.\n"
+             "\n"
+             "Example\n"
+             "-------\n"
+             ">>> height, width = (20, 10)\n"
+             ">>> R = np.random.rand(height, width).astype('f')\n"
+             ">>> G = np.random.rand(height, width).astype('f')\n"
+             ">>> B = np.random.rand(height, width).astype('f')\n"
+             ">>> channels = { \"R\" : R, \"G\" : G, \"B\" : B }\n"
+             ">>> header = { \"compression\" : OpenEXR.ZIP_COMPRESSION,\n"
+             "               \"type\" : OpenEXR.scanlineimage }\n"
+             ">>> f = OpenEXR.File(header, channels)")
         .def("__enter__", &PyFile::__enter__)
         .def("__exit__", &PyFile::__exit__)
         .def_readwrite("filename", &PyFile::filename,

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -294,9 +294,9 @@ PythonBinaryOStream::seekp(uint64_t pos)
     _fo.attr("seek")(pyLongFromUint64(pos), pyLongFromLong(0));
 }
 
-PyFile::PyFile()
+PyFile::PyFile(int num_threads)
     : _header_only(false),
-      _num_threads(globalThreadCount())
+      _num_threads(num_threads < 0 ? globalThreadCount() : num_threads)
 {
 }
     
@@ -307,7 +307,7 @@ PyFile::PyFile()
 PyFile::PyFile(const py::list& parts, int num_threads)
     : parts(parts),
       _header_only(false),
-      _num_threads(num_threads)
+      _num_threads(num_threads < 0 ? globalThreadCount() : num_threads)
 {
     int part_index = 0;
     for (auto p : this->parts)
@@ -328,7 +328,7 @@ PyFile::PyFile(const py::list& parts, int num_threads)
 PyFile::PyFile(const py::dict& header, const py::dict& channels,
                int num_threads)
     : _header_only(false),
-      _num_threads(num_threads)
+      _num_threads(num_threads < 0 ? globalThreadCount() : num_threads)
 {
     parts.append(py::cast<PyPart>(PyPart(header, channels, "")));
 }
@@ -354,8 +354,8 @@ PyFile::PyFile(const std::string& filename, bool separate_channels,
                bool header_only, int num_threads)
     : filename(filename),
       _header_only(header_only),
-      _inputFile(std::make_unique<MultiPartInputFile>(filename.c_str(), num_threads)),
-      _num_threads(num_threads)
+      _num_threads(num_threads < 0 ? globalThreadCount() : num_threads),
+      _inputFile(std::make_unique<MultiPartInputFile>(filename.c_str(), _num_threads))
 {
     readPartsFromOpenInput(separate_channels);
 }
@@ -364,7 +364,7 @@ PyFile::PyFile(py::object binary_stream, bool separate_channels,
                bool header_only, int num_threads)
     : filename("<buffer>"),
       _header_only(header_only),
-      _num_threads(num_threads)
+      _num_threads(num_threads < 0 ? globalThreadCount() : num_threads)
 {
     if (py::isinstance<py::str>(binary_stream))
     {
@@ -1549,7 +1549,8 @@ void
 PyFile::write(const char* outfilename)
 {
     std::vector<Header> headers = buildOutputHeaders();
-    MultiPartOutputFile outfile(outfilename, headers.data(), headers.size());
+    MultiPartOutputFile outfile (
+        outfilename, headers.data (), headers.size (), false, _num_threads);
     runMultiPartOutput(outfile, headers);
     filename = outfilename;
 }
@@ -1566,7 +1567,8 @@ PyFile::write(py::object binary_stream)
     
     std::vector<Header> headers = buildOutputHeaders();
     PythonBinaryOStream pstream(std::move(binary_stream));
-    MultiPartOutputFile outfile(pstream, headers.data(), headers.size());
+    MultiPartOutputFile outfile (
+        pstream, headers.data (), headers.size (), false, _num_threads);
     runMultiPartOutput(outfile, headers);
 
     filename = "<buffer>";
@@ -3091,12 +3093,20 @@ PYBIND11_MODULE(OpenEXR, m)
                                   ">>> f = OpenEXR.File(\"image.exr\")\n"
                                   ">>> f.header()[\"comment\"] = \"Hello, image.\"\n"
                                   ">>> f.write(\"out.exr\")")
-        .def(py::init<>())
+        .def(py::init<int>(),
+             py::arg("num_threads")=-1,
+             "Initialize an empy File.\n"
+             "\n"
+             "Parameters\n"
+             "----------\n"
+             "    Number of threads for multithreaded I/O and encode/decode of the File.\n"
+             "\n"
+             )
         .def(py::init<std::string,bool,bool,int>(),
              py::arg("filename"),
              py::arg("separate_channels")=false,
              py::arg("header_only")=false,
-             py::arg("num_threads")=globalThreadCount(),
+             py::arg("num_threads")=-1,
              "Initialize a File by reading the image from the given filename.\n"
              "\n"
              "Parameters\n"
@@ -3109,7 +3119,7 @@ PYBIND11_MODULE(OpenEXR, m)
              "header_only : bool\n"
              "    If True, read only the header metadata, not the image pixel data.\n"
              "num_threads : int\n"
-             "    Number of threads for multithreaded I/O and encode/decode.\n"
+             "    Number of threads for multithreaded I/O and encode/decode of the File.\n"
              "\n"
              "Example\n"
              "-------  \n"
@@ -3121,7 +3131,7 @@ PYBIND11_MODULE(OpenEXR, m)
         //
         .def(py::init<py::list,int>(),
              py::arg("parts"),
-             py::arg("num_threads")=globalThreadCount(),
+             py::arg("num_threads")=-1,
              "Initialize a File with a list of Part objects.\n"
              "\n"
              "Parameters\n"
@@ -3129,7 +3139,7 @@ PYBIND11_MODULE(OpenEXR, m)
              "parts : list\n"
              "    List of Part objects\n"
              "num_threads : int\n"
-             "    Number of threads for multithreaded I/O and encode/decode.\n"
+             "    Number of threads for multithreaded I/O and encode/decode for this File.\n"
              "\n"
              "Example\n"
              "-------\n"
@@ -3143,7 +3153,7 @@ PYBIND11_MODULE(OpenEXR, m)
              py::arg("stream"),
              py::arg("separate_channels") = false,
              py::arg("header_only") = false,
-             py::arg("num_threads")=globalThreadCount(),
+             py::arg("num_threads")=-1,
              "Initialize a File by reading from a binary stream.\n"
              "\n"
              "The stream must implement read(), tell(), and seek() and contain a\n"
@@ -3159,11 +3169,11 @@ PYBIND11_MODULE(OpenEXR, m)
              "header_only : bool\n"
              "    Same as for the filename constructor.\n"
              "num_threads : int\n"
-             "    Number of threads for multithreaded I/O and encode/decode.\n")
+             "    Number of threads for multithreaded I/O and encode/decode for this File.\n")
         .def(py::init<py::dict,py::dict,int>(),
              py::arg("header"),
              py::arg("channels"),
-             py::arg("num_threads")=globalThreadCount(),
+             py::arg("num_threads")=-1,
              "Initialize a File with metadata and pixels. Creates a single-part EXR file.\n"
              "\n"
              "Parameters\n"
@@ -3173,7 +3183,7 @@ PYBIND11_MODULE(OpenEXR, m)
              "channels : list\n"
              "    List of `Channel` objects, which hold pixel numpy arrays.\n"
              "num_threads : int\n"
-             "    Number of threads for multithreaded I/O and encode/decode.\n"
+             "    Number of threads for multithreaded I/O and encode/decode for this File.\n"
              "\n"
              "Example\n"
              "-------\n"

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -59,10 +59,13 @@ class PyFile
 {
 public:
     PyFile();
-    PyFile(const std::string& filename, bool separate_channels = false, bool header_only = false);
-    PyFile(py::object binary_stream, bool separate_channels = false, bool header_only = false);
-    PyFile(const py::dict& header, const py::dict& channels);
-    PyFile(const py::list& parts);
+    PyFile(const std::string& filename, bool separate_channels = false,
+           bool header_only = false, int num_threads = globalThreadCount());
+    PyFile(py::object binary_stream, bool separate_channels = false, bool header_only = false,
+           int num_threads = globalThreadCount());
+    PyFile(const py::dict& header, const py::dict& channels,
+           int num_threads = globalThreadCount());
+    PyFile(const py::list& parts, int num_threads = globalThreadCount());
 
     py::object   __enter__();
     void         __exit__(py::args args);
@@ -87,6 +90,7 @@ protected:
     bool                                _header_only;
     std::unique_ptr<IStream>            _readStream;
     std::unique_ptr<MultiPartInputFile> _inputFile;
+    int                                 _num_threads;
     
     py::object   getAttributeObject(const std::string& name, const Attribute* a);
     

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -58,14 +58,14 @@ class PyChannel;
 class PyFile 
 {
 public:
-    PyFile();
+    PyFile(int num_threads = -1);
     PyFile(const std::string& filename, bool separate_channels = false,
-           bool header_only = false, int num_threads = globalThreadCount());
+           bool header_only = false, int num_threads = -1);
     PyFile(py::object binary_stream, bool separate_channels = false, bool header_only = false,
-           int num_threads = globalThreadCount());
+           int num_threads = -1);
     PyFile(const py::dict& header, const py::dict& channels,
-           int num_threads = globalThreadCount());
-    PyFile(const py::list& parts, int num_threads = globalThreadCount());
+           int num_threads = -1);
+    PyFile(const py::list& parts, int num_threads = -1);
 
     py::object   __enter__();
     void         __exit__(py::args args);
@@ -88,9 +88,9 @@ private:
 protected:
     
     bool                                _header_only;
+    int                                 _num_threads;
     std::unique_ptr<IStream>            _readStream;
     std::unique_ptr<MultiPartInputFile> _inputFile;
-    int                                 _num_threads;
     
     py::object   getAttributeObject(const std::string& name, const Attribute* a);
     

--- a/src/wrappers/python/tests/test_exceptions.py
+++ b/src/wrappers/python/tests/test_exceptions.py
@@ -26,7 +26,7 @@ class TestExceptions(unittest.TestCase):
 
         # invalid argument
         with self.assertRaises(Exception):
-            f = OpenEXR.File(1)
+            f = OpenEXR.File(None)
 
         # invalid number of arguments
         with self.assertRaises(Exception):

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -731,6 +731,28 @@ class TestUnittest(unittest.TestCase):
 
             with OpenEXR.File(multithread_filename, num_threads=num_threads) as i1:
                 compare_files(i0, i1)
+
+    def test_num_threads_default_uses_global_pool(self):
+        #
+        # num_threads=-1 (the default) should resolve to global_thread_count()
+        # at File construction time.
+        #
+        width = 64
+        height = 64
+        R = np.random.rand(height, width).astype('f')
+        channels = {"R": OpenEXR.Channel("R", R)}
+
+        OpenEXR.set_global_thread_count(4)
+
+        outfilename = mktemp_outfilename()
+        with OpenEXR.File({}, channels) as outfile:
+            outfile.write(outfilename)
+
+        with OpenEXR.File(outfilename) as infile:
+            self.assertEqual(infile.channels()["R"].pixels.shape, (height, width))
+
+        with OpenEXR.File(outfilename, num_threads=-1) as infile:
+            self.assertEqual(infile.channels()["R"].pixels.shape, (height, width))
         
     def test_gil_released_during_io(self):
 

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -693,6 +693,45 @@ class TestUnittest(unittest.TestCase):
             with OpenEXR.File(outfilename, separate_channels=True) as i:
                 compare_files (i, outfile2)
 
+    def test_multithread_read(self):
+
+        #
+        # There's not a great way to test if multiple threads were
+        # actually used, but at least this confirms the API works.
+        #
+
+        width = 1000
+        height = 1000
+        size = width * height
+        R = np.random.rand(height, width).astype('f')
+        G = np.random.rand(height, width).astype('f')
+        B = np.random.rand(height, width).astype('f')
+        channels = {
+            "R": OpenEXR.Channel("R", R),
+            "G": OpenEXR.Channel("G", G),
+            "B": OpenEXR.Channel("B", B),
+        }
+
+        # Write a file single-threaded, then read it back in
+
+        singlethread_filename = mktemp_outfilename()
+        with OpenEXR.File({}, channels) as outfile:
+            outfile.write(singlethread_filename)
+
+        with OpenEXR.File(singlethread_filename) as i0:
+
+            # Write the same data as multithreaded, then read it back in, too.
+            
+            num_threads = 4
+            OpenEXR.set_global_thread_count(num_threads)
+            
+            multithread_filename = mktemp_outfilename()
+            with OpenEXR.File({}, channels, num_threads=num_threads) as outfile:
+                outfile.write(multithread_filename)
+
+            with OpenEXR.File(multithread_filename, num_threads=num_threads) as i1:
+                compare_files(i0, i1)
+        
     def test_gil_released_during_io(self):
 
         #

--- a/website/python.rst
+++ b/website/python.rst
@@ -489,31 +489,76 @@ Multithreaded Reading and Writing
 
 (new in OpenEXR v3.5)
 
-The ``File`` object constructor accepts a ``num_threads`` parameter that
-specifies the number of worker threads to use for both read/write and
-decode/encode:
+OpenEXR can decode and encode image data in parallel. The Python bindings
+expose two related settings:
 
-.. code-block::
+``OpenEXR.set_global_thread_count(count)``
+    Configures the **process-wide** worker thread pool used for parallel
+    compression and decompression. ``count`` must be non-negative; ``0``
+    means single-threaded operation. This setting is shared by all OpenEXR
+    I/O in the process (including the legacy ``InputFile`` / ``OutputFile``
+    API).
 
-    with OpenEXR.File("image.exr", num_threads=8) as infile:
-        ...
+``OpenEXR.global_thread_count()``
+    Returns the current global pool size.
 
-and:
+``num_threads`` on ``OpenEXR.File(...)``
+    Limits how many worker threads **this file** may use when reading or
+    writing. The default is ``-1``, which means **use the full global pool**:
+    at ``File`` construction time the bindings call
+    ``OpenEXR.global_thread_count()`` and store that value on the object.
+    Any non-negative integer sets an explicit per-file limit instead.
 
-.. code-block::
+    Parallel decode/encode runs only when the resolved ``num_threads`` is
+    greater than 1 **and** the global pool is non-zero.
 
-    with OpenEXR.File(header, channels, num_threads=8) as outfile:
-        ...
+Both settings matter. A non-zero global pool with ``num_threads=1`` (or
+``0``) on the ``File`` object stays on the single-threaded path. Setting
+``num_threads=8`` without calling ``set_global_thread_count`` first leaves
+no workers in the pool, so work still runs on the calling thread.
 
-OpenEXR maintains a process-wide thread pool to use for such
-reading. That threadpool must be initialized via
-``OpenEXR.set_global_thread_count`` before reading and writing:
+Recommended usage
+-------------------
+
+Configure the global pool **once at process startup**, before opening
+files. With the default ``num_threads=-1``, each ``File`` picks up the
+current pool size when it is created. To cap parallelism below the
+pool size, pass an explicit value (for example ``num_threads=4``). To
+pin the limit at construction time, pass
+``num_threads=OpenEXR.global_thread_count()`` explicitly instead of
+relying on ``-1``.
 
 .. code-block::
 
     import os
+    import OpenEXR
 
     OpenEXR.set_global_thread_count(os.cpu_count())
-
     n = OpenEXR.global_thread_count()
+    
+    with OpenEXR.File("image.exr", num_threads=n) as infile:
+        ...
+
+    with OpenEXR.File(header, channels, num_threads=n) as outfile:
+        outfile.write("out.exr")
+
+
+Do **not** call ``set_global_thread_count`` from a background thread
+while another thread is inside a ``File(filename)`` read or a
+``File.write()`` (or from inside OpenEXR worker logic). Resize the
+pool only when no OpenEXR I/O is in progress.
+
+Threading and Python
+----------------------
+
+During file I/O the extension releases the Python GIL so other Python
+threads can run. That does **not** make channel dictionaries or NumPy
+pixel arrays safe to modify from another thread while a ``File`` is
+reading or writing. Each thread should use its own ``File`` object and
+its own buffers, or serialize access.
+
+Parallelism is most effective for large scanline or tiled files read from
+or written to disk. In-memory streams (for example ``io.BytesIO``) still
+acquire the GIL on each stream call, so multithreading provides less
+benefit there.
 

--- a/website/python.rst
+++ b/website/python.rst
@@ -484,3 +484,36 @@ All deep pixel arrays within a given part must have the same number of
 samples, so the pixel arrays must have the same size and shape.  The
 ``write`` method will throw an exception if they are not.
 
+Multithreaded Reading and Writing
+=================================
+
+(new in OpenEXR v3.5)
+
+The ``File`` object constructor accepts a ``num_threads`` parameter that
+specifies the number of worker threads to use for both read/write and
+decode/encode:
+
+.. code-block::
+
+    with OpenEXR.File("image.exr", num_threads=8) as infile:
+        ...
+
+and:
+
+.. code-block::
+
+    with OpenEXR.File(header, channels, num_threads=8) as outfile:
+        ...
+
+OpenEXR maintains a process-wide thread pool to use for such
+reading. That threadpool must be initialized via
+``OpenEXR.set_global_thread_count`` before reading and writing:
+
+.. code-block::
+
+    import os
+
+    OpenEXR.set_global_thread_count(os.cpu_count())
+
+    n = OpenEXR.global_thread_count()
+


### PR DESCRIPTION
The `OpenEXR.File` object now takes a `num_threads` argument specifying the number of threads for I/O (passed directly to the `MultiPartInputFile/MultiPartOutputFile` object constructors).

`OpenEXR.set_global_thread_count(int)` specifies the number of worker threads for the process-wide thread pool (calls
`Imf::setGlobalThreadCount`), and `OpenEXR.global_thread_count()` returns the current value.

This also fixes a bug where the `File` object destructor was clearing the channel dict and pixel numpy arrays even if they are owned by the caller, a bug revealed by the new multithreading test.