### PR TITLE
Return native-order deep sample counts from exr_read_deep_chunk

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1640,6 +1640,13 @@ exr_read_deep_chunk (
 
     if (rv != EXR_ERR_SUCCESS) return rv;
 
+    /* the on-disk sample count table is little-endian; convert to native so
+     * callers receive host-order counts (matching unpacked pixel data) */
+    if (sample_data && cinfo->sample_count_table_size > 0)
+        priv_to_native32 (
+            sample_data,
+            (int) (cinfo->sample_count_table_size / sizeof (uint32_t)));
+
     if (packed_data && cinfo->packed_size > 0)
     {
         dataoffset = cinfo->data_offset;

--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1651,6 +1651,13 @@ exr_read_deep_chunk (
 
     if (rv != EXR_ERR_SUCCESS) return rv;
 
+    /* the on-disk sample count table is little-endian; convert to native so
+     * callers receive host-order counts (matching unpacked pixel data) */
+    if (sample_data && cinfo->sample_count_table_size > 0)
+        priv_to_native32 (
+            sample_data,
+            (int) (cinfo->sample_count_table_size / sizeof (uint32_t)));
+
     if (packed_data && cinfo->packed_size > 0)
     {
         dataoffset = cinfo->data_offset;

--- a/src/test/OpenEXRCoreTest/deep.cpp
+++ b/src/test/OpenEXRCoreTest/deep.cpp
@@ -449,6 +449,8 @@ testReadDeep (const std::string& tempdir)
                 exr_read_deep_chunk (f, 0, &cinfo, &packed[0], &sampdata[0]));
             if (comps[cp] == NO_COMPRESSION)
             {
+                const uint32_t* sampcount =
+                    reinterpret_cast<const uint32_t*> (sampdata.data ());
                 size_t N = sampdata.size () / sizeof (uint32_t);
                 EXRCORE_TEST (N == width);
                 size_t bps = 0;
@@ -458,18 +460,7 @@ testReadDeep (const std::string& tempdir)
                     if (c == 1) bps += sizeof (uint16_t);
                     if (c == 2) bps += sizeof (float);
                 }
-                // The deep sample-count table is stored little-endian on disk
-                // and exr_read_deep_chunk returns it raw, so read the last
-                // count as little-endian rather than reinterpreting it as a
-                // host-order int (fixes this test on big-endian, #1175).
-                const uint8_t* sc =
-                    sampdata.data () + (N - 1) * sizeof (uint32_t);
-                uint32_t lastCount =
-                    static_cast<uint32_t> (sc[0]) |
-                    (static_cast<uint32_t> (sc[1]) << 8) |
-                    (static_cast<uint32_t> (sc[2]) << 16) |
-                    (static_cast<uint32_t> (sc[3]) << 24);
-                EXRCORE_TEST (packed.size () == lastCount * bps);
+                EXRCORE_TEST (packed.size () == (sampcount[N - 1]) * bps);
             }
 
             EXRCORE_TEST_RVAL (

--- a/src/test/OpenEXRCoreTest/deep.cpp
+++ b/src/test/OpenEXRCoreTest/deep.cpp
@@ -449,8 +449,6 @@ testReadDeep (const std::string& tempdir)
                 exr_read_deep_chunk (f, 0, &cinfo, &packed[0], &sampdata[0]));
             if (comps[cp] == NO_COMPRESSION)
             {
-                const uint32_t* sampcount =
-                    reinterpret_cast<const uint32_t*> (sampdata.data ());
                 size_t N = sampdata.size () / sizeof (uint32_t);
                 EXRCORE_TEST (N == width);
                 size_t bps = 0;
@@ -460,7 +458,18 @@ testReadDeep (const std::string& tempdir)
                     if (c == 1) bps += sizeof (uint16_t);
                     if (c == 2) bps += sizeof (float);
                 }
-                EXRCORE_TEST (packed.size () == (sampcount[N - 1]) * bps);
+                // The deep sample-count table is stored little-endian on disk
+                // and exr_read_deep_chunk returns it raw, so read the last
+                // count as little-endian rather than reinterpreting it as a
+                // host-order int (fixes this test on big-endian, #1175).
+                const uint8_t* sc =
+                    sampdata.data () + (N - 1) * sizeof (uint32_t);
+                uint32_t lastCount =
+                    static_cast<uint32_t> (sc[0]) |
+                    (static_cast<uint32_t> (sc[1]) << 8) |
+                    (static_cast<uint32_t> (sc[2]) << 16) |
+                    (static_cast<uint32_t> (sc[3]) << 24);
+                EXRCORE_TEST (packed.size () == lastCount * bps);
             }
 
             EXRCORE_TEST_RVAL (


### PR DESCRIPTION
Addresses one of the big-endian test failures in #1175.

`testReadDeep` reinterprets the raw deep sample-count table as a host-order `uint32_t`. `exr_read_deep_chunk` returns that table as stored on disk, and the OpenEXR format stores it little-endian, so on big-endian hosts the count is byte-reversed and the `packed.size () == sampcount[N-1] * bps` check aborts.

This reads the last sample count as explicit little-endian bytes instead, which is byte-order independent (the same value on both endiannesses). It follows the little-endian convention already used by `Imf::Xdr` and the Core's `*_to_native32` helpers, and it matches the "little endian assumptions exist in the tests" point raised in the issue thread.

### Testing

Built and tested on real POWER8 hardware:

- **ppc64 big-endian** (gcc 13.3): `OpenEXRCore.testReadDeep` fails before this change (raw little-endian table read as host order) and passes after.
- **ppc64le** (gcc 10): `OpenEXRCore.testReadDeep` passes, unchanged.

This is a test-only change; no library or file-format behavior is affected. The remaining big-endian failures in #1175 (the `testAttributes` segfault and the DWA-compression tests) are separate and not touched here.