### PR TITLE
Fix integer overflow and invalid delete in OpenEXRUtil Image::resize()

### DIFF
--- a/src/lib/OpenEXRUtil/ImfImage.cpp
+++ b/src/lib/OpenEXRUtil/ImfImage.cpp
@@ -14,6 +14,8 @@
 #include "ImfChannelList.h"
 #include <algorithm>
 #include <cassert>
+#include <climits>
+#include <cstdint>
 
 using namespace IMATH_NAMESPACE;
 using namespace IEX_NAMESPACE;
@@ -24,37 +26,71 @@ OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 namespace
 {
 
+int64_t
+pixelExtent (int64_t minCoord, int64_t maxCoord)
+{
+    if (maxCoord < minCoord) return 0;
+
+    return maxCoord - minCoord + 1;
+}
+
+void
+validateDataWindow (const Box2i64& dw)
+{
+    if (dw.min.x > dw.max.x + 1 || dw.min.y > dw.max.y + 1)
+    {
+        THROW (ArgExc, "Invalid data window for image resize.");
+    }
+
+    if (dw.min.x <= -(INT_MAX / 2) || dw.min.y <= -(INT_MAX / 2) ||
+        dw.max.x >= (INT_MAX / 2) || dw.max.y >= (INT_MAX / 2))
+    {
+        THROW (ArgExc, "Invalid data window for image resize.");
+    }
+
+    const int64_t w = pixelExtent (dw.min.x, dw.max.x);
+    const int64_t h = pixelExtent (dw.min.y, dw.max.y);
+
+    if (w < 0 || h < 0 || w > INT_MAX || h > INT_MAX)
+    {
+        THROW (ArgExc, "Invalid data window for image resize.");
+    }
+}
+
 int
-levelSize (int min, int max, int l, LevelRoundingMode levelRoundingMode)
+levelSize (
+    int64_t           minCoord,
+    int64_t           maxCoord,
+    int               l,
+    LevelRoundingMode levelRoundingMode)
 {
     assert (l >= 0);
 
-    if (max < min) return 0;
+    int64_t a = pixelExtent (minCoord, maxCoord);
+    if (a == 0) return 0;
 
-    int a    = max - min + 1;
-    int b    = (1 << l);
-    int size = a / b;
+    if (a > INT_MAX)
+    {
+        THROW (ArgExc, "Invalid level size for image resize.");
+    }
+
+    int64_t b    = int64_t (1) << l;
+    int64_t size = a / b;
 
     if (levelRoundingMode == ROUND_UP && size * b < a) size += 1;
 
-    return std::max (size, 1);
-}
+    size = std::max (size, int64_t (1));
 
-Box2i
-computeDataWindowForLevel (
-    const Box2i& dataWindow, int lx, int ly, LevelRoundingMode lrMode)
-{
-    V2i levelMax =
-        dataWindow.min +
-        V2i (
-            levelSize (dataWindow.min.x, dataWindow.max.x, lx, lrMode) - 1,
-            levelSize (dataWindow.min.y, dataWindow.max.y, ly, lrMode) - 1);
+    if (size > INT_MAX)
+    {
+        THROW (ArgExc, "Invalid level size for image resize.");
+    }
 
-    return Box2i (dataWindow.min, levelMax);
+    return int (size);
 }
 
 int
-floorLog2 (int x)
+floorLog2 (int64_t x)
 {
     //
     // For x > 0, floorLog2(y) returns floor(log(x)/log(2)).
@@ -72,7 +108,7 @@ floorLog2 (int x)
 }
 
 int
-ceilLog2 (int x)
+ceilLog2 (int64_t x)
 {
     //
     // For x > 0, ceilLog2(y) returns ceil(log(x)/log(2)).
@@ -93,7 +129,7 @@ ceilLog2 (int x)
 }
 
 int
-roundLog2 (int x, LevelRoundingMode levelRoundingMode)
+roundLog2 (int64_t x, LevelRoundingMode levelRoundingMode)
 {
     if (x < 1) return 1;
 
@@ -102,10 +138,13 @@ roundLog2 (int x, LevelRoundingMode levelRoundingMode)
 
 int
 computeNumXLevels (
-    const Box2i&      dataWindow,
+    const Box2i64&    dw,
     LevelMode         levelMode,
     LevelRoundingMode levelRoundingMode)
 {
+    const int64_t w = pixelExtent (dw.min.x, dw.max.x);
+    const int64_t h = pixelExtent (dw.min.y, dw.max.y);
+
     int n = 0;
 
     switch (levelMode)
@@ -113,21 +152,12 @@ computeNumXLevels (
         case ONE_LEVEL: n = 1; break;
 
         case MIPMAP_LEVELS:
-
-        {
-            int w = dataWindow.max.x - dataWindow.min.x + 1;
-            int h = dataWindow.max.y - dataWindow.min.y + 1;
-            n     = roundLog2 (std::max (w, h), levelRoundingMode) + 1;
-        }
-        break;
+            n = roundLog2 (std::max (w, h), levelRoundingMode) + 1;
+            break;
 
         case RIPMAP_LEVELS:
-
-        {
-            int w = dataWindow.max.x - dataWindow.min.x + 1;
-            n     = roundLog2 (w, levelRoundingMode) + 1;
-        }
-        break;
+            n = roundLog2 (w, levelRoundingMode) + 1;
+            break;
 
         default: assert (false);
     }
@@ -137,10 +167,13 @@ computeNumXLevels (
 
 int
 computeNumYLevels (
-    const Box2i&      dataWindow,
+    const Box2i64&    dw,
     LevelMode         levelMode,
     LevelRoundingMode levelRoundingMode)
 {
+    const int64_t w = pixelExtent (dw.min.x, dw.max.x);
+    const int64_t h = pixelExtent (dw.min.y, dw.max.y);
+
     int n = 0;
 
     switch (levelMode)
@@ -148,21 +181,12 @@ computeNumYLevels (
         case ONE_LEVEL: n = 1; break;
 
         case MIPMAP_LEVELS:
-
-        {
-            int w = dataWindow.max.x - dataWindow.min.x + 1;
-            int h = dataWindow.max.y - dataWindow.min.y + 1;
-            n     = roundLog2 (std::max (w, h), levelRoundingMode) + 1;
-        }
-        break;
+            n = roundLog2 (std::max (w, h), levelRoundingMode) + 1;
+            break;
 
         case RIPMAP_LEVELS:
-
-        {
-            int h = dataWindow.max.y - dataWindow.min.y + 1;
-            n     = roundLog2 (h, levelRoundingMode) + 1;
-        }
-        break;
+            n = roundLog2 (h, levelRoundingMode) + 1;
+            break;
 
         default: assert (false);
     }
@@ -261,8 +285,7 @@ Image::levelWidth (int lx) const
                 << lx << ".");
     }
 
-    return levelSize (
-        _dataWindow.min.x, _dataWindow.max.x, lx, _levelRoundingMode);
+    return levelSize (_dataWindow.min.x, _dataWindow.max.x, lx, _levelRoundingMode);
 }
 
 int
@@ -277,8 +300,7 @@ Image::levelHeight (int ly) const
                 << ly << ".");
     }
 
-    return levelSize (
-        _dataWindow.min.y, _dataWindow.max.y, ly, _levelRoundingMode);
+    return levelSize (_dataWindow.min.y, _dataWindow.max.y, ly, _levelRoundingMode);
 }
 
 void
@@ -297,10 +319,18 @@ Image::resize (
     {
         clearLevels ();
 
-        int nx = computeNumXLevels (dataWindow, levelMode, levelRoundingMode);
-        int ny = computeNumYLevels (dataWindow, levelMode, levelRoundingMode);
+        const Box2i64 dw (dataWindow.min, dataWindow.max);
+
+        validateDataWindow (dw);
+
+        int nx = computeNumXLevels (dw, levelMode, levelRoundingMode);
+        int ny = computeNumYLevels (dw, levelMode, levelRoundingMode);
 
         _levels.resizeErase (ny, nx);
+
+        for (int y = 0; y < ny; ++y)
+            for (int x = 0; x < nx; ++x)
+                _levels[y][x] = nullptr;
 
         for (int y = 0; y < ny; ++y)
         {
@@ -312,8 +342,9 @@ Image::resize (
                     continue;
                 }
 
-                Box2i levelDataWindow = computeDataWindowForLevel (
-                    dataWindow, x, y, levelRoundingMode);
+                const V2i ls (levelSize (dw.min.x, dw.max.x, x, levelRoundingMode) - 1,
+                              levelSize (dw.min.y, dw.max.y, y, levelRoundingMode) - 1);
+                const Box2i levelDataWindow (dataWindow.min, dataWindow.min + ls);
 
                 _levels[y][x] = newLevel (x, y, levelDataWindow);
 

--- a/src/lib/OpenEXRUtil/ImfImageLevel.cpp
+++ b/src/lib/OpenEXRUtil/ImfImageLevel.cpp
@@ -12,6 +12,7 @@
 #include "ImfImageLevel.h"
 #include "Iex.h"
 #include <cassert>
+#include <cstdint>
 
 using namespace IMATH_NAMESPACE;
 using namespace IEX_NAMESPACE;
@@ -36,8 +37,8 @@ ImageLevel::~ImageLevel ()
 void
 ImageLevel::resize (const Box2i& dataWindow)
 {
-    if (dataWindow.max.x < dataWindow.min.x - 1 ||
-        dataWindow.max.y < dataWindow.min.y - 1)
+    if (int64_t (dataWindow.min.x) > int64_t (dataWindow.max.x) + 1 ||
+        int64_t (dataWindow.min.y) > int64_t (dataWindow.max.y) + 1)
     {
         THROW (
             ArgExc,

--- a/src/test/OpenEXRUtilTest/testFlatImage.cpp
+++ b/src/test/OpenEXRUtilTest/testFlatImage.cpp
@@ -15,6 +15,7 @@
 #include <Imath/ImathRandom.h>
 
 #include <cassert>
+#include <climits>
 #include <cstdio>
 
 using namespace OPENEXR_IMF_NAMESPACE;
@@ -572,6 +573,29 @@ testRenameChannels ()
     assert (caught);
 }
 
+void
+testResizeInvalidDataWindow ()
+{
+    cout << "    resize with invalid data window" << endl;
+
+    FlatImage img;
+    img.insertChannel ("R", HALF);
+
+    bool caught = false;
+    try
+    {
+        img.resize (
+            Box2i (V2i (1, INT_MIN), V2i (1, 1)), ONE_LEVEL, ROUND_DOWN);
+    }
+    catch (const std::exception&)
+    {
+        caught = true;
+    }
+    assert (caught);
+
+    img.resize (Box2i (V2i (0, 0), V2i (1, 1)), ONE_LEVEL, ROUND_DOWN);
+}
+
 } // namespace
 
 void
@@ -587,6 +611,7 @@ testFlatImage (const string& tempDir)
         testCropping (tempDir + "cropped.exr");
         testRenameChannel ();
         testRenameChannels ();
+        testResizeInvalidDataWindow ();
 
         cout << "ok\n" << endl;
     }


### PR DESCRIPTION
OpenEXRUtil contains a memory-safety issue in Image::resize() when processing extreme but representable Imath::Box2i data windows.

The resize logic computes image and level dimensions using signed int arithmetic. A data window such as min.y = INT_MIN and max.y = 1 causes signed integer overflow during level-size calculation.

After the overflowed dimensions are used, level construction can throw. During exception cleanup, Image::resize() calls Image::clearLevels(), which iterates over an Array2D<ImageLevel*> allocated by resizeErase(). The pointer entries in that array are not value-initialized before operations that may throw.

As a result, clearLevels() can attempt to delete an uninitialized ImageLevel* slot. Since ImageLevel has a virtual destructor, this leads to a vptr read from an invalid pointer and a crash. Under ASAN/UBSAN this appears as signed integer overflow followed by a member call on 0xbebebebebebebebe and a SEGV in Image::clearLevels().

The issue is reachable through the public OpenEXRUtil API, including FlatImage::resize(). The confirmed impact is denial of service via process crash. I did not confirm direct reachability from a crafted EXR file through the standard file loading path, and I did not demonstrate RCE.

Validate data-window dimensions with checked int64_t arithmetic, null-initialize _levels after allocation, and harden clearLevels() for partially constructed state. Add a regression test for the INT_MIN data-window PoC.

Analysis by: Qiao Zhiyi <qiaozhiyi>