### PR TITLE
Fix ILP32 deep sample-count table size overflow in decoding

### DIFF
--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -26,12 +26,14 @@ update_pack_unpack_ptrs (exr_decode_pipeline_t* decode)
     if (stortype == EXR_STORAGE_DEEP_SCANLINE ||
         stortype == EXR_STORAGE_DEEP_TILED)
     {
-        size_t sampsize =
-            (((size_t) decode->chunk.width) * ((size_t) decode->chunk.height));
+        uint64_t sampsize64 =
+            ((uint64_t) decode->chunk.width) * ((uint64_t) decode->chunk.height);
 
         if ((decode->decode_flags & EXR_DECODE_SAMPLE_COUNTS_AS_INDIVIDUAL))
-            sampsize += 1;
-        sampsize *= sizeof (int32_t);
+            sampsize64 += 1;
+        sampsize64 *= sizeof (int32_t);
+        if (sampsize64 != (size_t) sampsize64) return EXR_ERR_OUT_OF_MEMORY;
+        size_t sampsize = (size_t) sampsize64;
 
         if (decode->chunk.sample_count_table_size == sampsize)
         {


### PR DESCRIPTION
In update_pack_unpack_ptrs(), sampsize was computed as size_t, so on ILP32 builds a tile with width*height >= 2^30 wraps to zero (or four with the INDIVIDUAL flag), causing the sample-count table to be allocated too small and unpack_sample_table() to read far past it.

Compute the size in uint64_t, check for truncation before converting to size_t, and return EXR_ERR_OUT_OF_MEMORY if the required size exceeds SIZE_MAX.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-p42q-g5c9-mh9w