### PR TITLE
Reject DWA RLE streams shorter than required channel data

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -867,6 +867,26 @@ DwaCompressor_uncompress (
     rv = DwaCompressor_setupChannelData (me);
     if (rv != EXR_ERR_SUCCESS) { return rv; }
 
+    uint64_t requiredRleSize = 0;
+    for (int c = 0; c < me->_numChannels; ++c)
+    {
+        if (me->_channelData[c].compression == RLE)
+            requiredRleSize += (uint64_t) me->_channelData[c].planarUncSize;
+    }
+
+    if (requiredRleSize > 0)
+    {
+        if (rleRawSize < requiredRleSize || rleCompressedSize == 0)
+        {
+            return EXR_ERR_CORRUPT_CHUNK;
+        }
+    }
+    else if (
+        rleRawSize > 0 || rleCompressedSize > 0 || rleUncompressedSize > 0)
+    {
+        return EXR_ERR_CORRUPT_CHUNK;
+    }
+
     //
     // Uncompress the UNKNOWN data into _planarUncBuffer[UNKNOWN]
     //


### PR DESCRIPTION
A malformed DWAA/DWAB chunk can declare RLE_RAW_SIZE smaller than the byte count needed by RLE-classified channels. The decoder only rejected sizes larger than the planar buffer, so the RLE expander filled fewer raw bytes than the channel reconstruction consumed and stale heap contents were copied into caller-visible pixel output.

After classifying channels, sum each RLE channel's planarUncSize and reject the chunk when RLE_RAW_SIZE is smaller than that total or when RLE data is required but no compressed RLE stream is present. Also reject non-zero RLE stream sizes when no channels require RLE data.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-wwx8-2v36-rhr8