### PR TITLE
Add missing IMF_EXPORT to KeyCode::operator==

### DIFF
--- a/src/lib/OpenEXR/ImfKeyCode.h
+++ b/src/lib/OpenEXR/ImfKeyCode.h
@@ -93,6 +93,7 @@ public:
     IMF_EXPORT
     KeyCode& operator= (const KeyCode& other);
 
+    IMF_EXPORT
     bool operator== (const KeyCode& other) const;
 
     //----------------------------

--- a/src/test/OpenEXRTest/testStandardAttributes.cpp
+++ b/src/test/OpenEXRTest/testStandardAttributes.cpp
@@ -388,6 +388,10 @@ writeReadKeyCode (const char fileName[])
         3,      // perfsPerFrame
         80);    // perfsPerCount
 
+    KeyCode k2 = k1;
+
+    assert (k2 == k1);
+    
     assert (k1.filmMfcCode () == 12);
     assert (k1.filmType () == 34);
     assert (k1.prefix () == 123456);


### PR DESCRIPTION
Fixes #2591.

The existing CI didn't fail because the only use of KeyCode::operator== was in PyOpenEXR.cpp, but the CI only builds the python module via the python_wheels.yml workflow that only builds it as static, where the symbol visibility rules don't require the export.

Also adds a test of KeyCode::operator== in testStandardAttributes.cpp that would have failed before.