### PR TITLE
Reject invalid HTJ2K SIZ tile geometry before decode

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -224,6 +224,19 @@ ht_undo_impl (
     ojph::ui32 image_width =
         siz.get_image_extent ().x - siz.get_image_offset ().x;
 
+    ojph::size  tile_size   = siz.get_tile_size ();
+    ojph::point tile_offset = siz.get_tile_offset ();
+    if (!validate_htj2k_siz_geometry (
+            siz.get_image_extent ().x,
+            siz.get_image_extent ().y,
+            siz.get_image_offset ().x,
+            siz.get_image_offset ().y,
+            tile_size.w,
+            tile_size.h,
+            tile_offset.x,
+            tile_offset.y))
+        return EXR_ERR_CORRUPT_CHUNK;
+
     if (decode->chunk.width != image_width
         || decode->chunk.height != image_height
         || decode->channel_count != siz.get_num_components())

--- a/src/lib/OpenEXRCore/internal_ht_common.cpp
+++ b/src/lib/OpenEXRCore/internal_ht_common.cpp
@@ -313,3 +313,29 @@ read_header (
 
     return prefix_sz + payload_sz;
 }
+
+bool
+validate_htj2k_siz_geometry (
+    uint32_t xsiz,
+    uint32_t ysiz,
+    uint32_t xosiz,
+    uint32_t yosiz,
+    uint32_t xtsiz,
+    uint32_t ytsiz,
+    uint32_t xtosiz,
+    uint32_t ytosiz)
+{
+    if (xtsiz == 0 && ytsiz == 0)
+    {
+        xtsiz = xsiz + xosiz;
+        ytsiz = ysiz + yosiz;
+    }
+
+    if (xsiz == 0 || ysiz == 0 || xtsiz == 0 || ytsiz == 0) return false;
+
+    if (xtosiz > xosiz || ytosiz > yosiz) return false;
+
+    if (xtsiz + xtosiz <= xosiz || ytsiz + ytosiz <= yosiz) return false;
+
+    return true;
+}

--- a/src/lib/OpenEXRCore/internal_ht_common.h
+++ b/src/lib/OpenEXRCore/internal_ht_common.h
@@ -84,4 +84,18 @@ size_t read_header (
     size_t                              max_sz,
     std::vector<CodestreamChannelInfo>& map);
 
+/** Validate JPEG 2000 SIZ image/tile geometry before HTJ2K decode.
+ *
+ *  Matches the tile/image intersection rules enforced by OpenJPH on encode.
+ */
+bool validate_htj2k_siz_geometry (
+    uint32_t xsiz,
+    uint32_t ysiz,
+    uint32_t xosiz,
+    uint32_t yosiz,
+    uint32_t xtsiz,
+    uint32_t ytsiz,
+    uint32_t xtosiz,
+    uint32_t ytosiz);
+
 #endif /* OPENEXR_PRIVATE_HT_COMMON_H */


### PR DESCRIPTION
Validate JPEG 2000 SIZ image/tile offset relationships in ht_undo_impl before OpenJPH decode, matching the intersection rules enforced on encode. Return EXR_ERR_CORRUPT_CHUNK instead of stack OOB in the decoder.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-fw66-6xph-56jm