### PR TITLE
Fix Imath include on CMake reconfigure

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -279,6 +279,11 @@ jobs:
           set -x
           "$CMAKE" --version
           "$CMAKE" ${{ env.CMAKE_ARGS }}
+          # Reconfigure in the same build dir to catch Imath include-path
+          # regressions on CMake reconfigure (see #2441).
+          if [ "${{ inputs.OPENEXR_FORCE_INTERNAL_IMATH }}" == "ON" ]; then
+            "$CMAKE" ${{ env.CMAKE_ARGS }}
+          fi
           if [ -n "${{ inputs.configure_install_prefix }}" ]; then
             "$CMAKE" --build "$BUILD_DIR" --config ${{ inputs.build-type }}
             "$CMAKE" --install "$BUILD_DIR" --prefix "$INSTALL_DIR" --config ${{ inputs.build-type }}
@@ -293,6 +298,11 @@ jobs:
           set -x
           "$CMAKE" --version
           "$CMAKE" ${{ env.CMAKE_ARGS }}
+          # Reconfigure in the same build dir to catch Imath include-path
+          # regressions on CMake reconfigure (see #2441).
+          if [ "${{ inputs.OPENEXR_FORCE_INTERNAL_IMATH }}" == "ON" ]; then
+            "$CMAKE" ${{ env.CMAKE_ARGS }}
+          fi
           if [ -n "${{ inputs.configure_install_prefix }}" ]; then
             "$CMAKE" --build "$BUILD_DIR" --config ${{ inputs.build-type }}
             "$CMAKE" --install "$BUILD_DIR" --prefix "$INSTALL_DIR" --config ${{ inputs.build-type }}

--- a/cmake/OpenEXRSetup.cmake
+++ b/cmake/OpenEXRSetup.cmake
@@ -432,18 +432,11 @@ if(TARGET Imath AND TARGET ImathConfig)
                      "${_openexr_imath_cfg_compat}/Imath/ImathConfig.h" COPYONLY)
     endif()
 
-    # Add the build interface include directory, but only do it once;
-    # if the cache key exists, it's already been added by a previous
-    # configuration run.
-    set(_openexr_imath_inc_patch_key "${Imath_SOURCE_DIR}|${Imath_BINARY_DIR}")
-    if(NOT OPENEXR_IMATH_SUBDIR_INCLUDE_PATCH STREQUAL _openexr_imath_inc_patch_key)
-      target_include_directories(Imath INTERFACE
-        "$<BUILD_INTERFACE:${Imath_SOURCE_DIR}/src>")
-      if(EXISTS "${_openexr_imath_gen_cfg}")
-        target_include_directories(ImathConfig INTERFACE
-          "$<BUILD_INTERFACE:${_openexr_imath_cfg_compat}>")
-      endif()
-      set(OPENEXR_IMATH_SUBDIR_INCLUDE_PATCH "${_openexr_imath_inc_patch_key}" CACHE INTERNAL "")
+    target_include_directories(Imath INTERFACE
+      "$<BUILD_INTERFACE:${Imath_SOURCE_DIR}/src>")
+    if(EXISTS "${_openexr_imath_gen_cfg}")
+      target_include_directories(ImathConfig INTERFACE
+        "$<BUILD_INTERFACE:${_openexr_imath_cfg_compat}>")
     endif()
   endif()
 endif()


### PR DESCRIPTION
Remove the `OPENEXR_IMATH_SUBDIR_INCLUDE_PATCH` cache guard so internal-Imath include directories are re-applied on every configure.

Also, add a configure-twice smoke test to CI for internal-Imath builds to catch this class of regression.

Addresses #2441.