### PR TITLE
don't preallocate _manifest when parsing IDManifests

### DIFF
--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -487,7 +487,8 @@ IDManifest::init (const char* data, const char* endOfData)
          ++manifestEntry)
     {
 
-        ChannelGroupManifest m;
+        _manifest.push_back(ChannelGroupManifest());
+        ChannelGroupManifest& m = _manifest.back();
 
         //
         // read header of this manifest entry
@@ -573,7 +574,6 @@ IDManifest::init (const char* data, const char* endOfData)
                 (insertion.first)->second[i] = stringList[mapping[stringIndex]];
             }
         }
-	_manifest.push_back(m);
     }
 }
 

--- a/src/lib/OpenEXR/ImfIDManifest.cpp
+++ b/src/lib/OpenEXR/ImfIDManifest.cpp
@@ -478,13 +478,16 @@ IDManifest::init (const char* data, const char* endOfData)
 
     _manifest.clear ();
 
-    _manifest.resize (manifestEntries);
+    if (manifestEntries <0)
+    {
+        throw IEX_NAMESPACE::InputExc ("bad number of ChannelGroupsManifests in IDManifest");
+    }
 
     for (int manifestEntry = 0; manifestEntry < manifestEntries;
          ++manifestEntry)
     {
 
-        ChannelGroupManifest& m = _manifest[manifestEntry];
+        ChannelGroupManifest m;
 
         //
         // read header of this manifest entry
@@ -570,6 +573,7 @@ IDManifest::init (const char* data, const char* endOfData)
                 (insertion.first)->second[i] = stringList[mapping[stringIndex]];
             }
         }
+	_manifest.push_back(m);
     }
 }
 


### PR DESCRIPTION
IDManifest parsing trusted the field indicating count of number of manifestEntries and preallocated memory accordingly. Large values would cause excessive memory allocation, but only in code which explicitly decodes `idmanifest` attributes (simply reading an OpenEXR with an `idmanifest` attribute would not cause excessive memory allocation)

Since #2453 switched from vector to deque, it is efficient to append each ChannelGroupManifest as it is read, rather than allocating up front. The test for negative entry count is not strictly necessary to read files correctly, but is a useful warning for a corrupt file.


addresses https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-rmgv-rm47-38g3