### PR TITLE
Fix deep pixelmode heap buffer overflow in exrmetrics

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -379,8 +379,8 @@ initAndReadDeepScanLine (
 
     sampleData.resize (numChans);
     channelNumber = 0;
-    for (ChannelList::ConstIterator i = in.header ().channels ().begin ();
-         i != in.header ().channels ().end ();
+    for (ChannelList::ConstIterator i = outHeader.channels ().begin ();
+         i != outHeader.channels ().end ();
          ++i)
     {
         int samplesize = pixelTypeSize (i.channel ().type);


### PR DESCRIPTION
When --pixelmode float (or --bench) is used, outHeader channels are rewritten from the input type (e.g. HALF) to FLOAT.  The DeepSlice framebuffer entries were already built from outHeader, requesting 4-byte FLOAT writes.  However, the sample data buffers were allocated using the *input* header's channel types (2 bytes for HALF), so readPixels() wrote 4-byte values into 2-byte buffers — a heap buffer overflow.

Fix: allocate sampleData using outHeader.channels() (the output/requested type) so that buffer sizes match the per-sample write size.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-6jj8-cxcr-j8hm