### PR TITLE
Add section on CVE Assignment to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,12 +25,14 @@ bugfix, document it in a GitHub security advisory or release notes when
 helpful, and do not request a CVE for API-only or caller-controlled
 failures with no realistic adversarial path.
 
-Flaws whose root cause lies in a bundled dependency (such as OpenJPH) are
-fixed upstream; the upstream project owns the CVE when one is warranted.
-OpenEXR addresses them by updating the dependency and noting the upstream
-advisory in release notes. We request a CVE for OpenEXR itself only when
-the flaw is in our code and untrusted input can reach it through normal
-use of the library.
+Flaws whose root cause lies in a bundled dependency (such as OpenJPH)
+are fixed upstream; the upstream project owns the CVE when one is
+warranted.  Note that this applies even when a flaw is detected in
+dependency code vendored into OpenEXR's `external/` source directory.
+OpenEXR addresses them by updating the dependency and noting the
+upstream advisory in release notes. We request a CVE for OpenEXR
+itself only when the flaw is in our code and untrusted input can reach
+it through normal use of the library.
 
 ## Known Vulnerabilities
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,22 @@ Our policy is to acknowledge the receipt of vulnerability reports
 within 48 hours. Our policy is to address critical security vulnerabilities
 rapidly and post patches within 14 days if possible.
 
+## CVE Assignment
+
+We request a CVE when an untrusted party can plausibly trigger the flaw
+through normal product inputs (for example, a crafted EXR or other data
+the application is meant to process); otherwise we treat it as a regular
+bugfix, document it in a GitHub security advisory or release notes when
+helpful, and do not request a CVE for API-only or caller-controlled
+failures with no realistic adversarial path.
+
+Flaws whose root cause lies in a bundled dependency (such as OpenJPH) are
+fixed upstream; the upstream project owns the CVE when one is warranted.
+OpenEXR addresses them by updating the dependency and noting the upstream
+advisory in release notes. We request a CVE for OpenEXR itself only when
+the flaw is in our code and untrusted input can reach it through normal
+use of the library.
+
 ## Known Vulnerabilities
 
 | CVE | Affected Versions | Patched Versions |


### PR DESCRIPTION
We've gotten several security advisories that identify flaws in the API (failure to reject invalid arguments) but aren't strictly "security" issues. We should limit CVEs to true vulnerabilities, especially given the increased volume of the reports.