### PR TITLE
Unlock write context in exr_get_chunk_table_offset() return paths

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -516,10 +516,11 @@ exr_get_chunk_table_offset (
     EXR_LOCK_WRITE_AND_DEFINE_PART (part_index);
 
     if (!chunk_offset_out)
-        return ctxt->standard_error (ctxt, EXR_ERR_INVALID_ARGUMENT);
+        return EXR_UNLOCK_WRITE_AND_RETURN (
+            ctxt->standard_error (ctxt, EXR_ERR_INVALID_ARGUMENT));
 
     *chunk_offset_out = part->chunk_table_offset;
-    return EXR_ERR_SUCCESS;
+    return EXR_UNLOCK_WRITE_AND_RETURN (EXR_ERR_SUCCESS);
 }
 
 exr_result_t

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -88,6 +88,17 @@ testStartWriteScan (const std::string& tempdir)
     EXRCORE_TEST_RVAL (
         exr_add_part (outf, "beauty", EXR_STORAGE_SCANLINE, &partidx));
     EXRCORE_TEST (partidx == 0);
+    {
+        uint64_t chunk_table_offset = 0;
+        int      count              = 0;
+        EXRCORE_TEST_RVAL (
+            exr_get_chunk_table_offset (outf, 0, &chunk_table_offset));
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_get_chunk_table_offset (outf, 0, NULL));
+        EXRCORE_TEST_RVAL (exr_get_count (outf, &count));
+        EXRCORE_TEST (count == 1);
+    }
     /* dup name check */
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_INVALID_ARGUMENT,


### PR DESCRIPTION
EXR_LOCK_WRITE_AND_DEFINE_PART() acquires the mutex on write contexts but both success and error returns leaked the lock, deadlocking later API calls such as exr_get_count().

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-9pfw-x4vc-xqx7