### PR TITLE
Fix subsampled row addressing in generic_unpack for multi-line chunks

### DIFF
--- a/src/lib/OpenEXRCore/unpack.c
+++ b/src/lib/OpenEXRCore/unpack.c
@@ -1267,8 +1267,10 @@ generic_unpack (exr_decode_pipeline_t* decode)
                     continue;
                 }
 
+                const int fb_y = uls + (int) decode->chunk.start_y;
                 cdata +=
-                    ((uint64_t) ((y - uls) / decc->y_samples) *
+                    ((uint64_t) (cury / decc->y_samples -
+                                  fb_y / decc->y_samples) *
                      (uint64_t) decc->user_line_stride);
             }
             else


### PR DESCRIPTION
generic_unpack() tests row membership with the absolute file row (cury = y + chunk.start_y) but computed the compact FrameBuffer destination using the chunk-local row (y - user_line_begin_skip). For multi-line compressed chunks such as ZIP's 16-line blocks, later chunks often begin at a file row that is not a multiple of ySampling. The first sampled row in such a chunk then has a non-zero chunk-local index, and (y - uls) / y_samples truncates to the wrong compact row. Decoded rows land in the wrong buffer rows and the last sampled row may remain stale.

Compute the destination offset relative to decode_to_ptr, which callers already position at the compact row for the current read origin (fb_y = user_line_begin_skip + chunk.start_y):

  (cury / y_samples - fb_y / y_samples) * user_line_stride

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-7828-c4f6-7v6p