### PR TITLE
Fix empty multiView crash in viewFromChannelName()

### DIFF
--- a/src/lib/OpenEXR/ImfMultiView.cpp
+++ b/src/lib/OpenEXR/ImfMultiView.cpp
@@ -118,7 +118,7 @@ viewFromChannelName (const string& channel, const StringVector& multiView)
         // in the name belong to the default view.
         //
 
-        return multiView[0];
+        return defaultViewName (multiView);
     }
     else
     {

--- a/src/test/OpenEXRTest/testMultiView.cpp
+++ b/src/test/OpenEXRTest/testMultiView.cpp
@@ -111,6 +111,13 @@ testMultiViewFunctions ()
         viewFromChannelName ("devon.and.cornwall.longwool", multiView) == "");
 
     //
+    // Regression test for GHSA-g8f2-r72m-48vx: empty multiView must not
+    // index element 0; dotless channels belong to no named view.
+    //
+
+    assert (viewFromChannelName ("R", StringVector ()) == "");
+
+    //
     // Test areCounterparts()
     //
 


### PR DESCRIPTION
Dotless channel names used multiView[0] without checking for an empty vector. Use defaultViewName() so malformed files return "" instead of OOB access.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-g8f2-r72m-48vx