### PR TITLE
Upgrade manylinux cibuildwheel images to manylinux_2_28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ test-extras = ["test"]
 test-skip = ["*universal2:arm64"]
 build-verbosity = 1
 
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-i686-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 # Needed for full C++17 support
 [tool.cibuildwheel.macos.environment]


### PR DESCRIPTION
NumPy 2.5+ no longer ships manylinux_2_17 wheels and requires GCC >= 10.3 when building from source. The manylinux2014 containers only provides GCC 10.2.1, so cibuildwheel's test phase fails when pip cannot install numpy.

Use manylinux_2_28 for aarch64, x86_64, and i686 builds (GCC 11, glibc 2.28), which has compatible pre-built numpy wheels and satisfies the compiler requirement.