### PR TITLE
Reject NO_COMPRESSION scanline chunks with short packed size.

### DIFF
--- a/src/lib/OpenEXRCore/chunk.c
+++ b/src/lib/OpenEXRCore/chunk.c
@@ -1120,6 +1120,17 @@ exr_read_scanline_chunk_info (
     if (cinfo->packed_size == 0 && cinfo->unpacked_size > 0)
         return ctxt->report_error (
             ctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid packed size of 0");
+
+    if (part->comp_type == EXR_COMPRESSION_NONE &&
+        cinfo->packed_size != cinfo->unpacked_size)
+    {
+        return ctxt->print_error (
+            ctxt,
+            EXR_ERR_BAD_CHUNK_LEADER,
+            "Mismatch between unpacked and packed size with uncompressed data: packed is %" PRIu64 "; unpacked is %" PRIu64,
+            cinfo->packed_size, cinfo->unpacked_size);
+    }
+
     return EXR_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
Mirror the existing tile-path check in exr_read_scanline_chunk_info(): for EXR_COMPRESSION_NONE, require packed_size to equal unpacked_size before decode allocates an unpack buffer that no decompressor fills.

Covers flat and deep scanline chunk leaders.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-7hgm-jxjc-6hgg

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-fwhm-jj7c-mx7v