### PR TITLE
Bound IDManifest uncompressed size and version-field read

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -14,6 +14,7 @@
 #include "openexr_compression.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -348,6 +349,11 @@ IDManifest::IDManifest (const char* data, const char* endOfData)
 void
 IDManifest::init (const char* data, const char* endOfData)
 {
+    if (data + sizeof (unsigned int) > endOfData)
+    {
+        throw IEX_NAMESPACE::InputExc (
+            "IDManifest too small for version field");
+    }
 
     unsigned int version;
     Xdr::read<CharPtrIO> (data, version);
@@ -576,6 +582,34 @@ IDManifest::init (const char* data, const char* endOfData)
 IDManifest::IDManifest (const CompressedIDManifest& compressed)
 {
     //
+    // Reject an implausible declared uncompressed size before allocating
+    // anything for it. The declared size is otherwise an unvalidated
+    // 64-bit value taken directly from the file, used as a buffer size
+    // before decompression (and thus before any check on its contents),
+    // which allows a tiny file to force an enormous, fully-committed
+    // allocation (a denial of service) or, at 0, a null-pointer
+    // dereference during `init`.
+    //
+    // OpenEXR places no fixed limit on data size (see setMaxImageSize(),
+    // which is off/unlimited by default), so a manifest legitimately may
+    // be very large; an absolute cap here would reject valid files. What
+    // must hold regardless of size is zlib's own maximum expansion ratio
+    // of ~1032:1, so scale the bound by the compressed size actually
+    // present in the file instead of an arbitrary constant.
+    //
+    static const uint64_t MAX_EXPANSION = 1032;
+
+    if (compressed._uncompressedDataSize == 0 ||
+        compressed._compressedDataSize >
+            std::numeric_limits<uint64_t>::max () / MAX_EXPANSION ||
+        compressed._uncompressedDataSize >
+            compressed._compressedDataSize * MAX_EXPANSION)
+    {
+        throw IEX_NAMESPACE::InputExc (
+            "IDManifest has an implausible uncompressed data size");
+    }
+
+    //
     // decompress the compressed manifest
     //
 
@@ -599,7 +633,7 @@ IDManifest::IDManifest (const CompressedIDManifest& compressed)
             "IDManifest decompression (zlib) failed: mismatch in decompressed data size");
     }
 
-    init ((const char*) &uncomp[0], (const char*) &uncomp[0] + outSize);
+    init (uncomp.data (), uncomp.data () + outSize);
 }
 
 void


### PR DESCRIPTION
A single unvalidated 64-bit `_uncompressedDataSize` field, read directly from an EXR file's `idManifest` attribute, was used as a `std::vector` allocation size in `IDManifest::IDManifest(const CompressedIDManifest&)` before decompression and before any consistency check. Depending on the value an attacker writes into that field, an application that reads ID manifests can be forced to either exhaust memory (an uncatchable SIGKILL, since the vector's value-initialization physically dirties every page) or dereference a null pointer, because a declared size of 0 makes `uncomp.data()` null while the length check that follows decompression still passes (0 == 0). Declared sizes of 1-3 instead produce a silent heap out-of-bounds read of the version field. All of this is reachable from a 343-byte file through the public, non-explicit, IMF_EXPORT constructors `IDManifest(const CompressedIDManifest&)` and `IDManifest(const char*, const char*)`.

Two independent checks are added, since either alone leaves the other failure mode reachable:

- In the `CompressedIDManifest` constructor, reject the declared uncompressed size before allocating anything for it if it is zero, or exceeds the compressed size scaled by zlib's maximum expansion ratio (~1032:1) -- tying the claim to bytes that must actually be present in the file, rather than trusting an arbitrary 64-bit value. This does *not* impose an absolute size ceiling: OpenEXR places no fixed limit on data size by default (see `Header::setMaxImageSize()`, which is off/unlimited unless an application opts in), so a legitimate manifest may be arbitrarily large provided the file actually contains that much compressed data.

- In `IDManifest::init()`, bounds-check the 4-byte version field read against the end of the buffer, exactly as the adjacent `readStringList()` already does for its own reads. This is the fix that actually matters for the null/overread cases, since `init()` is reachable directly through the public `IDManifest(const char*, const char*)` constructor without ever passing through the size check above.

Also replaced `&uncomp[0]` with `uncomp.data()`, which is well-defined for an empty vector.

Verified by regenerating the reporter's PoC files (declared sizes of 512 MiB, 0, and 1) against `exrmanifest`: all are now rejected with a clean exception instead of crashing or being killed by the OOM killer. Also verified that a legitimate, honestly-compressed 300 MB manifest is still accepted. The existing `testIDManifest` suite, which round-trips legitimate manifests up to ~44 MB decoded, continues to pass.

Assisted-by: GitHub Copilot CLI (model: Claude Sonnet 5)

Addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-5j5m-22wr-mhc6