### PR TITLE
Bugfix: Fix interger overflows

### DIFF
--- a/src/lib/OpenEXRCore/encoding.c
+++ b/src/lib/OpenEXRCore/encoding.c
@@ -319,9 +319,13 @@ exr_encoding_run (
          part->storage_mode == EXR_STORAGE_DEEP_TILED) &&
         encode->sample_count_table != NULL)
     {
-        priv_from_native32 (
-            encode->sample_count_table,
-            encode->chunk.width * encode->chunk.height);
+        /* Process the sample count table line by line to avoid integer overflows */
+        int32_t* current_line = encode->sample_count_table;
+        for (int y = 0; y < encode->chunk.height; ++y)
+        {
+            priv_from_native32 (current_line, encode->chunk.width);
+            current_line += encode->chunk.width;
+        }
     }
 
     if (rv == EXR_ERR_SUCCESS)
@@ -366,9 +370,13 @@ exr_encoding_run (
          part->storage_mode == EXR_STORAGE_DEEP_TILED) &&
         encode->sample_count_table != NULL)
     {
-        priv_to_native32 (
-            encode->sample_count_table,
-            encode->chunk.width * encode->chunk.height);
+        /* Process the sample count table line by line to avoid integer overflows */
+        int32_t* current_line = encode->sample_count_table;
+        for (int y = 0; y < encode->chunk.height; ++y)
+        {
+            priv_to_native32 (current_line, encode->chunk.width);
+            current_line += encode->chunk.width;
+        }
     }
 
     return rv;

--- a/src/lib/OpenEXRCore/internal_dwa_encoder.h
+++ b/src/lib/OpenEXRCore/internal_dwa_encoder.h
@@ -968,7 +968,7 @@ LossyDctEncoder_execute (
     uint16_t halfZigCoef[64];
 
     uint16_t* currAcComp            = (uint16_t*) e->_packedAc;
-    int       tmpHalfBufferElements = 0;
+    size_t    tmpHalfBufferElements = 0;
     uint16_t* tmpHalfBuffer         = NULL;
     uint16_t* tmpHalfBufferPtr      = NULL;
 
@@ -984,13 +984,13 @@ LossyDctEncoder_execute (
     {
         chanData[chan] = e->_channel_encode_data[chan];
         if (chanData[chan]->_type == EXR_PIXEL_FLOAT)
-            tmpHalfBufferElements += e->_width * e->_height;
+            tmpHalfBufferElements += (size_t) e->_width * (size_t) e->_height;
     }
 
     if (tmpHalfBufferElements)
     {
-        tmpHalfBuffer = (uint16_t*) alloc_fn (
-            (size_t) tmpHalfBufferElements * sizeof (uint16_t));
+        tmpHalfBuffer =
+            (uint16_t*) alloc_fn (tmpHalfBufferElements * sizeof (uint16_t));
         if (!tmpHalfBuffer) return EXR_ERR_OUT_OF_MEMORY;
         tmpHalfBufferPtr = tmpHalfBuffer;
     }

--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -1931,7 +1931,8 @@ exr_attr_set_preview (
             attr->preview->height == val->height &&
             attr->preview->alloc_size > 0)
         {
-            size_t copybytes = val->width * val->height * 4;
+            size_t copybytes =
+                (size_t) val->width * (size_t) val->height * (size_t) 4;
             memcpy (
                 EXR_CONST_CAST (void*, attr->preview->rgba),
                 val->rgba,


### PR DESCRIPTION
Fix various interger overflows that cause crashes when processing large images:

- [Fix integer overflow in internal_dwa_encoder.h](https://github.com/AcademySoftwareFoundation/openexr/commit/1707c532bfed68812fe51c389f8edb244f9a5302) 
Cast width and height to size_t and change the tmpHalfBufferElements to size_t
to avoid overflow and potential crash.

- [Fix integer overflow in part_attr.c](https://github.com/AcademySoftwareFoundation/openexr/commit/53e790e6aefbd95f379227543763b26904ec30cf) 
Cast width and height to size_t to fix overflow and crash.

- [Fix integer overflow in encoding.c](https://github.com/AcademySoftwareFoundation/openexr/commit/f9000ac96926c7d4b460e34d68c1b249ccdf4f22) 
Since `priv_to/from_native32(void*, int)` are widely used, instead of changing the
function definition, process the sample count table line by line to fix a crash
related to integer overflows.

All tests pass.