### PR TITLE
Fix CI-old workflow failure due to Node 24 on old VFX platform containers

### DIFF
--- a/.github/workflows/ci_workflow_old.yml
+++ b/.github/workflows/ci_workflow_old.yml
@@ -64,6 +64,9 @@ jobs:
         - /node20217:/node20217:rw,rshared
         - /node20217:/__e/node20:ro,rshared
 
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     strategy:
       matrix:
         include:


### PR DESCRIPTION
GitHub Actions deprecated Node 20 and now forces Node 24 by default, which requires glibc >= 2.25. The VFX 2021/2022 containers are CentOS 7 (glibc 2.17) and can't run Node 24, breaking the checkout step.

Set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true to allow the runner to use the Node 20 glibc-2.17 build installed in /node20217, which is the existing workaround for these old containers.