### PR TITLE
Fix signed integer overflow in unpack_sample_table()

### DIFF
--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -226,7 +226,7 @@ unpack_sample_table (exr_const_context_t ctxt, exr_decode_pipeline_t* decode)
 
     if ((decode->decode_flags & EXR_DECODE_SAMPLE_COUNTS_AS_INDIVIDUAL))
     {
-        for (int32_t y = 0; y < h; ++y)
+        for (int64_t y = 0; y < h; ++y)
         {
             int32_t* cursampline = samptable + y * w;
             int32_t  prevsamp    = 0;
@@ -246,7 +246,7 @@ unpack_sample_table (exr_const_context_t ctxt, exr_decode_pipeline_t* decode)
     }
     else
     {
-        for (int32_t y = 0; y < h; ++y)
+        for (int64_t y = 0; y < h; ++y)
         {
             int32_t* cursampline = samptable + y * w;
             int32_t  prevsamp    = 0;

--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -215,8 +215,8 @@ static exr_result_t
 unpack_sample_table (exr_const_context_t ctxt, exr_decode_pipeline_t* decode)
 {
     exr_result_t rv           = EXR_ERR_SUCCESS;
-    int32_t      w            = decode->chunk.width;
-    int32_t      h            = decode->chunk.height;
+    int64_t      w            = decode->chunk.width;
+    int64_t      h            = decode->chunk.height;
     uint64_t     totsamp      = 0;
     int32_t*     samptable    = decode->sample_count_table;
     size_t       combSampSize = 0;


### PR DESCRIPTION
Declare w and h as int64_t instead of int32_t so that index arithmetic y*w and w*h in unpack_sample_table() does not overflow when tile dimensions are large (e.g. 46342x46342).

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-rqp5-pmwm-wj6x