### PR TITLE
Fix/suppress compiler warnings

### DIFF
--- a/src/lib/OpenEXRCore/parse_header.c
+++ b/src/lib/OpenEXRCore/parse_header.c
@@ -557,7 +557,7 @@ extract_attr_float_vector (
                 tname);
         }
 
-        priv_to_native32 (attrdata->arr, n);
+        priv_to_native32 ((void*) attrdata->arr, n);
     }
 
     return rv;

--- a/src/wrappers/python/PyOpenEXR_old.cpp
+++ b/src/wrappers/python/PyOpenEXR_old.cpp
@@ -104,7 +104,6 @@ using namespace std;
 using namespace OPENEXR_IMF_NAMESPACE;
 using namespace IMATH_NAMESPACE;
 
-static PyObject* OpenEXR_error = NULL;
 static PyObject* pModuleImath;
 
 int

--- a/website/src/all.cpp
+++ b/website/src/all.cpp
@@ -3,6 +3,21 @@
 // Copyright (c) Contributors to the OpenEXR Project.
 //
 
+// This file assembles a collection of documentation code snippets
+// (via #include of individual .cpp files below) that are compiled
+// here purely to verify they build, not to be run in any meaningful
+// way. As a result, several of the snippets intentionally leave
+// variables unused; suppress those warnings for the whole file
+// rather than editing each snippet.
+#if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable : 4101) // unused local variable
+#elif defined(__GNUC__) || defined(__clang__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wunused-variable"
+#    pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
+
 #include "ImfHeader.h"
 #include "ImfArray.h"
 #include "ImfInputFile.h"
@@ -134,3 +149,9 @@ int
 main(int argc, char* argv[])
 {
 }
+
+#if defined(_MSC_VER)
+#    pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#    pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
- unused variable in PyOpenEXR_old.cpp
- (void*) cast in read.c
- all.cpp: suppress unused variable warnings altogther since this is example code for the website