### PR TITLE
Fix MSYS2 MINGW32 CI: build Imath/OpenJPH from source instead of pacboy

### DIFF
--- a/.github/workflows/ci_steps.yml
+++ b/.github/workflows/ci_steps.yml
@@ -147,13 +147,14 @@ jobs:
         if: inputs.msystem != ''
         run: |
           PACKAGES="cc:p cmake:p"
-          if [ "${{ inputs.OPENEXR_FORCE_INTERNAL_IMATH }}" == "OFF" ]; then
+          # mingw32 has no package for imath and openjph
+          if [[ "${{ inputs.OPENEXR_FORCE_INTERNAL_IMATH }}" == "OFF" && "${{ inputs.msystem }}" != "MINGW32" ]]; then
             PACKAGES="$PACKAGES imath:p"
           fi
           if [ "${{ inputs.OPENEXR_FORCE_INTERNAL_DEFLATE }}" == "OFF" ]; then
             PACKAGES="$PACKAGES libdeflate:p"
           fi
-          if [ "${{ inputs.OPENEXR_FORCE_INTERNAL_OPENJPH }}" == "OFF" && "${{ inputs.msystem }}" != "MINGW32" ]; then
+          if [[ "${{ inputs.OPENEXR_FORCE_INTERNAL_OPENJPH }}" == "OFF" && "${{ inputs.msystem }}" != "MINGW32" ]]; then
             PACKAGES="$PACKAGES openjph:p"
           fi
           echo "PACBOY_PACKAGES=$PACKAGES" >> $GITHUB_ENV
@@ -200,6 +201,14 @@ jobs:
           echo "OPENEXR_PATH=$OPENEXR_PATH:$PROGRAM_FILES/Imath/bin:$PROGRAM_FILES/Imath/lib" >> $GITHUB_ENV
         shell: bash
 
+      - name: Install Imath (msys2)
+        # mingw32 has no package for imath, so install manually
+        if: inputs.OPENEXR_FORCE_INTERNAL_IMATH == 'OFF' && inputs.msystem == 'MINGW32'
+        run: |
+          set -x
+          share/ci/scripts/install_imath.sh main
+        shell: msys2 {0}
+
       - name: Install libdeflate
         # Pre-install libdeflate so the builds validate that find_package sees the external installation
         if: inputs.OPENEXR_FORCE_INTERNAL_DEFLATE == 'OFF' && inputs.msystem == ''
@@ -217,6 +226,14 @@ jobs:
           share/ci/scripts/install_openjph.sh 0.22.0
           echo "OPENEXR_PATH=$OPENEXR_PATH:$PROGRAM_FILES/openjph/bin:$PROGRAM_FILES/openjph/lib" >> $GITHUB_ENV
         shell: bash
+
+      - name: Install OpenJPH (msys2)
+        # mingw32 has no package for openjph, so install manually
+        if: inputs.OPENEXR_FORCE_INTERNAL_OPENJPH == 'OFF' && inputs.msystem == 'MINGW32'
+        run: |
+          set -x
+          share/ci/scripts/install_openjph.sh 0.22.0
+        shell: msys2 {0}
 
       - name: Install help2man
         # TODO: this could go in the ASWF Linux docker

--- a/share/ci/scripts/install_imath.sh
+++ b/share/ci/scripts/install_imath.sh
@@ -15,12 +15,20 @@ TAG="$1"
 # The sudo is nececessary since the installation goes to /usr/local.
 SUDO=$(command -v sudo >/dev/null 2>&1 && echo sudo || echo "")
 
+# In an MSYS2 mingw shell, install into $MINGW_PREFIX (e.g. /mingw32)
+# instead of the default /usr/local, so find_package() locates it the
+# same way it would find a pacboy-installed package.
+PREFIX_ARG=()
+if [ -n "$MINGW_PREFIX" ]; then
+  PREFIX_ARG=("-DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX")
+fi
+
 git clone https://github.com/AcademySoftwareFoundation/Imath.git
 cd Imath
 
 git checkout ${TAG}
 
-cmake -S . -B _build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+cmake -S . -B _build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF "${PREFIX_ARG[@]}"
 $SUDO cmake --build _build \
       --target install \
       --config Release \

--- a/share/ci/scripts/install_openjph.sh
+++ b/share/ci/scripts/install_openjph.sh
@@ -15,13 +15,21 @@ TAG="$1"
 # The sudo is nececessary since the installation goes to /usr/local.
 SUDO=$(command -v sudo >/dev/null 2>&1 && echo sudo || echo "")
 
+# In an MSYS2 mingw shell, install into $MINGW_PREFIX (e.g. /mingw32)
+# instead of the default /usr/local, so find_package()/pkg_check_modules()
+# locates it the same way it would find a pacboy-installed package.
+PREFIX_ARG=()
+if [ -n "$MINGW_PREFIX" ]; then
+  PREFIX_ARG=("-DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX")
+fi
+
 git clone https://github.com/aous72/OpenJPH.git
 cd OpenJPH
 
 git checkout ${TAG}
 
 cd build
-cmake -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DCMAKE_BUILD_TYPE=Release .. 
+cmake -DOJPH_ENABLE_TIFF_SUPPORT=OFF -DCMAKE_BUILD_TYPE=Release "${PREFIX_ARG[@]}" ..
 $SUDO cmake --build . \
       --target install \
       --config Release \


### PR DESCRIPTION
MSYS2 dropped mingw32 (i686) builds of the imath and openjph packages (msys2/MINGW-packages#30777, merged 2026-08-02), so the "Determine MSYS2 Packages" step's pacboy -S imath:p ... openjph:p install fails on MINGW32 with "error: target not found: mingw-w64-i686-imath".

This adds new "Install Imath (msys2)" and "Install OpenJPH (msys2)" steps build and install each dependency from source, using the msys2 MINGW32 shell/toolchain, whenever OPENEXR_FORCE_INTERNAL_* is OFF and msystem is MINGW32.

install_imath.sh and install_openjph.sh now install into MINGW_PREFIX (e.g. /mingw32) when that environment variable is set, so the installed package lands in the same sysroot location a pacboy-installed package would use, and is discovered the same way by find_package() / pkg_check_modules(). When MINGW_PREFIX is unset (all other existing callers: Linux, macOS, native Windows), behavior is unchanged.

Also fixed a pre-existing bash syntax bug in the openjph MINGW32 exclusion conditional (single-bracket [ ... && ... ] is invalid for the test builtin; now uses [[ ... ]]), and applied the same conditional to the new imath exclusion.

Generated-by: GitHub Copilot CLI (model: Claude Sonnet 5)