### PR TITLE
Fix the DWAA size checks regression

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -774,8 +774,7 @@ DwaCompressor_uncompress (
        be checked below */
     if (unknownUncompressedSize > uncompressed_size ||
         rleRawSize > uncompressed_size ||
-        (unknownUncompressedSize + rleRawSize) > uncompressed_size ||
-        totalAcUncompressedCount > uncompressed_size)
+        (unknownUncompressedSize + rleRawSize) > uncompressed_size)
     {
         return EXR_ERR_CORRUPT_CHUNK;
     }


### PR DESCRIPTION
This was introduced by https://github.com/AcademySoftwareFoundation/openexr/pull/2383
I was able to read a DWAA file using RB-3.4 (67de2bffbd7da508f75fbdc56e6e551a4e31fb83) but not latest main.

The original file was generated with Nuke15.1v5 . I was unable to generate a problematic file synthetically.

From what I can read inside this file is that totalAcUncompressedCount is not a bytecount but rather a "count of uint16 DCT (AC) coefficients/elements,".
It would normally have to multiplied with sizeof(uint16). A similar condition is already enforced here:
https://github.com/AcademySoftwareFoundation/openexr/blob/0565c021ae6fd84facedeabac6743cad08e8f202/src/lib/OpenEXRCore/internal_dwa_compressor.h#L901

Testing:
* I rebuilt 67de2bffbd7da508f75fbdc56e6e551a4e31fb83 with ASAN and noticed that it chokes with the special defective file( clusterfuzz-testcase-openexr_exrcorecheck )
* after my fix ASAN is happy and original DWAA file can be read