### PR TITLE
Split macOS wheel arches across CI runners

### DIFF
--- a/.github/workflows/python-wheels-publish-test.yml
+++ b/.github/workflows/python-wheels-publish-test.yml
@@ -64,8 +64,10 @@ jobs:
             arch: arm64
           - os: macos-15-intel
             arch: x64
+            cibw_archs_macos: x86_64 universal2
           - os: macos-latest
             arch: arm64
+            cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
 
@@ -96,7 +98,8 @@ jobs:
           output-dir: wheelhouse
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          # Split macOS arches across runners so artifact merge does not collide on filenames.
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           # Build Python 3.9 through 3.13.
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -60,8 +60,10 @@ jobs:
             arch: arm64
           - os: macos-15-intel
             arch: x64
+            cibw_archs_macos: x86_64 universal2
           - os: macos-latest
             arch: arm64
+            cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
 
@@ -90,7 +92,8 @@ jobs:
           output-dir: wheelhouse
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          # Split macOS arches across runners so artifact merge does not collide on filenames.
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -48,8 +48,10 @@ jobs:
             arch: arm64
           - os: macos-15-intel
             arch: x64
+            cibw_archs_macos: x86_64 universal2
           - os: macos-latest
             arch: arm64
+            cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
 
@@ -77,7 +79,8 @@ jobs:
         with:
           output-dir: wheelhouse
         env:
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          # Split macOS arches across runners so artifact merge does not collide on filenames.
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
@@ -91,3 +94,61 @@ jobs:
           path: |
             ./wheelhouse/*.whl
             ./wheelhouse/*.tar.gz
+
+  verify_publish_artifacts:
+    name: Verify merged wheel artifacts
+    needs: build_wheels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Download wheel artifacts separately
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          path: artifacts
+
+      - name: Detect duplicate distribution filenames
+        run: |
+          set -euo pipefail
+
+          mapfile -t dupes < <(
+            find artifacts -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec basename {} \; \
+              | sort \
+              | uniq -d
+          )
+
+          if ((${#dupes[@]} > 0)); then
+            echo "::error::Duplicate distribution filenames across build artifacts:"
+            printf '  %s\n' "${dupes[@]}"
+            exit 1
+          fi
+
+      - name: Download wheel artifacts (as publish does)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Verify wheel ZIP integrity
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          wheels=(dist/*.whl)
+          if ((${#wheels[@]} == 0)); then
+            echo "::error::No wheels found in dist/"
+            exit 1
+          fi
+
+          for wheel in "${wheels[@]}"; do
+            echo "Checking $wheel"
+            python3 -m zipfile -t "$wheel"
+          done
+
+      - name: Validate distribution metadata
+        run: pipx run twine==6.1.0 check dist/*


### PR DESCRIPTION
Both macOS matrix jobs previously built x86_64, arm64, and universal2, producing duplicate wheel filenames. Prior to #2433, the workflow downloaded each built wheel in succession, which would cause the duplicate wheel to overwrite the original, but it avoided an error. The new merge-multiple in the publish job corrupt the files, causing TestPyPI uploads to fail with "Mis-matched data size".

This change builds x86_64 and universal2 on macos-15-intel and arm64 on macos-latest so merged artifacts have unique names.

This also adds a validation step to the python-wheels.yml workflow to ensure the wheels have the expected structure.