### PR TITLE
fix signed/unsigned wraparound in HTJ2K planar decode row loop

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -270,9 +270,16 @@ ht_undo_impl (
 
             uint8_t* line_pixels = static_cast<uint8_t*> (uncompressed_data);
 
-            for (int64_t y = decode->chunk.start_y;
-                 y < image_height + decode->chunk.start_y;
-                 y++)
+            /* image_height is an unsigned OpenJPH type; compute the loop
+             * bounds in a signed 64-bit type so that a negative start_y
+             * (from a negative data-window Y origin) does not get
+             * promoted to unsigned and wrap the end condition to a huge
+             * positive value, which would cause the loop to run far past
+             * the declared image data (CWE-190 / CWE-835). */
+            const int64_t start_y = static_cast<int64_t> (decode->chunk.start_y);
+            const int64_t end_y   = start_y + static_cast<int64_t> (image_height);
+
+            for (int64_t y = start_y; y < end_y; y++)
             {
                 for (int16_t line_c = 0; line_c < decode->channel_count;
                      line_c++)


### PR DESCRIPTION
The planar HTJ2K decode path in ht_undo_impl() (internal_ht.cpp) computed the loop endpoint for the final decoded row as:

    for (int64_t y = decode->chunk.start_y;
         y < image_height + decode->chunk.start_y;
         y++)

image_height is an unsigned OpenJPH type (ojph::ui32), while decode->chunk.start_y is a signed int32_t that can be negative when the data window's Y origin is negative. The usual arithmetic conversions convert the negative start_y to unsigned before the addition, so "image_height + start_y" wraps to a very large positive value instead of the intended (small or negative) endpoint.

With vertical channel subsampling selecting the planar decode path, this causes the loop to keep calling cs.pull() far past the declared reconstruction height. In a release build the decoder spins consuming CPU until externally terminated; in a debug build an OpenJPH assertion is hit. A 448-byte crafted EXR file with a negative data-window Y origin and vertical subsampling is sufficient to trigger the hang, making this a cheap denial-of-service against any application that decodes untrusted EXR files with HTJ2K compression.

Fix: compute the loop start/end explicitly in a signed 64-bit type before comparing, so a negative start_y is handled correctly instead of being promoted to unsigned.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-hphq-wq62-4mj3

Generated-by: GitHub Copilot CLI (model: Claude Sonnet 5)