### PR TITLE
Fix exrmetrics heap OOB on subsampled scanlines

### DIFF
--- a/src/bin/exrmetrics/exrmetrics.cpp
+++ b/src/bin/exrmetrics/exrmetrics.cpp
@@ -80,8 +80,6 @@ initScanLine (
     int      numChans  = channelCount (in.header ());
 
     pixelData.resize (numChans);
-    uint64_t offsetToOrigin = width * static_cast<uint64_t> (dw.min.y) +
-                              static_cast<uint64_t> (dw.min.x);
 
     int    channelNumber = 0;
     size_t rawSize       = 0;
@@ -98,9 +96,10 @@ initScanLine (
 
         buf.insert (
             i.name (),
-            Slice (
+            Slice::Make (
                 i.channel ().type,
-                pixelData[channelNumber].data () - offsetToOrigin * samplesize,
+                pixelData[channelNumber].data (),
+                dw,
                 samplesize,
                 samplesize * width,
                 i.channel ().xSampling,


### PR DESCRIPTION
initScanLine() adjusted Slice base pointers using full pixel-space origin offsets, but OpenEXR addresses subsampled channels with origin.x / xSampling and origin.y / ySampling. Use Slice::Make() so the base pointer matches the library's coordinate math.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-7h7v-98cr-8ppw