### PR TITLE
Add setMaxImageSize/setMaxTileSize to python module

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -2736,6 +2736,48 @@ PYBIND11_MODULE(OpenEXR, m)
         &globalThreadCount,
         "Return the current number of worker threads in OpenEXR's global pool.\n\n");
 
+    m.def(
+        "setMaxImageSize",
+        &Header::setMaxImageSize,
+        py::arg("max_width"),
+        py::arg("max_height"),
+        "Set the maximum allowed image width and height for subsequent OpenEXR reads "
+        "and writes in this process.\n\n"
+        "Pass ``0`` for either dimension to mean no limit for that dimension. "
+        "Maps to ``Imf::Header::setMaxImageSize()``.\n\n");
+
+    m.def(
+        "getMaxImageSize",
+        [](){
+            int w = 0;
+            int h = 0;
+            Header::getMaxImageSize (w, h);
+            return py::make_tuple (w, h);
+        },
+        "Return ``(max_width, max_height)`` for the current image dimension limits.\n\n"
+        "Maps to ``Imf::Header::getMaxImageSize()``.\n\n");
+
+    m.def(
+        "setMaxTileSize",
+        &Header::setMaxTileSize,
+        py::arg("max_width"),
+        py::arg("max_height"),
+        "Set the maximum allowed tile width and height for subsequent OpenEXR reads "
+        "and writes in this process.\n\n"
+        "Pass ``0`` for either dimension to mean no limit for that dimension. "
+        "Maps to ``Imf::Header::setMaxTileSize()``.\n\n");
+
+    m.def(
+        "getMaxTileSize",
+        [](){
+            int w = 0;
+            int h = 0;
+            Header::getMaxTileSize (w, h);
+            return py::make_tuple (w, h);
+        },
+        "Return ``(max_width, max_height)`` for the current tile dimension limits.\n\n"
+        "Maps to ``Imf::Header::getMaxTileSize()``.\n\n");
+
     //
     // Add symbols from the legacy implementation of the bindings for
     // backwards compatibility

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -781,6 +781,18 @@ class TestUnittest(unittest.TestCase):
             with OpenEXR.File(multithread_filename, num_threads=num_threads) as i1:
                 compare_files(i0, i1)
 
+    def test_max_image_and_tile_size(self):
+        image_w, image_h = OpenEXR.getMaxImageSize()
+        tile_w, tile_h = OpenEXR.getMaxTileSize()
+        try:
+            OpenEXR.setMaxImageSize(2048, 4096)
+            OpenEXR.setMaxTileSize(512, 1024)
+            self.assertEqual(OpenEXR.getMaxImageSize(), (2048, 4096))
+            self.assertEqual(OpenEXR.getMaxTileSize(), (512, 1024))
+        finally:
+            OpenEXR.setMaxImageSize(image_w, image_h)
+            OpenEXR.setMaxTileSize(tile_w, tile_h)
+
     def test_num_threads_default_uses_global_pool(self):
         #
         # num_threads=-1 (the default) should resolve to global_thread_count()

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -784,11 +784,14 @@ class TestUnittest(unittest.TestCase):
     def test_max_image_and_tile_size(self):
         image_w, image_h = OpenEXR.getMaxImageSize()
         tile_w, tile_h = OpenEXR.getMaxTileSize()
+        infilename = f"{test_dir}/test.exr"
         try:
-            OpenEXR.setMaxImageSize(2048, 4096)
+            OpenEXR.setMaxImageSize(5, 10)
             OpenEXR.setMaxTileSize(512, 1024)
-            self.assertEqual(OpenEXR.getMaxImageSize(), (2048, 4096))
+            self.assertEqual(OpenEXR.getMaxImageSize(), (5, 10))
             self.assertEqual(OpenEXR.getMaxTileSize(), (512, 1024))
+            with self.assertRaises(Exception):
+                OpenEXR.File(infilename)
         finally:
             OpenEXR.setMaxImageSize(image_w, image_h)
             OpenEXR.setMaxTileSize(tile_w, tile_h)

--- a/website/ReadingAndWritingImageFiles.rst
+++ b/website/ReadingAndWritingImageFiles.rst
@@ -1548,6 +1548,8 @@ are currently in use.
 Miscellaneous
 =============
 
+.. _image-size-limits:
+
 Image Size Limits and Out-of-Memory Failures
 --------------------------------------------
 

--- a/website/python.rst
+++ b/website/python.rst
@@ -484,6 +484,76 @@ All deep pixel arrays within a given part must have the same number of
 samples, so the pixel arrays must have the same size and shape.  The
 ``write`` method will throw an exception if they are not.
 
+Maximum Image and Tile Dimensions
+=================================
+
+(new in OpenEXR v3.5)
+
+By default, OpenEXR places no limit on image size, and through
+compression, small files can represent images too large to load into
+memory, leading to failure on read. Applications reading untrusted
+images should take steps to prevent this.  See :ref:`Image Size Limits
+and Out-of-Memory Failures <image-size-limits>` for more details.
+
+By default, ``OpenEXR.File`` allocates NumPy arrays to store full pixel
+data, although if you only need metadata, you can provide
+``header_only=True``, which will read only the headers without the
+pixel data. This provides a way of querying image dimensions before a
+full read.
+
+OpenEXR can reject files whose width or height exceed configurable limits
+**before** allocating large buffers. The limits are **process-wide** (shared by
+all OpenEXR I/O in the process, including the legacy ``InputFile`` /
+``OutputFile`` API).
+
+``OpenEXR.setMaxImageSize(max_width, max_height)``
+    Set the maximum allowed image width and height. Use ``0`` for either
+    argument to mean no limit for that dimension. Corresponds to
+    ``Imf::Header::setMaxImageSize()`` in the C++ API.
+
+``OpenEXR.getMaxImageSize()``
+    Return ``(max_width, max_height)`` for the current image limits.
+    Corresponds to ``Imf::Header::getMaxImageSize()``.
+
+``OpenEXR.setMaxTileSize(max_width, max_height)``
+    Set the maximum allowed tile width and height. Use ``0`` for either
+    argument to mean no limit for that dimension. Corresponds to
+    ``Imf::Header::setMaxTileSize()``.
+
+``OpenEXR.getMaxTileSize()``
+    Return ``(max_width, max_height)`` for the current tile limits.
+    Corresponds to ``Imf::Header::getMaxTileSize()``.
+
+Recommended usage
+-----------------
+
+If your application reads **untrusted** EXR files (user uploads, network
+sources, malware scanners, etc.), call ``setMaxImageSize`` and
+``setMaxTileSize`` **once at startup**, before opening any files, with limits
+appropriate for your deployment. That reduces the risk of excessive memory
+use from hostile dimension metadata.
+
+Production VFX pipelines often work with images larger than 10k pixels; a
+limit that is too low will reject legitimate assets. Prefer a configurable
+limit (environment variable, config file, or command-line option) over a
+hard-coded value. For a minimal C++ example that sets limits before opening a
+file, see ``website/src/exrreader_max/exrreader_max.cpp``.
+
+.. code-block::
+
+    import OpenEXR
+
+    # Example: cap scanline images at 16k and tiles at 4k (adjust for your site).
+    OpenEXR.setMaxImageSize(16384, 16384)
+    OpenEXR.setMaxTileSize(4096, 4096)
+
+    with OpenEXR.File("untrusted.exr") as infile:
+        ...
+
+These settings do not replace normal memory planning: decoding a very large
+but in-bounds image can still require substantial RAM. They only prevent
+OpenEXR from accepting dimensions above your chosen ceiling.
+
 Multithreaded Reading and Writing
 =================================
 


### PR DESCRIPTION
This gives access to size limits in the python module, necessary for guarding against OOM errors on untrusted input files.

Address F-5 of
https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-gvmj-5qjh-fh8x