### PR TITLE
Break release.py into separate small scripts for each step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 * [Version 3.4.12](#version-3412-may-24-2026) May 24, 2026
 * [Version 3.4.11](#version-3411-april-29-2026) April 29, 2026
 * [Version 3.4.10](#version-3410-april-17-2026) April 17, 2026
-* [Version 3.4.9](#version-349-april--3-2026) April  3, 2026
+* [Version 3.4.9](#version-349-april-3-2026) April 3, 2026
 * [Version 3.4.8](#version-348-march-26-2026) March 26, 2026
 * [Version 3.4.7](#version-347-march-15-2026) March 15, 2026
 * [Version 3.4.6](#version-346-march-1-2026) March 1, 2026
@@ -18,7 +18,7 @@
 * [Version 3.4.0](#version-340-september-5-2025) September 5, 2025
 * [Version 3.3.11](#version-3311-april-29-2026) April 29, 2026
 * [Version 3.3.10](#version-339-april-17-2026) April 17, 2026
-* [Version 3.3.9](#version-339-april--4-2026) April  4, 2026
+* [Version 3.3.9](#version-339-april-4-2026) April 4, 2026
 * [Version 3.3.8](#version-338-march-1-2026) March 1, 2026
 * [Version 3.3.7](#version-337-february-19-2026) February 19, 2026
 * [Version 3.3.6](#version-336-november-4-2025) November 5, 2025
@@ -306,7 +306,7 @@ Bump pypa/cibuildwheel from 3.4.0 to 3.4.1
 * [2333](https://github.com/AcademySoftwareFoundation/openexr/pull/2333)
 Add CI test to validate "cmake --install .. --prefix <path>
 
-## Version 3.4.9 (April  3, 2026)
+## Version 3.4.9 (April 3, 2026)
 
 Patch release that addresses several security vulnerabilities.
 
@@ -1075,7 +1075,7 @@ Patch release that addresses the following security vulnerabilities:
 * [2346](https://github.com/AcademySoftwareFoundation/openexr/pull/2346)
 Fix integer overflow in internal_dwa_compressor.h
 
-## Version 3.3.9 (April  4, 2026)
+## Version 3.3.9 (April 4, 2026)
 
 Patch release for v3.3 that addresses the following security vulnerabilities:
 
@@ -6730,7 +6730,7 @@ we're working to restore them.
 
 * Added new function, isImfMagic (). (Florian Kainz)
 	
-## Version 1.0.6:
+## Version 1.0.6
 
 * Added README.win32 to disted files.
 
@@ -6856,7 +6856,7 @@ the source code.
 * OpenEXR is now covered by a modified BSD license.  See LICENSE
 	  for the new terms.
 
-## Version 1.0.3:
+## Version 1.0.3
 
 ### Detailed Changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -508,6 +508,7 @@ Once you submit a PR, a check labeled ``docs/readthedocs.org:openexr``
 will validate the build. Click on the ``Details`` link to
 preview. Also, a link to this preview will be added automatically to
 the PR description.
+
 ### Test Images
 
 To contribute a new test image, commit it to the
@@ -527,154 +528,182 @@ then commit the new/modified ``.rst`` files to git and submit a PR.
 
 ## Creating a Patch Release
 
-Making a patch release typically involves merging changes from the
-main branch into the release branch, since all development generally
-takes place on the main branch. The usual workflow is to group these
-changes together and merge them all just prior to a release, rather
-than merging one-by-one as the changes go into main, although merging
-along the way is acceptable as well. For OpenEXR and Imath, a patch
-release typically involves under a dozen commits, so it's not a huge
-amount of work to organize them all at once.
+These instructions are for project administrators who have "push"
+access on the GitHub repo.
+
+Making a patch release involves merging changes from the main branch
+into the release branch, since all development takes place on the main
+branch. The process involves these steps:
+
+1. Cherry-pick commits from main to the RB- release branch
+2. Bump the version number
+3. Add release notes to CHANGES.md
+4. Create a "release candidate" tag and announce it publicly
+5. Draft the GitHub release
+6. Create a signed release tag
+7. Publish the release
+8. Add an entry to the website news page
+
+Helper scripts in ``share/util/release/`` automate many of the steps
+in the process.
 
 A patch release *must* be ABI-compatible with preceding minor releases
 and should be validated with an ABI-checker tool such as
 [``abipkgdiff``](https://manpages.ubuntu.com/manpages/lunar/en/man1/abipkgdiff.1.html).
 
-These instructions are for project administrators who have "push"
-access on the GitHub repo.
+### Labeling PRs for Release
 
-The preferred workflow is:
+Commits for the patch release are identified via labels on PRs. Create
+a label for the release, beginning with a `v`, as in
+``v3.4.11``. Assign this label to all PRs to be included in the
+release.
 
-1. Cherry-pick commits from the main branch to the release branch,
-   compose release notes, and bump the version number.
+If a PR should be merged into more than one release branch, i.e. a fix
+goes into v3.4 and v3.3, simply add multiple labels, one per release.
 
-   a. Create a new PR label for the new release (on the GitHub "Pull
-      Request" page), identify all PRs to be included, and assign the
-      label to them.  Run:
+It's good practice to label _every_ PR to identify what
+release it goes into, even if it's the next minor/major release. That
+helps make sure PRs don't get overlooked.
 
-          % share/util/release.py log
+The `share/util/release/log.py` script prints all PRs in the order
+they were merged, annotated by their release labels.
 
-      to print recent commits and their associated PRs and release
-      labels. The best practice is to ensure that every PR is labeled
-      with the release it should go into, even if that is the next
-      major release.
-   
-      Note that this relies on the commit message having the PR number
-      appended to the end, which GitHub adds on "Squash and
-      merge". PRs merged via "Rebase and merge" do *not* get this PR
-      number, which leaves you to manually decipher the PRs to report
-      in the release notes. Our project policy is to "Squash and
-      merge" whenever possible, unless the PR's individual commits
-      really do need to be preserved in the history.
+### Security Issues
 
-   b. Identify the main branch commits to cherry pick to the release
-      branch:
-   
-          % share/util/release.py cherry <tag>
+When a PR addresses a security vulnerability, mention it in the
+description or comments:
 
-      This will print the SHAs for the commits associated with the
-      labeled PRs. The output will look something like:
+    Addresses CVE-2026-39886
+
+The release scripts will detect this an add appropriate entry to the
+release notes.
+
+When a PR addresses an OSS-Fuzz issue, mention it by url in the
+description or comments:
+
+    Addresses https://issues.oss-fuzz.com/issues/456158449
+
+The release scripts will detect this an add appropriate entry to the
+release notes.
+
+### GPG
+
+The signed git tags associated with the release require a [GPG
+key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)
+that is
+[registered](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
+with your GitHub account and git config.
+
+## Release Workflow
+
+Once all PRs have appropriate release labels, follow these steps, all
+while on the appropriate `RB-` branch:
+
+1. Cherry-pick commits from the main branch to the release branch.
+
+   This print the SHAs for the commits associated with the
+   labeled PRs. The output will look something like:
       
-          git cherry-pick 2e32c6b # Bump actions/cache from 5.0.3 to 5.0.4 (#2311)
-          git cherry-pick 3df0122 # Pin pypa/cibuildwheel actions to release sha (#2294)
-          git cherry-pick 6155271 # Force macos cibuildwheel to use Xcode clang (#2315)
-          share/util/release.py changes v3.4.8 2311 2294 2315
+        % python share/util/release/cherry.py v3.4.8
+        git cherry-pick 2e32c6b 3df0122 6155271
+        changes.py v3.4.8 2311 2294 2315
           
-   c. Cherry-pick the commits (copy & execute output from `release.py cherry`):
+   Copy/paste the `git cherry-pick` command to the shell.
 
-          % git checkout RB-3.4
-          % git cherry-pick 2e32c6b
-          % git cherry-pick 3df0122
-          % git cherry-pick 6155271
+   If there are conflicts, resolve them and continue.
 
-      This may involve resolving conflicts along the way. Confirm the
-      updated branch builds successfully.
+   If the conflicts are too messy to resolve, consider
+   cherry-picking the commits one at a time. The `cherry.py`
+   script accepts a `--single` option that prints the commits one
+   `git cherry-pick` command per line:
 
-   d. Create a new section in the `CHANGES.md` release notes file:
+        % python share/util/release/cherry.py --single v3.4.8
+        git cherry-pick 2e32c6b # Bump actions/cache from 5.0.3 to 5.0.4 (#2311)
+        git cherry-pick 3df0122 # Pin pypa/cibuildwheel actions to release sha (#2294)
+        git cherry-pick 6155271 # Force macos cibuildwheel to use Xcode clang (#2315)
+        changes.py v3.4.8 2311 2294 2315
+
+2. Bump the OpenEXR version.
+
+   Edit the number in `src/lib/OpenEXRCore/openexr_version.h`. Commit
+   and push the change.
+
+3. Create an entry in the release notes file `CHANGES.md`.
+
+   The `changes.py` script takes a list of PRs
+   and adds entries in the `CHANGES.md` file:
+        
+        % python share/util/release/changes.py v3.4.8 2311 2294 2315
+
+   This adds the `Merged Pull Requests` and the
+   `Merged Workflow Requests` sections. It also adds a `Security` section
+   that lists the CVEs and OSS-Fuzz issues addressed. 
    
-          % share/util/release.py changes <tag> <pr list>
+   Edit the section by hand to add a summary.
 
-      This is the command as printed at the end of the output of the
-      "cherry" command. This will add a new section to `CHANGES.md`
-      and add entries to the PR lists. Run this from the release
-      branch, since it's preparing a commit for there.
+4. Create a `-rc` "release candidate" tag.
+
+   Obviously, build locally and confirm nothing broke in the
+   cherry-picking commits and resolving conflicts.
    
-   e. Edit `CHANGES.md` and compose a release notes summary. Commit
-      this change.
+   Push the release branch and confirm the CI succeeds before creating
+   the release candidate tag.
 
-   f. Bump the version number in
-      `src/lib/OpenEXRCore/openexr_version.h`. Commit this change.
-
-   g. Push the release branch and confirm the CI passes.
+   Create the tag with a `-rc` suffix, e.g. `v3.4.12-rc`.
    
-2. Tag the release with a ``-rc`` "release candidate" tag,
-   e.g. ``v3.1.9-rc``.  Push the tag via `git push --tags`. This will
-   trigger the release candidate workflow.
+   The `tag.py` script create a signed tag using the release notes as
+   the tag message:
 
-3. Validate ABI compatibility. Build at the release candidate tag and
-   run
-   [abipkgdiff](https://manpages.ubuntu.com/manpages/lunar/en/man1/abipkgdiff.1.html)
-   against a build of the previous patch release to confirm that no
-   ABI changes have leaked in. Additions to the ABI are acceptable for
-   a patch release, but there should be no symbol changes and no
-   symbols removed. If there are, back up and fix them before proceeding.
+        % python share/util/release/tag.py v3.4.12-rc
 
-4. Send mail to ``openexr-dev@lists.aswf.io`` announcing the staging
-   of the release with link to the release candidate tag. Include the
-   release notes from [CHANGES.md](CHANGES.md) for review.
+   Adding the release notes as the tag message is good practice.
 
-5. Draft the GitHub release via:
+   Push the tags. This triggers the `python-wheels-publish-test`
+   CI workflow. Confirm it succeeds.
 
-        % share/util/release.py draft <tag>
+   Run the `candidate.py` script to format a
+   message about the release candidate, formatted in HTML. Pipe the
+   output to a `.html` file:
+   
+        % python share/util/release/candidate.py v3.4.12-rc > v3.4.12.html
+
+   Load the file in a browers to render the formatting, then
+   copy/paste the contents into an email to `openexr-dev@list.aswf.io`
+   and the `#openexr` Slack channel.
+
+   If any problems arise after tagging the candidate, fix them in
+   subsequent commits and create an
+   additional tag with a number appended:
+   
+        % python share/util/release/tag.py v3.4.12-rc2
+
+5. Draft the GitHub release
+
+        % python share/util/release/draft.py v3.4.12
        
    Verify the notes look correct on the
    [Releases](https://github.com/AcademySoftwareFoundation/openexr/releases)
-   page and edit as appropriate. Save as a "draft".
+   page and edit as appropriate. Save as a "draft". DO NOT PUBLISH THE
+   RELEASE YET.
 
-6. Wait at least 48 hours, to give the community time to discover and
-   report any obvious problems. Avoid the temptation to rush changes
-   into a release and publish it immediately, as that is uncomfortably
-   error prone.
+6. Create a signed release tag
 
-   If additional fixes need to go in before release:
-
-   a. Merge commits to the release branch. Push them directly.
-
-   b. Update the release notes in a separate commit.
-
-   c. Re-tag with a incremented "release candidate" number,
-      e.g. ``v3.1.9-rc2``.
-
-   d. Send an email update to ``openexr-dev@lists.aswf.io`` notifying
-      the community of the addition and the new tag.
-
-7. Create a signed release tag
-
-   a. Make sure you have a [GPG
-      key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)
-      and it is
-      [registered](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
-      with your GitHub account and git config.
-
-   b. Create a signed tag with the release name via:
+   Assuming you have your PGP key set up, create the release tag at
+   the same commit as the release candidate:
    
-          git tag -s v3.1.9
+        % python share/util/release/tag.py v3.4.12
 
-   c. Push the tag via:
+7. Publish the release
 
-          git push --tags
+   Set the GitHub release to correspond to the release tag (the `Tag:
+   Select tag` option), then click the "Publish release" button on the
+   GitHub release draft.
 
-8. Publish the release
-
-   a. Set the release to correspond to the latest release candidate
-      tag.
+   Monitor the GitHub actions on the
+   `https://github.com/AcademySoftwareFoundation/openexr` repo to
+   ensure everything builds properly. 
    
-   b. Click the "Publish release" button on the GitHub release draft
-
-   c. Send an email to ``openexr-dev@lists.aswf.io`` officially
-      announcing the release.
-
-9. Update the ``release`` branch, which should always point to the
+   Update the `release` branch, which should always point to the
    most recent patch of the most recent minor release, i.e. the most
    preferred release.
 
@@ -683,152 +712,65 @@ The preferred workflow is:
         % git checkout release
         % git merge RB-3.1
         % git push
-         
-10. Submit a PR that adds the release notes to [CHANGES.md](CHANGES.md)
-    on the main branch. Cherry-pick the release notes commit from
-    the release branch.
 
-    - If any changes have gone into [SECURITY.md](SECURITY), cherry-pick
-      the associated commit as well.
+   Publishing the release triggers a post on the `#openexr` Slack
+   channel, but you must manually send an email to
+   `openexr-dev@lists.aswf.io` officially announcing the release.
 
-    - Also include in this PR edits to [``website/news.rst``](website/news.rst)
-      that add an announcement of the release:
+8. Add an entry to the website news page.
 
-            share/util/release.py news v3.4.8
+        % python share/util/release/news.py v3.4.12
 
-      This will edit the website source files to add the news item.
+   This pulls the release notes from `CHANGES.md` and inserts a news
+   item in `website/news.html`.
 
-    - Get the PR approved and merged promptly so the news item appears
-      on the website. The website rebuilds automatically at
-      https://readthedocs.org/projects/openexr on changes to the main
-      branch, so no action is required.
-      
-12. If the release has resolved any OSS-Fuzz issues, update the
-    associated pages at https://bugs.chromium.org/p/oss-fuzz with a
-    reference to the release.
-
-13. If the release has resolved any public CVEs, request an update
-    from the registry service providing the release and a link to the
-    release notes.  Add a reference to resolved public CVEs to
-    `SECURITY.md` and submit as a PR.
+   Commit this change, and then cherry-pick the commit from the
+   release branch containing the notes and submit the pair as a
+   PR. This pulls the release notes for the patch into the main branch.
 
 ## Creating a Major/Minor Release
 
 A major/minor release is created from the main branch, assuming there
 are no changes on ``main`` that should *not* go into the release. We
 don't generally allow experimental changes onto ``main``. Anything
-accepted onto ``main`` should be intended for the next release.
+accepted onto ``main`` should be intended for the next minor/major
+(not _patch_)release.
 
 The overall workflow is similar to a patch release, as described
-above, but it's simpler because there is no cherry-picking and merging
-of commits. The major/minor release is simply a snapshot of ``main``.
+above, but it's simpler because there is no cherry-picking of
+commits. The major/minor release is simply a snapshot of ``main``.
 
-To create a new release from the ``main`` branch:
+To create a new release from the ``main`` branch, start by creating
+the new "release branch", e.g. `RB-3.5` from the tip of `main`. Then
+follow the same instructions above as for a patch release.
 
-1. Confirm that the ``OPENEXR_VERSION_MAJOR``,
+Assuming all PRs that have _not_ been merged into a patch release are
+labeled with the new minor release, e.g. `v3.5`, the helper scripts in
+`share/util/release` will automate the various steps in generating the
+release notes, drafting the release, and helping with the various
+announcements. 
+
+In addition to the above:
+    
+1. Increment the ``OPENEXR_LIB_SOVERSION`` setting in [CMakeLists.txt](CMakeLists.txt).
+
+   The SO version increases whenever, and only when, the ABI changes
+   in non-backwards-compatible ways. Consistent with the semantic
+   versioning policy, this usually happens at major and minor
+   releases, but never on a patch release.
+
+   Commit this change to the `RB-` branch.
+
+
+2. Confirm that the ``OPENEXR_VERSION_MAJOR``,
    ``OPENEXR_VERSION_MINOR``, and ``OPENEXR_VERSION_PATCH`` value in
    [src/lib/OpenEXRCore/openexr_version.h](src/lib/OpenEXRCore/openexr_version.h)
-   are correct. The OpenEXR project policy is that the values on the
-   main branch, which is the bleeding edge of development, correspond
-   to the next minor release, with the patch set to 0.
+   are correct on the main branch. The OpenEXR project policy is that
+   the values on the main branch, which is the bleeding edge of
+   development, correspond to the next minor release, with the patch
+   set to 0.
 
-2. Update the release notes in [CHANGES.md](CHANGES.md):
-
-   - Write a high-level summary of the features and improvements.
-
-   - Include the log of all PR's that have *not* been merged into the
-     previous minor release.
-
-   - Mention any OSS-Fuzz issues. Provide a link in the notes to the issue at
-     https://bugs.chromium.org/p/oss-fuzz, including the issue id
-     number and description.
-
-   - If there are any public CVE's, mention them explicitly with a
-     link to the CVE registry item.
-
-   - Submit this change as a separate PR.
-
-3. Add a mention of the release to [``website/news.rst``](website/news.rst)
-
-   - Submit this change as a separate PR.
-
-4. Increment the ``OPENEXR_LIB_SOVERSION`` setting in [CMakeLists.txt](CMakeLists.txt).
-
-   - The SO version increases whenever, and only when, the ABI changes
-     in non-backwards-compatible ways. Consistent with the semantic
-     versioning policy, this usually happens at major and minor
-     releases, but never on a patch release.
-
-   - Submit this change as a separate PR for review.
-
-5. Once the above PR's are merged, create the release branch with the
-   ``RB`` prefix, e.g. ``RB-3.2``.
-
-6. Update the ``IMATH_TAG`` setting in
+3. Update the ``IMATH_TAG`` setting in
    [cmake/OpenEXRSetup.cmake](cmake/OpenEXRSetup.cmake) to correspond
    to the proper Imath release.
 
-7. Tag the release with a ``-rc`` "release candidate" tag,
-   e.g. ``v3.2.0-rc``.
-
-8. Send mail to ``openexr-dev@lists.aswf.io`` announcing the staging
-   of the release with link to the release candidate tag. Include the
-   release notes from [CHANGES.md](CHANGES.md) for review.
-
-9. If additional fixes need to go in before release:
-
-   a. Merge commits to the release branch. Push them directly, no need
-      for a pull request.
-
-   b. Update the release notes in a separate commit.
-
-   c. Re-tag with a incremented "release candidate" number,
-      e.g. ``v3.2.0-rc2``.  
-
-   d. Send a email update to ``openexr-dev@lists.aswf.io`` notifying
-      the community of the addition.
-
-10. Draft the release on the GitHub
-    [Releases](https://github.com/AcademySoftwareFoundation/openexr/releases)
-    page.  Include the summary from the notes in
-    [CHANGES.md](CHANGES.md), but don't include the list of PR's.
-
-    - Create the release from the latest ``--rc`` tag, and give it a name
-      that begins with ``v`` and ends in ``0``, e.g. ``v3.2.0``.
-
-    - Save the release as a "draft".
-
-11. Wait at least 48 hours after the email announcement.
-
-12. Publish the release
-
-    a. Click the "Publish release" button on the GitHub release draft
-
-    b. Send an email to ``openexr-dev@lists.aswf.io`` officially
-       announcing the release.
-
-13. Update the ``release`` branch, which should always point to the
-    most recent release.
-
-    From a clone of the main repo:
-
-        % git checkout release
-        % git merge RB-3.1
-        % git push
-         
-14. Increment ``OPENEXR_VERSION_MINOR`` in
-    [src/lib/OpenEXRCore/openexr_version.h](src/lib/OpenEXRCore/openexr_version.h) on the main branch
-
-    - Submit a PR for this. This leaves the release version on the
-      main branch pointing to the next minor release, as described in
-      Step #1.
-
-15. Build the website at https://readthedocs.org/projects/openexr.
-
-16. If the release has resolved any OSS-Fuzz issues, update the
-    associated pages at https://bugs.chromium.org/p/oss-fuzz with a
-    reference to the release.
-
-17. If the release has resolved any public CVE's, request an update
-    from the registry service providing the release and a link to the
-    release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -575,7 +575,7 @@ description or comments:
 
     Addresses CVE-2026-39886
 
-The release scripts will detect this an add appropriate entry to the
+The release scripts will detect this and add an appropriate entry to the
 release notes.
 
 When a PR addresses an OSS-Fuzz issue, mention it by url in the
@@ -583,7 +583,7 @@ description or comments:
 
     Addresses https://issues.oss-fuzz.com/issues/456158449
 
-The release scripts will detect this an add appropriate entry to the
+The release scripts will detect this and add an appropriate entry to the
 release notes.
 
 ### GPG
@@ -601,7 +601,7 @@ while on the appropriate `RB-` branch:
 
 1. Cherry-pick commits from the main branch to the release branch.
 
-   This print the SHAs for the commits associated with the
+   This prints the SHAs for the commits associated with the
    labeled PRs. The output will look something like:
       
         % python share/util/release/cherry.py v3.4.8
@@ -668,7 +668,7 @@ while on the appropriate `RB-` branch:
         % python share/util/release/candidate.py v3.4.12-rc > v3.4.12.html
 
    Load the file in a browers to render the formatting, then
-   copy/paste the contents into an email to `openexr-dev@list.aswf.io`
+   copy/paste the contents into an email to `openexr-dev@lists.aswf.io`
    and the `#openexr` Slack channel.
 
    If any problems arise after tagging the candidate, fix them in
@@ -722,7 +722,7 @@ while on the appropriate `RB-` branch:
         % python share/util/release/news.py v3.4.12
 
    This pulls the release notes from `CHANGES.md` and inserts a news
-   item in `website/news.html`.
+   item in `website/news.rst` and `website/latest_news_title.rst`.
 
    Commit this change, and then cherry-pick the commit from the
    release branch containing the notes and submit the pair as a

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -839,7 +839,7 @@ def pr_labels(line):
     """line is from `git log --pretty:format='%h %s'`, so for
     squash/merge commits, it ends in (#<pr>).
 
-    Return the pr nmber and its release-related labels, i.e.
+    Return the PR number and its release-related labels, i.e.
     labels of the form 'v<major>.<minor>.<patch>'
     """
 

--- a/share/util/release.py
+++ b/share/util/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenEXR Project.
 
@@ -8,6 +8,7 @@
 # `release.py news <tag>` - edit the website/news.rst file to add reference to the tagged release
 # `release.py draft <tag>` - create a draft release on GitHub
 # `release.py candidate <tag>` - format a message about the upcoming release, print to stdout
+# `release.py tag <tag>` - create a signed annotated git tag with the release notes as the tag message
 # `release.py cherry <label>` - list merged PRs with the given label, print cherry-pick lines (oldest merge first)
 # `release.py changes <tag> [pr#> ... ]` - add section to CHANGES.md with given PRs
 # `release.py log` - print a `git log` annotated with the labels from each commit's associated PR, if there is one.
@@ -31,7 +32,12 @@ import subprocess
 from pathlib import Path
 from subprocess import PIPE, run
 from datetime import datetime, timedelta
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 import markdown
+
+OSS_FUZZ_ISSUE_JSON_PREFIX = ")]}'"
+OSS_FUZZ_ISSUE_API = "https://issues.oss-fuzz.com/action/issues/{issue_id}?format=json"
 
 def extract_section(content, version_tag):
     """Extract the section of release notes starting with a heading
@@ -189,13 +195,15 @@ def cmd_cherry(label):
     merged.sort(key=lambda x: x[0])
 
     changes_prs = ""
+    
     for _merged_at, oid, title, id in merged:
         abbrev = oid[:7]
         title_one_line = " ".join(title.split())
         print(f"git cherry-pick {abbrev} # {title_one_line} (#{id})")
         changes_prs += f" {id}" 
 
-    print(f"share/util/release.py changes {label} {changes_prs}")
+    print(f"git cherry-pick {' '.join(o[:7] for a, o, t, i in merged)}")
+    print(f"release.py changes {label} {' '.join(str(id) for a, o, t, id in merged)}")
 
 def prev_patch_version(base_tag):
     """
@@ -218,7 +226,7 @@ def gh_pr_view(pr_number):
             "gh",
             "pr",
             "view",
-            str(pr_number),
+            pr_number,
             "--json",
             "title,author",
         ],
@@ -233,13 +241,297 @@ def gh_pr_view(pr_number):
     return json.loads(result.stdout)
 
 
+def gh_security_advisories_cve_titles() -> dict[str, str]:
+    """
+    List all repository security advisories for the current repo via ``gh api``
+    (``GET .../security-advisories``, paginated). Build a dict mapping each
+    assigned ``CVE-YYYY-NNNN`` id (uppercase) to the advisory ``summary``
+    (GitHub's short title). Entries without ``cve_id`` are omitted.
+
+    Requires ``gh`` authentication with permission to read repository security
+    advisories. Returns ``{}`` if ``gh`` fails, the repo cannot be resolved, or
+    the response is not a JSON array. If multiple advisories share the same
+    ``cve_id``, the first wins.
+    """
+    r = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if r.returncode != 0:
+        return {}
+    nwo = (r.stdout or "").strip()
+    if "/" not in nwo:
+        return {}
+
+    r2 = run(
+        [
+            "gh",
+            "api",
+            f"repos/{nwo}/security-advisories",
+            "--paginate",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if r2.returncode != 0:
+        return {}
+
+    try:
+        items = json.loads(r2.stdout or "[]")
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(items, list):
+        return {}
+
+    out: dict[str, str] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        cve = item.get("cve_id")
+        if not cve or not isinstance(cve, str):
+            continue
+        key = cve.strip().upper()
+        summary = item.get("summary")
+        title = summary.strip() if isinstance(summary, str) else ""
+        if key not in out:
+            out[key] = title
+    return out
+
+
+# Line must contain address / addresses / addressed / addressing (word-boundary);
+# collect every CVE-YYYY-nnnn and OSS-Fuzz issue URL on that line.
+PR_LINE_ADDRESS_RE = re.compile(r"(?i)\bAddress(?:es|ed|ing)?\b")
+CVE_ID_RE = re.compile(r"CVE-\d{4}-\d+", re.IGNORECASE)
+OSS_FUZZ_ISSUE_RE = re.compile(
+    r"https://issues\.oss-fuzz\.com/issues/(\d+)", re.IGNORECASE
+)
+
+
+def _collect_addressed_security_refs(blocks: list[str]) -> tuple[list[str], list[str]]:
+    """
+    On each line containing ``Address`` / ``Addresses`` / etc., collect CVE ids
+    and OSS-Fuzz issue ids (from ``https://issues.oss-fuzz.com/issues/<id>`` URLs).
+    Returns ``(cves, oss_fuzz_issue_ids)`` in first-seen order within each list.
+    """
+    cves: list[str] = []
+    cves_seen: set[str] = set()
+    oss_fuzz: list[str] = []
+    oss_seen: set[str] = set()
+    for block in blocks:
+        for line in block.splitlines():
+            if not PR_LINE_ADDRESS_RE.search(line):
+                continue
+            for m in CVE_ID_RE.finditer(line):
+                cve = m.group(0).upper()
+                if cve not in cves_seen:
+                    cves_seen.add(cve)
+                    cves.append(cve)
+            for m in OSS_FUZZ_ISSUE_RE.finditer(line):
+                issue_id = m.group(1)
+                if issue_id not in oss_seen:
+                    oss_seen.add(issue_id)
+                    oss_fuzz.append(issue_id)
+    return cves, oss_fuzz
+
+
+def _oss_fuzz_short_title(full_title: str) -> str:
+    """
+    Strip the ``project:fuzzer:`` prefix from an OSS-Fuzz issue title, leaving
+    the crash description (matches manual CHANGES.md style).
+    """
+    parts = full_title.split(":", 2)
+    if len(parts) >= 3:
+        return parts[2].strip()
+    return full_title.strip()
+
+
+def _oss_fuzz_full_title_from_fetch(data, issue_id: str) -> str | None:
+    """Extract the full issue title from an IssueFetchResponse JSON payload."""
+    if isinstance(data, dict):
+        return None
+    target = int(issue_id)
+
+    def walk(obj):
+        if isinstance(obj, list):
+            if (
+                len(obj) >= 3
+                and obj[0] is None
+                and obj[1] == target
+                and isinstance(obj[2], list)
+                and len(obj[2]) > 5
+                and isinstance(obj[2][5], str)
+            ):
+                return obj[2][5]
+            for item in obj:
+                found = walk(item)
+                if found:
+                    return found
+        return None
+
+    return walk(data)
+
+
+def _fetch_oss_fuzz_issue_json(issue_id: str):
+    """
+    Fetch issue metadata from issues.oss-fuzz.com. Public issues return JSON;
+    private or restricted issues may return HTTP 403 or a JSON error object.
+    """
+    url = OSS_FUZZ_ISSUE_API.format(issue_id=issue_id)
+    try:
+        with urlopen(url, timeout=30) as resp:
+            raw = resp.read().decode()
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        print(
+            f"Warning: could not fetch OSS-Fuzz issue {issue_id}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+    if raw.startswith(OSS_FUZZ_ISSUE_JSON_PREFIX):
+        raw = raw[len(OSS_FUZZ_ISSUE_JSON_PREFIX) :]
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        print(
+            f"Warning: invalid JSON fetching OSS-Fuzz issue {issue_id}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def oss_fuzz_issue_titles(issue_ids: list[str]) -> dict[str, str]:
+    """
+    Map OSS-Fuzz issue id to a short title (crash description only) for use in
+    release notes. Issues that cannot be fetched are omitted from the dict.
+    """
+    titles: dict[str, str] = {}
+    for issue_id in issue_ids:
+        data = _fetch_oss_fuzz_issue_json(issue_id)
+        if data is None:
+            continue
+        if isinstance(data, dict) and data.get("message"):
+            print(
+                f"Warning: OSS-Fuzz issue {issue_id}: {data['message']}",
+                file=sys.stderr,
+            )
+            continue
+        full = _oss_fuzz_full_title_from_fetch(data, issue_id)
+        if full:
+            titles[issue_id] = _oss_fuzz_short_title(full)
+    return titles
+
+
+def _gh_pr_text_blocks(pr_number: str) -> list[str]:
+    result = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_number,
+            "--json",
+            "body,comments,reviews",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    data = json.loads(result.stdout or "{}")
+    blocks: list[str] = []
+    body = data.get("body")
+    if body:
+        blocks.append(body)
+    for c in data.get("comments") or []:
+        if isinstance(c, dict):
+            b = c.get("body")
+            if b:
+                blocks.append(b)
+    for r in data.get("reviews") or []:
+        if isinstance(r, dict):
+            b = r.get("body")
+            if b:
+                blocks.append(b)
+    return blocks
+
+
+def pr_addressed_cves(pr_number: str) -> tuple[list[str], list[str]]:
+    """
+    Scan the GitHub PR description, issue comments, and review bodies.
+    On each line that contains ``Address``, ``Addresses``, ``address``, etc.
+    (case-insensitive, word-boundary match), collect:
+
+    * every ``CVE-<year>-<number>`` substring
+    * every OSS-Fuzz issue referenced as
+      ``https://issues.oss-fuzz.com/issues/<id>``
+
+    Return ``(cves, oss_fuzz_issue_ids)``, each list in first-seen order.
+    Empty lists if nothing matches.
+
+    This approximates prose such as "Addresses CVE-2024-12345" or
+    "Addresses https://issues.oss-fuzz.com/issues/512314697".
+    """
+
+    if not pr_number:
+        return [], []
+
+    return _collect_addressed_security_refs(_gh_pr_text_blocks(pr_number))
+
+
 MERGED_PR_HEADING_RE = re.compile(
     r"^###\s+Merged Pull Requests\s*:?\s*$", re.IGNORECASE
 )
 MERGED_WORKFLOW_HEADING_RE = re.compile(
     r"^###\s+Merged Workflow Pull Requests\s*:?\s*$", re.IGNORECASE
 )
+SECURITY_HEADING_RE = re.compile(r"^###\s+Security\s*:?\s*$", re.IGNORECASE)
 PR_BULLET_RE = re.compile(r"^\*\s*\[(\d+)\]\(")
+
+
+def strip_security_from_heading(heading_lines: list[str]) -> list[str]:
+    """
+    Remove an existing ``### Security`` subsection from release section heading
+    lines so ``cmd_changes`` can regenerate it from current PR references.
+
+    Preserves a single blank line that separated descriptive text from
+    ``### Security``; that blank is reinserted when the section is rewritten.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(heading_lines)
+    while i < n:
+        if SECURITY_HEADING_RE.match(heading_lines[i].strip()):
+            # Drop the blank line between descriptive text and ### Security.
+            if out and not out[-1].strip():
+                out.pop()
+            i += 1
+            while i < n and not heading_lines[i].startswith("### "):
+                i += 1
+            continue
+        out.append(heading_lines[i])
+        i += 1
+    return out
+
+
+def collect_security_refs_for_prs(pr_numbers: list[str]) -> tuple[list[str], list[str]]:
+    """
+    Scan the given PR numbers for CVE and OSS-Fuzz references. Returns
+    ``(cves, oss_fuzz_issue_ids)`` in first-seen order (deduped per list).
+    """
+    cves: list[str] = []
+    oss_fuzz_issues: list[str] = []
+    for pr_number in pr_numbers:
+        pr_cves, pr_oss_fuzz = pr_addressed_cves(pr_number)
+        cves.extend(pr_cves)
+        oss_fuzz_issues.extend(pr_oss_fuzz)
+    return cves, oss_fuzz_issues
 
 
 def parse_pr_blocks_dict(lines, i, stop_at_workflow_heading):
@@ -259,7 +551,7 @@ def parse_pr_blocks_dict(lines, i, stop_at_workflow_heading):
             break
         mo = PR_BULLET_RE.match(line.strip())
         if mo:
-            pr = int(mo.group(1))
+            pr = mo.group(1)
             bullet = line
             if i + 1 < n:
                 nxt = lines[i + 1]
@@ -304,19 +596,19 @@ def parse_section(lines):
     merged_prs = {}
     if i < n and MERGED_PR_HEADING_RE.match(lines[i].strip()):
         i += 1
-        merged_prs, i = _parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=True)
+        merged_prs, i = parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=True)
 
     merged_workflow_prs = {}
     if i < n and MERGED_WORKFLOW_HEADING_RE.match(lines[i].strip()):
         i += 1
-        merged_workflow_prs, i = _parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=False)
+        merged_workflow_prs, i = parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=False)
 
     return heading, merged_prs, merged_workflow_prs
 
-def pr_is_workflow_only(pr_number: int) -> bool:
+def pr_is_workflow_only(pr_number: str) -> bool:
     """Return True if every file changed by the PR is under .github/workflows/."""
     result = run(
-        ["gh", "pr", "view", str(pr_number), "--json", "files",
+        ["gh", "pr", "view", pr_number, "--json", "files",
          "--jq", "[.files[].path]"],
         stdout=PIPE, stderr=PIPE, universal_newlines=True, check=False,
     )
@@ -325,6 +617,7 @@ def pr_is_workflow_only(pr_number: int) -> bool:
         sys.exit(1)
     paths = json.loads(result.stdout or "[]")
     return bool(paths) and all(p.startswith(".github/workflows/") for p in paths)
+
 def cmd_changes(tag, prs):
     """
     Add a section to CHANGES.md for the given release if one doesn't already exist, and add the given PR 
@@ -370,7 +663,7 @@ def cmd_changes(tag, prs):
         )
         sys.exit(1)
 
-    release_date = datetime.now() + timedelta(days=3)
+    release_date = datetime.now() + timedelta(days=2)
     date_str = release_date.strftime("%B %e, %Y")
 
     if section_index is not None:
@@ -379,6 +672,7 @@ def cmd_changes(tag, prs):
         section_heading, merged_prs, merged_workflow_prs = parse_section(
             lines[section_index:footer_index]
         )
+        section_heading = strip_security_from_heading(section_heading)
     else:
         # The section does not exist, so create the stub of a new one
         section_heading = [f"## Version {base_tag} ({date_str})\n"]
@@ -413,6 +707,18 @@ def cmd_changes(tag, prs):
         else:
             merged_prs[pr_number] = pr_block
 
+    # Scan every PR listed in the section (not only those on the command line)
+    # so Security stays complete when ``changes`` is re-run incrementally.
+    all_prs_for_security = sorted(
+        set(merged_prs) | set(merged_workflow_prs),
+        key=int,
+        reverse=True,
+    )
+    cves, oss_fuzz_issues = collect_security_refs_for_prs(all_prs_for_security)
+
+    advisory_titles = gh_security_advisories_cve_titles()
+    oss_fuzz_titles = oss_fuzz_issue_titles(list(dict.fromkeys(oss_fuzz_issues)))
+
     with open("CHANGES.md", "w", encoding="utf-8", newline="\n") as f:
         if toc is None:
             # No table of contents entry for this release, so add one.
@@ -428,12 +734,28 @@ def cmd_changes(tag, prs):
             f.write("\n".join(lines[:header_index]) + "\n")
         # Write the release section
         f.write("\n".join(section_heading))
+        if cves or oss_fuzz_issues:
+            f.write("\n\n### Security\n")
+            f.write(
+                "\nThis release addresses the following security "
+                "vulnerabilities:\n\n"
+            )
+            for cve in sorted(set(cves), reverse=True):
+                title = advisory_titles.get(cve, "")
+                suffix = f"\n  {title}" if title else ""
+                f.write(f"* [{cve}](https://www.cve.org/CVERecord?id={cve}){suffix}\n")
+            for issue_id in sorted(set(oss_fuzz_issues), reverse=True):
+                url = f"https://issues.oss-fuzz.com/issues/{issue_id}"
+                f.write(f"* OSS-Fuzz [{issue_id}]({url})\n")
+                short = oss_fuzz_titles.get(issue_id, "")
+                if short:
+                    f.write(f"  {short}\n")
         f.write("\n### Merged Pull Requests\n\n")
         for pr, value in sorted(merged_prs.items(), reverse=True):
-            f.write(value + "\n")
+            f.write("  " + value + "\n")
         f.write("\n### Merged Workflow Pull Requests\n\n")
         for pr, value in sorted(merged_workflow_prs.items(), reverse=True):
-            f.write(value + "\n")
+            f.write("  " + value + "\n")
         # Write the rest of the file
         f.write("\n" + "\n".join(lines[footer_index:]))
 
@@ -517,14 +839,14 @@ def pr_labels(line):
     """line is from `git log --pretty:format='%h %s'`, so for
     squash/merge commits, it ends in (#<pr>).
 
-    Return the release-related labels for the identified PR, i.e.
+    Return the pr nmber and its release-related labels, i.e.
     labels of the form 'v<major>.<minor>.<patch>'
     """
 
     LOG_PR_SUFFIX_RE = re.compile(r"\(#(\d+)\)\s*$")
     m = LOG_PR_SUFFIX_RE.search(line)
     if not m:
-        return ""
+        return "", ""
     pr_number = m.group(1)
     result = run(
         ["gh", "pr", "view", pr_number, "--json", "labels"],
@@ -534,17 +856,17 @@ def pr_labels(line):
         check=False,
     )
     if result.returncode != 0:
-        return ""
+        return pr_number, ""
     try:
         data = json.loads(result.stdout or "{}")
     except json.JSONDecodeError:
-        return ""
+        return pr_number, ""
     out = []
     for lab in data.get("labels") or []:
         name = lab.get("name") or ""
         if name.startswith("v"):
             out.append(name)
-    return " ".join(out)
+    return pr_number, " ".join(out)
 
 def cmd_log():
     """
@@ -568,8 +890,22 @@ def cmd_log():
         sys.exit(1)
 
     for line in result.stdout.splitlines():
-        l = pr_labels(line)
-        print(f"{l:7} {line}")
+        pr, l = pr_labels(line)
+        pr_cves, pr_oss_fuzz = pr_addressed_cves(pr)
+        extras = " ".join(pr_cves + [f"oss-fuzz:{i}" for i in pr_oss_fuzz])
+        print(f"{l:7} {line} {extras}")
+
+def cmd_tag(tag, release_date, release_notes) -> None:
+    """
+    Create a signed annotated tag at the current ``HEAD`` using the
+    given release date and notes
+    """
+
+    tag_message = f"{tag} - {release_date}\n{release_notes}\n"
+    
+    cmd = ["git", "tag", "-s", tag, "-F", "-"]
+    run(cmd, input=tag_message, text=True, check=True)
+
 
 def main():
 
@@ -582,8 +918,9 @@ def main():
     if len(sys.argv) < 2:
         print(
             "Usage: python release.py "
-            "<notes|news|draft|candidate|cherry|changes> ...\n"
-            "  release.py changes <tag> <pr-number>   e.g. release.py changes v3.4.7 1234"
+            "<notes|news|draft|candidate|tag|cherry|changes> ...\n"
+            "  release.py changes <tag> <pr-number>   e.g. release.py changes v3.4.7 1234\n"
+            "  release.py tag <tag> [--force]       e.g. release.py tag v3.4.7"
         )
         sys.exit(1)
 
@@ -615,40 +952,36 @@ def main():
     if len(sys.argv) < 3:
         print(
             "Usage: python release.py "
-            "<notes|news|draft|candidate|cherry|changes> <tag-or-label> [date]"
+            "<notes|news|draft|candidate|tag|cherry|changes> <tag-or-label> [date]"
         )
         sys.exit(1)
 
     tag = sys.argv[2]
 
     # Strip leading 'v' and trailing '-rc<candidate>' if necessary
-    base_tag = tag.lstrip('v').split('-rc')[0]
-    result = run(['git', 'tag', '--list', tag], stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    if result.stdout == "":
-        tag += "-rc"
-        result = run(['git', 'tag', '--list', tag], stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        if result.stdout != "":
-            print(f"Using {tag} instead...")
-        else:
-            print(f"No such tag: {tag}")
-            sys.exit(1)
+    release_version = tag.lstrip('v').split('-rc')[0]
 
     # Get the content of the CHANGES.md at the specified git tag
-    try:
-        result = run(['git', 'show', f"{tag}:CHANGES.md"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        content = result.stdout
-        if content == None or content == "":
-            print(f"No news.txt at tag {tag}")
-            sys.exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    with open("CHANGES.md", "r") as f:
+        content = f.read()
 
     # Extract the release notes
-    release_date, release_notes = extract_section(content, base_tag)
+    release_date, release_notes = extract_section(content, release_version)
     if release_date == None:
         print("No release found.")
         return
+
+    # Convert the special symbols
+    release_notes = re.sub(r':bug:', "🐛", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':rocket:', "🚀", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':hammer_and_wrench:', "🛠️", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':wrench:', "🔧", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':sparkles:', "✨", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':snake:', "🐍", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':package:', "📦", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':warning:', "⚠️", release_notes, flags=re.DOTALL)
+    release_notes = re.sub(r':book:', "📖", release_notes, flags=re.DOTALL)
+
 
     if action == "notes":
         print(release_notes)
@@ -658,17 +991,19 @@ def main():
 
     elif action == "news":
         rst_text = markdown_to_rst(release_notes)
-        update_news_file(rst_text, base_tag, release_date)
+        update_news_file(rst_text, release_version, release_date)
 
     elif action == "candidate":
-        version = base_tag
         html_notes = markdown_to_html(release_notes)
         date_string = release_date.strftime("%A, %B %e")
         url = get_repo_url()
         project = url.split('/')[-1]
         if project == "openexr":
             project = "OpenEXR"
-        print(f"{project} {version} is staged for release at tag <a href={url}/releases/tag/{tag}>{tag}</a> and will be released officially {date_string} barring any issues. <br><br> {html_notes}")
+        print(f"{project} {release_version} is staged for release at tag <a href={url}/releases/tag/{tag}>{tag}</a> and will be released officially {date_string} barring any issues. <br><br> {html_notes}")
 
+    elif action == "tag":
+        cmd_tag(tag, release_date, release_notes)
+        
 if __name__ == "__main__":
     main()

--- a/share/util/release/__init__.py
+++ b/share/util/release/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""OpenEXR release automation scripts (see share/util/release.py)."""

--- a/share/util/release/_common.py
+++ b/share/util/release/_common.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Shared helpers for OpenEXR release utility scripts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from subprocess import PIPE, run
+
+
+def extract_section(content: str, version_tag: str) -> tuple[datetime | None, str]:
+    """
+    Extract the section of release notes starting with a heading like
+    ``## Version <tag>``. Include only the text in the section itself,
+    omitting subsections (merged PRs, etc.).
+    """
+    version_header = re.compile(
+        rf"^##.*Version {re.escape(version_tag)}\b.*\(([^)]+)\)",
+        re.IGNORECASE,
+    )
+    subsection_header_pattern = re.compile(r"^##\s+")
+    lines = content.splitlines()
+    capture = False
+    section_lines: list[str] = []
+    release_date = None
+
+    for line in lines:
+        m = version_header.match(line)
+        if m:
+            release_date = datetime.strptime(m.group(1), "%B %d, %Y")
+            capture = True
+            continue
+        if capture and (
+            subsection_header_pattern.match(line)
+            or "Merged Pull Requests" in line
+            or "Merged pull requests" in line
+        ):
+            break
+        if capture:
+            section_lines.append(line)
+
+    return release_date, "\n".join(section_lines).strip()
+
+
+def apply_release_note_emojis(release_notes: str) -> str:
+    """Replace :emoji: shortcodes in release notes with Unicode symbols."""
+    subs = (
+        (r":bug:", "🐛"),
+        (r":rocket:", "🚀"),
+        (r":hammer_and_wrench:", "🛠️"),
+        (r":wrench:", "🔧"),
+        (r":sparkles:", "✨"),
+        (r":snake:", "🐍"),
+        (r":package:", "📦"),
+        (r":warning:", "⚠️"),
+        (r":book:", "📖"),
+    )
+    for pattern, repl in subs:
+        release_notes = re.sub(pattern, repl, release_notes, flags=re.DOTALL)
+    return release_notes
+
+
+def parse_release_version(tag: str) -> str:
+    """Strip leading ``v`` and trailing ``-rc*`` from a release tag."""
+    return tag.lstrip("v").split("-rc")[0]
+
+
+def get_repo_url() -> str | None:
+    try:
+        result = run(
+            ["git", "config", "--get", "remote.upstream.url"],
+            stdout=PIPE,
+            stderr=PIPE,
+            universal_newlines=True,
+            check=False,
+        )
+        url = (result.stdout or "").strip().rstrip(".git")
+        if url:
+            return url
+        result = run(
+            ["git", "config", "--get", "remote.origin.url"],
+            stdout=PIPE,
+            stderr=PIPE,
+            universal_newlines=True,
+            check=False,
+        )
+        return (result.stdout or "").strip().rstrip(".git") or None
+    except OSError:
+        return None
+
+
+def load_release_notes(tag: str) -> tuple[datetime, str, str]:
+    """
+    Read ``CHANGES.md`` and return ``(release_date, release_notes, release_version)``.
+    Exits the process if the section is missing.
+    """
+    release_version = parse_release_version(tag)
+    changes_path = Path("CHANGES.md")
+    if not changes_path.is_file():
+        print("CHANGES.md not found.", file=sys.stderr)
+        sys.exit(1)
+    content = changes_path.read_text(encoding="utf-8")
+    release_date, release_notes = extract_section(content, release_version)
+    if release_date is None:
+        print("No release found.", file=sys.stderr)
+        sys.exit(1)
+    release_notes = apply_release_note_emojis(release_notes)
+    return release_date, release_notes, release_version
+
+
+def prev_patch_version(base_tag: str) -> str | None:
+    """
+    Previous release in the same major.minor line, e.g. ``3.4.5`` -> ``3.4.4``.
+    """
+    parts = base_tag.split(".")
+    if not parts or not parts[-1].isdigit():
+        return None
+    patch = int(parts[-1])
+    if patch <= 0:
+        return None
+    parts[-1] = str(patch - 1)
+    return ".".join(parts)

--- a/share/util/release/_common.py
+++ b/share/util/release/_common.py
@@ -12,6 +12,26 @@ from pathlib import Path
 from subprocess import PIPE, run
 
 
+def format_month_day_year(dt: datetime) -> str:
+    """Portable long date, e.g. ``May 7, 2026`` (no leading zero on day)."""
+    return f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+
+
+def format_weekday_month_day(dt: datetime) -> str:
+    """Portable weekday date, e.g. ``Wednesday, May 7``."""
+    return f"{dt.strftime('%A, %B')} {dt.day}"
+
+
+def parse_release_date(date_text: str) -> datetime:
+    """Parse a CHANGES.md release date, tolerating extra whitespace."""
+    return datetime.strptime(" ".join(date_text.split()), "%B %d, %Y")
+
+
+def changes_anchor_date_slug(dt: datetime) -> str:
+    """Markdown anchor fragment for a release date, e.g. ``may-7-2026``."""
+    return format_month_day_year(dt).lower().replace(",", "").replace(" ", "-")
+
+
 def extract_section(content: str, version_tag: str) -> tuple[datetime | None, str]:
     """
     Extract the section of release notes starting with a heading like
@@ -31,7 +51,7 @@ def extract_section(content: str, version_tag: str) -> tuple[datetime | None, st
     for line in lines:
         m = version_header.match(line)
         if m:
-            release_date = datetime.strptime(m.group(1), "%B %d, %Y")
+            release_date = parse_release_date(m.group(1))
             capture = True
             continue
         if capture and (

--- a/share/util/release/_common.py
+++ b/share/util/release/_common.py
@@ -69,6 +69,13 @@ def parse_release_version(tag: str) -> str:
     return tag.lstrip("v").split("-rc")[0]
 
 
+def _strip_git_suffix(url: str) -> str:
+    url = url.strip()
+    if url.endswith(".git"):
+        return url[: -len(".git")]
+    return url
+
+
 def get_repo_url() -> str | None:
     try:
         result = run(
@@ -78,7 +85,7 @@ def get_repo_url() -> str | None:
             universal_newlines=True,
             check=False,
         )
-        url = (result.stdout or "").strip().rstrip(".git")
+        url = _strip_git_suffix(result.stdout or "")
         if url:
             return url
         result = run(
@@ -88,9 +95,20 @@ def get_repo_url() -> str | None:
             universal_newlines=True,
             check=False,
         )
-        return (result.stdout or "").strip().rstrip(".git") or None
+        return _strip_git_suffix(result.stdout or "") or None
     except OSError:
         return None
+
+
+def require_repo_url() -> str:
+    url = get_repo_url()
+    if not url:
+        print(
+            "Could not determine repository URL from git remotes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return url
 
 
 def load_release_notes(tag: str) -> tuple[datetime, str, str]:

--- a/share/util/release/_common.py
+++ b/share/util/release/_common.py
@@ -144,7 +144,7 @@ def load_release_notes(tag: str) -> tuple[datetime, str, str]:
     content = changes_path.read_text(encoding="utf-8")
     release_date, release_notes = extract_section(content, release_version)
     if release_date is None:
-        print("No release found.", file=sys.stderr)
+        print(f"No release notes found in CHANGES.md for {tag}", file=sys.stderr)
         sys.exit(1)
     release_notes = apply_release_note_emojis(release_notes)
     return release_date, release_notes, release_version

--- a/share/util/release/_security.py
+++ b/share/util/release/_security.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""CVE and OSS-Fuzz reference scanning for release notes (used by changes and log)."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from subprocess import PIPE, run
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+OSS_FUZZ_ISSUE_JSON_PREFIX = ")]}'"
+OSS_FUZZ_ISSUE_API = "https://issues.oss-fuzz.com/action/issues/{issue_id}?format=json"
+
+PR_LINE_ADDRESS_RE = re.compile(r"(?i)\bAddress(?:es|ed|ing)?\b")
+CVE_ID_RE = re.compile(r"CVE-\d{4}-\d+", re.IGNORECASE)
+OSS_FUZZ_ISSUE_RE = re.compile(
+    r"https://issues\.oss-fuzz\.com/issues/(\d+)", re.IGNORECASE
+)
+
+
+def _collect_addressed_security_refs(
+    blocks: list[str],
+) -> tuple[list[str], list[str]]:
+    cves: list[str] = []
+    cves_seen: set[str] = set()
+    oss_fuzz: list[str] = []
+    oss_seen: set[str] = set()
+    for block in blocks:
+        for line in block.splitlines():
+            if not PR_LINE_ADDRESS_RE.search(line):
+                continue
+            for m in CVE_ID_RE.finditer(line):
+                cve = m.group(0).upper()
+                if cve not in cves_seen:
+                    cves_seen.add(cve)
+                    cves.append(cve)
+            for m in OSS_FUZZ_ISSUE_RE.finditer(line):
+                issue_id = m.group(1)
+                if issue_id not in oss_seen:
+                    oss_seen.add(issue_id)
+                    oss_fuzz.append(issue_id)
+    return cves, oss_fuzz
+
+
+def _oss_fuzz_short_title(full_title: str) -> str:
+    parts = full_title.split(":", 2)
+    if len(parts) >= 3:
+        return parts[2].strip()
+    return full_title.strip()
+
+
+def _oss_fuzz_full_title_from_fetch(data, issue_id: str) -> str | None:
+    if isinstance(data, dict):
+        return None
+    target = int(issue_id)
+
+    def walk(obj):
+        if isinstance(obj, list):
+            if (
+                len(obj) >= 3
+                and obj[0] is None
+                and obj[1] == target
+                and isinstance(obj[2], list)
+                and len(obj[2]) > 5
+                and isinstance(obj[2][5], str)
+            ):
+                return obj[2][5]
+            for item in obj:
+                found = walk(item)
+                if found:
+                    return found
+        return None
+
+    return walk(data)
+
+
+def _fetch_oss_fuzz_issue_json(issue_id: str):
+    url = OSS_FUZZ_ISSUE_API.format(issue_id=issue_id)
+    try:
+        with urlopen(url, timeout=30) as resp:
+            raw = resp.read().decode()
+    except (HTTPError, URLError, TimeoutError, OSError) as exc:
+        print(
+            f"Warning: could not fetch OSS-Fuzz issue {issue_id}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+    if raw.startswith(OSS_FUZZ_ISSUE_JSON_PREFIX):
+        raw = raw[len(OSS_FUZZ_ISSUE_JSON_PREFIX) :]
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        print(
+            f"Warning: invalid JSON fetching OSS-Fuzz issue {issue_id}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def oss_fuzz_issue_titles(issue_ids: list[str]) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    for issue_id in issue_ids:
+        data = _fetch_oss_fuzz_issue_json(issue_id)
+        if data is None:
+            continue
+        if isinstance(data, dict) and data.get("message"):
+            print(
+                f"Warning: OSS-Fuzz issue {issue_id}: {data['message']}",
+                file=sys.stderr,
+            )
+            continue
+        full = _oss_fuzz_full_title_from_fetch(data, issue_id)
+        if full:
+            titles[issue_id] = _oss_fuzz_short_title(full)
+    return titles
+
+
+def _gh_pr_text_blocks(pr_number: str) -> list[str]:
+    result = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_number,
+            "--json",
+            "body,comments,reviews",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    data = json.loads(result.stdout or "{}")
+    blocks: list[str] = []
+    body = data.get("body")
+    if body:
+        blocks.append(body)
+    for c in data.get("comments") or []:
+        if isinstance(c, dict):
+            b = c.get("body")
+            if b:
+                blocks.append(b)
+    for r in data.get("reviews") or []:
+        if isinstance(r, dict):
+            b = r.get("body")
+            if b:
+                blocks.append(b)
+    return blocks
+
+
+def pr_addressed_cves(pr_number: str) -> tuple[list[str], list[str]]:
+    if not pr_number:
+        return [], []
+    return _collect_addressed_security_refs(_gh_pr_text_blocks(pr_number))
+
+
+def gh_security_advisories_cve_titles() -> dict[str, str]:
+    r = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if r.returncode != 0:
+        return {}
+    nwo = (r.stdout or "").strip()
+    if "/" not in nwo:
+        return {}
+
+    r2 = run(
+        [
+            "gh",
+            "api",
+            f"repos/{nwo}/security-advisories",
+            "--paginate",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if r2.returncode != 0:
+        return {}
+
+    try:
+        items = json.loads(r2.stdout or "[]")
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(items, list):
+        return {}
+
+    out: dict[str, str] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        cve = item.get("cve_id")
+        if not cve or not isinstance(cve, str):
+            continue
+        key = cve.strip().upper()
+        summary = item.get("summary")
+        title = summary.strip() if isinstance(summary, str) else ""
+        if key not in out:
+            out[key] = title
+    return out
+
+
+def collect_security_refs_for_prs(
+    pr_numbers: list[str],
+) -> tuple[list[str], list[str]]:
+    cves: list[str] = []
+    oss_fuzz_issues: list[str] = []
+    for pr_number in pr_numbers:
+        pr_cves, pr_oss_fuzz = pr_addressed_cves(pr_number)
+        cves.extend(pr_cves)
+        oss_fuzz_issues.extend(pr_oss_fuzz)
+    return cves, oss_fuzz_issues

--- a/share/util/release/candidate.py
+++ b/share/util/release/candidate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sys
 from subprocess import PIPE, run
 
-from _common import load_release_notes, require_repo_url
+from _common import format_weekday_month_day, load_release_notes, require_repo_url
 
 
 def markdown_to_html(markdown_text: str) -> str:
@@ -34,7 +34,7 @@ def main() -> None:
     tag = sys.argv[1]
     release_date, release_notes, release_version = load_release_notes(tag)
     html_notes = markdown_to_html(release_notes)
-    date_string = release_date.strftime("%A, %B %e")
+    date_string = format_weekday_month_day(release_date)
     url = require_repo_url()
     project = url.split("/")[-1]
     if project == "openexr":

--- a/share/util/release/candidate.py
+++ b/share/util/release/candidate.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sys
 from subprocess import PIPE, run
 
-from _common import get_repo_url, load_release_notes
+from _common import load_release_notes, require_repo_url
 
 
 def markdown_to_html(markdown_text: str) -> str:
@@ -35,13 +35,13 @@ def main() -> None:
     release_date, release_notes, release_version = load_release_notes(tag)
     html_notes = markdown_to_html(release_notes)
     date_string = release_date.strftime("%A, %B %e")
-    url = get_repo_url() or ""
-    project = url.split("/")[-1] if url else "OpenEXR"
+    url = require_repo_url()
+    project = url.split("/")[-1]
     if project == "openexr":
         project = "OpenEXR"
     print(
         f"{project} {release_version} is staged for release at tag "
-        f"<a href={url}/releases/tag/{tag}>{tag}</a> and will be released "
+        f'<a href="{url}/releases/tag/{tag}">{tag}</a> and will be released '
         f"officially {date_string} barring any issues. <br><br> {html_notes}"
     )
 

--- a/share/util/release/candidate.py
+++ b/share/util/release/candidate.py
@@ -29,7 +29,7 @@ def markdown_to_html(markdown_text: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: candidate.py <tag>   e.g. candidate.py v3.4.7", file=sys.stderr)
+        print("Usage: python share/util/release/candidate.py <tag> e.g. candidate.py v3.4.7-rc", file=sys.stderr)
         sys.exit(1)
     tag = sys.argv[1]
     release_date, release_notes, release_version = load_release_notes(tag)

--- a/share/util/release/candidate.py
+++ b/share/util/release/candidate.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Format a staged-release announcement message and print to stdout."""
+
+from __future__ import annotations
+
+import sys
+from subprocess import PIPE, run
+
+from _common import get_repo_url, load_release_notes
+
+
+def markdown_to_html(markdown_text: str) -> str:
+    result = run(
+        ["pandoc", "-f", "markdown", "-t", "html"],
+        input=markdown_text,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return (
+        "<style> body { line-height: 1.0; margin: 0; padding: 0; } "
+        "p, h1, h2, h3, h4, h5, h6 { margin: 0; padding: 0; } </style> "
+        f"{result.stdout}"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: candidate.py <tag>   e.g. candidate.py v3.4.7", file=sys.stderr)
+        sys.exit(1)
+    tag = sys.argv[1]
+    release_date, release_notes, release_version = load_release_notes(tag)
+    html_notes = markdown_to_html(release_notes)
+    date_string = release_date.strftime("%A, %B %e")
+    url = get_repo_url() or ""
+    project = url.split("/")[-1] if url else "OpenEXR"
+    if project == "openexr":
+        project = "OpenEXR"
+    print(
+        f"{project} {release_version} is staged for release at tag "
+        f"<a href={url}/releases/tag/{tag}>{tag}</a> and will be released "
+        f"officially {date_string} barring any issues. <br><br> {html_notes}"
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/share/util/release/changes.py
+++ b/share/util/release/changes.py
@@ -12,7 +12,7 @@ import sys
 from datetime import datetime, timedelta
 from subprocess import PIPE, run
 
-from _common import get_repo_url, prev_patch_version
+from _common import prev_patch_version, require_repo_url
 from _security import (
     collect_security_refs_for_prs,
     gh_security_advisories_cve_titles,
@@ -145,7 +145,7 @@ def pr_is_workflow_only(pr_number: str) -> bool:
 
 
 def main() -> None:
-    if len(sys.argv) < 4:
+    if len(sys.argv) < 3:
         print(
             "Usage: changes.py <tag> <pr-number> ...\n"
             "Example: changes.py v3.4.7 1234 1235",
@@ -153,8 +153,8 @@ def main() -> None:
         )
         sys.exit(1)
 
-    tag = sys.argv[2]
-    prs = sys.argv[3:]
+    tag = sys.argv[1]
+    prs = sys.argv[2:]
 
     with open("CHANGES.md", encoding="utf-8") as f:
         lines = f.read().splitlines()
@@ -215,7 +215,7 @@ def main() -> None:
             prev_toc = i
             break
 
-    url = get_repo_url()
+    url = require_repo_url()
     for pr_number in prs:
         info = gh_pr_view(pr_number)
         title = info.get("title") or ""

--- a/share/util/release/changes.py
+++ b/share/util/release/changes.py
@@ -12,7 +12,12 @@ import sys
 from datetime import datetime, timedelta
 from subprocess import PIPE, run
 
-from _common import prev_patch_version, require_repo_url
+from _common import (
+    changes_anchor_date_slug,
+    format_month_day_year,
+    prev_patch_version,
+    require_repo_url,
+)
 from _security import (
     collect_security_refs_for_prs,
     gh_security_advisories_cve_titles,
@@ -189,7 +194,7 @@ def main() -> None:
         sys.exit(1)
 
     release_date = datetime.now() + timedelta(days=2)
-    date_str = release_date.strftime("%B %e, %Y")
+    date_str = format_month_day_year(release_date)
 
     if section_index is not None:
         section_heading, merged_prs, merged_workflow_prs = parse_section(
@@ -242,7 +247,7 @@ def main() -> None:
         if toc is None:
             f.write("\n".join(lines[:prev_toc]) + "\n")
             base_tag_nonum = base_tag.replace(".", "")
-            date_str_lower = date_str.lower().replace(",", "").replace(" ", "-")
+            date_str_lower = changes_anchor_date_slug(release_date)
             f.write(
                 f"* [Version {base_tag}](#version-{base_tag_nonum}-{date_str_lower}) "
                 f"{date_str}\n"

--- a/share/util/release/changes.py
+++ b/share/util/release/changes.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Add or update a release section in CHANGES.md with merged PR entries."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+from subprocess import PIPE, run
+
+from _common import get_repo_url, prev_patch_version
+from _security import (
+    collect_security_refs_for_prs,
+    gh_security_advisories_cve_titles,
+    oss_fuzz_issue_titles,
+)
+
+MERGED_PR_HEADING_RE = re.compile(
+    r"^###\s+Merged Pull Requests\s*:?\s*$", re.IGNORECASE
+)
+MERGED_WORKFLOW_HEADING_RE = re.compile(
+    r"^###\s+Merged Workflow Pull Requests\s*:?\s*$", re.IGNORECASE
+)
+SECURITY_HEADING_RE = re.compile(r"^###\s+Security\s*:?\s*$", re.IGNORECASE)
+PR_BULLET_RE = re.compile(r"^\*\s*\[(\d+)\]\(")
+
+
+def gh_pr_view(pr_number: str) -> dict:
+    result = run(
+        [
+            "gh",
+            "pr",
+            "view",
+            pr_number,
+            "--json",
+            "title,author",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+def strip_security_from_heading(heading_lines: list[str]) -> list[str]:
+    out: list[str] = []
+    i = 0
+    n = len(heading_lines)
+    while i < n:
+        if SECURITY_HEADING_RE.match(heading_lines[i].strip()):
+            if out and not out[-1].strip():
+                out.pop()
+            i += 1
+            while i < n and not heading_lines[i].startswith("### "):
+                i += 1
+            continue
+        out.append(heading_lines[i])
+        i += 1
+    return out
+
+
+def parse_pr_blocks_dict(lines, i, stop_at_workflow_heading):
+    out = {}
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if stop_at_workflow_heading and MERGED_WORKFLOW_HEADING_RE.match(
+            line.strip()
+        ):
+            break
+        mo = PR_BULLET_RE.match(line.strip())
+        if mo:
+            pr = mo.group(1)
+            bullet = line
+            if i + 1 < n:
+                nxt = lines[i + 1]
+                if stop_at_workflow_heading and MERGED_WORKFLOW_HEADING_RE.match(
+                    nxt.strip()
+                ):
+                    out[pr] = bullet
+                    i += 1
+                    continue
+                if PR_BULLET_RE.match(nxt.strip()):
+                    out[pr] = bullet
+                    i += 1
+                    continue
+                out[pr] = "\n".join([bullet, nxt])
+                i += 2
+                continue
+            out[pr] = bullet
+            i += 1
+            continue
+        i += 1
+    return out, i
+
+
+def parse_section(lines):
+    heading = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        if MERGED_PR_HEADING_RE.match(line.strip()):
+            break
+        heading.append(line)
+        i += 1
+
+    merged_prs = {}
+    if i < n and MERGED_PR_HEADING_RE.match(lines[i].strip()):
+        i += 1
+        merged_prs, i = parse_pr_blocks_dict(lines, i, stop_at_workflow_heading=True)
+
+    merged_workflow_prs = {}
+    if i < n and MERGED_WORKFLOW_HEADING_RE.match(lines[i].strip()):
+        i += 1
+        merged_workflow_prs, i = parse_pr_blocks_dict(
+            lines, i, stop_at_workflow_heading=False
+        )
+
+    return heading, merged_prs, merged_workflow_prs
+
+
+def pr_is_workflow_only(pr_number: str) -> bool:
+    result = run(
+        ["gh", "pr", "view", pr_number, "--json", "files", "--jq", "[.files[].path]"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr view failed\n")
+        sys.exit(1)
+    paths = json.loads(result.stdout or "[]")
+    return bool(paths) and all(p.startswith(".github/workflows/") for p in paths)
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print(
+            "Usage: changes.py <tag> <pr-number> ...\n"
+            "Example: changes.py v3.4.7 1234 1235",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tag = sys.argv[2]
+    prs = sys.argv[3:]
+
+    with open("CHANGES.md", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    base_tag = tag.lstrip("v").split("-rc")[0]
+    prev_tag = prev_patch_version(base_tag)
+
+    section_re = re.compile(
+        rf"^##\s+Version\s+{re.escape(base_tag)}\b", re.IGNORECASE
+    )
+    prev_re = (
+        re.compile(rf"^##\s+Version\s+{re.escape(prev_tag)}\b", re.IGNORECASE)
+        if prev_tag
+        else None
+    )
+
+    section_index = None
+    footer_index = None
+    for i, line in enumerate(lines):
+        if section_index is None and section_re.match(line):
+            section_index = i
+        if prev_re is not None and footer_index is None and prev_re.match(line):
+            footer_index = i
+
+    header_index = section_index if section_index is not None else footer_index
+    if header_index is None:
+        print(
+            "Could not locate insertion point (no matching version section and no "
+            "previous patch release heading in CHANGES.md).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    release_date = datetime.now() + timedelta(days=2)
+    date_str = release_date.strftime("%B %e, %Y")
+
+    if section_index is not None:
+        section_heading, merged_prs, merged_workflow_prs = parse_section(
+            lines[section_index:footer_index]
+        )
+        section_heading = strip_security_from_heading(section_heading)
+    else:
+        section_heading = [f"## Version {base_tag} ({date_str})\n"]
+        merged_prs = {}
+        merged_workflow_prs = {}
+
+    toc, prev_toc = None, None
+    toc_re = re.compile(rf"^\*\s+\[Version\s+{re.escape(base_tag)}\]", re.IGNORECASE)
+    prev_toc_re = (
+        re.compile(rf"^\*\s+\[Version\s+{re.escape(prev_tag)}\]", re.IGNORECASE)
+        if prev_tag
+        else None
+    )
+    for i, line in enumerate(lines[:footer_index]):
+        if toc is None and toc_re.match(line):
+            toc = i
+        elif prev_toc is None and prev_toc_re and prev_toc_re.match(line):
+            prev_toc = i
+            break
+
+    url = get_repo_url()
+    for pr_number in prs:
+        info = gh_pr_view(pr_number)
+        title = info.get("title") or ""
+        author = (info.get("author") or {}).get("login") or ""
+        is_workflow = "dependabot" in author or pr_is_workflow_only(pr_number)
+        title_one_line = " ".join(title.split())
+        pr_block = f"* [{pr_number}]({url}/pull/{pr_number})\n{title_one_line}"
+        if is_workflow:
+            merged_workflow_prs[pr_number] = pr_block
+        else:
+            merged_prs[pr_number] = pr_block
+
+    all_prs_for_security = sorted(
+        set(merged_prs) | set(merged_workflow_prs),
+        key=int,
+        reverse=True,
+    )
+    cves, oss_fuzz_issues = collect_security_refs_for_prs(all_prs_for_security)
+
+    advisory_titles = gh_security_advisories_cve_titles()
+    oss_fuzz_titles = oss_fuzz_issue_titles(list(dict.fromkeys(oss_fuzz_issues)))
+
+    with open("CHANGES.md", "w", encoding="utf-8", newline="\n") as f:
+        if toc is None:
+            f.write("\n".join(lines[:prev_toc]) + "\n")
+            base_tag_nonum = base_tag.replace(".", "")
+            date_str_lower = date_str.lower().replace(",", "").replace(" ", "-")
+            f.write(
+                f"* [Version {base_tag}](#version-{base_tag_nonum}-{date_str_lower}) "
+                f"{date_str}\n"
+            )
+            f.write("\n".join(lines[prev_toc:header_index]) + "\n")
+        else:
+            f.write("\n".join(lines[:header_index]) + "\n")
+        f.write("\n".join(section_heading))
+        if cves or oss_fuzz_issues:
+            f.write("\n\n### Security\n")
+            f.write(
+                "\nThis release addresses the following security "
+                "vulnerabilities:\n\n"
+            )
+            for cve in sorted(set(cves), reverse=True):
+                title = advisory_titles.get(cve, "")
+                suffix = f"\n  {title}" if title else ""
+                f.write(f"* [{cve}](https://www.cve.org/CVERecord?id={cve}){suffix}\n")
+            for issue_id in sorted(set(oss_fuzz_issues), reverse=True):
+                url_issue = f"https://issues.oss-fuzz.com/issues/{issue_id}"
+                f.write(f"* OSS-Fuzz [{issue_id}]({url_issue})\n")
+                short = oss_fuzz_titles.get(issue_id, "")
+                if short:
+                    f.write(f"  {short}\n")
+        f.write("\n### Merged Pull Requests\n\n")
+        for pr, value in sorted(merged_prs.items(), reverse=True):
+            f.write("  " + value + "\n")
+        f.write("\n### Merged Workflow Pull Requests\n\n")
+        for pr, value in sorted(merged_workflow_prs.items(), reverse=True):
+            f.write("  " + value + "\n")
+        f.write("\n" + "\n".join(lines[footer_index:]))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/share/util/release/changes.py
+++ b/share/util/release/changes.py
@@ -268,10 +268,10 @@ def main() -> None:
                 if short:
                     f.write(f"  {short}\n")
         f.write("\n### Merged Pull Requests\n\n")
-        for pr, value in sorted(merged_prs.items(), reverse=True):
+        for pr, value in sorted(merged_prs.items(), key=lambda kv: int(kv[0]), reverse=True):
             f.write("  " + value + "\n")
         f.write("\n### Merged Workflow Pull Requests\n\n")
-        for pr, value in sorted(merged_workflow_prs.items(), reverse=True):
+        for pr, value in sorted(merged_workflow_prs.items(), key=lambda kv: int(kv[0]), reverse=True):
             f.write("  " + value + "\n")
         f.write("\n" + "\n".join(lines[footer_index:]))
 

--- a/share/util/release/cherry.py
+++ b/share/util/release/cherry.py
@@ -74,6 +74,8 @@ def main() -> None:
     merged.sort(key=lambda x: x[0])
 
     if not merged:
+        dym = f"; did you mean v{label}?" if not label.startswith('v') else ""
+        print(f"No PRs with label {label}{dym}")
         return
 
     if single:
@@ -85,7 +87,7 @@ def main() -> None:
         print(f"git cherry-pick {' '.join(o[:7] for a, o, t, i in merged)}")
 
     pr_ids = " ".join(str(i) for a, o, t, i in merged)
-    print(f"share/util/release/changes.py {label} {pr_ids}")
+    print(f"python share/util/release/changes.py {label} {pr_ids}")
 
 if __name__ == "__main__":
     try:

--- a/share/util/release/cherry.py
+++ b/share/util/release/cherry.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""List merged PRs with a GitHub label; print cherry-pick commands (oldest merge first).
+
+By default prints one combined ``git cherry-pick`` line plus a ``changes.py`` line.
+With ``--single``, prints one ``git cherry-pick`` command per PR instead.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from subprocess import PIPE, run
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    single = False
+    if "--single" in args:
+        single = True
+        args.remove("--single")
+    if len(args) != 1:
+        print(
+            "Usage: cherry.py [--single] <label>\n"
+            "  --single   print one git cherry-pick command per PR",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    label = args[0]
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--label",
+            label,
+            "--state",
+            "merged",
+            "--limit",
+            "500",
+            "--json",
+            "mergedAt,mergeCommit,title,number",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "gh pr list failed\n")
+        sys.exit(1)
+
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        print(f"Invalid JSON from gh: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    merged = []
+    for pr in prs:
+        pr_id = pr.get("number") or "?"
+        mc = pr.get("mergeCommit") or {}
+        oid = mc.get("oid")
+        merged_at = pr.get("mergedAt")
+        title = pr.get("title") or ""
+        if not oid or not merged_at:
+            continue
+        merged.append((merged_at, oid, title, pr_id))
+
+    # sort by merged_at
+    merged.sort(key=lambda x: x[0])
+
+    if not merged:
+        return
+
+    if single:
+        for _merged_at, oid, title, pr_id in merged:
+            abbrev = oid[:7]
+            title_one_line = " ".join(title.split())
+            print(f"git cherry-pick {abbrev} # {title_one_line} (#{pr_id})")
+    else:
+        print(f"git cherry-pick {' '.join(o[:7] for a, o, t, i in merged)}")
+
+    pr_ids = " ".join(str(i) for a, o, t, i in merged)
+    print(f"share/util/release/changes.py {label} {pr_ids}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+

--- a/share/util/release/draft.py
+++ b/share/util/release/draft.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Create a draft GitHub release for a tagged release."""
+
+from __future__ import annotations
+
+import sys
+from subprocess import run
+
+from _common import load_release_notes
+
+
+def create_draft_release(tag: str, release_notes: str) -> None:
+    release_tag = tag.split("-rc")[0]
+    run(
+        ["gh", "release", "create", tag, "--draft", "--title", release_tag, "-F", "-"],
+        input=release_notes,
+        text=True,
+        check=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: draft.py <tag>   e.g. draft.py v3.4.7", file=sys.stderr)
+        sys.exit(1)
+    tag = sys.argv[1]
+    _release_date, release_notes, _release_version = load_release_notes(tag)
+    create_draft_release(tag, release_notes)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+

--- a/share/util/release/log.py
+++ b/share/util/release/log.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Print git log annotated with release labels and security refs from each commit's PR."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from subprocess import PIPE, run
+
+from _security import pr_addressed_cves
+
+LOG_PR_SUFFIX_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def pr_labels(line: str) -> tuple[str, str]:
+    m = LOG_PR_SUFFIX_RE.search(line)
+    if not m:
+        return "", ""
+    pr_number = m.group(1)
+    result = run(
+        ["gh", "pr", "view", pr_number, "--json", "labels"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return pr_number, ""
+    try:
+        data = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return pr_number, ""
+    out = []
+    for lab in data.get("labels") or []:
+        name = lab.get("name") or ""
+        if name.startswith("v"):
+            out.append(name)
+    return pr_number, " ".join(out)
+
+
+def main() -> None:
+    result = run(
+        ["git", "log", "--pretty=format:%h %s"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "git log failed\n")
+        sys.exit(1)
+
+    for line in result.stdout.splitlines():
+        pr, labels = pr_labels(line)
+        pr_cves, pr_oss_fuzz = pr_addressed_cves(pr)
+        refs = pr_cves + [f"oss-fuzz:{i}" for i in pr_oss_fuzz]
+        suffix = f" [{' '.join(refs)}]" if refs else ""
+        print(f"{labels:7} {line}{suffix}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/share/util/release/log.py
+++ b/share/util/release/log.py
@@ -43,6 +43,10 @@ def pr_labels(line: str) -> tuple[str, str]:
 
 
 def main() -> None:
+    if len(sys.argv) > 1:
+        print("Usage: python share/util/release/log.py", file=sys.stderr)
+        sys.exit(1)
+        
     result = run(
         ["git", "log", "--pretty=format:%h %s"],
         stdout=PIPE,

--- a/share/util/release/news.py
+++ b/share/util/release/news.py
@@ -44,21 +44,43 @@ def markdown_to_rst(markdown_text: str) -> str:
     return "\n".join(rst_lines).strip()
 
 
+def _git_show(path: str) -> str:
+    result = run(
+        ["git", "show", f"HEAD:{path}"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            result.stderr or f"git show HEAD:{path} failed\n"
+        )
+        sys.exit(1)
+    return result.stdout
+
+
+def _parse_latest_news_title(content: str) -> str:
+    for line in reversed(content.splitlines()):
+        if "replace:: " in line:
+            title = line.split("replace:: ", 1)[1].strip()
+            return title.lstrip("**").rstrip("**")
+    print(
+        "Could not parse previous title from website/latest_news_title.rst",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def update_news_file(
     release_notes: str, tag: str, release_date: datetime
 ) -> None:
     date_str = release_date.strftime("%B %e, %Y")
     new_section_title = f"{date_str} - OpenEXR {tag} Released"
 
-    result = run(
-        ["git", "show", "HEAD:website/latest_news_title.rst"],
-        stdout=PIPE,
-        stderr=PIPE,
-        universal_newlines=True,
-        check=False,
+    old_section_title = _parse_latest_news_title(
+        _git_show("website/latest_news_title.rst")
     )
-    line = result.stdout.split("\n")[-1]
-    old_section_title = line.split("replace:: ")[1].rstrip().lstrip("**").rstrip("**")
 
     with open("website/latest_news_title.rst", "w", encoding="utf-8") as f:
         f.write("..\n")
@@ -66,18 +88,14 @@ def update_news_file(
         f.write("  Copyright (c) Contributors to the OpenEXR Project.\n")
         f.write(f".. |latest-news-title| replace:: **{new_section_title}**")
 
-    result = run(
-        ["git", "show", "HEAD:website/news.rst"],
-        stdout=PIPE,
-        stderr=PIPE,
-        universal_newlines=True,
-        check=False,
-    )
-    content = result.stdout
-    if content is None:
-        print(f"No news.rst at tag {tag}")
-
+    content = _git_show("website/news.rst")
     old_news = re.split(r"^=+\s*$", content, maxsplit=1, flags=re.MULTILINE)
+    if len(old_news) < 2:
+        print(
+            "Unexpected format in website/news.rst (missing section divider)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     old_news[1] = re.sub(
         r"\.\. _LatestNewsStart:\n", "", old_news[1], flags=re.DOTALL
     )

--- a/share/util/release/news.py
+++ b/share/util/release/news.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Update website/news.rst and latest_news_title.rst for a release."""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime
+from subprocess import PIPE, run
+
+from _common import load_release_notes
+
+
+def markdown_to_rst(markdown_text: str) -> str:
+    markdown_text = re.sub(r"(?<!`)`([^`]+)`(?!`)", r"``\1``", markdown_text)
+    markdown_text = re.sub(
+        r"\[([\s\S]*?)\]\(([\s\S]*?)\)",
+        r"`\1 <\2>`_",
+        markdown_text,
+    )
+    emoji_subs = (
+        (r":bug:", "🐛"),
+        (r":rocket:", "🚀"),
+        (r":hammer_and_wrench:", "🛠️"),
+        (r":wrench:", "🔧"),
+        (r":sparkles:", "✨"),
+        (r":snake:", "🐍"),
+        (r":package:", "📦"),
+        (r":warning:", "⚠️"),
+    )
+    for pattern, repl in emoji_subs:
+        markdown_text = re.sub(pattern, repl, markdown_text, flags=re.DOTALL)
+
+    rst_lines = []
+    for line in markdown_text.splitlines():
+        if line.startswith("- "):
+            line = line.replace("- ", "* ", 1)
+        line = re.sub(r"\*\*(.*?)\*\*", r"**\1**", line)
+        line = re.sub(r"\*(.*?)\*", r"*\1*", line)
+        rst_lines.append(line)
+    return "\n".join(rst_lines).strip()
+
+
+def update_news_file(
+    release_notes: str, tag: str, release_date: datetime
+) -> None:
+    date_str = release_date.strftime("%B %e, %Y")
+    new_section_title = f"{date_str} - OpenEXR {tag} Released"
+
+    result = run(
+        ["git", "show", "HEAD:website/latest_news_title.rst"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    line = result.stdout.split("\n")[-1]
+    old_section_title = line.split("replace:: ")[1].rstrip().lstrip("**").rstrip("**")
+
+    with open("website/latest_news_title.rst", "w", encoding="utf-8") as f:
+        f.write("..\n")
+        f.write("  SPDX-License-Identifier: BSD-3-Clause\n")
+        f.write("  Copyright (c) Contributors to the OpenEXR Project.\n")
+        f.write(f".. |latest-news-title| replace:: **{new_section_title}**")
+
+    result = run(
+        ["git", "show", "HEAD:website/news.rst"],
+        stdout=PIPE,
+        stderr=PIPE,
+        universal_newlines=True,
+        check=False,
+    )
+    content = result.stdout
+    if content is None:
+        print(f"No news.rst at tag {tag}")
+
+    old_news = re.split(r"^=+\s*$", content, maxsplit=1, flags=re.MULTILINE)
+    old_news[1] = re.sub(
+        r"\.\. _LatestNewsStart:\n", "", old_news[1], flags=re.DOTALL
+    )
+    old_news[1] = re.sub(
+        r"\.\. _LatestNewsEnd:\n", "", old_news[1], flags=re.DOTALL
+    )
+
+    with open("website/news.rst", "w", encoding="utf-8") as f:
+        f.write(old_news[0])
+        f.write("=" * len(new_section_title) + "\n\n")
+        f.write(".. _LatestNewsStart:\n\n")
+        f.write(release_notes + "\n\n")
+        f.write(".. _LatestNewsEnd:\n\n")
+        f.write(old_section_title + "\n")
+        f.write("=" * len(old_section_title))
+        f.write(old_news[1])
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: news.py <tag>   e.g. news.py v3.4.8", file=sys.stderr)
+        sys.exit(1)
+    tag = sys.argv[1]
+    release_date, release_notes, release_version = load_release_notes(tag)
+    rst_text = markdown_to_rst(release_notes)
+    update_news_file(rst_text, release_version, release_date)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/share/util/release/news.py
+++ b/share/util/release/news.py
@@ -11,7 +11,7 @@ import sys
 from datetime import datetime
 from subprocess import PIPE, run
 
-from _common import load_release_notes
+from _common import format_month_day_year, load_release_notes
 
 
 def markdown_to_rst(markdown_text: str) -> str:
@@ -75,7 +75,7 @@ def _parse_latest_news_title(content: str) -> str:
 def update_news_file(
     release_notes: str, tag: str, release_date: datetime
 ) -> None:
-    date_str = release_date.strftime("%B %e, %Y")
+    date_str = format_month_day_year(release_date)
     new_section_title = f"{date_str} - OpenEXR {tag} Released"
 
     old_section_title = _parse_latest_news_title(

--- a/share/util/release/notes.py
+++ b/share/util/release/notes.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Extract release notes from CHANGES.md for a tagged release and print to stdout."""
+
+from __future__ import annotations
+
+import sys
+
+from _common import load_release_notes
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: notes.py <tag>   e.g. notes.py v3.4.7", file=sys.stderr)
+        sys.exit(1)
+    _release_date, release_notes, _release_version = load_release_notes(sys.argv[1])
+    print(release_notes)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+

--- a/share/util/release/tag.py
+++ b/share/util/release/tag.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenEXR Project.
+
+"""Create a signed annotated git tag using release notes from CHANGES.md."""
+
+from __future__ import annotations
+
+import sys
+from subprocess import run
+
+from _common import load_release_notes
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: tag.py <tag>   e.g. tag.py v3.4.7", file=sys.stderr)
+        sys.exit(1)
+    tag = sys.argv[1]
+    release_date, release_notes, _release_version = load_release_notes(tag)
+    tag_message = f"{tag} - {release_date}\n{release_notes}\n"
+    run(["git", "tag", "-s", tag, "-F", "-"], input=tag_message, text=True, check=True)
+    run(["git", "tag", "-v", tag], check=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(130)
+

--- a/share/util/release/tag.py
+++ b/share/util/release/tag.py
@@ -18,7 +18,7 @@ def main() -> None:
         sys.exit(1)
     tag = sys.argv[1]
     release_date, release_notes, _release_version = load_release_notes(tag)
-    tag_message = f"{tag} - {release_date}\n{release_notes}\n"
+    tag_message = f"{tag} - {release_date.strftime('%B %d, %Y')}\n{release_notes}\n"
     run(["git", "tag", "-s", tag, "-F", "-"], input=tag_message, text=True, check=True)
     run(["git", "tag", "-v", tag], check=True)
 

--- a/share/util/release/tag.py
+++ b/share/util/release/tag.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sys
 from subprocess import run
 
-from _common import load_release_notes
+from _common import format_month_day_year, load_release_notes
 
 
 def main() -> None:
@@ -18,7 +18,7 @@ def main() -> None:
         sys.exit(1)
     tag = sys.argv[1]
     release_date, release_notes, _release_version = load_release_notes(tag)
-    tag_message = f"{tag} - {release_date.strftime('%B %d, %Y')}\n{release_notes}\n"
+    tag_message = f"{tag} - {format_month_day_year(release_date)}\n{release_notes}\n"
     run(["git", "tag", "-s", tag, "-F", "-"], input=tag_message, text=True, check=True)
     run(["git", "tag", "-v", tag], check=True)
 


### PR DESCRIPTION
It's much easier to follow the logic this way than having everything in a single file.

log.py - Prints PRs w/labels and CVE/OSS-Fuzz issues 
cherry.py - Reports commits to cherry pick
changes.py - Adds entries to CHANGES.md release notes 
tag.py - creates a tag with release notes as message 
candidate.py - Formats the release candidate mail
draft.py - Draft the GitHub release w/notes

This also updates the release instructions in CONTRIBUTING.md