### PR TITLE
Reject NULL bytes type_hint and data in exr_attr_bytes_create()

### DIFF
--- a/src/lib/OpenEXRCore/bytes.c
+++ b/src/lib/OpenEXRCore/bytes.c
@@ -76,11 +76,25 @@ exr_attr_bytes_create (
     const void* t,
     const void* d)
 {
+    if (h > 0 && !t)
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_INVALID_ARGUMENT,
+            "Invalid NULL type hint for bytes attribute with hint length %u",
+            h);
+
+    if (b > 0 && !d)
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_INVALID_ARGUMENT,
+            "Invalid NULL bytes data for bytes attribute with size %zu",
+            b);
+
     exr_result_t rv = exr_attr_bytes_init (ctxt, u, h, b);
     if (rv == EXR_ERR_SUCCESS)
     {
-        if (d && u->data) memcpy ((void*) u->data, d, b);
-        if (d && u->type_hint) memcpy ((void*) u->type_hint, t, h);
+        if (b > 0 && u->data) memcpy ((void*) u->data, d, b);
+        if (h > 0 && u->type_hint) memcpy ((void*) u->type_hint, t, h);
     }
 
     return rv;

--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -1333,14 +1333,28 @@ exr_attr_set_bytes (
         if (attr->bytes->size == val->size &&
             attr->bytes->hint_length == val->hint_length)
         {
-            memcpy (
-                EXR_CONST_CAST (void*, attr->bytes->type_hint),
-                val->type_hint,
-                val->hint_length);
-            memcpy (
-                EXR_CONST_CAST (void*, attr->bytes->data),
-                val->data,
-                val->size);
+            if (val->hint_length > 0 && !val->type_hint)
+                return EXR_UNLOCK_AND_RETURN (ctxt->print_error (
+                    ctxt,
+                    EXR_ERR_INVALID_ARGUMENT,
+                    "Invalid NULL type hint for setting '%s'",
+                    name));
+            if (val->size > 0 && !val->data)
+                return EXR_UNLOCK_AND_RETURN (ctxt->print_error (
+                    ctxt,
+                    EXR_ERR_INVALID_ARGUMENT,
+                    "Invalid NULL bytes data for setting '%s'",
+                    name));
+            if (val->hint_length > 0)
+                memcpy (
+                    EXR_CONST_CAST (void*, attr->bytes->type_hint),
+                    val->type_hint,
+                    val->hint_length);
+            if (val->size > 0)
+                memcpy (
+                    EXR_CONST_CAST (void*, attr->bytes->data),
+                    val->data,
+                    val->size);
         }
         else if (ctxt->mode != EXR_CONTEXT_WRITE && ctxt->mode != EXR_CONTEXT_TEMPORARY)
         {

--- a/src/test/OpenEXRCoreTest/general_attr.cpp
+++ b/src/test/OpenEXRCoreTest/general_attr.cpp
@@ -1028,6 +1028,39 @@ testBytesHelper (exr_context_t f)
     EXRCORE_TEST_RVAL (exr_attr_bytes_destroy (f, &b));
 
     EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_attr_bytes_create (f, &b, 1, 1, NULL, data4));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_attr_bytes_create (f, &b, 0, 4, "hint", NULL));
+
+    {
+        exr_attr_bytes_t bytes;
+        bytes.size        = 1;
+        bytes.data        = data4;
+        bytes.hint_length = 1;
+        bytes.type_hint   = NULL;
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_set_bytes (f, 0, "badBytes", &bytes));
+    }
+
+    {
+        exr_attr_bytes_t bytes;
+        bytes.size        = 4;
+        bytes.data        = data4;
+        bytes.hint_length = 11;
+        bytes.type_hint   = "a cool hint";
+        EXRCORE_TEST_RVAL (
+            exr_attr_set_bytes (f, 0, "goodBytes", &bytes));
+
+        bytes.type_hint = NULL;
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_set_bytes (f, 0, "goodBytes", &bytes));
+    }
+
+    EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT, exr_attr_bytes_copy (f, &b2, NULL));
 }
 


### PR DESCRIPTION
Validate non-null pointers when hint length or data size is non-zero, and apply the same checks in the in-place exr_attr_set_bytes() path.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-xx72-f24p-cf6r