### PR TITLE
Use std::deque for IDManifest storage to keep references stable

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.h
+++ b/src/lib/OpenEXR/ImfIDManifest.h
@@ -12,6 +12,7 @@
 #include "ImfForward.h"
 
 #include <cstdint>
+#include <deque>
 #include <map>
 #include <set>
 #include <string>
@@ -220,7 +221,9 @@ public:
     };
 
 private:
-    std::vector<ChannelGroupManifest> _manifest;
+    // deque vs vector: add() returns references to groups; vector may reallocate
+    // and invalidate them when another group is added 
+    std::deque<ChannelGroupManifest> _manifest;
 
 public:
     // add a new channel group definition to the table, presumably populated with mappings


### PR DESCRIPTION
While working on the new Python bindings #1812, we ran into a crash on macOS where references to existing ChannelGroupManifest elements were getting wiped out. This happens because std::vector reallocates its memory under the hood as it grows, invalidating active references.

Switching to std::deque fixes this by guaranteeing that pointers and references stay perfectly stable when elements are added. Performance-wise, std::deque still gives us constant-time O(1) random access, so the public operator[] won't see any index-traversal slowdowns.

Relates to PR #2432
Fixes: Part of #1812

Signed-off-by: Moira Shooter <mshooter@ilm.com>