### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/python-wheels-publish-test.yml
+++ b/.github/workflows/python-wheels-publish-test.yml
@@ -97,10 +97,10 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          # Build Python 3.8 through 3.13.
+          # Build Python 3.9 through 3.13.
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 *_i686"
           CIBW_ENVIRONMENT: OPENEXR_RELEASE_CANDIDATE_TAG="${{ github.ref_name }}"
 

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -91,10 +91,10 @@ jobs:
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          # Build Python 3.8 through 3.13
+          # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 *_i686"
 
       - name: Upload artifact

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -78,10 +78,10 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          # Build Python 3.8 through 3.13
+          # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: "*-win32 *_i686"
 
       - name: Upload artifact


### PR DESCRIPTION
3.8 was never actually included in any vfx reference platform year, and the platform has been at Python 3.9+ since CY2022. And cibuildwheel 4.0 drops support for 3.8.

This will take effect in OpenEXR v3.5.