### PR TITLE
Validate HTJ2K chunk header length before decode

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -182,6 +182,8 @@ ht_undo_impl (
         return EXR_ERR_CORRUPT_CHUNK;
     }
 
+    /* this should never be true since read_header() throws an exception if the
+    header is larger than comp_buf_size */
     if (header_sz > comp_buf_size)
         return EXR_ERR_CORRUPT_CHUNK;
 

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -172,8 +172,23 @@ ht_undo_impl (
     /* read the channel map */
 
     size_t header_sz;
-    header_sz = read_header (
-        (uint8_t*) compressed_data, comp_buf_size, cs_to_file_ch);
+    try
+    {
+        header_sz = read_header (
+            (uint8_t*) compressed_data, comp_buf_size, cs_to_file_ch);
+    }
+    catch (...)
+    {
+        return EXR_ERR_CORRUPT_CHUNK;
+    }
+
+    if (header_sz > comp_buf_size)
+        return EXR_ERR_CORRUPT_CHUNK;
+
+    const uint64_t codestream_sz = comp_buf_size - header_sz;
+    if (codestream_sz == 0)
+        return EXR_ERR_CORRUPT_CHUNK;
+
     if (static_cast<std::size_t>(decode->channel_count) != cs_to_file_ch.size ())
         return EXR_ERR_CORRUPT_CHUNK;
 
@@ -195,7 +210,7 @@ ht_undo_impl (
     ojph::mem_infile infile;
     infile.open (
         reinterpret_cast<const ojph::ui8*> (compressed_data) + header_sz,
-        comp_buf_size - header_sz);
+        codestream_sz);
 
     ojph::codestream cs;
     cs.read_headers (&infile);

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -215,6 +215,11 @@ public:
         return (v << 8) + *cur++;
     }
 
+    size_t tell() const
+    {
+        return this->cur - this->buffer;
+    }
+
 protected:
     uint8_t* buffer;
     uint8_t* cur;
@@ -288,39 +293,23 @@ read_header (
     size_t                              max_sz,
     std::vector<CodestreamChannelInfo>& map)
 {
-    if (max_sz < HEADER_SZ)
-        throw std::runtime_error ("HTJ2K chunk is too small for a header");
-
-    MemoryReader prefix ((uint8_t*) buffer, max_sz);
-    if (prefix.pull_uint16 () != HEADER_MARKER)
+    MemoryReader header ((uint8_t*) buffer, max_sz);
+    if (header.pull_uint16 () != HEADER_MARKER)
         throw std::runtime_error (
-            "HTJ2K chunk header missing does not start with magic number.");
+            "HTJ2K chunk header does not start with magic number.");
 
-    const uint32_t payload_len = prefix.pull_uint32 ();
+    size_t payload_sz = header.pull_uint32 ();
+    size_t prefix_sz = header.tell ();
 
-    if (payload_len < 2)
-        throw std::runtime_error ("Error while reading the channel map");
-
-    const uint64_t total_header =
-        static_cast<uint64_t> (payload_len) + HEADER_SZ;
-    if (total_header > max_sz)
+    if (payload_sz + prefix_sz > max_sz)
         throw std::runtime_error (
-            "HTJ2K header length exceeds compressed chunk size");
+            "HTJ2K chunk header length is larger than the chunk size.");
 
-    MemoryReader payload (
-        static_cast<uint8_t*> (buffer) + HEADER_SZ,
-        static_cast<size_t> (payload_len));
-
-    const uint16_t nch = payload.pull_uint16 ();
-    const uint64_t map_bytes = 2ULL + 2ULL * static_cast<uint64_t> (nch);
-    if (map_bytes > payload_len)
-        throw std::runtime_error ("HTJ2K channel map exceeds header payload");
-
-    map.resize (nch);
+    map.resize (header.pull_uint16 ());
     for (size_t i = 0; i < map.size (); i++)
     {
-        map.at (i).file_index = payload.pull_uint16 ();
+        map.at (i).file_index = header.pull_uint16 ();
     }
 
-    return static_cast<size_t> (total_header);
+    return prefix_sz + payload_sz;
 }

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -288,23 +288,39 @@ read_header (
     size_t                              max_sz,
     std::vector<CodestreamChannelInfo>& map)
 {
-    MemoryReader header ((uint8_t*) buffer, max_sz);
-    if (header.pull_uint16 () != HEADER_MARKER)
+    if (max_sz < HEADER_SZ)
+        throw std::runtime_error ("HTJ2K chunk is too small for a header");
+
+    MemoryReader prefix ((uint8_t*) buffer, max_sz);
+    if (prefix.pull_uint16 () != HEADER_MARKER)
         throw std::runtime_error (
             "HTJ2K chunk header missing does not start with magic number.");
 
-    size_t length = header.pull_uint32 ();
+    const uint32_t payload_len = prefix.pull_uint32 ();
 
-    if (length < 2)
+    if (payload_len < 2)
         throw std::runtime_error ("Error while reading the channel map");
 
-    length += HEADER_SZ;
+    const uint64_t total_header =
+        static_cast<uint64_t> (payload_len) + HEADER_SZ;
+    if (total_header > max_sz)
+        throw std::runtime_error (
+            "HTJ2K header length exceeds compressed chunk size");
 
-    map.resize (header.pull_uint16 ());
+    MemoryReader payload (
+        static_cast<uint8_t*> (buffer) + HEADER_SZ,
+        static_cast<size_t> (payload_len));
+
+    const uint16_t nch = payload.pull_uint16 ();
+    const uint64_t map_bytes = 2ULL + 2ULL * static_cast<uint64_t> (nch);
+    if (map_bytes > payload_len)
+        throw std::runtime_error ("HTJ2K channel map exceeds header payload");
+
+    map.resize (nch);
     for (size_t i = 0; i < map.size (); i++)
     {
-        map.at (i).file_index = header.pull_uint16 ();
+        map.at (i).file_index = payload.pull_uint16 ();
     }
 
-    return length;
+    return static_cast<size_t> (total_header);
 }

--- a/src/lib/OpenEXRCore/internal_ht_common.h
+++ b/src/lib/OpenEXRCore/internal_ht_common.h
@@ -10,22 +10,75 @@
 #include <stdlib.h>
 #include "openexr_coding.h"
 
+/** Maps a JPEG 2000 codestream component index to the corresponding OpenEXR
+ *  file channel index and its byte offset within a packed raster line. */
 struct CodestreamChannelInfo
 {
     int    file_index;
     size_t raster_line_offset;
 };
 
+/** Build a codestream-to-file channel map for @p channel_count OpenEXR
+ *  channels.
+ *
+ *  When the channels include a matching RGB triplet (e.g. R/G/B, Red/Green/Blue,
+ *  or layer-prefixed variants), the first three entries of @p cs_to_file_ch are
+ *  assigned to R, G, and B respectively so that the JPEG 2000 Reversible Color
+ *  Transform (RCT) can be applied by the encoder.  All remaining channels follow
+ *  in their original order.  When no RGB triplet is detected the channels are
+ *  mapped in their original order.
+ *
+ *  @param channel_count  Number of channels in @p channels.
+ *  @param channels       OpenEXR per-channel coding descriptors.
+ *  @param cs_to_file_ch  Output map from J2K component index to file channel.
+ *                        Resized to @p channel_count on return.
+ *  @return true  if an RGB triplet was detected (RCT will be applied),
+ *          false otherwise.
+ */
 bool make_channel_map (
     int                                 channel_count,
     exr_coding_channel_info_t*          channels,
     std::vector<CodestreamChannelInfo>& cs_to_file_ch);
 
+/** Write an HTJ2K chunk header into @p buffer.
+ *
+ *  The header encodes the channel map so that a decoder can reconstruct the
+ *  original OpenEXR channel ordering from the JPEG 2000 codestream.  It has
+ *  the following on-disk layout (all integers big-endian):
+ *  @code
+ *    uint16_t  MAGIC  = 0x4854 ('H','T')
+ *    uint32_t  PLEN          // payload length in bytes
+ *    uint16_t  NCH           // number of entries in the channel map
+ *    uint16_t  CS_TO_F[NCH]  // OpenEXR channel index for each J2K component
+ *    // optional opaque extension bytes up to PLEN
+ *    // JPEG 2000 codestream follows immediately after the header
+ *  @endcode
+ *
+ *  @param buffer   Destination buffer; must be at least @p max_sz bytes.
+ *  @param max_sz   Capacity of @p buffer in bytes.
+ *  @param map      Channel map produced by make_channel_map().
+ *  @return Number of bytes written; the JPEG 2000 codestream should be
+ *          placed at this offset within @p buffer.
+ */
 size_t write_header (
     uint8_t*                                  buffer,
     size_t                                    max_sz,
     const std::vector<CodestreamChannelInfo>& map);
 
+/** Parse an HTJ2K chunk header from @p buffer and populate the channel map.
+ *
+ *  Validates the magic number, reads the payload length, and decodes the
+ *  per-component OpenEXR channel indices.  Extension bytes inside the payload
+ *  (beyond the channel map) are silently skipped.
+ *
+ *  @param buffer   Chunk data; must be at least @p max_sz bytes.
+ *  @param max_sz   Number of readable bytes starting at @p buffer.
+ *  @param map      Populated with one entry per J2K component on success.
+ *  @return Byte offset of the JPEG 2000 codestream within @p buffer, i.e. the
+ *          total size of the header including its payload.
+ *  @throws std::runtime_error if the magic number is absent, the header is
+ *          larger than @p max_sz.
+ */
 size_t read_header (
     void*                               buffer,
     size_t                              max_sz,

--- a/src/test/OpenEXRCoreTest/CMakeLists.txt
+++ b/src/test/OpenEXRCoreTest/CMakeLists.txt
@@ -128,6 +128,7 @@ define_openexrcore_tests(
  testDWAACompression
  testDWABCompression
  testHTChannelMap
+ testHTHeaderBounds
  testDeepNoCompression
  testDeepZIPCompression
  testDeepZIPSCompression

--- a/src/test/OpenEXRCoreTest/compression.cpp
+++ b/src/test/OpenEXRCoreTest/compression.cpp
@@ -1753,6 +1753,58 @@ testHTChannelMap (const std::string& tempdir)
     EXRCORE_TEST (! make_channel_map (3, channels_2, cs_to_file_ch));
 }
 
+static bool
+read_header_throws (void* buffer, size_t max_sz)
+{
+    std::vector<CodestreamChannelInfo> map;
+    try
+    {
+        read_header (buffer, max_sz, map);
+        return false;
+    }
+    catch (...)
+    {
+        return true;
+    }
+}
+
+void
+testHTHeaderBounds (const std::string& tempdir)
+{
+    (void) tempdir;
+
+    exr_coding_channel_info_t channels[] = {
+        { "R" }, { "G" }, { "B" }
+    };
+    std::vector<CodestreamChannelInfo> cs_to_file_ch;
+    EXRCORE_TEST (make_channel_map (3, channels, cs_to_file_ch));
+
+    uint8_t buf[64];
+    const size_t hdr_sz =
+        write_header (buf, sizeof (buf), cs_to_file_ch);
+    EXRCORE_TEST (hdr_sz > HEADER_SZ);
+
+    std::vector<CodestreamChannelInfo> read_map;
+    EXRCORE_TEST (read_header (buf, hdr_sz, read_map) == hdr_sz);
+    EXRCORE_TEST (read_map.size () == 3);
+
+    EXRCORE_TEST (read_header_throws (buf, hdr_sz - 1));
+
+    uint8_t bad_plen[64];
+    memcpy (bad_plen, buf, hdr_sz);
+    bad_plen[2] = 0xff;
+    bad_plen[3] = 0xff;
+    bad_plen[4] = 0xff;
+    bad_plen[5] = 0xf0;
+    EXRCORE_TEST (read_header_throws (bad_plen, sizeof (bad_plen)));
+
+    uint8_t bad_nch[64];
+    memcpy (bad_nch, buf, hdr_sz);
+    bad_nch[HEADER_SZ]     = 0;
+    bad_nch[HEADER_SZ + 1] = 32;
+    EXRCORE_TEST (read_header_throws (bad_nch, hdr_sz));
+}
+
 void
 testDeepNoCompression (const std::string& tempdir)
 {}

--- a/src/test/OpenEXRCoreTest/compression.h
+++ b/src/test/OpenEXRCoreTest/compression.h
@@ -23,6 +23,7 @@ void testB44ACompression (const std::string& tempdir);
 void testDWAACompression (const std::string& tempdir);
 void testDWABCompression (const std::string& tempdir);
 void testHTChannelMap (const std::string& tempdir);
+void testHTHeaderBounds (const std::string& tempdir);
 
 void testDeepNoCompression (const std::string& tempdir);
 void testDeepZIPCompression (const std::string& tempdir);

--- a/src/test/OpenEXRCoreTest/main.cpp
+++ b/src/test/OpenEXRCoreTest/main.cpp
@@ -210,6 +210,7 @@ main (int argc, char* argv[])
     TEST (testDWAACompression, "core_compression");
     TEST (testDWABCompression, "core_compression");
     TEST (testHTChannelMap, "core_compression");
+    TEST (testHTHeaderBounds, "core_compression");
 
     TEST (testDeepNoCompression, "core_compression");
     TEST (testDeepZIPCompression, "core_compression");


### PR DESCRIPTION
Reject oversized or inconsistent header payload lengths so corrupted chunks cannot advance the codestream pointer past the compressed buffer. Add regression tests for truncated, inflated PLEN, and channel-count cases.

Addresses the "F-6: Oversized HTJ2K PLEN causes out-of-bounds pointer arithmetic in OpenEXR HT decoder" part of https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-gvmj-5qjh-fh8x
