### PR TITLE
Reject oversized Array2D allocations on ILP32

### DIFF
--- a/src/lib/OpenEXR/ImfArray.h
+++ b/src/lib/OpenEXR/ImfArray.h
@@ -8,8 +8,11 @@
 
 #include "ImfForward.h"
 #include "IexBaseExc.h"
+#include "IexMathExc.h"
 
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 
 //-------------------------------------------------------------------------
 //
@@ -160,6 +163,21 @@ private:
 // Implementation
 //---------------
 
+namespace {
+
+inline size_t
+array2DElementCount (long sizeX, long sizeY)
+{
+    const uint64_t x       = static_cast<uint64_t> (sizeX);
+    const uint64_t y       = static_cast<uint64_t> (sizeY);
+    const uint64_t maxSize = std::numeric_limits<size_t>::max ();
+    if (y > 0 && x > maxSize / y)
+        throw IEX_NAMESPACE::OverflowExc ("Array2D dimensions too large");
+    return static_cast<size_t> (x * y);
+}
+
+} // namespace
+
 template <class T>
 inline void
 Array<T>::resizeErase (long size)
@@ -202,7 +220,7 @@ inline Array2D<T>::Array2D (long sizeX, long sizeY)
 
     _sizeX = sizeX;
     _sizeY = sizeY;
-    _data  = new T[(size_t) sizeX * (size_t) sizeY];
+    _data  = new T[array2DElementCount (sizeX, sizeY)];
 }
 
 template <class T> inline Array2D<T>::~Array2D ()
@@ -231,7 +249,7 @@ Array2D<T>::resizeErase (long sizeX, long sizeY)
     if (sizeX < 0 || sizeY < 0)
         throw IEX_NAMESPACE::ArgExc ("Array2D dimensions must be non-negative");
 
-    T* tmp = new T[(size_t) sizeX * (size_t) sizeY];
+    T* tmp = new T[array2DElementCount (sizeX, sizeY)];
     delete[] _data;
     _sizeX = sizeX;
     _sizeY = sizeY;
@@ -249,7 +267,7 @@ Array2D<T>::resizeEraseUnsafe (long sizeX, long sizeY)
     _data  = 0;
     _sizeX = 0;
     _sizeY = 0;
-    _data  = new T[(size_t) sizeX * (size_t) sizeY];
+    _data  = new T[array2DElementCount (sizeX, sizeY)];
     _sizeX = sizeX;
     _sizeY = sizeY;
 }


### PR DESCRIPTION
Array2D computed sizeX * sizeY in 32-bit arithmetic before new[]. On ILP32, a 65537 x 65537 allocation wraps to a tiny buffer while decode still writes the full image.

Validate the element count in uint64_t and reject dimensions whose product exceeds size_t before constructing or resizing Array2D.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-h56j-j82x-w3fp

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-wrw5-mm52-r3h8