### PR TITLE
Fix name comparison in deep prefixed RGB channel coalescing

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -681,11 +681,12 @@ PyPart::setDeepSliceData(const ChannelList& channel_list, size_t height, size_t 
         size_t channel_offset = 0;
         if (C._nrgba > 0)
         {
-            if (!strcmp(c.name(), "G"))
+            char last = c.name()[strlen(c.name()) - 1];
+            if (last == 'G')
                 channel_offset = 1;
-            else if (!strcmp(c.name(), "B"))
+            else if (last == 'B')
                 channel_offset = 2;
-            else if (!strcmp(c.name(), "A"))
+            else if (last == 'A')
                 channel_offset = 3;
         }
 


### PR DESCRIPTION
setDeepSliceData() used strcmp(c.name(), "G"/"B"/"A") to select the RGB channel offset, which only matched unprefixed channel names. For layer-prefixed channels like left.G and left.B the comparison failed, leaving channels 1 and 2 pointing at their initial (stale heap) data while channel 0 received all decoded samples.

Fix: check only the final character of the channel name, consistent with how channelNameToRGBA() already identifies the channel suffix.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-pf59-r2mc-x746