### PR TITLE
Reject short zlib inflates before pixel unpack.

### DIFF
--- a/src/lib/OpenEXRCore/internal_dwa_compressor.h
+++ b/src/lib/OpenEXRCore/internal_dwa_compressor.h
@@ -873,18 +873,21 @@ DwaCompressor_uncompress (
 
     if (unknownCompressedSize > 0)
     {
+        size_t actualUnknown;
+
         if (unknownUncompressedSize > me->_planarUncBufferSize[UNKNOWN])
         {
             return EXR_ERR_CORRUPT_CHUNK;
         }
 
-        if (EXR_ERR_SUCCESS != exr_uncompress_buffer (
-                                   me->_decode->context,
-                                   compressedUnknownBuf,
-                                   unknownCompressedSize,
-                                   me->_planarUncBuffer[UNKNOWN],
-                                   unknownUncompressedSize,
-                                   NULL))
+        rv = exr_uncompress_buffer (
+            me->_decode->context,
+            compressedUnknownBuf,
+            unknownCompressedSize,
+            me->_planarUncBuffer[UNKNOWN],
+            unknownUncompressedSize,
+            &actualUnknown);
+        if (rv != EXR_ERR_SUCCESS || actualUnknown != unknownUncompressedSize)
         {
             return EXR_ERR_CORRUPT_CHUNK;
         }

--- a/src/lib/OpenEXRCore/internal_zip.c
+++ b/src/lib/OpenEXRCore/internal_zip.c
@@ -313,7 +313,7 @@ undo_zip_impl (
     if (res == EXR_ERR_SUCCESS)
     {
         decode->bytes_decompressed = actual_out_bytes;
-        if (comp_buf_size > actual_out_bytes || actual_out_bytes > uncompressed_size)
+        if (actual_out_bytes != uncompressed_size)
             res = EXR_ERR_CORRUPT_CHUNK;
         else
             internal_zip_reconstruct_bytes (


### PR DESCRIPTION
DWA UNKNOWN: pass actual_out to exr_uncompress_buffer() and require the inflated byte count to match UNKNOWN_UNCOMPRESSED_SIZE before copying planar data to output rows.

ZIP/ZIPS: require actual_out_bytes to equal the expected uncompressed chunk size before reconstructing and unpacking pixels.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-38j8-88v6-jrm7

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-r864-gwqv-q2hp