### PR TITLE
Fix missing packed/unpacked size guard in scanline chunk reader

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1120,6 +1120,17 @@ exr_read_scanline_chunk_info (
     if (cinfo->packed_size == 0 && cinfo->unpacked_size > 0)
         return ctxt->report_error (
             ctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid packed size of 0");
+
+    if (part->comp_type == EXR_COMPRESSION_NONE &&
+        cinfo->packed_size != cinfo->unpacked_size)
+    {
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_BAD_CHUNK_LEADER,
+            "Mismatch between unpacked and packed size with uncompressed data: packed is %" PRIu64 "; unpacked is %" PRIu64,
+            cinfo->packed_size, cinfo->unpacked_size);
+    }
+
     return EXR_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
PR #2162 added a check to reject uncompressed chunks where packed_size != unpacked_size in exr_read_tile_chunk_info, but the equivalent check was missing from exr_read_scanline_chunk_info. A crafted uncompressed deep-scanline EXR with a mismatched packed_size caused the decoder to allocate an unpacked_buffer via malloc that was never filled, leaking stale heap contents into caller-visible pixels.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-9c7r-mp54-x46f