### PR TITLE
Use Qfactor instead of Qstep to specify HTJ2KL256 compression quality

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -201,6 +201,7 @@ cc_library(
         "src/lib/OpenEXRCore/internal_ht.cpp",
         "src/lib/OpenEXRCore/internal_ht_common.cpp",
         "src/lib/OpenEXRCore/internal_ht_common.h",
+        "src/lib/OpenEXRCore/internal_ht_quality.h",
         "src/lib/OpenEXRCore/internal_huf.c",
         "src/lib/OpenEXRCore/internal_huf.h",
         "src/lib/OpenEXRCore/internal_memory.h",

--- a/src/lib/OpenEXR/ImfCompression.h
+++ b/src/lib/OpenEXR/ImfCompression.h
@@ -94,6 +94,9 @@ IMF_EXPORT void setDefaultZipCompressionLevel (int level);
 /// Controls the default quality level for the DWA lossy compression
 IMF_EXPORT void setDefaultDwaCompressionLevel (float level);
 
+/// Controls the default quality level for the lossy HTJ2K compression
+IMF_EXPORT void setDefaultLossyHTJ2KQuality (float quality);
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
 
 #endif

--- a/src/lib/OpenEXR/ImfHeader.cpp
+++ b/src/lib/OpenEXR/ImfHeader.cpp
@@ -264,6 +264,12 @@ setDefaultDwaCompressionLevel (float level)
     exr_set_default_dwa_compression_quality (level);
 }
 
+void
+setDefaultLossyHTJ2KQuality (float quality)
+{
+    exr_set_default_lossy_htj2k_quality (quality);
+}
+
 Header::Header (
     int         width,
     int         height,

--- a/src/lib/OpenEXRCore/base.c
+++ b/src/lib/OpenEXRCore/base.c
@@ -213,13 +213,13 @@ exr_get_default_dwa_compression_quality (float* q)
 
 /**************************************/
 
-static float sDefaultJ2kQuality = 80.f;
+static float sDefaultJ2kQuality = 130.f;
 
 void
 exr_set_default_lossy_htj2k_quality (float q)
 {
     if (q < 1.f) q = 1.f;
-    if (q > 100.f) q = 100.f;
+    if (q > 150.f) q = 150.f;
     sDefaultJ2kQuality = q;
 }
 

--- a/src/lib/OpenEXRCore/base.c
+++ b/src/lib/OpenEXRCore/base.c
@@ -7,6 +7,8 @@
 #include "openexr_errors.h"
 #include "openexr_version.h"
 
+#include "internal_ht_quality.h"
+
 /**************************************/
 
 void
@@ -213,14 +215,12 @@ exr_get_default_dwa_compression_quality (float* q)
 
 /**************************************/
 
-static float sDefaultJ2kQuality = 130.f;
+static float sDefaultJ2kQuality = 110.f;
 
 void
 exr_set_default_lossy_htj2k_quality (float q)
 {
-    if (q < 1.f) q = 1.f;
-    if (q > 150.f) q = 150.f;
-    sDefaultJ2kQuality = q;
+    sDefaultJ2kQuality = clamp_lossy_htj2k_quality (q);
 }
 
 /**************************************/

--- a/src/lib/OpenEXRCore/base.c
+++ b/src/lib/OpenEXRCore/base.c
@@ -213,11 +213,13 @@ exr_get_default_dwa_compression_quality (float* q)
 
 /**************************************/
 
-static float sDefaultJ2kQuality = 0.0003f;
+static float sDefaultJ2kQuality = 80.f;
 
 void
 exr_set_default_lossy_htj2k_quality (float q)
 {
+    if (q < 1.f) q = 1.f;
+    if (q > 100.f) q = 100.f;
     sDefaultJ2kQuality = q;
 }
 

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -19,6 +19,7 @@
 #include "openexr_encode.h"
 #include "openexr_part.h"
 #include "internal_ht_common.h"
+#include "internal_ht_quality.h"
 
 /**
  * OpenJPH output file that is backed by a fixed-size memory buffer
@@ -468,9 +469,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
         float qfactor = -1.f;
         exr_get_lossy_htj2k_quality (
             encode->context, encode->part_index, &qfactor);
-        if (qfactor < 1.f || qfactor > 150.f) {
-            return EXR_ERR_INVALID_ARGUMENT;
-        }
+        if (!is_lossy_htj2k_quality (qfactor)) { return EXR_ERR_INVALID_ARGUMENT; }
 
         ojph::param_qcd qcd = cs.access_qcd ();
 

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -479,15 +479,10 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
         }
         else
         {
-            // qcd.set_irrev_quant (pow(2, (-13.5 * qfactor / 100) - 3.0));
             double k = pow(2, -16.5);
-            // double n = log(0.002/k)/log(51.);
-            //double qstep = 0.002 * pow((150. - qfactor)/51., n) + k;
             double scaled_q = (qfactor - 99.)/51.;
-            double kd = 0.002 - 51. * k;
-            double kc = 0.1/kd - 1;
-            double kb = 0.0002/kd - 0.102;
-            double alpha_m = (1 - scaled_q)*(0.002 + kb * scaled_q)/(1 + kc * scaled_q);
+            double kd = 1/(25500. * k) - 51.;
+            double alpha_m = 0.002*(1 - scaled_q)/(1 + 50. * scaled_q + kd * pow(scaled_q, 2));
             double qstep = alpha_m + k;
             qcd.set_irrev_quant (qstep);
         }

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -465,15 +465,32 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
     {
         cod.set_reversible (false);
 
-        float lossy_htj2k_quality = -1.f;
+        float qfactor = -1.f;
         exr_get_lossy_htj2k_quality (
-            encode->context, encode->part_index, &lossy_htj2k_quality);
-        if (lossy_htj2k_quality < 1.f || lossy_htj2k_quality > 100.f) {
+            encode->context, encode->part_index, &qfactor);
+        if (qfactor < 1.f || qfactor > 150.f) {
             return EXR_ERR_INVALID_ARGUMENT;
         }
 
         ojph::param_qcd qcd = cs.access_qcd ();
-        qcd.set_qfactor ((ojph::ui8) std::lround (lossy_htj2k_quality));
+        if (qfactor <= 99)
+        {
+            qcd.set_qfactor ((ojph::ui8) std::lround (qfactor));
+        }
+        else
+        {
+            // qcd.set_irrev_quant (pow(2, (-13.5 * qfactor / 100) - 3.0));
+            double k = pow(2, -16.5);
+            // double n = log(0.002/k)/log(51.);
+            //double qstep = 0.002 * pow((150. - qfactor)/51., n) + k;
+            double scaled_q = (qfactor - 99.)/51.;
+            double kd = 0.002 - 51. * k;
+            double kc = 0.1/kd - 1;
+            double kb = 0.0002/kd - 0.102;
+            double alpha_m = (1 - scaled_q)*(0.002 + kb * scaled_q)/(1 + kc * scaled_q);
+            double qstep = alpha_m + k;
+            qcd.set_irrev_quant (qstep);
+        }
 
         /* set all channels but the first 3 channels to reversible */
         for (int16_t c = 3; c < encode->channel_count; c++)

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -473,23 +473,43 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
         }
 
         ojph::param_qcd qcd = cs.access_qcd ();
-        if (qfactor <= 99)
+
+        /*
+         * Qfactor is intended for quality levels consistent with 8-bit imagery.
+         * It is therefore extended here from 97 to 150 to take into account the
+         * fact that OpenEXR accommodates 32-bit imagery.
+         */
+        if (qfactor < 97.)
         {
             qcd.set_qfactor ((ojph::ui8) std::lround (qfactor));
         }
         else
         {
-            double k = pow(2, -16.5);
-            double scaled_q = (qfactor - 99.)/51.;
-            double kd = 1/(25500. * k) - 51.;
-            double alpha_m = 0.002*(1 - scaled_q)/(1 + 50. * scaled_q + kd * pow(scaled_q, 2));
-            double qstep = alpha_m + k;
-            qcd.set_irrev_quant (qstep);
+            double scaled_q = (qfactor - 97.)/53.;
+            double delta_ref = 0.005 * pow(2, -28.478*scaled_q) + 0.001 * pow(2, -10.534*scaled_q);
+
+            /*
+             * Setting Qstep taking into account the gain from the ICT
+             * converting encoded color-difference components to RGB (see
+             * "Controlling JPEG 2000 image quality using a single parameter
+             * (Qfactor) v2.0").
+             */
+
+            /* Y */
+            qcd.set_irrev_quant (delta_ref);
+            /* Cb */
+            qcd.set_irrev_quant (1, delta_ref / sqrt(3.2584/3.));
+            /* Cr */
+            qcd.set_irrev_quant (1, delta_ref / sqrt(2.4756/3.));
+
         }
 
         /* set all channels but the first 3 channels to reversible */
         for (int16_t c = 3; c < encode->channel_count; c++)
+        {
             cod.set_reversible (c, true);
+        }
+
     } else {
         cod.set_reversible (true);
     }

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -3,6 +3,7 @@
 ** Copyright Contributors to the OpenEXR Project.
 */
 
+#include <cmath>
 #include <limits>
 #include <string>
 #include <fstream>
@@ -439,33 +440,46 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
 
     exr_compression_t comp = EXR_COMPRESSION_HTJ2K256;
     exr_get_compression (encode->context, encode->part_index, &comp);
-    bool lossy = (comp == EXR_COMPRESSION_HTJ2KL256);
 
     ojph::param_cod cod = cs.access_cod ();
 
     cod.set_color_transform (isRGB && !isPlanar);
-    cod.set_reversible (!lossy);
     cod.set_block_dims (128, 32);
     cod.set_num_decomposition (5);
 
+    /* enable lossy compression on the first 3 channels, only if the compressor
+    is EXR_COMPRESSION_HTJ2KL256, we have RGB channels, all RGB channels are
+    visual, and none of the RGB channels are subsampled */
+    bool lossy = comp == EXR_COMPRESSION_HTJ2KL256 && isRGB;
+    if (lossy) {
+        for (int16_t c = 0; c < 3; c++)
+        {
+            int file_c = cs_channel_info[c].file_index;
+            lossy      = cs_channel_info[c].kind == J2KChannelKind::visual &&
+                        encode->channels[file_c].x_samples == 1 &&
+                        encode->channels[file_c].y_samples == 1;
+        }
+    }
+
     if (lossy)
     {
+        cod.set_reversible (false);
+
         float lossy_htj2k_quality = -1.f;
         exr_get_lossy_htj2k_quality (
             encode->context, encode->part_index, &lossy_htj2k_quality);
-        if (lossy_htj2k_quality <= 0.f) {
+        if (lossy_htj2k_quality < 1.f || lossy_htj2k_quality > 100.f) {
             return EXR_ERR_INVALID_ARGUMENT;
         }
 
         ojph::param_qcd qcd = cs.access_qcd ();
-        qcd.set_irrev_quant (lossy_htj2k_quality);
+        qcd.set_qfactor ((ojph::ui8) std::lround (lossy_htj2k_quality));
 
-        /* exclude data channels */
-        for (int16_t c = 0; c < encode->channel_count; c++)
-        {
-            if (cs_channel_info[c].kind != visual)
-                cod.set_reversible(c, true);
-        }
+        /* set all channels but the first 3 channels to reversible */
+        for (int16_t c = 3; c < encode->channel_count; c++)
+            cod.set_reversible (c, true);
+    } else {
+        cod.set_reversible (true);
     }
 
     try

--- a/src/lib/OpenEXRCore/internal_ht_common.h
+++ b/src/lib/OpenEXRCore/internal_ht_common.h
@@ -10,6 +10,41 @@
 #include <stdlib.h>
 #include "openexr_coding.h"
 
+/**
+ *
+ * Routines are common to the three HTJ2K compression methods:
+ *  - EXR_COMPRESSION_HTJ2K256: lossless coding in blocks of 256 scanlines,
+ *    using the High-Throughput block coder specified in Rec. ITU-T T.814 and
+ *    ISO/IEC 15444-15.
+ *  - EXR_COMPRESSION_HTJ2K32: same lossless coding as HTJ2K256, but in blocks
+ *    of 32 scanlines, trading some coding efficiency for cheaper partial-buffer
+ *    access.
+ *  - EXR_COMPRESSION_HTJ2KL256: same block coder and block size as HTJ2K256,
+ *    but with lossy coding, producing smaller files at the cost of distortion
+ *    controlled via a quality level parameter.
+ *
+ * EXR_COMPRESSION_HTJ2KL256
+ * -------------------------
+ *
+ * The lossy HTJ2KL256 quality level ranges from 1 to 150 and controls the level
+ * of distortion in the compressed image. Values below 97 are passed through
+ * directly as the Qfactor scheme described in "Controlling JPEG 2000 image
+ * quality using a single parameter (Qfactor) v2.0". Qfactor is defined over [0,
+ * 100] and is tuned for lower-quality imagery. Values from 97 to 150 are an
+ * OpenEXR-specific extension of that range, added to reach the higher quality
+ * levels needed for OpenEXR's 32-bit float imagery. In that extended range, the
+ * quality value is mapped to an explicit quantization step value via an
+ * exponential model. See internal_ht.cpp for the actual Qfactor-to-Qstep
+ * computation. Values around 108 are generally visually lossless over the
+ * entire range of half-float values.
+ *
+ * In contrast with DWAA/DWAB, HTJ2KL256 does not apply a transfer function, and
+ * treats equally all pixel values across the half-float or float dynamic range.
+ *
+ * HTJ2KL256 apply lossy compression to RGB channels only, and use lossless
+ * compression otherwise.
+ */
+
 /** Indicates the kind of samples carried by a channel */
 enum J2KChannelKind {
     visual,

--- a/src/lib/OpenEXRCore/internal_ht_quality.h
+++ b/src/lib/OpenEXRCore/internal_ht_quality.h
@@ -1,0 +1,32 @@
+/*
+** SPDX-License-Identifier: BSD-3-Clause
+** Copyright Contributors to the OpenEXR Project.
+*/
+
+#ifndef OPENEXR_PRIVATE_HT_QUALITY_H
+#define OPENEXR_PRIVATE_HT_QUALITY_H
+
+#include <math.h>
+
+/** Lower bound of the valid range for the HTJ2KL256 lossy quality level. */
+#define MIN_LOSSY_HTJ2K_QUALITY 1.f
+
+/** Upper bound of the valid range for the HTJ2KL256 lossy quality level. */
+#define MAX_LOSSY_HTJ2K_QUALITY 150.f
+
+static inline int
+is_lossy_htj2k_quality (float q)
+{
+    return isfinite (q) && q >= MIN_LOSSY_HTJ2K_QUALITY &&
+           q <= MAX_LOSSY_HTJ2K_QUALITY;
+}
+
+static inline float
+clamp_lossy_htj2k_quality (float q)
+{
+    if (q < MIN_LOSSY_HTJ2K_QUALITY) return MIN_LOSSY_HTJ2K_QUALITY;
+    if (q > MAX_LOSSY_HTJ2K_QUALITY) return MAX_LOSSY_HTJ2K_QUALITY;
+    return q;
+}
+
+#endif /* OPENEXR_PRIVATE_HT_QUALITY_H */

--- a/src/lib/OpenEXRCore/openexr_base.h
+++ b/src/lib/OpenEXRCore/openexr_base.h
@@ -138,10 +138,12 @@ EXR_EXPORT void exr_get_default_dwa_compression_quality (float* q);
 
 /** @brief Assigns a default lossy HTJ2K compression quality.
  *
- * The value is a JPEG-style Qfactor between 1 (worst quality, highest
- * compression) and 100 (best quality, least compression). See "Guideline on
- * controlling JPEG 2000 image quality using a single parameter" at jpeg.org
- * for a description of Qfactor.
+ * For values between 1 and 99, the value corresponds directly to Qfactor as
+ * specified in "Guideline on controlling JPEG 2000 image quality using a
+ * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
+ * is close to best quality/least compression). Values between 100 and 150
+ * map onto the Qfactor range between 99 and 100, giving finer-grained
+ * control over that highest-quality end of the scale.
  *
  * This value may be controlled separately on each part, but this global control
  * determines the initial value.

--- a/src/lib/OpenEXRCore/openexr_base.h
+++ b/src/lib/OpenEXRCore/openexr_base.h
@@ -138,13 +138,6 @@ EXR_EXPORT void exr_get_default_dwa_compression_quality (float* q);
 
 /** @brief Assigns a default lossy HTJ2K compression quality.
  *
- * For values between 1 and 99, the value corresponds directly to Qfactor as
- * specified in "Guideline on controlling JPEG 2000 image quality using a
- * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
- * is close to best quality/least compression). Values between 100 and 150
- * map onto the Qfactor range between 99 and 100, giving finer-grained
- * control over that highest-quality end of the scale.
- *
  * This value may be controlled separately on each part, but this global control
  * determines the initial value.
  */

--- a/src/lib/OpenEXRCore/openexr_base.h
+++ b/src/lib/OpenEXRCore/openexr_base.h
@@ -138,7 +138,10 @@ EXR_EXPORT void exr_get_default_dwa_compression_quality (float* q);
 
 /** @brief Assigns a default lossy HTJ2K compression quality.
  *
- * The value is used as the irreversible quantization delta (q-step) value
+ * The value is a JPEG-style Qfactor between 1 (worst quality, highest
+ * compression) and 100 (best quality, least compression). See "Guideline on
+ * controlling JPEG 2000 image quality using a single parameter" at jpeg.org
+ * for a description of Qfactor.
  *
  * This value may be controlled separately on each part, but this global control
  * determines the initial value.

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -325,9 +325,11 @@ typedef struct _exr_context_initializer_v4
 
     /** Initialize the default HTJ2K compression quality.
      *
-     * The value is passed directly to the irreversible quantization step via
-     * ojph::param_qcd::set_irrev_quant() when the compression
-     * type is HTJ2KL256.
+     * The value is a JPEG-style Qfactor between 1 (worst quality, highest
+     * compression) and 100 (best quality, least compression), passed directly
+     * to ojph::param_qcd::set_qfactor() when the compression type is HTJ2KL256.
+     * See "Guideline on controlling JPEG 2000 image quality using a single
+     * parameter" at jpeg.org for a description of Qfactor.
      *
      * See exr_set_default_lossy_htj2k_quality() to set the default for all
      * contexts.

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -325,11 +325,14 @@ typedef struct _exr_context_initializer_v4
 
     /** Initialize the default HTJ2K compression quality.
      *
-     * The value is a JPEG-style Qfactor between 1 (worst quality, highest
-     * compression) and 100 (best quality, least compression), passed directly
-     * to ojph::param_qcd::set_qfactor() when the compression type is HTJ2KL256.
-     * See "Guideline on controlling JPEG 2000 image quality using a single
-     * parameter" at jpeg.org for a description of Qfactor.
+     * For values between 1 and 99, the value corresponds directly to Qfactor
+     * as specified in "Guideline on controlling JPEG 2000 image quality
+     * using a single parameter" at jpeg.org (1 is worst quality/highest
+     * compression, 99 is close to best quality/least compression), passed
+     * directly to ojph::param_qcd::set_qfactor() when the compression type
+     * is HTJ2KL256. Values between 100 and 150 map onto the Qfactor range
+     * between 99 and 100, giving finer-grained control over that
+     * highest-quality end of the scale.
      *
      * See exr_set_default_lossy_htj2k_quality() to set the default for all
      * contexts.

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -323,18 +323,8 @@ typedef struct _exr_context_initializer_v4
      */
     int flags;
 
-    /** Initialize the default HTJ2K compression quality.
-     *
-     * For values between 1 and 99, the value corresponds directly to Qfactor
-     * as specified in "Guideline on controlling JPEG 2000 image quality
-     * using a single parameter" at jpeg.org (1 is worst quality/highest
-     * compression, 99 is close to best quality/least compression), passed
-     * directly to ojph::param_qcd::set_qfactor() when the compression type
-     * is HTJ2KL256. Values between 100 and 150 map onto the Qfactor range
-     * between 99 and 100, giving finer-grained control over that
-     * highest-quality end of the scale.
-     *
-     * See exr_set_default_lossy_htj2k_quality() to set the default for all
+    /** Initialize the default HTJ2K compression quality. See
+     * exr_set_default_lossy_htj2k_quality() to set the default for all
      * contexts.
      */
     float lossy_htj2k_quality;

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -239,13 +239,6 @@ exr_set_dwa_compression_level (exr_context_t ctxt, int part_index, float level);
  *
  * This only applies when the compression method is HTJ2KL256.
  *
- * For values between 1 and 99, the value corresponds directly to Qfactor as
- * specified in "Guideline on controlling JPEG 2000 image quality using a
- * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
- * is close to best quality/least compression). Values between 100 and 150
- * map onto the Qfactor range between 99 and 100, giving finer-grained
- * control over that highest-quality end of the scale.
- *
  * This value is NOT persisted in the file, and only exists for the lifetime of
  * the context, so will be at the default value when just reading a file.
  */
@@ -255,13 +248,6 @@ EXR_EXPORT exr_result_t exr_get_lossy_htj2k_quality (
 /** @brief Set the lossy HTJ2K compression quality for the specified part.
  *
  * This only applies when the compression method is HTJ2KL256.
- *
- * For values between 1 and 99, the value corresponds directly to Qfactor as
- * specified in "Guideline on controlling JPEG 2000 image quality using a
- * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
- * is close to best quality/least compression). Values between 100 and 150
- * map onto the Qfactor range between 99 and 100, giving finer-grained
- * control over that highest-quality end of the scale.
  *
  * This value is NOT persisted in the file, and only exists for the lifetime of
  * the context, so this value will be ignored when reading a file.

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -239,10 +239,12 @@ exr_set_dwa_compression_level (exr_context_t ctxt, int part_index, float level);
  *
  * This only applies when the compression method is HTJ2KL256.
  *
- * The value is a JPEG-style Qfactor between 1 (worst quality, highest
- * compression) and 100 (best quality, least compression). See "Guideline on
- * controlling JPEG 2000 image quality using a single parameter" at jpeg.org for
- * a description of Qfactor.
+ * For values between 1 and 99, the value corresponds directly to Qfactor as
+ * specified in "Guideline on controlling JPEG 2000 image quality using a
+ * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
+ * is close to best quality/least compression). Values between 100 and 150
+ * map onto the Qfactor range between 99 and 100, giving finer-grained
+ * control over that highest-quality end of the scale.
  *
  * This value is NOT persisted in the file, and only exists for the lifetime of
  * the context, so will be at the default value when just reading a file.
@@ -254,10 +256,12 @@ EXR_EXPORT exr_result_t exr_get_lossy_htj2k_quality (
  *
  * This only applies when the compression method is HTJ2KL256.
  *
- * The value must be a JPEG-style Qfactor between 1 (worst quality, highest
- * compression) and 100 (best quality, least compression). See "Guideline on
- * controlling JPEG 2000 image quality using a single parameter" at jpeg.org for
- * a description of Qfactor.
+ * For values between 1 and 99, the value corresponds directly to Qfactor as
+ * specified in "Guideline on controlling JPEG 2000 image quality using a
+ * single parameter" at jpeg.org (1 is worst quality/highest compression, 99
+ * is close to best quality/least compression). Values between 100 and 150
+ * map onto the Qfactor range between 99 and 100, giving finer-grained
+ * control over that highest-quality end of the scale.
  *
  * This value is NOT persisted in the file, and only exists for the lifetime of
  * the context, so this value will be ignored when reading a file.

--- a/src/lib/OpenEXRCore/openexr_part.h
+++ b/src/lib/OpenEXRCore/openexr_part.h
@@ -234,15 +234,18 @@ EXR_EXPORT exr_result_t exr_get_dwa_compression_level (
 EXR_EXPORT exr_result_t
 exr_set_dwa_compression_level (exr_context_t ctxt, int part_index, float level);
 
-/** @brief Retrieve the lossy HTJ2K compression quality used for the specified part.
+/** @brief Retrieve the lossy HTJ2K compression quality used for the specified
+ * part.
  *
  * This only applies when the compression method is HTJ2KL256.
  *
- * The value is used as the irreversible quantization delta.
+ * The value is a JPEG-style Qfactor between 1 (worst quality, highest
+ * compression) and 100 (best quality, least compression). See "Guideline on
+ * controlling JPEG 2000 image quality using a single parameter" at jpeg.org for
+ * a description of Qfactor.
  *
- * This value is NOT persisted in the file, and only exists for the
- * lifetime of the context, so will be at the default value when just
- * reading a file.
+ * This value is NOT persisted in the file, and only exists for the lifetime of
+ * the context, so will be at the default value when just reading a file.
  */
 EXR_EXPORT exr_result_t exr_get_lossy_htj2k_quality (
     exr_const_context_t ctxt, int part_index, float* level);
@@ -251,11 +254,13 @@ EXR_EXPORT exr_result_t exr_get_lossy_htj2k_quality (
  *
  * This only applies when the compression method is HTJ2KL256.
  *
- * The value is used as the irreversible quantization delta.
+ * The value must be a JPEG-style Qfactor between 1 (worst quality, highest
+ * compression) and 100 (best quality, least compression). See "Guideline on
+ * controlling JPEG 2000 image quality using a single parameter" at jpeg.org for
+ * a description of Qfactor.
  *
- * This value is NOT persisted in the file, and only exists for the
- * lifetime of the context, so this value will be ignored when
- * reading a file.
+ * This value is NOT persisted in the file, and only exists for the lifetime of
+ * the context, so this value will be ignored when reading a file.
  */
 EXR_EXPORT exr_result_t
 exr_set_lossy_htj2k_quality (exr_context_t ctxt, int part_index, float level);

--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -657,11 +657,11 @@ exr_set_lossy_htj2k_quality (exr_context_t ctxt, int part_index, float level)
         return EXR_UNLOCK_AND_RETURN (
             ctxt->standard_error (ctxt, EXR_ERR_NOT_OPEN_WRITE));
 
-    if (!isfinite (level))
+    if (!isfinite (level) || level < 1.f || level > 100.f)
         return EXR_UNLOCK_AND_RETURN (ctxt->report_error (
             ctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "Invalid j2k quality level specified"));
+            "Invalid HTJ2K Qfactor specified, must be between 1 and 100"));
 
     part->lossy_htj2k_quality = level;
     rv                          = EXR_ERR_SUCCESS;

--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -657,11 +657,11 @@ exr_set_lossy_htj2k_quality (exr_context_t ctxt, int part_index, float level)
         return EXR_UNLOCK_AND_RETURN (
             ctxt->standard_error (ctxt, EXR_ERR_NOT_OPEN_WRITE));
 
-    if (!isfinite (level) || level < 1.f || level > 100.f)
+    if (!isfinite (level) || level < 1.f || level > 150.f)
         return EXR_UNLOCK_AND_RETURN (ctxt->report_error (
             ctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "Invalid HTJ2K Qfactor specified, must be between 1 and 100"));
+            "Invalid HTJ2K Qfactor specified, must be between 1 and 150"));
 
     part->lossy_htj2k_quality = level;
     rv                          = EXR_ERR_SUCCESS;

--- a/src/lib/OpenEXRCore/part.c
+++ b/src/lib/OpenEXRCore/part.c
@@ -7,6 +7,7 @@
 
 #include "internal_attr.h"
 #include "internal_constants.h"
+#include "internal_ht_quality.h"
 #include "internal_structs.h"
 
 #include <math.h>
@@ -657,11 +658,11 @@ exr_set_lossy_htj2k_quality (exr_context_t ctxt, int part_index, float level)
         return EXR_UNLOCK_AND_RETURN (
             ctxt->standard_error (ctxt, EXR_ERR_NOT_OPEN_WRITE));
 
-    if (!isfinite (level) || level < 1.f || level > 150.f)
+    if (!is_lossy_htj2k_quality (level))
         return EXR_UNLOCK_AND_RETURN (ctxt->report_error (
             ctxt,
             EXR_ERR_INVALID_ARGUMENT,
-            "Invalid HTJ2K Qfactor specified, must be between 1 and 150"));
+            "Invalid HTJ2K quality level specified, must be between 1 and 150"));
 
     part->lossy_htj2k_quality = level;
     rv                          = EXR_ERR_SUCCESS;

--- a/src/test/OpenEXRCoreTest/base_units.cpp
+++ b/src/test/OpenEXRCoreTest/base_units.cpp
@@ -355,6 +355,20 @@ testBaseLimits (const std::string& tempdir)
     exr_get_default_dwa_compression_quality (&dcq);
     EXRCORE_TEST (dcq == 100.f);
     exr_set_default_dwa_compression_quality (45.f);
+
+    float hcq;
+    exr_set_default_lossy_htj2k_quality (75.f);
+    exr_get_default_lossy_htj2k_quality (&hcq);
+    EXRCORE_TEST (hcq == 75.f);
+
+    exr_set_default_lossy_htj2k_quality (-1.f);
+    exr_get_default_lossy_htj2k_quality (&hcq);
+    EXRCORE_TEST (hcq == 1.f);
+
+    exr_set_default_lossy_htj2k_quality (200.f);
+    exr_get_default_lossy_htj2k_quality (&hcq);
+    EXRCORE_TEST (hcq == 150.f);
+    exr_set_default_lossy_htj2k_quality (110.f);
 }
 
 void

--- a/src/test/OpenEXRCoreTest/write.cpp
+++ b/src/test/OpenEXRCoreTest/write.cpp
@@ -469,6 +469,50 @@ testWriteBaseHeader (const std::string& tempdir)
     EXRCORE_TEST_RVAL (exr_get_dwa_compression_level (outf, 0, &dlev));
     EXRCORE_TEST (dlev == 420.f);
 
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_get_lossy_htj2k_quality (NULL, 0, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_lossy_htj2k_quality (outf, -1, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_get_lossy_htj2k_quality (outf, 5, NULL));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_get_lossy_htj2k_quality (outf, 0, NULL));
+    float hlev = -3.f;
+    EXRCORE_TEST_RVAL (exr_get_lossy_htj2k_quality (outf, 0, &hlev));
+    EXRCORE_TEST (hlev == 110.f);
+
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_MISSING_CONTEXT_ARG,
+        exr_set_lossy_htj2k_quality (NULL, 0, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_lossy_htj2k_quality (outf, -1, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_ARGUMENT_OUT_OF_RANGE,
+        exr_set_lossy_htj2k_quality (outf, 5, 5));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_lossy_htj2k_quality (outf, 0, 0.f));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_lossy_htj2k_quality (outf, 0, 151.f));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_lossy_htj2k_quality (outf, 0, INFINITY));
+    EXRCORE_TEST_RVAL_FAIL (
+        EXR_ERR_INVALID_ARGUMENT,
+        exr_set_lossy_htj2k_quality (outf, 0, NAN));
+    EXRCORE_TEST_RVAL (exr_set_lossy_htj2k_quality (outf, 0, 42.f));
+    EXRCORE_TEST_RVAL (exr_get_lossy_htj2k_quality (outf, 0, &hlev));
+    EXRCORE_TEST (hlev == 42.f);
+    EXRCORE_TEST_RVAL (exr_set_lossy_htj2k_quality (outf, 0, 150.f));
+    EXRCORE_TEST_RVAL (exr_get_lossy_htj2k_quality (outf, 0, &hlev));
+    EXRCORE_TEST (hlev == 150.f);
+
     EXRCORE_TEST_RVAL (exr_finish (&outf));
     remove (outfn.c_str ());
 

--- a/website/ReadingAndWritingImageFiles.rst
+++ b/website/ReadingAndWritingImageFiles.rst
@@ -1843,47 +1843,59 @@ on the ``Header`` object:
 
 Supported compression types are:
 
-+----------------------+------------------------------------------------+
-| RLE_COMPRESSION      | run length encoding                            |
-+----------------------+------------------------------------------------+
-| ZIPS_COMPRESSION     | zlib compression, one scan line at a time      |
-+----------------------+------------------------------------------------+
-| ZIP_COMPRESSION      | zlib compression, in blocks of 16 scan lines   |
-+----------------------+------------------------------------------------+
-| PIZ_COMPRESSION      | piz-based wavelet compression                  |
-+----------------------+------------------------------------------------+
-| PXR24_COMPRESSION    | lossy 24-bit float compression                 |
-+----------------------+------------------------------------------------+
-| B44_COMPRESSION      | lossy 4-by-4 pixel block compression,          |
-|                      | fixed compression rate                         |
-+----------------------+------------------------------------------------+
-| B44A_COMPRESSION     | lossy 4-by-4 pixel block compression,          |
-|                      | flat fields are compressed more                |
-+----------------------+------------------------------------------------+
-| DWAA_COMPRESSION     | lossy DCT based compression, in blocks of      |
-|                      | 32 scanlines. More efficient for partial       |
-|                      | buffer access.                                 |
-+----------------------+------------------------------------------------+
-| DWAB_COMPRESSION     | lossy DCT based compression, in blocks of 256  |
-|                      | scanlines. More efficient space-wise and       |
-|                      | faster to decode full frames than              |
-|                      | ``DWAA_COMPRESSION``.                          |
-+----------------------+------------------------------------------------+
-| HTJ2K256_COMPRESSION | JPEG 2000 lossless coding, in blocks of 256    |
-|                      | scanlines and using the High-Throughput block  |
-|                      | coder specified in Rec. ITU-T T.814 and        |
-|                      | ISO/IEC 15444-15. The compressor offers both   |
-|                      | speed and high coding efficiency.              |
-+----------------------+------------------------------------------------+
-| HTJ2K32_COMPRESSION  | Same as ``HTJ2K256_COMPRESSION``, but in       |
-|                      | blocks of 32 scanlines, More efficient for     |
-|                      | partial buffer access, but slightly less       |
-|                      | efficient space-wise.                          |
-+----------------------+------------------------------------------------+
++-----------------------+------------------------------------------------+
+| RLE_COMPRESSION       | run length encoding                            |
++-----------------------+------------------------------------------------+
+| ZIPS_COMPRESSION      | zlib compression, one scan line at a time      |
++-----------------------+------------------------------------------------+
+| ZIP_COMPRESSION       | zlib compression, in blocks of 16 scan lines   |
++-----------------------+------------------------------------------------+
+| PIZ_COMPRESSION       | piz-based wavelet compression                  |
++-----------------------+------------------------------------------------+
+| PXR24_COMPRESSION     | lossy 24-bit float compression                 |
++-----------------------+------------------------------------------------+
+| B44_COMPRESSION       | lossy 4-by-4 pixel block compression,          |
+|                       | fixed compression rate                         |
++-----------------------+------------------------------------------------+
+| B44A_COMPRESSION      | lossy 4-by-4 pixel block compression,          |
+|                       | flat fields are compressed more                |
++-----------------------+------------------------------------------------+
+| DWAA_COMPRESSION      | lossy DCT based compression, in blocks of      |
+|                       | 32 scanlines. More efficient for partial       |
+|                       | buffer access.                                 |
++-----------------------+------------------------------------------------+
+| DWAB_COMPRESSION      | lossy DCT based compression, in blocks of 256  |
+|                       | scanlines. More efficient space-wise and       |
+|                       | faster to decode full frames than              |
+|                       | ``DWAA_COMPRESSION``.                          |
++-----------------------+------------------------------------------------+
+| HTJ2K256_COMPRESSION  | JPEG 2000 lossless coding, in blocks of 256    |
+|                       | scanlines and using the High-Throughput block  |
+|                       | coder specified in Rec. ITU-T T.814 and        |
+|                       | ISO/IEC 15444-15. The compressor offers both   |
+|                       | speed and high coding efficiency.              |
++-----------------------+------------------------------------------------+
+| HTJ2K32_COMPRESSION   | Same as ``HTJ2K256_COMPRESSION``, but in       |
+|                       | blocks of 32 scanlines, More efficient for     |
+|                       | partial buffer access, but slightly less       |
+|                       | efficient space-wise.                          |
++-----------------------+------------------------------------------------+
+| HTJ2KL256_COMPRESSION | Same as ``HTJ2K256_COMPRESSION`` but with      |
+|                       | lossy coding, resulting in smaller files at    |
+|                       | the expense of introducing distortion. The     |
+|                       | amount of distortion can be controlled from    |
+|                       | visually lossless for larger files, to visible |
+|                       | artifacts for smaller files.                   |
++-----------------------+------------------------------------------------+
 
-``ZIP_COMPRESSION`` and ``DWA`` compression compress to a
-user-controllable compression level, which determines the space/time
-tradeoff. You can control these levels either by setting a global
+For the ``ZIP_COMPRESSION`` compressor, a single level parameter controls
+the tradeoff between compression speed and file size.
+
+For the ``DWA`` and ``HTJ2KL256_COMPRESSION`` compressors, a single level
+parameter controls the tradeoff between quality and file size. Additional
+details on HTJ2K256_COMPRESSION are provided at ``internal_ht_common.h``.
+
+You can control these levels either by setting a global
 default or by setting the level directly on the ``Header`` object.
 
 .. literalinclude:: src/compression.cpp
@@ -1894,6 +1906,7 @@ default or by setting the level directly on the ``Header`` object.
 
 The default zip compression level is 4 for OpenEXR v3.1.3+ and 6 for
 previous versions. The default DWA compression level is 45.0f.
+The default HTJ2K quality level is 110.0f.
 
 Alternatively, set the compression level on the ``Header`` object:
 

--- a/website/TechnicalIntroduction.rst
+++ b/website/TechnicalIntroduction.rst
@@ -866,15 +866,23 @@ Supported compression schemes:
        access.
 
    * - HTJ2K256 (lossless)
- 
-     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 256 scanlines, 
-       using `JPEG 2000 Part 15 (High-throughput JPEG 2000) <https://www.itu.int/rec/T-REC-T.814>`_, 
+
+     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 256
+       scanlines, using `JPEG 2000 Part 15 (High-throughput JPEG 2000)
+       <https://www.itu.int/rec/T-REC-T.814>`_,
 
    * - HTJ2K32 (lossless)
- 
-     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 32 scanlines, 
-       using `JPEG 2000 Part 15 (High-throughput JPEG 2000) <https://www.itu.int/rec/T-REC-T.814>`_, 
-       
+
+     - Lossless compression of HALF, FLOAT and UINT data types in blocks of 32
+       scanlines, using `JPEG 2000 Part 15 (High-throughput JPEG 2000)
+       <https://www.itu.int/rec/T-REC-T.814>`_,
+
+   * - HTJ2KL256 (lossy)
+
+     - Lossy compression of HALF and FLOAT data types in blocks of 256
+       scanlines, using `JPEG 2000 Part 15 (High-throughput JPEG 2000)
+       <https://www.itu.int/rec/T-REC-T.814>`_,
+
 
 Luminance/Chroma Images
 =======================
@@ -1344,6 +1352,10 @@ By default, OpenEXR files have the following attributes:
 **dwaCompressionLevel**
   Sets the quality level for images compressed with the DWAA or DWAB
   method.
+
+**lossyHTJ2KQuality**
+  Sets the quality level for images compressed with the HTJ2KL256
+  compressor.
 
 **ID Manifest**
   ID manifest. See `A scheme for storing object ID manifests in


### PR DESCRIPTION
Qfactor is a JPEG-like parameter between 1 (worse quality) to 100 (best quality) that controls HTJ2K compression quality. 

[wg1n101553-112-COM-Controlling_JPEG_2000_quality_using_Qfactor_v2.pdf](https://ds.jpeg.org/documents/jpeg2000/wg1n101553-112-COM-Controlling_JPEG_2000_quality_using_Qfactor_v2.pdf)

This pull request redefines the HTJ2K quality level to be between 1 and 150, where:

- a level between 1 and 99 maps to Qfactor exactly
- a level between 100 and 150 maps to a value of Qfactor between 99 and 100, allowing greater control at high-quality.

Lossy compression is currently disabled on all channels but the first three RGB channels.