### PR TITLE
Fix OpenEXRUtil row() OOB read with non-zero data window origin

### DIFF
--- a/src/lib/OpenEXRUtil/ImfDeepImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfDeepImageChannel.h
@@ -248,14 +248,14 @@ template <class T>
 inline T* const*
 TypedDeepImageChannel<T>::row (int r)
 {
-    return _base + r * pixelsPerRow ();
+    return _sampleListPointers + r * pixelsPerRow ();
 }
 
 template <class T>
 inline const T* const*
 TypedDeepImageChannel<T>::row (int r) const
 {
-    return _base + r * pixelsPerRow ();
+    return _sampleListPointers + r * pixelsPerRow ();
 }
 
 #ifndef COMPILING_IMF_DEEP_IMAGE_CHANNEL

--- a/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
+++ b/src/lib/OpenEXRUtil/ImfFlatImageChannel.h
@@ -199,14 +199,14 @@ template <class T>
 inline T*
 TypedFlatImageChannel<T>::row (int r)
 {
-    return _base + r * pixelsPerRow ();
+    return _pixels + r * pixelsPerRow ();
 }
 
 template <class T>
 inline const T*
 TypedFlatImageChannel<T>::row (int n) const
 {
-    return _base + n * pixelsPerRow ();
+    return _pixels + n * pixelsPerRow ();
 }
 
 #ifndef COMPILING_IMF_FLAT_IMAGE_CHANNEL

--- a/src/lib/OpenEXRUtil/ImfSampleCountChannel.h
+++ b/src/lib/OpenEXRUtil/ImfSampleCountChannel.h
@@ -316,7 +316,7 @@ SampleCountChannel::at (int x, int y) const
 inline const unsigned int*
 SampleCountChannel::row (int n) const
 {
-    return _base + n * pixelsPerRow ();
+    return _numSamples + n * pixelsPerRow ();
 }
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT

--- a/src/test/OpenEXRUtilTest/testDeepImage.cpp
+++ b/src/test/OpenEXRUtilTest/testDeepImage.cpp
@@ -479,6 +479,39 @@ testSetSampleCountRowOffset ()
 }
 
 void
+testDeepChannelRowOffset ()
+{
+    //
+    // Regression test for GHSA-hwmv-39v6-739m: row() is 0-based relative
+    // to the data window and must not use the _base pointer offset.
+    //
+
+    cout << "deep channel row() with non-zero data window origin" << endl;
+
+    DeepImage img;
+    img.insertChannel ("Z", FLOAT, 1, 1, false);
+
+    const Box2i dataWindow (V2i (1024, -1024), V2i (1031, -1017));
+    img.resize (dataWindow, ONE_LEVEL, ROUND_DOWN);
+
+    DeepImageLevel&               level   = img.level (0);
+    TypedDeepImageChannel<float>& channel = level.typedChannel<float> ("Z");
+    SampleCountChannel&           sc      = level.sampleCounts ();
+
+    assert (channel.row (0)[0] ==
+            channel.at (dataWindow.min.x, dataWindow.min.y));
+    assert (&sc.row (0)[0] == &sc.at (dataWindow.min.x, dataWindow.min.y));
+
+    const int lastRow = channel.pixelsPerColumn () - 1;
+    const int lastCol = channel.pixelsPerRow () - 1;
+
+    assert (channel.row (lastRow)[lastCol] ==
+            channel.at (dataWindow.max.x, dataWindow.max.y));
+    assert (&sc.row (lastRow)[lastCol] ==
+            &sc.at (dataWindow.max.x, dataWindow.max.y));
+}
+
+void
 testShiftPixels ()
 {
     cout << "pixel shifting" << endl;
@@ -752,6 +785,7 @@ testDeepImage (const string& tempDir)
         testTiledImages (tempDir + "deepTiles.exr");
         testSetSampleCounts ();
         testSetSampleCountRowOffset ();
+        testDeepChannelRowOffset ();
         testRoundListSizeUpLimits ();
         testShiftPixels ();
         testCropping (tempDir + "deepCropped.exr");


### PR DESCRIPTION
The row() method in TypedDeepImageChannel, TypedFlatImageChannel, and SampleCountChannel is documented as 0-based within the data window, but used the _base offset meant for absolute (x, y) access. Index the compact backing arrays instead so row(0) aliases the first pixel when dataWindow.min is non-zero.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-hwmv-39v6-739m