### PR TITLE
Fix HTJ2K channel map permutation validation

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -194,11 +194,15 @@ ht_undo_impl (
     if (static_cast<std::size_t>(decode->channel_count) != cs_to_file_ch.size ())
         return EXR_ERR_CORRUPT_CHUNK;
 
+    std::vector<bool> seen (decode->channel_count, false);
     for (int cs_i = 0; cs_i < decode->channel_count; cs_i++)
     {
         int file_i = cs_to_file_ch[cs_i].file_index;
         if (file_i >= decode->channel_count)
             return EXR_ERR_CORRUPT_CHUNK;
+        if (seen[file_i])
+            return EXR_ERR_CORRUPT_CHUNK;
+        seen[file_i] = true;
 
         int64_t computedoffset = 0;
         for (int i = 0; i < file_i; ++i)


### PR DESCRIPTION
Validate that the channel map is a true permutation of [0, channel_count): range check alone permitted duplicate file_index values, leaving channels unwritten in the scratch buffer and returning stale heap data.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-8ggg-fhxp-95p9