### PR TITLE
Fix setting the level in the exrmetrics (#2)

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -1042,9 +1042,11 @@ exrmetrics (
                     outHeaders[p].zipCompressionLevel () = level;
                     compressionSet                       = true;
                     break;
-                    //            case ZSTD_COMPRESSION :
-                    //                outHeader.zstdCompressionLevel()=level;
-                    //                break;
+                case ZSTD_COMPRESSION:
+                    outHeaders[p].zstdCompressionLevel () =
+                        static_cast<int> (level);
+                    compressionSet = true;
+                    break;
                 default: break;
             }
         }

--- a/src/bin/exrmetrics/main.cpp
+++ b/src/bin/exrmetrics/main.cpp
@@ -64,7 +64,7 @@ usageMessage (ostream& stream, const char* program_name, bool verbose = false)
                "  -t n                        Use a pool of n worker threads for processing files.\n"
                "                              Default is single threaded (no thread pool)\n"
                "\n"
-               "  -l level                    set DWA or ZIP compression level\n"
+               "  -l level                    set DWA, ZIP or ZSTD compression level\n"
                "\n"
                "  -z,--compression list       list of compression methods to test\n"
                "                              ("


### PR DESCRIPTION
This commented out code is causing exrmetrics to complain whenever you pass -l (level) with zstd