### PR TITLE
Fix OOB write in TypedFlatImageChannel::row() for non-zero dataWindow.min

### DIFF
--- a/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
@@ -199,14 +199,14 @@ template <class T>
 inline T*
 TypedFlatImageChannel<T>::row (int r)
 {
-    return _base + r * pixelsPerRow ();
+    return _pixels + (size_t) r * pixelsPerRow ();
 }
 
 template <class T>
 inline const T*
-TypedFlatImageChannel<T>::row (int n) const
+TypedFlatImageChannel<T>::row (int r) const
 {
-    return _base + n * pixelsPerRow ();
+    return _pixels + (size_t) r * pixelsPerRow ();
 }
 
 #ifndef COMPILING_IMF_FLAT_IMAGE_CHANNEL


### PR DESCRIPTION
row(r) is documented as 0-based row access, but used _base which is adjusted by dataWindow.min for EXR-coordinate indexing. For files with non-zero dataWindow.min, row(0) pointed outside the allocated _pixels buffer, causing heap OOB writes and use-after-free.

Fix by using _pixels (the raw allocation) directly so that row(r) is genuinely 0-based. Also cast r to size_t before multiplication to avoid overflow on large images.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-pqp9-558c-453q