### PR TITLE
Fix handling of subsampled channels in PyOpenEXR

### DIFF
--- a/src/wrappers/python/PyOpenEXR.cpp
+++ b/src/wrappers/python/PyOpenEXR.cpp
@@ -507,11 +507,21 @@ PyPart::readPixels(MultiPartInputFile& infile, const ChannelList& channel_list,
             std::vector<size_t> c_shape = shape;
 
             //
+            // For subsampled channels, shrink the allocated array to
+            // the actual sampled dimensions so no stale rows/columns
+            // are returned to Python.
+            //
+            if (C.xSampling > 1)
+                c_shape[1] = (shape[1] - 1) / C.xSampling + 1;
+            if (C.ySampling > 1)
+                c_shape[0] = (shape[0] - 1) / C.ySampling + 1;
+
+            //
             // If this channel belongs to one of the rgba's, give
             // the PyChannel the extra dimension and the proper shape.
             // nrgba is 3 for RGB and 4 for RGBA.
             //
-            
+
             if (rgbaChannels.find(c.name()) != rgbaChannels.end())
                 c_shape.push_back(nrgba);
 
@@ -570,7 +580,10 @@ PyPart::readPixels(MultiPartInputFile& infile, const ChannelList& channel_list,
             }
         }
 
-        size_t yStride = xStride * shape[1] / C.xSampling;
+        size_t sampledWidth = (C.xSampling > 1)
+            ? (shape[1] - 1) / C.xSampling + 1
+            : shape[1];
+        size_t yStride = xStride * sampledWidth;
 
         frameBuffer.insert (c.name(),
                             Slice::Make (c.channel().type,


### PR DESCRIPTION
readPixels() allocated the pixel array with the full data-window shape (height, width) for all channels, but for subsampled channels the EXR reader only wrote width/xSampling values per row and height/ySampling rows total. The unwritten rows/columns retained stale heap contents that were returned to Python as valid pixel data.

Fix: shrink c_shape to the actual sampled dimensions before allocating, using ceiling division consistent with EXR's sampling convention. The framebuffer yStride calculation already used shape[1]/C.xSampling, so no stride change is needed.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-c32g-9w8w-3px6