### PR TITLE
Refuse to coalesce RGB channels when there's a conflicting channel name

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -432,7 +432,7 @@ PyFile::readPartsFromOpenInput(bool separate_channels)
             std::vector<size_t> shape ({height, width});
 
             if (!separate_channels)
-                P.validateCoalescedChannelTypes (header.channels (), rgbaChannels);
+                P.validateCoalescedChannels (header.channels (), rgbaChannels);
 
             //
             // Read the channel data, different for image vs. deep
@@ -475,7 +475,7 @@ PyPart::readPixels(MultiPartInputFile& infile, const ChannelList& channel_list,
                    const Box2i& dw, bool separate_channels)
 {
     if (!separate_channels)
-        validateCoalescedChannelTypes (channel_list, rgbaChannels);
+        validateCoalescedChannels (channel_list, rgbaChannels);
 
     FrameBuffer frameBuffer;
 
@@ -731,7 +731,7 @@ PyPart::readDeepPixels(MultiPartInputFile& infile, const std::string& type, cons
                        const Box2i& dw, bool separate_channels)
 {
     if (!separate_channels)
-        validateCoalescedChannelTypes (channel_list, rgbaChannels);
+        validateCoalescedChannels (channel_list, rgbaChannels);
 
     size_t width  = dw.max.x - dw.min.x + 1;
     size_t height = dw.max.y - dw.min.y + 1;
@@ -1209,18 +1209,20 @@ pixelTypeName (PixelType type)
 } // namespace
 
 //
-// Only combine RGB(A) channels into a single numpy array when they all have
-// the same pixel type. For example, if red is HALF and green is FLOAT, an
-// attempt to return an RGB pixel array will throw an exception.
+// Only combine RGB(A) channels into a single numpy array when coalescing is
+// unambiguous: all channels in a group must share the same pixel type, and no
+// literal channel name may collide with a coalesced group key (for example,
+// literal "left" plus "left.R", "left.G", "left.B", each of which would
+// attempt to add a channel dictionary entry with key "left"). 
 //
-// Note that attempting to combine mixed-type channels causes a failure of
+// Note that attempting to coalesce invalid channel layouts causes a failure of
 // the entire file read, whereas other read errors simply skip the offending
 // part. This is reasonable behavior since the condition is not a defect in
 // the data itself, but simply an inability to return the data in the format
 // the user requested.
 
 void
-PyPart::validateCoalescedChannelTypes (
+PyPart::validateCoalescedChannels (
     const ChannelList&           channel_list,
     const std::set<std::string>& rgbaChannels) const
 {
@@ -1228,6 +1230,7 @@ PyPart::validateCoalescedChannelTypes (
         return;
 
     std::map<std::string, PixelType> groupType;
+    std::set<std::string>            coalescedKeys;
 
     for (auto c = channel_list.begin (); c != channel_list.end (); ++c)
     {
@@ -1245,6 +1248,8 @@ PyPart::validateCoalescedChannelTypes (
         if (channelNameToRGBA (channel_list, c.name (), py_channel_name, channel_name) <= 0)
             continue;
 
+        coalescedKeys.insert (py_channel_name);
+
         const PixelType channelType = c.channel ().type;
         auto            it          = groupType.find (py_channel_name);
         if (it == groupType.end ())
@@ -1256,6 +1261,22 @@ PyPart::validateCoalescedChannelTypes (
                 << "\": channel \"" << c.name () << "\" has pixel type "
                 << pixelTypeName (channelType) << " but other channels in the group "
                 << "have pixel type " << pixelTypeName (it->second)
+                << "; use separate_channels=True";
+            throw std::invalid_argument (err.str ());
+        }
+    }
+
+    for (auto c = channel_list.begin (); c != channel_list.end (); ++c)
+    {
+        if (rgbaChannels.find (c.name ()) != rgbaChannels.end ())
+            continue;
+
+        if (coalescedKeys.find (c.name ()) != coalescedKeys.end ())
+        {
+            std::stringstream err;
+            err << "cannot coalesce channels into \"" << c.name ()
+                << "\": channel \"" << c.name ()
+                << "\" collides with a coalesced RGB/RGBA group key"
                 << "; use separate_channels=True";
             throw std::invalid_argument (err.str ());
         }

--- a/src/wrappers/python/PyOpenEXR.h
+++ b/src/wrappers/python/PyOpenEXR.h
@@ -142,7 +142,7 @@ class PyPart
     int            channelNameToRGBA(const ChannelList& channel_list, const std::string& name,
                                      std::string& py_channel_name, char& channel_name) const;
 
-    void           validateCoalescedChannelTypes(
+    void           validateCoalescedChannels(
         const ChannelList&           channel_list,
         const std::set<std::string>& rgbaChannels) const;
 

--- a/src/wrappers/python/tests/test_deep.py
+++ b/src/wrappers/python/tests/test_deep.py
@@ -291,6 +291,50 @@ class TestDeep(unittest.TestCase):
             if os.path.exists(path):
                 os.remove(path)
 
+    def test_literal_rgb_key_collision_deep_rejected(self):
+        dataWindow = ((0, 0), (0, 0))
+        height = width = 1
+
+        left = np.empty((height, width), dtype=object)
+        left_R = np.empty((height, width), dtype=object)
+        left_G = np.empty((height, width), dtype=object)
+        left_B = np.empty((height, width), dtype=object)
+        left[0, 0] = np.array([10.0, 11.0, 12.0, 13.0], dtype='float16')
+        left_R[0, 0] = np.array([10.0, 11.0, 12.0, 13.0], dtype='float16')
+        left_G[0, 0] = np.array([20.0, 21.0, 22.0, 23.0], dtype='float16')
+        left_B[0, 0] = np.array([30.0, 31.0, 32.0, 33.0], dtype='float16')
+
+        channels = {
+            "left": left,
+            "left.R": left_R,
+            "left.G": left_G,
+            "left.B": left_B,
+        }
+        header = {
+            "compression": OpenEXR.ZIPS_COMPRESSION,
+            "type": OpenEXR.deepscanline,
+            "dataWindow": dataWindow,
+        }
+
+        fd, path = tempfile.mkstemp(suffix=".exr")
+        os.close(fd)
+        try:
+            with OpenEXR.File(header, channels) as outfile:
+                outfile.write(path)
+
+            with self.assertRaises(ValueError) as ctx:
+                OpenEXR.File(path)
+            self.assertIn("separate_channels", str(ctx.exception))
+
+            with OpenEXR.File(path, separate_channels=True) as infile:
+                self.assertIn("left", infile.channels())
+                self.assertIn("left.R", infile.channels())
+                self.assertIn("left.G", infile.channels())
+                self.assertIn("left.B", infile.channels())
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
 if __name__ == '__main__':
     unittest.main()
     print("OK")

--- a/src/wrappers/python/tests/test_rgba.py
+++ b/src/wrappers/python/tests/test_rgba.py
@@ -203,6 +203,39 @@ class TestRGBA(unittest.TestCase):
     def test_rgba_f(self):
         self.do_rgba('f')
 
+    def test_literal_rgb_key_collision_flat_rejected(self):
+        dataWindow = ((0, 0), (1, 1))
+
+        channels = {
+            "left": np.array([[10.0, 11.0], [12.0, 13.0]], dtype='float16'),
+            "left.R": np.array([[10.0, 11.0], [12.0, 13.0]], dtype='float16'),
+            "left.G": np.array([[20.0, 21.0], [22.0, 23.0]], dtype='float16'),
+            "left.B": np.array([[30.0, 31.0], [32.0, 33.0]], dtype='float16'),
+        }
+        header = {
+            "type": OpenEXR.scanlineimage,
+            "dataWindow": dataWindow,
+        }
+
+        fd, path = tempfile.mkstemp(suffix=".exr")
+        os.close(fd)
+        try:
+            with OpenEXR.File(header, channels) as outfile:
+                outfile.write(path)
+
+            with self.assertRaises(ValueError) as ctx:
+                OpenEXR.File(path)
+            self.assertIn("separate_channels", str(ctx.exception))
+
+            with OpenEXR.File(path, separate_channels=True) as infile:
+                self.assertIn("left", infile.channels())
+                self.assertIn("left.R", infile.channels())
+                self.assertIn("left.G", infile.channels())
+                self.assertIn("left.B", infile.channels())
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
 if __name__ == '__main__':
     unittest.main()
     print("OK")


### PR DESCRIPTION
When separate_channels=False, a literal channel such as "left" must not share a Python dict key with coalesced left.R/G/B channels.

It is now an error to attempt to read a file with channels named "left.R", "left.G", "left.B", and also a raw "left" with separate_channels=False.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-rw5h-3q4v-c3vc 
Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-mw28-66qc-c883