### PR TITLE
Fix ILP32 unpacked buffer size truncation in RLE decode

### DIFF
--- a/src/lib/OpenEXRCore/decoding.c
+++ b/src/lib/OpenEXRCore/decoding.c
@@ -72,12 +72,14 @@ update_pack_unpack_ptrs (exr_decode_pipeline_t* decode)
     }
     else
     {
+        if (decode->chunk.unpacked_size != (size_t) decode->chunk.unpacked_size)
+            return EXR_ERR_OUT_OF_MEMORY;
         rv = internal_decode_alloc_buffer (
             decode,
             EXR_TRANSCODE_BUFFER_UNPACKED,
             &(decode->unpacked_buffer),
             &(decode->unpacked_alloc_size),
-            decode->chunk.unpacked_size);
+            (size_t) decode->chunk.unpacked_size);
     }
 
     return rv;


### PR DESCRIPTION
In update_pack_unpack_ptrs(), decode->chunk.unpacked_size is uint64_t but was passed directly to internal_decode_alloc_buffer() which takes size_t. On ILP32 builds a crafted chunk with unpacked_size > 4 GiB silently truncates, allocating a tiny buffer while the decompressor and unpacker iterate over the full declared channel width, causing an out-of-bounds read.

Add a truncation check before the allocation and return EXR_ERR_OUT_OF_MEMORY if unpacked_size exceeds SIZE_MAX.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-v6v5-344m-64vm