### PR TITLE
Check for xSize==0 in gaps fuzzer part_exceeds_memory_limits

### DIFF
--- a/src/test/oss-fuzz/openexr_exrgaps_fuzzer.cc
+++ b/src/test/oss-fuzz/openexr_exrgaps_fuzzer.cc
@@ -111,6 +111,9 @@ part_exceeds_memory_limits (const IMF::Header& hdr)
     if (!hdr.hasTileDescription ()) return false;
 
     const IMF::TileDescription& td = hdr.tileDescription ();
+    if (td.xSize == 0)
+        return false;
+        
     const uint64_t tilesPerScanline =
         (imageWidth + static_cast<uint64_t> (td.xSize) - 1) /
         static_cast<uint64_t> (td.xSize);


### PR DESCRIPTION
Otherwise, there's a division by 0.

Addresses https://issues.oss-fuzz.com/issues/514487287 
Addresses https://issues.oss-fuzz.com/issues/514423826