### PR TITLE
Group CodeQL GitHub Actions bumps in Dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: "daily"
     exclude-paths:
       - ".github/workflows/ci_workflow_old.yml"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "pip"
     directory: "/website"


### PR DESCRIPTION
Keep init, analyze, and upload-sarif on the same version so partial updates do not break the CodeQL workflow with a version mismatch.