### PR TITLE
Reject NULL preview rgba data in exr_attr_set_preview()

### DIFF
--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -1933,6 +1933,12 @@ exr_attr_set_preview (
         {
             size_t copybytes =
                 (size_t) val->width * (size_t) val->height * (size_t) 4;
+            if (copybytes > 0 && !val->rgba)
+                return EXR_UNLOCK_AND_RETURN (ctxt->print_error (
+                    ctxt,
+                    EXR_ERR_INVALID_ARGUMENT,
+                    "Invalid NULL preview rgba data for setting '%s'",
+                    name));
             memcpy (
                 EXR_CONST_CAST (void*, attr->preview->rgba),
                 val->rgba,

--- a/src/lib/OpenEXRCore/preview.c
+++ b/src/lib/OpenEXRCore/preview.c
@@ -59,13 +59,19 @@ exr_attr_preview_create (
     uint32_t            h,
     const uint8_t*      d)
 {
+    size_t copybytes = (size_t) w * (size_t) h * (size_t) 4;
+
+    if (copybytes > 0 && !d)
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_INVALID_ARGUMENT,
+            "Invalid NULL preview rgba data for %u x %u preview",
+            w,
+            h);
+
     exr_result_t rv = exr_attr_preview_init (ctxt, p, w, h);
-    if (rv == EXR_ERR_SUCCESS)
-    {
-        size_t copybytes = w * h * 4;
-        if (copybytes > 0)
-            memcpy (EXR_CONST_CAST (uint8_t*, p->rgba), d, copybytes);
-    }
+    if (rv == EXR_ERR_SUCCESS && copybytes > 0)
+        memcpy (EXR_CONST_CAST (uint8_t*, p->rgba), d, copybytes);
     return rv;
 }
 

--- a/src/test/OpenEXRCoreTest/general_attr.cpp
+++ b/src/test/OpenEXRCoreTest/general_attr.cpp
@@ -848,6 +848,35 @@ testPreviewHelper (exr_context_t f)
     // make sure we can re-delete something?
     EXRCORE_TEST_RVAL (exr_attr_preview_destroy (f, &p));
 
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT, exr_attr_preview_create (f, &p, 1, 1, NULL));
+
+    {
+        exr_attr_preview_t preview;
+        preview.width      = 1;
+        preview.height     = 1;
+        preview.alloc_size = 0;
+        preview.rgba       = NULL;
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_set_preview (f, 0, "badPreview", &preview));
+    }
+
+    {
+        exr_attr_preview_t preview;
+        preview.width      = 1;
+        preview.height     = 1;
+        preview.alloc_size = 4;
+        preview.rgba       = data1x1;
+        EXRCORE_TEST_RVAL (
+            exr_attr_set_preview (f, 0, "goodPreview", &preview));
+
+        preview.rgba = NULL;
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_set_preview (f, 0, "goodPreview", &preview));
+    }
+
     EXRCORE_TEST_RVAL_FAIL_MALLOC (
         EXR_ERR_OUT_OF_MEMORY, exr_attr_preview_create (f, &p, 1, 1, data1x1));
 }


### PR DESCRIPTION
Validate the source rgba pointer before memcpy in exr_attr_preview_create() and the same-dimensions update path in exr_attr_set_preview(), preventing a NULL pointer dereference when nonzero preview dimensions are supplied without pixel data.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-29q6-4p2c-77qq