### PR TITLE
Fix: Allow NumPy scalar values in Box2i and V2f tuple bindings

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1916,7 +1916,22 @@ PyFile::getAttributeObject(const std::string& name, const Attribute* a)
     
     return py::none();
 }
-    
+
+// Static helper functions to cache NumPy types and avoid repeated imports
+py::object
+numpy_integer ()
+{
+    static py::object type = py::module::import ("numpy").attr ("integer");
+    return type;
+}
+
+py::object
+numpy_floating ()
+{
+    static py::object type = py::module::import ("numpy").attr ("floating");
+    return type;
+}
+
 template <class P, class T>
 bool
 objectToV2(const py::object& object, Vec2<T>& v)
@@ -1936,15 +1951,12 @@ objectToV2(const py::object& object, Vec2<T>& v)
 
             // 2. Numpy scalar types included
 
-            // imports numpy to access the abstract base classes
-            py::module np = py::module::import ("numpy");
-
             // Assigning numpy equivalent to Python type P passed from the calling function
             // objectToV2 is currently instantiated only with py::int_ and py::float_, so the ternary
             // maps directly to numpy.integer / numpy.floating.
             py::object target_type = std::is_same_v<P, py::int_>
-                                         ? np.attr ("integer")
-                                         : np.attr ("floating");
+                                         ? numpy_integer ()
+                                         : numpy_floating ();
 
             // Allowing tuples that contain numpy scalars
             if ((py::isinstance<P> (tup[0]) ||

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1926,14 +1926,39 @@ objectToV2(const py::object& object, Vec2<T>& v)
         auto tup = object.cast<py::tuple>();
         if (tup.size() == 2)
         {
-            try
+            // 1. Standard Python types
+            if (py::isinstance<P> (tup[0]) && py::isinstance<P> (tup[1]))
             {
-                v.x = py::cast<T>(tup[0]);
-                v.y = py::cast<T>(tup[1]);
+                v.x = P (tup[0]);
+                v.y = P (tup[1]);
                 return true;
             }
-            catch (const py::cast_error&) {
-                return false;
+
+            // 2. Numpy scalar types
+
+            // imports numpy to access the abstract base classes
+            py::module np = py::module::import ("numpy");
+
+            // Assigning numpy equivalent to Python type P passed from the calling function
+            // objectToV2 is currently instantiated only with py::int_ and py::float_, so the ternary
+            // maps directly to numpy.integer / numpy.floating.
+            py::object target_type = std::is_same_v<P, py::int_>
+                                         ? np.attr ("integer")
+                                         : np.attr ("floating");
+
+            if (py::isinstance (tup[0], target_type) &&
+                py::isinstance (tup[1], target_type))
+            {
+                try
+                {
+                    v.x = py::cast<T> (tup[0]);
+                    v.y = py::cast<T> (tup[1]);
+                    return true;
+                }
+                catch (const py::cast_error&)
+                {
+                    return false;
+                }
             }
         }
     }

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1926,7 +1926,7 @@ objectToV2(const py::object& object, Vec2<T>& v)
         auto tup = object.cast<py::tuple>();
         if (tup.size() == 2)
         {
-            // 1. Standard Python types
+            // 1. Standard Python types only
             if (py::isinstance<P> (tup[0]) && py::isinstance<P> (tup[1]))
             {
                 v.x = P (tup[0]);
@@ -1934,7 +1934,7 @@ objectToV2(const py::object& object, Vec2<T>& v)
                 return true;
             }
 
-            // 2. Numpy scalar types
+            // 2. Numpy scalar types included
 
             // imports numpy to access the abstract base classes
             py::module np = py::module::import ("numpy");
@@ -1946,8 +1946,11 @@ objectToV2(const py::object& object, Vec2<T>& v)
                                          ? np.attr ("integer")
                                          : np.attr ("floating");
 
-            if (py::isinstance (tup[0], target_type) &&
-                py::isinstance (tup[1], target_type))
+            // Allowing tuples that contain numpy scalars
+            if ((py::isinstance<P> (tup[0]) ||
+                 py::isinstance (tup[0], target_type)) &&
+                (py::isinstance<P> (tup[1]) ||
+                 py::isinstance (tup[1], target_type)))
             {
                 try
                 {

--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -1924,13 +1924,17 @@ objectToV2(const py::object& object, Vec2<T>& v)
     if (py::isinstance<py::tuple>(object))
     {
         auto tup = object.cast<py::tuple>();
-        if (tup.size() == 2 &&
-            py::isinstance<P>(tup[0]) &&
-            py::isinstance<P>(tup[1]))
-        {       
-            v.x = P(tup[0]);
-            v.y = P(tup[1]);
-            return true;
+        if (tup.size() == 2)
+        {
+            try
+            {
+                v.x = py::cast<T>(tup[0]);
+                v.y = py::cast<T>(tup[1]);
+                return true;
+            }
+            catch (const py::cast_error&) {
+                return false;
+            }
         }
     }
     else if (py::isinstance<py::array_t<T>>(object))

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -871,5 +871,43 @@ class TestUnittest(unittest.TestCase):
 
         os.remove(outfilename)
 
+    def test_box2i_numpy_scalars(self):
+
+        # Verifying that numpy scalar values are also accepted for
+        # Box2i type
+
+        mn = np.array((0, 0), dtype=np.int32)
+        mx = np.array((15, 15), dtype=np.int32)
+
+        test_cases = [
+            # python int
+            ((0, 0), (15, 15)),  
+            # numpy array
+            (mn, mx),        
+            # numpy scalar values                
+            ((mn[0], mn[1]), (mx[0], mx[1])),    
+        ]
+
+        for data_window in test_cases:
+
+            w = data_window[1][0] - data_window[0][0] + 1
+            h = data_window[1][1] - data_window[0][1] + 1
+            
+            header = {
+                "type": OpenEXR.scanlineimage,
+                "dataWindow": data_window,
+            }
+            
+            channels = {"RGB": np.zeros((h, w, 3), dtype=np.float16)}
+
+            part = OpenEXR.Part(header, channels)
+            f = OpenEXR.File([part])
+            
+            outfilename = mktemp_outfilename()
+            f.write(outfilename)
+            
+            if os.path.isfile(outfilename):
+                os.remove(outfilename)
+                
 if __name__ == '__main__':
     unittest.main()

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -1000,6 +1000,31 @@ class TestUnittest(unittest.TestCase):
 
             if os.path.isfile(outfilename):
                 os.remove(outfilename)
+    
+    def test_mixed_standard_and_numpy_scalars(self):
+
+        # Allow mixed types seamlessly to match our convenient API design
+        mixed_data_window = ((0, np.int32(0)), (15, np.int64(15)))
+
+        header = {
+            "type": OpenEXR.scanlineimage,
+            "dataWindow": mixed_data_window,
+        }
+
+        channels = {"RGB": np.zeros((16, 16, 3), dtype=np.float16)}
+
+        part = OpenEXR.Part(header, channels)
+        f = OpenEXR.File([part])
+
+        outfilename = mktemp_outfilename()
+
+        f.write(outfilename)
+
+        # Verify the values were preserved accurately
+        self.assertEqual(part.header["dataWindow"], ((0, 0), (15, 15)))
+
+        if os.path.isfile(outfilename):
+            os.remove(outfilename)
 
 
 if __name__ == '__main__':

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -908,6 +908,47 @@ class TestUnittest(unittest.TestCase):
             
             if os.path.isfile(outfilename):
                 os.remove(outfilename)
-                
+
+    def test_v2f_numpy_scalars(self):
+        # Verifying that numpy scalar values are also accepted for
+        # V2f (float vector) types. 
+
+        # Setup numpy values for testing
+        center_np_float32 = np.array((0.5, 0.75), dtype=np.float32)
+        
+        test_cases = [
+            # python float 
+            (0.0, 0.0),
+            # numpy array
+            center_np_float32,
+            # numpy float scalars 
+            (center_np_float32[0], center_np_float32[1]),
+            # numpy float64 scalars 
+            (np.float64(0.5), np.float64(0.5)),
+        ]
+
+        # Use a fixed data window for the file structure
+        data_window = ((0, 0), (15, 15))
+        w, h = 16, 16
+
+        for center_value in test_cases:
+            header = {
+                "type": OpenEXR.scanlineimage,
+                "dataWindow": data_window,
+                "displayWindow": data_window,
+                "screenWindowCenter": center_value,  
+            }
+            
+            channels = {"RGB": np.zeros((h, w, 3), dtype=np.float16)}
+
+            part = OpenEXR.Part(header, channels)
+            f = OpenEXR.File([part])
+            
+            outfilename = mktemp_outfilename()
+            f.write(outfilename)
+            
+            if os.path.isfile(outfilename):
+                os.remove(outfilename)
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -950,5 +950,57 @@ class TestUnittest(unittest.TestCase):
             if os.path.isfile(outfilename):
                 os.remove(outfilename)
 
+    def test_box2i_float_rejection(self):
+        # dataWindow requires an integer-based bounding box (Box2i).
+        # We test Python floats, NumPy float32, and NumPy float64.
+        invalid_floats = [0.0, np.float32(0.0), np.float64(0.0)]
+        
+        for f in invalid_floats:
+            invalid_float_box = ((f, f), (f + 15.0, f + 15.0))
+            
+            header = {
+                "type": OpenEXR.scanlineimage,
+                "dataWindow": invalid_float_box, 
+            }
+            channels = {"RGB": np.zeros((16, 16, 3), dtype=np.float16)}
+
+            part = OpenEXR.Part(header, channels)
+
+            outfilename = mktemp_outfilename()
+            with self.assertRaises(Exception):
+                with OpenEXR.File([part]) as exr_file:
+                    exr_file.write(outfilename)
+
+            if os.path.isfile(outfilename):
+                os.remove(outfilename)
+
+    def test_v2f_int_rejection(self):
+        # screenWindowCenter requires floating-point coordinates (V2f).
+        # We test Python ints, NumPy int32, and NumPy int64.
+        invalid_ints = [1, np.int32(1), np.int64(1)]
+        
+        data_window = ((0, 0), (15, 15))
+        
+        for i in invalid_ints:
+            invalid_int_center = (i, i + 1) 
+            
+            header = {
+                "type": OpenEXR.scanlineimage,
+                "dataWindow": data_window,
+                "screenWindowCenter": invalid_int_center, 
+            }
+            channels = {"RGB": np.zeros((16, 16, 3), dtype=np.float16)}
+
+            part = OpenEXR.Part(header, channels)
+
+            outfilename = mktemp_outfilename()
+            with self.assertRaises(Exception):
+                with OpenEXR.File([part]) as exr_file:
+                    exr_file.write(outfilename)
+
+            if os.path.isfile(outfilename):
+                os.remove(outfilename)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/wrappers/python/tests/test_unittest.py
+++ b/src/wrappers/python/tests/test_unittest.py
@@ -892,20 +892,31 @@ class TestUnittest(unittest.TestCase):
 
             w = data_window[1][0] - data_window[0][0] + 1
             h = data_window[1][1] - data_window[0][1] + 1
-            
+
             header = {
                 "type": OpenEXR.scanlineimage,
                 "dataWindow": data_window,
             }
-            
+
             channels = {"RGB": np.zeros((h, w, 3), dtype=np.float16)}
 
             part = OpenEXR.Part(header, channels)
             f = OpenEXR.File([part])
-            
+
             outfilename = mktemp_outfilename()
             f.write(outfilename)
-            
+
+            # Read back and verify the file structure & attributes
+            with OpenEXR.File(outfilename, header_only=True) as infile:
+                actual_window = infile.parts[0].header["dataWindow"]
+                # Since getAttributeObject returns tuples of numpy arrays,
+                # we need to convert them to standard python tuples before comparison
+                actual_tuple = (
+                    (int(actual_window[0][0]), int(actual_window[0][1])),
+                    (int(actual_window[1][0]), int(actual_window[1][1]))
+                )
+                self.assertEqual(actual_tuple, ((0, 0), (15, 15)))
+
             if os.path.isfile(outfilename):
                 os.remove(outfilename)
 
@@ -946,6 +957,35 @@ class TestUnittest(unittest.TestCase):
             
             outfilename = mktemp_outfilename()
             f.write(outfilename)
+
+            # Read back and verify the file structure & attributes
+            with OpenEXR.File(outfilename, header_only=True) as inf:
+                header_to_verify = inf.parts[0].header
+
+                # Since getAttributeObject returns tuples of numpy arrays,
+                # we need to convert them to standard python tuples before comparison
+                act_dw = header_to_verify["dataWindow"]
+                dw_tuple = (
+                    (int(act_dw[0][0]), int(act_dw[0][1])),
+                    (int(act_dw[1][0]), int(act_dw[1][1]))
+                )
+                self.assertEqual(dw_tuple, ((0, 0), (15, 15)))
+                
+                act_disp = header_to_verify["displayWindow"]
+                disp_tuple = (
+                    (int(act_disp[0][0]), int(act_disp[0][1])),
+                    (int(act_disp[1][0]), int(act_disp[1][1]))
+                )
+                self.assertEqual(disp_tuple, ((0, 0), (15, 15)))
+                
+                actual_center = header_to_verify["screenWindowCenter"]
+                center_tuple = (float(actual_center[0]), float(actual_center[1]))
+                
+                expected_center = (float(center_value[0]), float(center_value[1]))
+                
+                # Uses assertAlmostEqual on individual items to compare float values 
+                self.assertAlmostEqual(center_tuple[0], expected_center[0], places=5)
+                self.assertAlmostEqual(center_tuple[1], expected_center[1], places=5)
             
             if os.path.isfile(outfilename):
                 os.remove(outfilename)
@@ -1020,8 +1060,15 @@ class TestUnittest(unittest.TestCase):
 
         f.write(outfilename)
 
-        # Verify the values were preserved accurately
-        self.assertEqual(part.header["dataWindow"], ((0, 0), (15, 15)))
+        with OpenEXR.File(outfilename, header_only=True) as inf:
+            act_dw = inf.parts[0].header["dataWindow"]
+            # Since getAttributeObject returns tuples of numpy arrays,
+            # we need to convert them to standard python tuples before comparison
+            dw_tuple = (
+                (int(act_dw[0][0]), int(act_dw[0][1])),
+                (int(act_dw[1][0]), int(act_dw[1][1]))
+            )
+            self.assertEqual(dw_tuple, ((0, 0), (15, 15)))
 
         if os.path.isfile(outfilename):
             os.remove(outfilename)


### PR DESCRIPTION
### Description
This PR resolves an issue where the OpenEXR Python bindings reject a `Box2i `attribute (such as `dataWindow`) if it is provided as a tuple containing NumPy scalar values (e.g., `np.int32`), even though pure Python int objects or NumPy arrays are accepted.

The underlying issue stemmed from a strict type-checking implementation in the template function `objectToV2` using `py::isinstance<P>`, which filters out NumPy scalar types since they do not inherit from pure `Python int_` or `float_` types.

To fix this, we updated `objectToV2` to perform a more flexible validation pass:

Fast-path: Retain the original quick evaluation for uniform standard Python types (`py::int_` / `py::float_`) to ensure zero performance overhead for standard use cases.

Flexible Fallback: If the elements are not uniformly standard Python types, the function uses `std::is_same_v` to map the template parameter `P` to its corresponding Python NumPy abstract base class (`np.integer `or `np.floating`). It then validates that both elements match either the standard Python type or the NumPy base type. 

This structure supports tuples containing NumPy scalar values and utilizes `py::cast` within `try/catch `scope to safely convert the values into the target C++ vector type (`Vec2`).

Fixes #2133

### Type of Change
[x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
We employed a TDD approach; we added unit tests to `src/wrappers/python/tests/test_unittest.py` to reproduce the issue then modified the `objectToV2` function in `PyOpenEXR.cpp` to make the tests pass. Since `objectToV2` function is used not only by `objectToV2i `but also `objectToV2f`, we verified that our solution would also work with numpy scalar floats.  

- `test_box2i_numpy_scalars`: Verifies that `Box2i `types (such as `dataWindow`) successfully accept and parse standard Python int tuples, NumPy arrays, and tuples containing individual NumPy integer scalar values (`np.int32`).
- `test_v2f_numpy_scalars`: Verifies that `V2f `types (such as `screenWindowCenter`) successfully accept and parse standard Python floats, NumPy arrays, and tuples containing `np.float32` or `np.float64` scalars.
- Strict Negative Constraint Testing:
        - Added `test_box2i_float_rejection` to assert that floating-point values (Python float, np.float32, np.float64) are cleanly rejected with an exception when passed to an integer-based Box2i attribute.
        - Added `test_v2f_int_rejection` to assert that integer values (Python int, `np.int32`, `np.int64`) are cleanly rejected with an exception when passed to a float-based `V2f` attribute.
- `test_mixed_standard_and_numpy_scalars`: Validates that an edge case of mixed coordinate pairs (e.g., combining a standard Python int with a NumPy `np.int64` scalar) parse seamlessly and accurately map to the expected output bounding window.

### Contributors
- Yuki Rivera (@YukiRivera)
- Kimhuy Chea (@KimhuyChea10307)

