### PR TITLE
Reject DWA RLE and UNKNOWN streams shorter than required channel data.

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -689,6 +689,33 @@ DwaCompressor_compress (DwaCompressor* me)
 /**************************************/
 
 exr_result_t
+validate_size(DwaCompressor* me, CompressorScheme compression,
+              uint64_t compressedSize, uint64_t uncompressedSize,
+              uint64_t extraSize)
+{
+    uint64_t requiredSize = 0;
+    for (int c = 0; c < me->_numChannels; ++c)
+    {
+        if (me->_channelData[c].compression == compression)
+            requiredSize += (uint64_t) me->_channelData[c].planarUncSize;
+    }
+
+    if (requiredSize > 0)
+    {
+        if (uncompressedSize < requiredSize || compressedSize == 0)
+        {
+            return EXR_ERR_CORRUPT_CHUNK;
+        }
+    }
+    else if (uncompressedSize > 0 || compressedSize > 0 || extraSize > 0)
+    {
+        return EXR_ERR_CORRUPT_CHUNK;
+    }
+
+    return EXR_ERR_SUCCESS;
+}
+
+exr_result_t
 DwaCompressor_uncompress (
     DwaCompressor* me,
     const uint8_t* inPtr,
@@ -867,6 +894,12 @@ DwaCompressor_uncompress (
     rv = DwaCompressor_setupChannelData (me);
     if (rv != EXR_ERR_SUCCESS) { return rv; }
 
+    rv = validate_size(me, UNKNOWN, unknownCompressedSize, unknownUncompressedSize, 0);
+    if (rv != EXR_ERR_SUCCESS) { return rv; }
+    
+    rv = validate_size(me, RLE, rleCompressedSize, rleRawSize, rleUncompressedSize);
+    if (rv != EXR_ERR_SUCCESS) { return rv; }
+    
     //
     // Uncompress the UNKNOWN data into _planarUncBuffer[UNKNOWN]
     //

--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -688,7 +688,7 @@ DwaCompressor_compress (DwaCompressor* me)
 
 /**************************************/
 
-exr_result_t
+static exr_result_t
 validate_size(DwaCompressor* me, CompressorScheme compression,
               uint64_t compressedSize, uint64_t uncompressedSize,
               uint64_t extraSize)
@@ -697,7 +697,17 @@ validate_size(DwaCompressor* me, CompressorScheme compression,
     for (int c = 0; c < me->_numChannels; ++c)
     {
         if (me->_channelData[c].compression == compression)
-            requiredSize += (uint64_t) me->_channelData[c].planarUncSize;
+        {
+            uint64_t chanSize = (uint64_t) me->_channelData[c].planarUncSize;
+
+            /* guard against wraparound when accumulating attacker-influenced
+             * per-channel sizes; a wrap would understate requiredSize and
+             * defeat the validation below */
+            if (chanSize > UINT64_MAX - requiredSize)
+                return EXR_ERR_CORRUPT_CHUNK;
+
+            requiredSize += chanSize;
+        }
     }
 
     if (requiredSize > 0)


### PR DESCRIPTION
After DwaCompressor_setupChannelData(), sum planarUncSize for each compression type and reject chunks whose declared stream sizes are too small or present when no channels use that type.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-cx6p-vjc6-3php

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-wwx8-2v36-rhr8