### PR TITLE
Fix heap out-of-bounds write in SampleCountChannel row setter.

### DIFF
--- a/src/lib/OpenEXRUtil/ImfSampleCountChannel.cpp
+++ b/src/lib/OpenEXRUtil/ImfSampleCountChannel.cpp
@@ -112,6 +112,8 @@ SampleCountChannel::set (int x, int y, unsigned int newNumSamples)
     // arrays that describe it.
     //
 
+    boundsCheck (x, y);
+
     size_t i = (_base + y * pixelsPerRow () + x) - _numSamples;
 
     if (newNumSamples <= _numSamples[i])
@@ -222,8 +224,18 @@ SampleCountChannel::set (int x, int y, unsigned int newNumSamples)
 void
 SampleCountChannel::set (int r, unsigned int newNumSamples[])
 {
+    if (r < 0 || r >= pixelsPerColumn ())
+    {
+        THROW (
+            ArgExc,
+            "Attempt to set sample counts for row "
+            << r
+            << " in an image channel with "
+            << pixelsPerColumn () << " rows.");
+    }
+
     int x = level ().dataWindow ().min.x;
-    int y = r + level ().dataWindow ().min.x;
+    int y = r + level ().dataWindow ().min.y;
 
     for (int i = 0; i < pixelsPerRow (); ++i, ++x)
         set (x, y, newNumSamples[i]);

--- a/src/test/OpenEXRUtilTest/testDeepImage.cpp
+++ b/src/test/OpenEXRUtilTest/testDeepImage.cpp
@@ -452,6 +452,32 @@ testSetSampleCounts ()
 }
 
 void
+testSetSampleCountRowOffset ()
+{
+    //
+    // Regression test for GHSA-54cp-3rq6-7mq8: row-based sample count setter
+    // must use dataWindow.min.y (not min.x) when mapping row index to Y.
+    //
+
+    cout << "sample count row setter with non-zero data window origin"
+         << endl;
+
+    DeepImage img;
+    img.insertChannel ("Z", FLOAT, 1, 1, false);
+
+    const Box2i dataWindow (V2i (0, 1), V2i (1, 1));
+    img.resize (dataWindow, ONE_LEVEL, ROUND_DOWN);
+
+    SampleCountChannel& sc = img.level (0).sampleCounts ();
+
+    unsigned int counts[2] = {1, 1};
+    sc.set (0, counts);
+
+    assert (sc.at (0, 1) == 1);
+    assert (sc.at (1, 1) == 1);
+}
+
+void
 testShiftPixels ()
 {
     cout << "pixel shifting" << endl;
@@ -684,6 +710,7 @@ testDeepImage (const string& tempDir)
         testScanLineImages (tempDir + "deepScanLines.exr");
         testTiledImages (tempDir + "deepTiles.exr");
         testSetSampleCounts ();
+        testSetSampleCountRowOffset ();
         testShiftPixels ();
         testCropping (tempDir + "deepCropped.exr");
         testRenameChannel ();


### PR DESCRIPTION
The row-based setter used dataWindow.min.x instead of min.y when mapping a row index to a Y coordinate, causing writes before the allocated sample-count buffer when min.x != min.y. Also add bounds checking to set(x,y) and validate row indices per the API contract.

GHSA-54cp-3rq6-7mq8