### PR TITLE
Avoid memory allocation in idmanifest parsing

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -177,6 +177,13 @@ readStringList (
         Xdr::read<CharPtrIO> (readPtr, numberOfStrings);
     }
 
+
+    if (numberOfStrings < 0)
+    {
+        throw IEX_NAMESPACE::InputExc (
+            "Negative count for number of strings");
+    }
+
     if (readPtr + numberOfStrings > endPtr)
     {
         throw IEX_NAMESPACE::InputExc (
@@ -193,7 +200,7 @@ readStringList (
 
     for (int i = 0; i < numberOfStrings; ++i)
     {
-        totalTableSize = readVariableLengthInteger (readPtr, endPtr);
+        totalTableSize += readVariableLengthInteger (readPtr, endPtr);
     }
 
 

--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -177,21 +177,46 @@ readStringList (
         Xdr::read<CharPtrIO> (readPtr, numberOfStrings);
     }
 
-    vector<size_t> lengths (numberOfStrings);
-
-    for (int i = 0; i < numberOfStrings; ++i)
+    if (readPtr + numberOfStrings > endPtr)
     {
-        lengths[i] = readVariableLengthInteger (readPtr, endPtr);
+        throw IEX_NAMESPACE::InputExc (
+            "IDManifest too small for string length table");
     }
+
+
+    //
+    // compute total table size
+    //
+    const char* tablePtr = readPtr;
+
+    size_t totalTableSize = 0;
+
+    for (int i = 0; i < numberOfStrings; ++i)
+    {
+        totalTableSize = readVariableLengthInteger (readPtr, endPtr);
+    }
+
+
+    if(readPtr + totalTableSize > endPtr)
+    {
+        throw IEX_NAMESPACE::InputExc ("IDManifest too small for string table");
+    }
+
+    //
+    // now tablePtr points to size of string in string table, and readPtr
+    // points to the string itself
+    //
+
     for (int i = 0; i < numberOfStrings; ++i)
     {
 
-        if (readPtr + lengths[i] > endPtr)
+        size_t length = readVariableLengthInteger (tablePtr, endPtr);
+        if (readPtr + length > endPtr)
         {
             throw IEX_NAMESPACE::InputExc ("IDManifest too small for string");
         }
-        outputVector.insert (outputVector.end (), string (readPtr, lengths[i]));
-        readPtr += lengths[i];
+        outputVector.insert (outputVector.end (), string (readPtr, length));
+        readPtr += length;
     }
 }
 


### PR DESCRIPTION
Fixes #2489

The IDManifest parser read the number of strings from the manifest and allocated an array of that size to store the string sizes without testing it. A specially crafted small file could cause excessive memory allocation.

This refactor removes the array entirely to avoid the issue