### PR TITLE
Fix Name::operator= to null-terminate long strings

### DIFF
--- a/src/lib/OpenEXR/ImfName.h
+++ b/src/lib/OpenEXR/ImfName.h
@@ -72,6 +72,7 @@ inline Name&
 Name::operator= (const char text[])
 {
     strncpy (_text, text, MAX_LENGTH);
+    _text[MAX_LENGTH] = 0;
     return *this;
 }
 


### PR DESCRIPTION
Name::operator= leaves the string without a terminating null if the string is longer than MAX_LENGTH. Write a null to ensure there is one.