### PR TITLE
Reject NULL channel list entries in exr_attr_chlist_duplicate()

### DIFF
--- a/src/lib/OpenEXRCore/channel_list.c
+++ b/src/lib/OpenEXRCore/channel_list.c
@@ -221,6 +221,13 @@ exr_attr_chlist_duplicate (
     if (!chl || !srcchl) return EXR_ERR_INVALID_ARGUMENT;
 
     numchans = srcchl->num_channels;
+    if (numchans > 0 && !srcchl->entries)
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_INVALID_ARGUMENT,
+            "Invalid NULL channel list entries with %d channels",
+            numchans);
+
     rv       = exr_attr_chlist_init (ctxt, chl, numchans);
     if (rv != EXR_ERR_SUCCESS) return rv;
 

--- a/src/lib/OpenEXRCore/part_attr.c
+++ b/src/lib/OpenEXRCore/part_attr.c
@@ -1419,37 +1419,9 @@ exr_attr_set_channels (
     if (rv == EXR_ERR_SUCCESS)
     {
         exr_attr_chlist_t clist;
-        int               numchans;
 
-        if (!channels)
-            return EXR_UNLOCK_AND_RETURN (ctxt->report_error (
-                ctxt,
-                EXR_ERR_INVALID_ARGUMENT,
-                "No channels provided for channel list"));
-
-        numchans = channels->num_channels;
-        rv       = exr_attr_chlist_init (ctxt, &clist, numchans);
+        rv = exr_attr_chlist_duplicate (ctxt, &clist, channels);
         if (rv != EXR_ERR_SUCCESS) return EXR_UNLOCK_AND_RETURN (rv);
-
-        for (int c = 0; c < numchans; ++c)
-        {
-            const exr_attr_chlist_entry_t* cur = channels->entries + c;
-
-            rv = exr_attr_chlist_add_with_length (
-                ctxt,
-                &clist,
-                cur->name.str,
-                cur->name.length,
-                cur->pixel_type,
-                cur->p_linear,
-                cur->x_sampling,
-                cur->y_sampling);
-            if (rv != EXR_ERR_SUCCESS)
-            {
-                exr_attr_chlist_destroy (ctxt, &clist);
-                return EXR_UNLOCK_AND_RETURN (rv);
-            }
-        }
 
         exr_attr_chlist_destroy (ctxt, attr->chlist);
         *(attr->chlist) = clist;

--- a/src/test/OpenEXRCoreTest/general_attr.cpp
+++ b/src/test/OpenEXRCoreTest/general_attr.cpp
@@ -774,6 +774,20 @@ testChlistHelper (exr_context_t f)
         1, EXR_ERR_OUT_OF_MEMORY, exr_attr_chlist_duplicate (f, &cl2, &cl));
     EXRCORE_TEST_RVAL (exr_attr_chlist_destroy (f, &cl2));
 
+    {
+        exr_attr_chlist_t bad = {0};
+        bad.num_channels      = 1;
+        bad.entries           = NULL;
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_chlist_duplicate (f, &cl2, &bad));
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT, exr_set_channels (f, 0, &bad));
+        EXRCORE_TEST_RVAL_FAIL (
+            EXR_ERR_INVALID_ARGUMENT,
+            exr_attr_set_channels (f, 0, "badChlist", &bad));
+    }
+
     /* without a file, max will be 31 */
     EXRCORE_TEST_RVAL_FAIL (
         EXR_ERR_NAME_TOO_LONG,


### PR DESCRIPTION
Validate num_channels > 0 with entries == NULL before pointer arithmetic, covering exr_set_channels() and exr_attr_set_channels().

Also, refactor exr_attr_set_channels to call exr_attr_chlist_duplicate() since it does the same work.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-mqmw-xv8w-5jh4