### PR TITLE
Bound IDManifest uncompressed size and version-field read

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -348,6 +348,11 @@ IDManifest::IDManifest (const char* data, const char* endOfData)
 void
 IDManifest::init (const char* data, const char* endOfData)
 {
+    if (data + sizeof (unsigned int) > endOfData)
+    {
+        throw IEX_NAMESPACE::InputExc (
+            "IDManifest too small for version field");
+    }
 
     unsigned int version;
     Xdr::read<CharPtrIO> (data, version);
@@ -576,6 +581,29 @@ IDManifest::init (const char* data, const char* endOfData)
 IDManifest::IDManifest (const CompressedIDManifest& compressed)
 {
     //
+    // Reject an implausible declared uncompressed size before allocating
+    // anything for it. The declared size is otherwise an unvalidated
+    // 64-bit value taken directly from the file, used as a buffer size
+    // before decompression (and thus before any check on its contents),
+    // which allows a tiny file to force an enormous, fully-committed
+    // allocation (a denial of service) or, at 0, a null-pointer
+    // dereference during `init`. zlib's maximum expansion ratio is
+    // approximately 1032:1, so a declared size that exceeds that ratio
+    // applied to the compressed size cannot be honest.
+    //
+    static const uint64_t MAX_MANIFEST_SIZE = 256 * 1024 * 1024;
+    static const uint64_t MAX_EXPANSION     = 1032;
+
+    if (compressed._uncompressedDataSize == 0 ||
+        compressed._uncompressedDataSize > MAX_MANIFEST_SIZE ||
+        compressed._uncompressedDataSize >
+            compressed._compressedDataSize * MAX_EXPANSION)
+    {
+        throw IEX_NAMESPACE::InputExc (
+            "IDManifest has an implausible uncompressed data size");
+    }
+
+    //
     // decompress the compressed manifest
     //
 
@@ -599,7 +627,7 @@ IDManifest::IDManifest (const CompressedIDManifest& compressed)
             "IDManifest decompression (zlib) failed: mismatch in decompressed data size");
     }
 
-    init ((const char*) &uncomp[0], (const char*) &uncomp[0] + outSize);
+    init (uncomp.data (), uncomp.data () + outSize);
 }
 
 void


### PR DESCRIPTION
A single unvalidated 64-bit `_uncompressedDataSize` field, read directly from an EXR file's `idManifest` attribute, was used as a `std::vector` allocation size in `IDManifest::IDManifest(const CompressedIDManifest&)` before decompression and before any consistency check. Depending on the value an attacker writes into that field, an application that reads ID manifests can be forced to either exhaust memory (an uncatchable SIGKILL, since the vector's value-initialization physically dirties every page) or dereference a null pointer, because a declared size of 0 makes `uncomp.data()` null while the length check that follows decompression still passes (0 == 0). Declared sizes of 1-3 instead produce a silent heap out-of-bounds read of the version field. All of this is reachable from a 343-byte file through the public, non-explicit, IMF_EXPORT constructors `IDManifest(const CompressedIDManifest&)` and `IDManifest(const char*, const char*)`.

Two independent checks are added, since either alone leaves the other failure mode reachable:

- In the `CompressedIDManifest` constructor, reject the declared uncompressed size before allocating anything for it if it is zero, exceeds a fixed ceiling, or exceeds the compressed size scaled by zlib's maximum expansion ratio (~1032:1) -- tying the claim to bytes that must actually be present in the file, rather than trusting an arbitrary 64-bit value.

- In `IDManifest::init()`, bounds-check the 4-byte version field read against the end of the buffer, exactly as the adjacent `readStringList()` already does for its own reads. This is the fix that actually matters for the null/overread cases, since `init()` is reachable directly through the public `IDManifest(const char*, const char*)` constructor without ever passing through the size check above.

Also replaced `&uncomp[0]` with `uncomp.data()`, which is well-defined for an empty vector.

Verified by regenerating the reporter's PoC files (declared sizes of 512 MiB, 0, and 1) against `exrmanifest`: all are now rejected with a clean exception instead of crashing or being killed by the OOM killer. The existing `testIDManifest` suite, which round-trips legitimate manifests up to ~44 MB decoded, continues to pass.

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-5j5m-22wr-mhc6

Assisted-by: GitHub Copilot CLI (model: Claude Sonnet 5)