### PR TITLE
Reject negative pixelDataSize in rawPixelDataToBuffer()

### DIFF
--- a/src/lib/OpenEXR/ImfScanLineInputFile.cpp
+++ b/src/lib/OpenEXR/ImfScanLineInputFile.cpp
@@ -361,7 +361,8 @@ ScanLineInputFile::rawPixelDataToBuffer (
     if (EXR_ERR_SUCCESS == exr_read_scanline_chunk_info (
                                _ctxt, _data->partNumber, scanLine, &cinfo))
     {
-        if (cinfo.packed_size > static_cast<uint64_t> (pixelDataSize))
+        if (pixelDataSize < 0 ||
+            cinfo.packed_size > static_cast<uint64_t> (pixelDataSize))
         {
             THROW (
                 IEX_NAMESPACE::ArgExc,


### PR DESCRIPTION
A negative int cast to uint64_t bypassed the buffer size check and allowed exr_read_chunk() to write past a caller buffer.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-fhfq-mv64-6q4j