### PR TITLE
Bump vendored OpenJPH to 0.31.0

### DIFF
--- a/external/OpenJPH/CMakeLists.txt
+++ b/external/OpenJPH/CMakeLists.txt
@@ -41,6 +41,7 @@ option(OJPH_BUILD_TESTS "Enables building test code" OFF)
 option(OJPH_BUILD_EXECUTABLES "Enables building command line executables" ON)
 option(OJPH_BUILD_STREAM_EXPAND "Enables building ojph_stream_expand executable" OFF)
 option(OJPH_INSTALL "Install OpenJPH libraries, headers, and CMake config" ON)
+option(OJPH_BUILD_FUZZER "Enables building oss-fuzzing target executable" OFF)
 
 option(OJPH_DISABLE_SIMD "Disables the use of SIMD instructions -- agnostic to architectures" OFF)
 option(OJPH_DISABLE_SSE "Disables the use of SSE SIMD instructions and associated files" OFF)
@@ -104,7 +105,9 @@ if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
   endif()
 endif()
 
-## Added by Michael Smith
+## Set build flags for AddressSanitizer (ASAN) 
+# these are used when the user sets -DCMAKE_BUILD_TYPE=asan i.e ("cmake .. -DCMAKE_BUILD_TYPE=asan")
+# setting flags for specific build types is documented here: https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS_CONFIG.html
 set(CMAKE_CXX_FLAGS_ASAN
   "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
   CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
@@ -190,53 +193,62 @@ endif()
 ################################################################################################
 
 if (OJPH_INSTALL)
-  install(EXPORT openjph-targets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
-  )
+install(EXPORT openjph-targets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
+)
 
-  include(CMakePackageConfigHelpers)
+include(CMakePackageConfigHelpers)
 
-  configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/src/openjph-config.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/openjph-config.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
-  )
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/src/openjph-config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/openjph-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
+)
 
-  write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/openjph-config-version.cmake
-                                   COMPATIBILITY SameMinorVersion)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/openjph-config-version.cmake
+                                 COMPATIBILITY SameMinorVersion)
 
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openjph-config.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/openjph-config-version.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
-  )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openjph-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/openjph-config-version.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/openjph
+)
 
-  if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
-    set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
-  else()
-    set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-  endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+  set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+  set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 
-  if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
-    set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
-  else()
-    set(PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
-  endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+  set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(PKG_CONFIG_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
 
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/openjph.pc.in"
-    "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
-    @ONLY
-  )
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/openjph.pc.in"
+  "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
+  @ONLY
+)
 
-  install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
+install(FILES "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)
 endif()
 
 ################################################################################################
-# Testing (OJPH_BUILD_TESTS)
+# Testing and fuzzing (OJPH_BUILD_TESTS)
 ################################################################################################
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND OJPH_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)
 endif()
+
+################################################################################################
+# Testing and fuzzing (OJPH_BUILD_FUZZER)
+################################################################################################
+
+if(OJPH_BUILD_FUZZER)
+  add_subdirectory(fuzzing)
+endif()
+

--- a/external/OpenJPH/README.md
+++ b/external/OpenJPH/README.md
@@ -18,7 +18,7 @@ The standard is available free of charge from [ITU website](https://www.itu.int/
 * [Usage Example](./docs/usage_examples.md)
 * [Web-based Demos](./docs/web_demos.md)
 * [Doxygen Documentation Style](./docs/doxygen_style.md)
+* [OSS-Fuzzing](./docs/fuzzing.md)
 
 # Repositories #
 [![Packaging status](https://repology.org/badge/vertical-allrepos/openjph.svg)](https://repology.org/project/openjph/versions)
-

--- a/external/OpenJPH/src/core/CMakeLists.txt
+++ b/external/OpenJPH/src/core/CMakeLists.txt
@@ -5,11 +5,13 @@ file(GLOB CODESTREAM_SSE2  "codestream/*_sse2.cpp")
 file(GLOB CODESTREAM_AVX   "codestream/*_avx.cpp")
 file(GLOB CODESTREAM_AVX2  "codestream/*_avx2.cpp")
 file(GLOB CODESTREAM_WASM  "codestream/*_wasm.cpp")
+file(GLOB CODESTREAM_VSX   "codestream/*_vsx.cpp")
 file(GLOB CODING           "coding/*.cpp" "coding/*.h")
 file(GLOB CODING_SSSE3     "coding/*_ssse3.cpp")
 file(GLOB CODING_WASM      "coding/*_wasm.cpp")
 file(GLOB CODING_AVX2      "coding/*_avx2.cpp")
 file(GLOB CODING_AVX512    "coding/*_avx512.cpp")
+file(GLOB CODING_VSX       "coding/*_vsx.cpp")
 file(GLOB COMMON           "openjph/*.h")
 file(GLOB OTHERS           "others/*.cpp" "others/*.c")
 file(GLOB TRANSFORM        "transform/*.cpp" "transform/*.h")
@@ -19,10 +21,11 @@ file(GLOB TRANSFORM_AVX    "transform/*_avx.cpp")
 file(GLOB TRANSFORM_AVX2   "transform/*_avx2.cpp")
 file(GLOB TRANSFORM_AVX512 "transform/*_avx512.cpp")
 file(GLOB TRANSFORM_WASM   "transform/*_wasm.cpp")
+file(GLOB TRANSFORM_VSX    "transform/*_vsx.cpp")
 
-list(REMOVE_ITEM CODESTREAM ${CODESTREAM_SSE} ${CODESTREAM_SSE2} ${CODESTREAM_AVX} ${CODESTREAM_AVX2} ${CODESTREAM_WASM})
-list(REMOVE_ITEM CODING ${CODING_SSSE3} ${CODING_WASM} ${CODING_AVX2} ${CODING_AVX512})
-list(REMOVE_ITEM TRANSFORM ${TRANSFORM_SSE} ${TRANSFORM_SSE2} ${TRANSFORM_AVX} ${TRANSFORM_AVX2} ${TRANSFORM_AVX512} ${TRANSFORM_WASM})
+list(REMOVE_ITEM CODESTREAM ${CODESTREAM_SSE} ${CODESTREAM_SSE2} ${CODESTREAM_AVX} ${CODESTREAM_AVX2} ${CODESTREAM_WASM} ${CODESTREAM_VSX})
+list(REMOVE_ITEM CODING ${CODING_SSSE3} ${CODING_WASM} ${CODING_AVX2} ${CODING_AVX512} ${CODING_VSX})
+list(REMOVE_ITEM TRANSFORM ${TRANSFORM_SSE} ${TRANSFORM_SSE2} ${TRANSFORM_AVX} ${TRANSFORM_AVX2} ${TRANSFORM_AVX512} ${TRANSFORM_WASM} ${TRANSFORM_VSX})
 list(APPEND SOURCES ${CODESTREAM} ${CODING} ${COMMON} ${OTHERS} ${TRANSFORM})
 
 source_group("codestream"        FILES ${CODESTREAM})
@@ -112,6 +115,24 @@ else()
 
     endif()
 
+    if (("${OJPH_TARGET_ARCH}" MATCHES "OJPH_ARCH_PPC64")
+        AND (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le|powerpc64le"))
+      if (NOT OJPH_DISABLE_SIMD)
+        # native 128-bit VSX kernels (see ojph_simd_vsx.h).  Supported
+        # targets are POWER9 (ISA 3.0) and newer, little-endian only.
+        # The block decoder dispatch is selective; see
+        # ojph_codeblock_fun.cpp.
+        list(APPEND SOURCES ${CODESTREAM_VSX} ${CODING_VSX} ${TRANSFORM_VSX})
+        source_group("codestream" FILES ${CODESTREAM_VSX})
+        source_group("coding" FILES ${CODING_VSX})
+        source_group("transform" FILES ${TRANSFORM_VSX})
+        set_source_files_properties(codestream/ojph_codestream_vsx.cpp PROPERTIES COMPILE_FLAGS "-mcpu=power9")
+        set_source_files_properties(coding/ojph_block_decoder_vsx.cpp PROPERTIES COMPILE_FLAGS "-mcpu=power9")
+        set_source_files_properties(transform/ojph_transform_vsx.cpp PROPERTIES COMPILE_FLAGS "-mcpu=power9")
+        set_source_files_properties(transform/ojph_colour_vsx.cpp PROPERTIES COMPILE_FLAGS "-mcpu=power9")
+      endif()
+    endif()
+
   endif()
 
 endif()
@@ -140,7 +161,11 @@ endif()
 ## include library version/name
 set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(openjph PUBLIC _FILE_OFFSET_BITS=64)
-target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/openjph> $<INSTALL_INTERFACE:include>)
+target_include_directories(openjph PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/openjph>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/shared>
+  $<INSTALL_INTERFACE:include>
+)
 
 ## This is to check if aligned_alloc or posix_memalign is available
 # We want the code to compile for C11 and C++11.
@@ -173,13 +198,13 @@ else()
 endif()
 
 if (OJPH_INSTALL)
-  install(TARGETS openjph
-    EXPORT openjph-targets
-  )
+install(TARGETS openjph
+  EXPORT openjph-targets
+)
 
-  install(DIRECTORY openjph/
-    DESTINATION include/openjph
-    FILES_MATCHING
-    PATTERN "*.h"
-  )
+install(DIRECTORY openjph/
+  DESTINATION include/openjph
+  FILES_MATCHING
+  PATTERN "*.h"
+)
 endif()

--- a/external/OpenJPH/src/core/codestream/ojph_bitbuffer_read.h
+++ b/external/OpenJPH/src/core/codestream/ojph_bitbuffer_read.h
@@ -40,6 +40,7 @@
 #define OJPH_BITBUFFER_READ_H
 
 #include "ojph_defs.h"
+#include "ojph_arch.h"
 #include "ojph_file.h"
 
 namespace ojph {
@@ -79,7 +80,7 @@ namespace ojph {
     {
       if (bbp->bytes_left > 0)
       {
-        ui32 t = 0;
+        ui8 t = 0;
         if (bbp->file->read(&t, 1) != 1)
           throw "error reading from file";
         bbp->tmp = t;
@@ -195,7 +196,7 @@ namespace ojph {
             ui16 com_len;
             if (bbp->file->read(&com_len, 2) != 2)
               throw "error reading from file";
-            com_len = swap_byte(com_len);
+            com_len = swap_bytes_if_le(com_len);
             if (com_len != 4)
               throw "something is wrong with SOP length";
             int result = 

--- a/external/OpenJPH/src/core/codestream/ojph_codeblock.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codeblock.cpp
@@ -3,21 +3,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -53,7 +53,7 @@ namespace ojph {
   {
 
     //////////////////////////////////////////////////////////////////////////
-    void codeblock::pre_alloc(codestream *codestream, const size& nominal, 
+    void codeblock::pre_alloc(codestream *codestream, const size& nominal,
                               ui32 precision)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
@@ -61,7 +61,7 @@ namespace ojph {
       assert(byte_alignment / sizeof(ui32) > 1);
       const ui32 f = byte_alignment / sizeof(ui32) - 1;
       ui32 stride = (nominal.w + f) & ~f; // a multiple of 8
-      
+
       if (precision <= 32)
         allocator->pre_alloc_data<ui32>(nominal.h * (size_t)stride, 0);
       else
@@ -114,23 +114,25 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void codeblock::push(line_buf *line)
     {
-      // convert to sign and magnitude and keep max_val      
+      // convert to sign and magnitude and keep max_val
       if (precision == BUF32)
       {
         assert(line->flags & line_buf::LFT_32BIT);
-        const si32 *sp = line->i32 + line_offset;
+        const void *sp = (line->flags & line_buf::LFT_INTEGER)
+          ? (const void*)(line->i32 + line_offset)
+          : (const void*)(line->f32 + line_offset);
         ui32 *dp = buf32 + cur_line * stride;
-        this->codeblock_functions.tx_to_cb32(sp, dp, K_max, delta_inv, 
+        this->codeblock_functions.tx_to_cb32(sp, dp, K_max, delta_inv,
                                              cb_size.w, max_val32);
         ++cur_line;
       }
-      else 
+      else
       {
         assert(precision == BUF64);
         assert(line->flags & line_buf::LFT_64BIT);
         const si64 *sp = line->i64 + line_offset;
         ui64 *dp = buf64 + cur_line * stride;
-        this->codeblock_functions.tx_to_cb64(sp, dp, K_max, delta_inv, 
+        this->codeblock_functions.tx_to_cb64(sp, dp, K_max, delta_inv,
                                              cb_size.w, max_val64);
         ++cur_line;
       }
@@ -148,7 +150,7 @@ namespace ojph {
           assert(coded_cb->missing_msbs > 0);
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
-          
+
           this->codeblock_functions.encode_cb32(buf32, K_max-1, 1,
             cb_size.w, cb_size.h, stride, coded_cb->pass_length,
             elastic, coded_cb->next_coded);
@@ -164,7 +166,7 @@ namespace ojph {
           assert(coded_cb->missing_msbs > 0);
           assert(coded_cb->missing_msbs < K_max);
           coded_cb->num_passes = 1;
-          
+
           this->codeblock_functions.encode_cb64(buf64, K_max-1, 1,
             cb_size.w, cb_size.h, stride, coded_cb->pass_length,
             elastic, coded_cb->next_coded);
@@ -199,7 +201,7 @@ namespace ojph {
             coded_cb->pass_length[0], coded_cb->pass_length[1],
             cb_size.w, cb_size.h, stride, stripe_causal);
         }
-        else 
+        else
         {
           assert(precision == BUF64);
           result = this->codeblock_functions.decode_cb64(
@@ -231,11 +233,13 @@ namespace ojph {
       if (precision == BUF32)
       {
         assert(line->flags & line_buf::LFT_32BIT);
-        si32 *dp = line->i32 + line_offset;
+        void *dp = (line->flags & line_buf::LFT_INTEGER)
+          ? (void*)(line->i32 + line_offset)
+          : (void*)(line->f32 + line_offset);
         if (!zero_block)
         {
           const ui32 *sp = buf32 + cur_line * stride;
-          this->codeblock_functions.tx_from_cb32(sp, dp, K_max, delta, 
+          this->codeblock_functions.tx_from_cb32(sp, dp, K_max, delta,
                                                  cb_size.w);
         }
         else
@@ -244,12 +248,13 @@ namespace ojph {
       else
       {
         assert(precision == BUF64);
-        assert(line->flags & line_buf::LFT_64BIT);
+        assert((reversible && (line->flags & line_buf::LFT_64BIT))
+               || (!reversible && (line->flags & line_buf::LFT_32BIT)));
         si64 *dp = line->i64 + line_offset;
         if (!zero_block)
         {
           const ui64 *sp = buf64 + cur_line * stride;
-          this->codeblock_functions.tx_from_cb64(sp, dp, K_max, delta, 
+          this->codeblock_functions.tx_from_cb64(sp, dp, K_max, delta,
                                                  cb_size.w);
         }
         else

--- a/external/OpenJPH/src/core/codestream/ojph_codeblock_fun.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codeblock_fun.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -61,16 +61,19 @@ namespace ojph {
     void sse_mem_clear(void* addr, size_t count);
     void avx_mem_clear(void* addr, size_t count);
     void wasm_mem_clear(void* addr, size_t count);
+    void vsx_mem_clear(void* addr, size_t count);
 
     //////////////////////////////////////////////////////////////////////////
     ui32  gen_find_max_val32(ui32* address);
     ui32 sse2_find_max_val32(ui32* address);
     ui32 avx2_find_max_val32(ui32* address);
     ui32 wasm_find_max_val32(ui32* address);
+    ui32 vsx_find_max_val32(ui32* address);
     ui64  gen_find_max_val64(ui64* address);
     ui64 sse2_find_max_val64(ui64* address);
     ui64 avx2_find_max_val64(ui64* address);
     ui64 wasm_find_max_val64(ui64* address);
+    ui64 vsx_find_max_val64(ui64* address);
 
 
     //////////////////////////////////////////////////////////////////////////
@@ -88,8 +91,12 @@ namespace ojph {
                              float delta_inv, ui32 count, ui32* max_val);
     void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui32* max_val);
+    void vsx_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                            float delta_inv, ui32 count, ui32* max_val);
     void wasm_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui32* max_val);
+    void vsx_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                            float delta_inv, ui32 count, ui32* max_val);
 
     void  gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui64* max_val);
@@ -99,6 +106,8 @@ namespace ojph {
                              float delta_inv, ui32 count, ui64* max_val);
     void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui64* max_val);
+    void vsx_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
+                            float delta_inv, ui32 count, ui64* max_val);
 
     //////////////////////////////////////////////////////////////////////////
     void  gen_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
@@ -115,8 +124,12 @@ namespace ojph {
                                float delta, ui32 count);
     void wasm_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
+    void vsx_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
     void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
+    void vsx_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
 
     void  gen_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
@@ -124,8 +137,12 @@ namespace ojph {
                                float delta, ui32 count);
     void avx2_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count);
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
     void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
-                               float delta, ui32 count);                               
+                               float delta, ui32 count);
+    void vsx_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count);
 
     void codeblock_fun::init(bool reversible) {
 
@@ -155,11 +172,11 @@ namespace ojph {
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result); ojph_unused(result);      
+      assert(result); ojph_unused(result);
 
   #ifndef OJPH_DISABLE_SIMD
 
@@ -190,7 +207,7 @@ namespace ojph {
           else
           {
             tx_to_cb64 = NULL;
-            tx_from_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
           }
         }
       #endif // !OJPH_DISABLE_SSE2
@@ -229,7 +246,7 @@ namespace ojph {
           else
           {
             tx_to_cb64 = NULL;
-            tx_from_cb64 = NULL;
+            tx_from_cb64 = gen_irv_tx_from_cb64;
           }
         }
       #endif // !OJPH_DISABLE_AVX2
@@ -243,7 +260,41 @@ namespace ojph {
       #endif // !OJPH_DISABLE_AVX512
 
     #elif defined(OJPH_ARCH_ARM)
-    
+
+    #elif defined(OJPH_ARCH_PPC64LE)
+
+      // 128-bit VSX kernels; see ojph_simd_vsx.h.
+      // The SIMD block decoder is used everywhere on POWER10 (ISA 3.1),
+      // where it beats the scalar decoder on all measured content.  On
+      // POWER9 it wins for irreversible content (more magnitude bits
+      // per sample) but trails the scalar decoder slightly on
+      // reversible content, so it is dispatched only for the former.
+      if (get_cpu_ext_level() >= PPC_CPU_EXT_LEVEL_ARCH_3_1 ||
+          (!reversible &&
+           get_cpu_ext_level() >= PPC_CPU_EXT_LEVEL_ARCH_3_00))
+        decode_cb32 = ojph_decode_codeblock_vsx;
+      if (get_cpu_ext_level() >= PPC_CPU_EXT_LEVEL_ARCH_3_00) {
+        find_max_val32 = vsx_find_max_val32;
+        mem_clear = vsx_mem_clear;
+        if (reversible) {
+          tx_to_cb32 = vsx_rev_tx_to_cb32;
+          tx_from_cb32 = vsx_rev_tx_from_cb32;
+        }
+        else {
+          tx_to_cb32 = vsx_irv_tx_to_cb32;
+          tx_from_cb32 = vsx_irv_tx_from_cb32;
+        }
+        find_max_val64 = vsx_find_max_val64;
+        if (reversible) {
+          tx_to_cb64 = vsx_rev_tx_to_cb64;
+          tx_from_cb64 = vsx_rev_tx_from_cb64;
+        }
+        else {
+          tx_to_cb64 = NULL;
+          tx_from_cb64 = gen_irv_tx_from_cb64;
+        }
+      }
+
     #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
   #endif // !OJPH_DISABLE_SIMD
@@ -273,11 +324,11 @@ namespace ojph {
       else
       {
         tx_to_cb64 = NULL;
-        tx_from_cb64 = NULL;
+        tx_from_cb64 = gen_irv_tx_from_cb64;
       }
       encode_cb64 = ojph_encode_codeblock64;
       bool result = initialize_block_encoder_tables();
-      assert(result); ojph_unused(result);      
+      assert(result); ojph_unused(result);
 
 #endif // !OJPH_ENABLE_WASM_SIMD
 

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_avx.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_avx.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -46,12 +46,11 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void avx_mem_clear(void* addr, size_t count)
     {
-      float* p = (float*)addr;
-      __m256 zero = _mm256_setzero_ps();
-      for (size_t i = 0; i < count; i += 32, p += 8)
-        _mm256_storeu_ps(p, zero);
+      __m256i zero = _mm256_setzero_si256();
+      for (size_t i = 0; i < count; i += 32, addr = (char*)addr + 32)
+        _mm256_storeu_si256((__m256i*)addr, zero);
     }
-    
+
  }
 }
 

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_gen.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_gen.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -35,6 +35,8 @@
 // Date: 15 May 2022
 //***************************************************************************/
 
+#include <climits>
+
 #include "ojph_defs.h"
 #include "ojph_arch.h"
 
@@ -44,9 +46,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void gen_mem_clear(void* addr, size_t count)
     {
-      si64* p = (si64*)addr;
-      for (size_t i = 0; i < count; i += 8)
-        *p++ = 0;
+      memset(addr, 0, count);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -56,8 +56,8 @@ namespace ojph {
     ui64 gen_find_max_val64(ui64* addr) { return addr[0]; }
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
-                            float delta_inv, ui32 count, 
+    void gen_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                            float delta_inv, ui32 count,
                             ui32* max_val)
     {
       ojph_unused(delta_inv);
@@ -78,8 +78,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
-                            float delta_inv, ui32 count, 
+    void gen_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
+                            float delta_inv, ui32 count,
                             ui64* max_val)
     {
       ojph_unused(delta_inv);
@@ -101,7 +101,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void gen_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
-                            float delta_inv, ui32 count, 
+                            float delta_inv, ui32 count,
                             ui32* max_val)
     {
       ojph_unused(K_max);
@@ -166,6 +166,21 @@ namespace ojph {
         *p++ = (v & 0x80000000U) ? -val : val;
       }
     }
-    
+
+    //////////////////////////////////////////////////////////////////////////
+    void gen_irv_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                              float delta, ui32 count)
+    {
+      ojph_unused(K_max);
+      //convert to sign and magnitude
+      float *p = (float*)dp;
+      for (ui32 i = count; i > 0; --i)
+      {
+        ui64 v = *sp++;
+        float val = (float)(v & LLONG_MAX) * delta;
+        *p++ = (v & (ui64)LLONG_MIN) ? -val : val;
+      }
+    }
+
  }
 }

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_local.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_local.cpp
@@ -182,15 +182,25 @@ namespace ojph {
         allocator->pre_alloc_obj<param_tlm::Ttlm_Ptlm_pair>(num_tileparts);
 
       //precinct scratch buffer
-      ui32 num_decomps = cod.get_num_decompositions();
-      size log_cb = cod.get_log_block_dims();
-
+      // The precinct scratch is shared by all components, but each component
+      // may override the codeblock/precinct geometry via a COC marker.  The
+      // per-component tag-tree storage (resolution.cpp) is derived from that
+      // component's effective params, so size the shared buffer from the
+      // largest ratio across every component (the main COD and all COC
+      // overrides).  Sizing from the COD alone under-reserves the buffer for
+      // any component whose COC declares a smaller codeblock than the COD.
       size ratio;
-      for (ui32 r = 0; r <= num_decomps; ++r)
+      for (ui32 c = 0; c < num_comps; ++c)
       {
-        size log_PP = cod.get_log_precinct_size(r);
-        ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
-        ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        const param_cod* cdp = cod.get_coc(c);
+        ui32 num_decomps = cdp->get_num_decompositions();
+        size log_cb = cdp->get_log_block_dims();
+        for (ui32 r = 0; r <= num_decomps; ++r)
+        {
+          size log_PP = cdp->get_log_precinct_size(r);
+          ratio.w = ojph_max(ratio.w, log_PP.w - ojph_min(log_cb.w, log_PP.w));
+          ratio.h = ojph_max(ratio.h, log_PP.h - ojph_min(log_cb.h, log_PP.h));
+        }
       }
       ui32 max_ratio = ojph_max(ratio.w, ratio.h);
       max_ratio = 1 << max_ratio;
@@ -548,7 +558,17 @@ namespace ojph {
                                    ui32 num_comments)
     {
       //finalize
-      siz.check_validity(cod);
+      siz.set_cod(cod);
+      // set the tile size if it was not set by the user
+      size tile_size = siz.get_tile_size();
+      if (tile_size.h == 0 && tile_size.w == 0)
+      {
+        point img_offset = siz.get_image_offset();
+        point img_extent = siz.get_image_extent();
+        size t(img_extent.x + img_offset.x, img_extent.y + img_offset.y);
+        siz.set_tile_size(t);
+      }
+      siz.check_validity();
       cod.check_validity(siz);
       cod.update_atk(&atk);
       qcd.check_validity(siz, cod);
@@ -620,7 +640,7 @@ namespace ojph {
       this->pre_alloc();
       this->finalize_alloc();
 
-      ui16 t = swap_byte(JP2K_MARKER::SOC);
+      ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOC);
       if (file->write(&t, 2) != 2)
         OJPH_ERROR(0x00030022, "Error writing to file");
 
@@ -645,29 +665,36 @@ namespace ojph {
       if (!nlt.write(file))
         OJPH_ERROR(0x00030027, "Error writing to file");
 
-      char buf[] = "      OpenJPH Ver "
+      const char* version_str = "OpenJPH Ver "
         OJPH_INT_TO_STRING(OPENJPH_VERSION_MAJOR) "."
         OJPH_INT_TO_STRING(OPENJPH_VERSION_MINOR) "."
         OJPH_INT_TO_STRING(OPENJPH_VERSION_PATCH) ".";
-      size_t len = strlen(buf);
-      *(ui16*)buf = swap_byte(JP2K_MARKER::COM);
-      *(ui16*)(buf + 2) = swap_byte((ui16)(len - 2));
-      //1 for General use (IS 8859-15:1999 (Latin) values)
-      *(ui16*)(buf + 4) = swap_byte((ui16)(1));
-      if (file->write(buf, len) != len)
+      size_t data_len = strlen(version_str);
+
+      t = swap_bytes_if_le((ui16)JP2K_MARKER::COM);
+      if (file->write(&t, sizeof(ui16)) != sizeof(ui16))
         OJPH_ERROR(0x00030028, "Error writing to file");
+      t = swap_bytes_if_le((ui16)(data_len + 4));
+      if (file->write(&t, sizeof(ui16)) != sizeof(ui16))
+        OJPH_ERROR(0x0003002D, "Error writing to file");
+      //1 for General use (IS 8859-15:1999 (Latin) values)
+      t = swap_bytes_if_le((ui16)(1));
+      if (file->write(&t, sizeof(ui16)) != sizeof(ui16))
+        OJPH_ERROR(0x0003002E, "Error writing to file");
+      if (file->write(version_str, data_len) != data_len)
+        OJPH_ERROR(0x0003002F, "Error writing to file");
 
       if (comments != NULL) {
         for (ui32 i = 0; i < num_comments; ++i)
         {
-          t = swap_byte(JP2K_MARKER::COM);
+          t = swap_bytes_if_le((ui16)JP2K_MARKER::COM);
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x00030029, "Error writing to file");
-          t = swap_byte((ui16)(comments[i].len + 4));
+          t = swap_bytes_if_le((ui16)(comments[i].len + 4));
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x0003002A, "Error writing to file");
           //1 for General use (IS 8859-15:1999 (Latin) values)
-          t = swap_byte(comments[i].Rcom);
+          t = swap_bytes_if_le(comments[i].Rcom);
           if (file->write(&t, 2) != 2)
             OJPH_ERROR(0x0003002B, "Error writing to file");
           if (file->write(comments[i].data, comments[i].len)!=comments[i].len)
@@ -716,7 +743,7 @@ namespace ojph {
         else
           OJPH_ERROR(0x00030041, "error reading marker");
       }
-      com_len = swap_byte(com_len);
+      com_len = swap_bytes_if_le(com_len);
       file->seek(com_len - 2, infile_base::OJPH_SEEK_CUR);
       if (msg != NULL && msg_level != OJPH_MSG_NO_MSG)
       {
@@ -1131,7 +1158,7 @@ namespace ojph {
       }
       for (si32 i = 0; i < repeat; ++i)
         tiles[i].flush(outfile);
-      ui16 t = swap_byte(JP2K_MARKER::EOC);
+      ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::EOC);
       if (!outfile->write(&t, 2))
         OJPH_ERROR(0x00030071, "Error writing to file");
     }

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_local.h
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_local.h
@@ -40,6 +40,7 @@
 #define OJPH_CODESTREAM_LOCAL_H
 
 #include "ojph_defs.h"
+#include "ojph_arch.h"
 #include "ojph_params_local.h"
 
 namespace ojph {
@@ -54,11 +55,6 @@ namespace ojph {
   namespace local {
 
     /////////////////////////////////////////////////////////////////////////
-    static inline
-    ui16 swap_byte(ui16 t)
-    {
-      return (ui16)((t << 8) | (t >> 8));
-    }
 
     //////////////////////////////////////////////////////////////////////////
     //defined elsewhere

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_sse.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_sse.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -47,10 +47,9 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void sse_mem_clear(void* addr, size_t count)
     {
-      float* p = (float*)addr;
-      __m128 zero = _mm_setzero_ps();
-      for (size_t i = 0; i < count; i += 16, p += 4)
-        _mm_storeu_ps(p, zero);
+      __m128i zero = _mm_setzero_si128();
+      for (size_t i = 0; i < count; i += 16, addr = (char*)addr + 16)
+        _mm_storeu_si128((__m128i*)addr, zero);
     }
   }
 }

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_vsx.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_vsx.cpp
@@ -1,0 +1,288 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2022, Aous Naman
+// Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2022, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: ojph_codestream_vsx.cpp
+// Author: Aous Naman
+// Date: 15 May 2022
+//***************************************************************************/
+
+#include <climits>
+#include <cstddef>
+#include "ojph_simd_vsx.h"
+
+#include "ojph_defs.h"
+
+namespace ojph {
+  namespace local {
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_mem_clear(void* addr, size_t count)
+    {
+      v128_t zero = vsx_i32x4_splat(0);
+      for (size_t i = 0; i < count; i += 16, addr = (char*)addr + 16)
+        vsx_v128_store(addr, zero);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    ui32 vsx_find_max_val32(ui32* address)
+    {
+      v128_t x1, x0 = vsx_v128_load(address);
+      x1 = vsx_i32x4_shuffle(x0, x0, 2, 3, 2, 3);   // x1 = x0[2,3,2,3]
+      x0 = vsx_v128_or(x0, x1);
+      x1 = vsx_i32x4_shuffle(x0, x0, 1, 1, 1, 1);   // x1 = x0[1,1,1,1]
+      x0 = vsx_v128_or(x0, x1);
+      ui32 t = (ui32)vsx_i32x4_extract_lane(x0, 0);
+      return t;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    ui64 vsx_find_max_val64(ui64* address)
+    {
+      v128_t x1, x0 = vsx_v128_load(address);
+      x1 = vsx_i64x2_shuffle(x0, x0, 1, 1);   // x1 = x0[2,3,2,3]
+      x0 = vsx_v128_or(x0, x1);
+      ui64 t = (ui64)vsx_i64x2_extract_lane(x0, 0);
+      return t;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui32* max_val)
+    {
+      ojph_unused(delta_inv);
+
+      // convert to sign and magnitude and keep max_val
+      int shift = 31 - (int)K_max;
+      v128_t m0 = vsx_i32x4_splat(INT_MIN);
+      v128_t zero = vsx_i32x4_splat(0);
+      v128_t one = vsx_i32x4_splat(1);
+      v128_t tmax = vsx_v128_load(max_val);
+      si32 *p = (si32*)sp;
+      for ( ; count >= 4; count -= 4, p += 4, dp += 4)
+      {
+        v128_t v = vsx_v128_load(p);
+        v128_t sign = vsx_i32x4_lt(v, zero);
+        v128_t val = vsx_v128_xor(v, sign); // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i32x4_add(val, ones);     // 2's complement
+        sign = vsx_v128_and(sign, m0);
+        val = vsx_i32x4_shl(val, shift);
+        tmax = vsx_v128_or(tmax, val);
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+      if (count)
+      {
+        v128_t v = vsx_v128_load(p);
+        v128_t sign = vsx_i32x4_lt(v, zero);
+        v128_t val = vsx_v128_xor(v, sign); // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i32x4_add(val, ones);     // 2's complement
+        sign = vsx_v128_and(sign, m0);
+        val = vsx_i32x4_shl(val, shift);
+
+        v128_t c = vsx_i32x4_splat((si32)count);
+        v128_t idx = vsx_i32x4_make(0, 1, 2, 3);
+        v128_t mask = vsx_i32x4_gt(c, idx);
+        c = vsx_v128_and(val, mask);
+        tmax = vsx_v128_or(tmax, c);
+
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+      vsx_v128_store(max_val, tmax);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui32* max_val)
+    {
+      ojph_unused(K_max);
+
+      //quantize and convert to sign and magnitude and keep max_val
+
+      v128_t d = vsx_f32x4_splat(delta_inv);
+      v128_t zero = vsx_i32x4_splat(0);
+      v128_t one = vsx_i32x4_splat(1);
+      v128_t tmax = vsx_v128_load(max_val);
+      float *p = (float*)sp;
+      for ( ; count >= 4; count -= 4, p += 4, dp += 4)
+      {
+        v128_t vf = vsx_v128_load(p);
+        vf = vsx_f32x4_mul(vf, d);                   // multiply
+        v128_t val = vsx_i32x4_trunc_sat_f32x4(vf);  // convert to signed int
+        v128_t sign = vsx_i32x4_lt(val, zero);       // get sign
+        val = vsx_v128_xor(val, sign);               // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i32x4_add(val, ones);              // 2's complement
+        tmax = vsx_v128_or(tmax, val);
+        sign = vsx_i32x4_shl(sign, 31);
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+      if (count)
+      {
+        v128_t vf = vsx_v128_load(p);
+        vf = vsx_f32x4_mul(vf, d);                   // multiply
+        v128_t val = vsx_i32x4_trunc_sat_f32x4(vf);  // convert to signed int
+        v128_t sign = vsx_i32x4_lt(val, zero);       // get sign
+        val = vsx_v128_xor(val, sign);               // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i32x4_add(val, ones);              // 2's complement
+
+        v128_t c = vsx_i32x4_splat((si32)count);
+        v128_t idx = vsx_i32x4_make(0, 1, 2, 3);
+        v128_t mask = vsx_i32x4_gt(c, idx);
+        c = vsx_v128_and(val, mask);
+        tmax = vsx_v128_or(tmax, c);
+
+        sign = vsx_i32x4_shl(sign, 31);
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+      vsx_v128_store(max_val, tmax);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count)
+    {
+      ojph_unused(delta);
+      int shift = 31 - (int)K_max;
+      v128_t m1 = vsx_i32x4_splat(INT_MAX);
+      v128_t zero = vsx_i32x4_splat(0);
+      v128_t one = vsx_i32x4_splat(1);
+      si32 *p = (si32*)dp;
+      for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
+      {
+          v128_t v = vsx_v128_load((v128_t*)sp);
+          v128_t val = vsx_v128_and(v, m1);
+          val = vsx_i32x4_shr(val, shift);
+          v128_t sign = vsx_i32x4_lt(v, zero);
+          val = vsx_v128_xor(val, sign); // negate 1's complement
+          v128_t ones = vsx_v128_and(sign, one);
+          val = vsx_i32x4_add(val, ones); // 2's complement
+          vsx_v128_store(p, val);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count)
+    {
+      ojph_unused(K_max);
+      v128_t m1 = vsx_i32x4_splat(INT_MAX);
+      v128_t d = vsx_f32x4_splat(delta);
+      float *p = (float*)dp;
+      for (ui32 i = 0; i < count; i += 4, sp += 4, p += 4)
+      {
+        v128_t v = vsx_v128_load((v128_t*)sp);
+        v128_t vali = vsx_v128_and(v, m1);
+        v128_t  valf = vsx_f32x4_convert_i32x4(vali);
+        valf = vsx_f32x4_mul(valf, d);
+        v128_t sign = vsx_v128_andnot(v, m1);
+        valf = vsx_v128_or(valf, sign);
+        vsx_v128_store(p, valf);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
+                             float delta_inv, ui32 count, ui64* max_val)
+    {
+      ojph_unused(delta_inv);
+
+      // convert to sign and magnitude and keep max_val
+      int shift = 63 - (int)K_max;
+      v128_t m0 = vsx_i64x2_splat(LLONG_MIN);
+      v128_t zero = vsx_i64x2_splat(0);
+      v128_t one = vsx_i64x2_splat(1);
+      v128_t tmax = vsx_v128_load(max_val);
+      si64 *p = (si64*)sp;
+      for ( ; count >= 2; count -= 2, p += 2, dp += 2)
+      {
+        v128_t v = vsx_v128_load(p);
+        v128_t sign = vsx_i64x2_lt(v, zero);
+        v128_t val = vsx_v128_xor(v, sign); // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i64x2_add(val, ones);     // 2's complement
+        sign = vsx_v128_and(sign, m0);
+        val = vsx_i64x2_shl(val, shift);
+        tmax = vsx_v128_or(tmax, val);
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+      if (count)
+      {
+        v128_t v = vsx_v128_load(p);
+        v128_t sign = vsx_i64x2_lt(v, zero);
+        v128_t val = vsx_v128_xor(v, sign); // negate 1's complement
+        v128_t ones = vsx_v128_and(sign, one);
+        val = vsx_i64x2_add(val, ones);     // 2's complement
+        sign = vsx_v128_and(sign, m0);
+        val = vsx_i64x2_shl(val, shift);
+
+        v128_t c = vsx_i32x4_make((si32)0xFFFFFFFF, (si32)0xFFFFFFFF, 0, 0);
+        c = vsx_v128_and(val, c);
+        tmax = vsx_v128_or(tmax, c);
+
+        val = vsx_v128_or(val, sign);
+        vsx_v128_store(dp, val);
+      }
+
+      vsx_v128_store(max_val, tmax);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
+                               float delta, ui32 count)
+    {
+      ojph_unused(delta);
+      int shift = 63 - (int)K_max;
+      v128_t m1 = vsx_i64x2_splat(LLONG_MAX);
+      v128_t zero = vsx_i64x2_splat(0);
+      v128_t one = vsx_i64x2_splat(1);
+      si64 *p = (si64*)dp;
+      for (ui32 i = 0; i < count; i += 2, sp += 2, p += 2)
+      {
+          v128_t v = vsx_v128_load((v128_t*)sp);
+          v128_t val = vsx_v128_and(v, m1);
+          val = vsx_i64x2_shr(val, shift);
+          v128_t sign = vsx_i64x2_lt(v, zero);
+          val = vsx_v128_xor(val, sign); // negate 1's complement
+          v128_t ones = vsx_v128_and(sign, one);
+          val = vsx_i64x2_add(val, ones); // 2's complement
+          vsx_v128_store(p, val);
+      }
+    }
+  }
+}

--- a/external/OpenJPH/src/core/codestream/ojph_codestream_wasm.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_codestream_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -36,7 +36,7 @@
 //***************************************************************************/
 
 #include <climits>
-#include <cstddef> 
+#include <cstddef>
 #include <wasm_simd128.h>
 
 #include "ojph_defs.h"
@@ -47,10 +47,9 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void wasm_mem_clear(void* addr, size_t count)
     {
-      float* p = (float*)addr;
       v128_t zero = wasm_i32x4_splat(0);
-      for (size_t i = 0; i < count; i += 16, p += 4)
-        wasm_v128_store(p, zero);
+      for (size_t i = 0; i < count; i += 16, addr = (char*)addr + 16)
+        wasm_v128_store(addr, zero);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -76,12 +75,12 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max, 
+    void wasm_rev_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui32* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val      
+      // convert to sign and magnitude and keep max_val
       ui32 shift = 31 - K_max;
       v128_t m0 = wasm_i32x4_splat(INT_MIN);
       v128_t zero = wasm_i32x4_splat(0);
@@ -122,7 +121,7 @@ namespace ojph {
       }
       wasm_v128_store(max_val, tmax);
     }
-                           
+
     //////////////////////////////////////////////////////////////////////////
     void wasm_irv_tx_to_cb32(const void *sp, ui32 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui32* max_val)
@@ -174,7 +173,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
+    void wasm_rev_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count)
     {
       ojph_unused(delta);
@@ -197,7 +196,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max, 
+    void wasm_irv_tx_from_cb32(const ui32 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count)
     {
       ojph_unused(K_max);
@@ -217,12 +216,12 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max, 
+    void wasm_rev_tx_to_cb64(const void *sp, ui64 *dp, ui32 K_max,
                              float delta_inv, ui32 count, ui64* max_val)
     {
       ojph_unused(delta_inv);
 
-      // convert to sign and magnitude and keep max_val      
+      // convert to sign and magnitude and keep max_val
       ui32 shift = 63 - K_max;
       v128_t m0 = wasm_i64x2_splat(LLONG_MIN);
       v128_t zero = wasm_i64x2_splat(0);
@@ -261,10 +260,10 @@ namespace ojph {
       }
 
       wasm_v128_store(max_val, tmax);
-    }   
+    }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max, 
+    void wasm_rev_tx_from_cb64(const ui64 *sp, void *dp, ui32 K_max,
                                float delta, ui32 count)
     {
       ojph_unused(delta);

--- a/external/OpenJPH/src/core/codestream/ojph_params.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_params.cpp
@@ -38,6 +38,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
+#include "ojph_arch.h"
 #include "ojph_base.h"
 #include "ojph_file.h"
 #include "ojph_params.h"
@@ -58,29 +59,25 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_image_extent(point dims)
   {
-    state->Xsiz = dims.x;
-    state->Ysiz = dims.y;
+    state->set_image_extent(dims);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_tile_size(size s)
   {
-    state->XTsiz = s.w;
-    state->YTsiz = s.h;
+    state->set_tile_size(s);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_image_offset(point offset)
-  { // WARNING need to check if these are valid
-    state->XOsiz = offset.x;
-    state->YOsiz = offset.y;
+  {
+    state->set_image_offset(offset);
   }
 
   ////////////////////////////////////////////////////////////////////////////
   void param_siz::set_tile_offset(point offset)
-  { // WARNING need to check if these are valid
-    state->XTOsiz = offset.x;
-    state->YTOsiz = offset.y;
+  {
+    state->set_tile_offset(offset);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -255,12 +252,32 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  param_coc param_cod::get_coc(ui32 component_idx)
+  void param_cod::set_num_decomposition(ui32 comp_idx, ui32 num_decompositions)
   {
-    local::param_cod *p = state->get_coc(component_idx);
-    if (p == state) // no COC segment marker for this component
-      p = state->add_coc_object(component_idx);
-    return param_coc(p);
+    local::param_cod* cdp = state->get_or_add_coc(comp_idx);
+    ojph::param_cod(cdp).set_num_decomposition(num_decompositions);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_cod::set_block_dims(ui32 comp_idx, ui32 width, ui32 height)
+  {
+    local::param_cod* cdp = state->get_or_add_coc(comp_idx);
+    ojph::param_cod(cdp).set_block_dims(width, height);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_cod::set_precinct_size(ui32 comp_idx, int num_levels,
+                                    size* precinct_size)
+  {
+    local::param_cod* cdp = state->get_or_add_coc(comp_idx);
+    ojph::param_cod(cdp).set_precinct_size(num_levels, precinct_size);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  void param_cod::set_reversible(ui32 comp_idx, bool reversible)
+  {
+    local::param_cod* cdp = state->get_or_add_coc(comp_idx);
+    ojph::param_cod(cdp).set_reversible(reversible);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -354,56 +371,32 @@ namespace ojph {
   }
 
   ////////////////////////////////////////////////////////////////////////////
-  //
-  //
-  //
-  //
-  //
-  ////////////////////////////////////////////////////////////////////////////
+  ui32 param_cod::get_num_decompositions(ui32 comp_idx) const
+  { return state->get_coc(comp_idx)->get_num_decompositions(); }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_coc::set_num_decomposition(ui32 num_decompositions)
-  { ojph::param_cod(state).set_num_decomposition(num_decompositions); }
+  size param_cod::get_block_dims(ui32 comp_idx) const
+  { return state->get_coc(comp_idx)->get_block_dims(); }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_coc::set_block_dims(ui32 width, ui32 height)
-  { ojph::param_cod(state).set_block_dims(width, height); }
+  size param_cod::get_log_block_dims(ui32 comp_idx) const
+  { return state->get_coc(comp_idx)->get_log_block_dims(); }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_coc::set_precinct_size(int num_levels, size* precinct_size)
-  { ojph::param_cod(state).set_precinct_size(num_levels, precinct_size); }
+  bool param_cod::is_reversible(ui32 comp_idx) const
+  { return state->get_coc(comp_idx)->is_reversible(); }
 
   ////////////////////////////////////////////////////////////////////////////
-  void param_coc::set_reversible(bool reversible)
-  { ojph::param_cod(state).set_reversible(reversible); }
+  size param_cod::get_precinct_size(ui32 comp_idx, ui32 level_num) const
+  { return state->get_coc(comp_idx)->get_precinct_size(level_num); }
 
   ////////////////////////////////////////////////////////////////////////////
-  ui32 param_coc::get_num_decompositions() const
-  { return ojph::param_cod(state).get_num_decompositions(); }
+  size param_cod::get_log_precinct_size(ui32 comp_idx, ui32 level_num) const
+  { return state->get_coc(comp_idx)->get_log_precinct_size(level_num); }
 
   ////////////////////////////////////////////////////////////////////////////
-  size param_coc::get_block_dims() const
-  { return ojph::param_cod(state).get_block_dims(); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  size param_coc::get_log_block_dims() const
-  { return ojph::param_cod(state).get_log_block_dims(); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  bool param_coc::is_reversible() const
-  { return ojph::param_cod(state).is_reversible(); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  size param_coc::get_precinct_size(ui32 level_num) const
-  { return ojph::param_cod(state).get_precinct_size(level_num); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  size param_coc::get_log_precinct_size(ui32 level_num) const
-  { return ojph::param_cod(state).get_log_precinct_size(level_num); }
-
-  ////////////////////////////////////////////////////////////////////////////
-  bool param_coc::get_block_vertical_causality() const
-  { return ojph::param_cod(state).get_block_vertical_causality(); }
+  bool param_cod::get_block_vertical_causality(ui32 comp_idx) const
+  { return state->get_coc(comp_idx)->get_block_vertical_causality(); }
 
 
   ////////////////////////////////////////////////////////////////////////////
@@ -421,9 +414,19 @@ namespace ojph {
   }
 
   //////////////////////////////////////////////////////////////////////////
+  void param_qcd::set_qfactor(ui8 qfactor) {
+    state->set_qfactor(qfactor);
+  }
+
+  //////////////////////////////////////////////////////////////////////////
   void param_qcd::set_irrev_quant(ui32 comp_idx, float delta)
   {
     state->set_delta(comp_idx, delta);
+  }
+
+  //////////////////////////////////////////////////////////////////////////
+  void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor) {
+    state->set_qfactor(comp_idx, ctype, qfactor);
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -488,41 +491,6 @@ namespace ojph {
   //////////////////////////////////////////////////////////////////////////
 
   namespace local {
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline
-    ui16 swap_byte(ui16 t)
-    {
-      return (ui16)((t << 8) | (t >> 8));
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline
-    ui32 swap_byte(ui32 t)
-    {
-      ui32 u = swap_byte((ui16)(t & 0xFFFFu));
-      u <<= 16;
-      u |= swap_byte((ui16)(t >> 16));
-      return u;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    static inline
-    ui64 swap_byte(ui64 t)
-    {
-      ui64 u = swap_byte((ui32)(t & 0xFFFFFFFFu));
-      u <<= 32;
-      u |= swap_byte((ui32)(t >> 32));
-      return u;
-    }
-
-    //////////////////////////////////////////////////////////////////////////
-    //
-    //
-    //
-    //
-    //
-    //////////////////////////////////////////////////////////////////////////
 
     //////////////////////////////////////////////////////////////////////////
     //static
@@ -626,6 +594,204 @@ namespace ojph {
       2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f, 2.8671e+00f,
       2.8671e+00f, 2.8671e+00f };
 
+    //////////////////////////////////////////////////////////////////////////
+    //static
+    class visual_weights
+    {
+      public:
+        enum colour_format : ui32
+        {
+          VW_COLOUR_FORMAT_400 = 0,
+          VW_COLOUR_FORMAT_420 = 1,
+          VW_COLOUR_FORMAT_422 = 2,
+          VW_COLOUR_FORMAT_444 = 3,
+          VW_COLOUR_FORMAT_ERROR = 4
+        };
+        using comp_type = param_qcd::comp_type;
+
+    public:
+      static colour_format get_format(const point& component_subsampling)
+      {
+        if (component_subsampling.x == 2 && component_subsampling.y == 2)
+          return VW_COLOUR_FORMAT_420;
+        else if (component_subsampling.x == 2 && component_subsampling.y == 1)
+          return VW_COLOUR_FORMAT_422;
+        else if (component_subsampling.x == 1 && component_subsampling.y == 1)
+          return VW_COLOUR_FORMAT_444;
+        else
+          return VW_COLOUR_FORMAT_ERROR;
+      }
+
+    public:
+      static const float* get_weights(ui32 format, ui32 comp_type)
+      {
+        if (comp_type == comp_type::OJPH_COMP_Y)
+          return y;
+        else if (comp_type == comp_type::OJPH_COMP_CB)
+        {
+          if (format == VW_COLOUR_FORMAT_420)        return cb420;
+          else if (format == VW_COLOUR_FORMAT_422)   return cb422;
+          else if (format == VW_COLOUR_FORMAT_444)   return cb444;
+          else {
+            assert(0);
+            return y;
+          }
+        }
+        else if (comp_type == comp_type::OJPH_COMP_CR)
+        {
+          if (format == VW_COLOUR_FORMAT_420)        return cr420;
+          else if (format == VW_COLOUR_FORMAT_422)   return cr422;
+          else if (format == VW_COLOUR_FORMAT_444)   return cr444;
+          else {
+            assert(0);
+            return y;
+          }
+        }
+        else {
+          assert(0);
+          return y;
+        }
+      }
+
+      static const float* get_no_weights()
+      { return no_weights; }
+
+      static float get_weight(const float *v, ui32 decomposition_level,
+                              ui32 subband_idx)
+
+      {
+        if (subband_idx == 0)
+          return v[18];
+        else {
+          assert(subband_idx >= 1 && subband_idx <= 3);
+          assert(decomposition_level > 0);
+          decomposition_level = ojph_min(decomposition_level, 6);
+          ui32 index = (decomposition_level - 1) * 3 + (3 - subband_idx);
+          return v[index];
+        }
+      }
+
+      //////////////////////////
+      static float get_gain(ui32 comp_type)
+      {
+        if (comp_type == comp_type::OJPH_COMP_Y)
+          return 1.0f;
+        else if (comp_type == comp_type::OJPH_COMP_CB)
+          return 1.8051f / 1.7321f;
+        else if (comp_type == comp_type::OJPH_COMP_CR)
+          return 1.5734f / 1.7321f;
+        else {
+          assert(0);
+          return 0.0f;
+        }
+      }
+
+      //////////////////////////
+      static float get_delta_ref(ui32 qfactor, ui32 bit_depth,
+                                 float& power)
+      {
+        // returns delta_ref & power to be used with visual weights
+        constexpr uint8_t t0     = 65, t1 = 97;
+        constexpr float alpha_t0 = 0.04f, alpha_t1 = 0.10f;
+        constexpr float m_t0     = 2.0f * (1.0f - t0 / 100.0f);
+        constexpr float m_t1     = 2.0f * (1.0f - t1 / 100.0f);
+
+        float m_q;
+        if (qfactor < 50)
+          m_q = 50.0f / (float)qfactor;
+        else
+          m_q = 2.0f * (1.0f - (float)qfactor / 100.0f);
+
+        float alpha_q;
+        if (qfactor <= t0)
+        {
+          power = 1.0f;
+          alpha_q = alpha_t0;
+        }
+        else if (qfactor < t1)
+        {
+          power = std::log(m_q) - std::log(m_t1);
+          power /= std::log(m_t0) - std::log(m_t1);
+          alpha_q = alpha_t1 * std::pow(alpha_t0 / alpha_t1, power);
+        }
+        else
+        {
+          power = 0.0f;
+          alpha_q = alpha_t1;
+        }
+        const float eps = std::sqrt(0.5f) * std::ldexp(1.0f, -(int)bit_depth);
+        return alpha_q * m_q + eps;
+      }
+
+    private:
+      static const float cb420[19];
+      static const float cr420[19];
+      static const float cb422[19];
+      static const float cr422[19];
+      static const float cb444[19];
+      static const float cr444[19];
+      static const float y[19];
+      static const float no_weights[19];
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    const float visual_weights::cb420[19] = {
+      0.2724f, 0.5128f, 0.5128f,              // level 1
+      0.6692f, 0.9382f, 0.9382f,              // level 2
+      1.0888f, 1.3046f, 1.3046f,              // level 3
+      1.4156f, 1.5594f, 1.5594f,              // level 4
+      2.0f,    2.0f,    2.0f,                 // level 5
+      2.0f,    2.0f,    2.0f,    2.0f};       // level 6 + LL
+    const float visual_weights::cr420[19] = {
+      0.5196f, 0.8260f, 0.8260f,              // level 1
+      1.0080f, 1.2928f, 1.2928f,              // level 2
+      1.4440f, 1.6508f, 1.6508f,              // level 3
+      1.7538f, 1.8848f, 1.8848f,              // level 4
+      2.0f,    2.0f,    2.0f,                 // level 5
+      2.0f,    2.0f,    2.0f,    2.0f};       // level 6 + LL
+    const float visual_weights::cb422[19] = {
+      0.1220f, 0.1220f, 0.3626f,              // level 1
+      0.3626f, 0.3626f, 0.6634f,              // level 2
+      0.6634f, 0.6634f, 0.9225f,              // level 3
+      0.9225f, 0.9225f, 1.1027f,              // level 4
+      1.1027f, 1.1027f, 1.4142f,              // level 5
+      1.4142f, 1.4142f, 1.4142f, 1.4142f};    // level 6 + LL
+    const float visual_weights::cr422[19] = {
+      0.2595f, 0.2595f, 0.5841f,              // level 1
+      0.5841f, 0.5841f, 0.9141f,              // level 2
+      0.9141f, 0.9141f, 1.1673f,              // level 3
+      1.1673f, 1.1673f, 1.3328f,              // level 4
+      1.3328f, 1.3328f, 1.4142f,              // level 5
+      1.4142f, 1.4142f, 1.4142f, 1.4142f};    // level 6 + LL
+    const float visual_weights::cb444[19] = {
+      0.0263f, 0.0863f, 0.0863f,              // level 1
+      0.1362f, 0.2564f, 0.2564f,              // level 2
+      0.3346f, 0.4691f, 0.4691f,              // level 3
+      0.5444f, 0.6523f, 0.6523f,              // level 4
+      0.7078f, 0.7797f, 0.7797f,              // level 5
+      1.0f,    1.0f,    1.0f,    1.0f};       // level 6 + LL
+    const float visual_weights::cr444[19] = {
+      0.0773f, 0.1835f, 0.1835f,              // level 1
+      0.2598f, 0.4130f, 0.4130f,              // level 2
+      0.5040f, 0.6464f, 0.6464f,              // level 3
+      0.7220f, 0.8254f, 0.8254f,              // level 4
+      0.8769f, 0.9424f, 0.9424f,              // level 5
+      1.0f,    1.0f,    1.0f,    1.0f};       // level 6 + LL
+    const float visual_weights::y[19]     = {
+      0.0901f, 0.2758f, 0.2758f,              // level 1
+      0.7018f, 0.8378f, 0.8378f,              // level 2
+      1.0f,    1.0f,    1.0f,                 // level 3
+      1.0f,    1.0f,    1.0f,                 // level 4
+      1.0f,    1.0f,    1.0f,                 // level 5
+      1.0f,    1.0f,    1.0f,    1.0f};       // level 6 + LL
+    const float visual_weights::no_weights[19] = {
+      1.0f,    1.0f,    1.0f,                 // level 1
+      1.0f,    1.0f,    1.0f,                 // level 2
+      1.0f,    1.0f,    1.0f,                 // level 3
+      1.0f,    1.0f,    1.0f,                 // level 4
+      1.0f,    1.0f,    1.0f,                 // level 5
+      1.0f,    1.0f,    1.0f,    1.0f};       // level 6 + LL
+
 
     //////////////////////////////////////////////////////////////////////////
     //
@@ -641,40 +807,44 @@ namespace ojph {
       //marker size excluding header
       Lsiz = (ui16)(38 + 3 * Csiz);
 
-      ui8 buf[4];
+      ui8  buf1;
+      ui16 buf2;
+      ui32 buf4;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::SIZ;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lsiz);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Rsiz);
-      result &= file->write(&buf, 2) == 2;
-      *(ui32*)buf = swap_byte(Xsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(Ysiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(XOsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(YOsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(XTsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(YTsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(XTOsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui32*)buf = swap_byte(YTOsiz);
-      result &= file->write(&buf, 4) == 4;
-      *(ui16*)buf = swap_byte(Csiz);
-      result &= file->write(&buf, 2) == 2;
+      buf2 = JP2K_MARKER::SIZ;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lsiz);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Rsiz);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf4 = swap_bytes_if_le(Xsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(Ysiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(XOsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(YOsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(XTsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(YTsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(XTOsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf4 = swap_bytes_if_le(YTOsiz);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
+      buf2 = swap_bytes_if_le(Csiz);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       for (int c = 0; c < Csiz; ++c)
       {
-        buf[0] = cptr[c].SSiz;
-        buf[1] = cptr[c].XRsiz;
-        buf[2] = cptr[c].YRsiz;
-        result &= file->write(&buf, 3) == 3;
+        buf1 = cptr[c].SSiz;
+        result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+        buf1 = cptr[c].XRsiz;
+        result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+        buf1 = cptr[c].YRsiz;
+        result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       }
 
       return result;
@@ -685,13 +855,13 @@ namespace ojph {
     {
       if (file->read(&Lsiz, 2) != 2)
         OJPH_ERROR(0x00050041, "error reading SIZ marker");
-      Lsiz = swap_byte(Lsiz);
+      Lsiz = swap_bytes_if_le(Lsiz);
       int num_comps = (Lsiz - 38) / 3;
       if (Lsiz != 38 + 3 * num_comps)
         OJPH_ERROR(0x00050042, "error in SIZ marker length");
       if (file->read(&Rsiz, 2) != 2)
         OJPH_ERROR(0x00050043, "error reading SIZ marker");
-      Rsiz = swap_byte(Rsiz);
+      Rsiz = swap_bytes_if_le(Rsiz);
       if ((Rsiz & 0x4000) == 0)
         OJPH_ERROR(0x00050044,
           "Rsiz bit 14 is not set (this is not a JPH file)");
@@ -699,33 +869,41 @@ namespace ojph {
         OJPH_WARN(0x00050001, "Rsiz in SIZ has unimplemented fields");
       if (file->read(&Xsiz, 4) != 4)
         OJPH_ERROR(0x00050045, "error reading SIZ marker");
-      Xsiz = swap_byte(Xsiz);
+      Xsiz = swap_bytes_if_le(Xsiz);
       if (file->read(&Ysiz, 4) != 4)
         OJPH_ERROR(0x00050046, "error reading SIZ marker");
-      Ysiz = swap_byte(Ysiz);
-      if (file->read(&XOsiz, 4) != 4)
+      Ysiz = swap_bytes_if_le(Ysiz);
+      ui32 t_XOsiz, t_YOsiz;
+      if (file->read(&t_XOsiz, 4) != 4)
         OJPH_ERROR(0x00050047, "error reading SIZ marker");
-      XOsiz = swap_byte(XOsiz);
-      if (file->read(&YOsiz, 4) != 4)
+      if (file->read(&t_YOsiz, 4) != 4)
         OJPH_ERROR(0x00050048, "error reading SIZ marker");
-      YOsiz = swap_byte(YOsiz);
-      if (file->read(&XTsiz, 4) != 4)
+      set_image_offset(point(
+        swap_bytes_if_le(t_XOsiz),
+        swap_bytes_if_le(t_YOsiz)));
+      ui32 t_XTsiz, t_YTsiz;
+      if (file->read(&t_XTsiz, 4) != 4)
         OJPH_ERROR(0x00050049, "error reading SIZ marker");
-      XTsiz = swap_byte(XTsiz);
-      if (file->read(&YTsiz, 4) != 4)
+      if (file->read(&t_YTsiz, 4) != 4)
         OJPH_ERROR(0x0005004A, "error reading SIZ marker");
-      YTsiz = swap_byte(YTsiz);
-      if (file->read(&XTOsiz, 4) != 4)
+      set_tile_size(size(
+        swap_bytes_if_le(t_XTsiz),
+        swap_bytes_if_le(t_YTsiz)));
+      ui32 t_XTOsiz, t_YTOsiz;
+      if (file->read(&t_XTOsiz, 4) != 4)
         OJPH_ERROR(0x0005004B, "error reading SIZ marker");
-      XTOsiz = swap_byte(XTOsiz);
-      if (file->read(&YTOsiz, 4) != 4)
+      if (file->read(&t_YTOsiz, 4) != 4)
         OJPH_ERROR(0x0005004C, "error reading SIZ marker");
-      YTOsiz = swap_byte(YTOsiz);
+      set_tile_offset(point(
+        swap_bytes_if_le(t_XTOsiz),
+        swap_bytes_if_le(t_YTOsiz)));
       if (file->read(&Csiz, 2) != 2)
         OJPH_ERROR(0x0005004D, "error reading SIZ marker");
-      Csiz = swap_byte(Csiz);
+      Csiz = swap_bytes_if_le(Csiz);
       if (Csiz != num_comps)
         OJPH_ERROR(0x0005004E, "Csiz does not match the SIZ marker size");
+      if (Csiz == 0)
+        OJPH_ERROR(0x0005004F, "Wrong Csiz value of 0 in SIZ marker segment");
       set_num_components(Csiz);
       for (int c = 0; c < Csiz; ++c)
       {
@@ -745,6 +923,8 @@ namespace ojph {
 
       ws_kern_support_needed = (Rsiz & 0x20) != 0;
       dfs_support_needed = (Rsiz & 0x80) != 0;
+
+      check_validity();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -790,19 +970,20 @@ namespace ojph {
       //marker size excluding header
       Lcap = 8;
 
-      char buf[4];
+      ui16 buf2;
+      ui32 buf4;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::CAP;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lcap);
-      result &= file->write(&buf, 2) == 2;
-      *(ui32*)buf = swap_byte(Pcap);
-      result &= file->write(&buf, 4) == 4;
+      buf2 = JP2K_MARKER::CAP;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lcap);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf4 = swap_bytes_if_le(Pcap);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
 
-      *(ui16*)buf = swap_byte(Ccap[0]);
-      result &= file->write(&buf, 2) == 2;
+      buf2 = swap_bytes_if_le(Ccap[0]);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
 
       return result;
     }
@@ -812,10 +993,10 @@ namespace ojph {
     {
       if (file->read(&Lcap, 2) != 2)
         OJPH_ERROR(0x00050061, "error reading CAP marker");
-      Lcap = swap_byte(Lcap);
+      Lcap = swap_bytes_if_le(Lcap);
       if (file->read(&Pcap, 4) != 4)
         OJPH_ERROR(0x00050062, "error reading CAP marker");
-      Pcap = swap_byte(Pcap);
+      Pcap = swap_bytes_if_le(Pcap);
       ui32 count = population_count(Pcap);
       if (Pcap & 0xFFFDFFFF)
         OJPH_ERROR(0x00050063,
@@ -859,34 +1040,38 @@ namespace ojph {
       Lcod = 12;
       Lcod = (ui16)(Lcod + (Scod & 1 ? 1 + SPcod.num_decomp : 0));
 
-      ui8 buf[4];
+      ui8  buf1;
+      ui16 buf2;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::COD;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lcod);
-      result &= file->write(&buf, 2) == 2;
-      *(ui8*)buf = Scod;
-      result &= file->write(&buf, 1) == 1;
-      *(ui8*)buf = SGCod.prog_order;
-      result &= file->write(&buf, 1) == 1;
-      *(ui16*)buf = swap_byte(SGCod.num_layers);
-      result &= file->write(&buf, 2) == 2;
-      *(ui8*)buf = SGCod.mc_trans;
-      result &= file->write(&buf, 1) == 1;
-      buf[0] = SPcod.num_decomp;
-      buf[1] = SPcod.block_width;
-      buf[2] = SPcod.block_height;
-      buf[3] = SPcod.block_style;
-      result &= file->write(&buf, 4) == 4;
-      *(ui8*)buf = SPcod.wavelet_trans;
-      result &= file->write(&buf, 1) == 1;
+      buf2 = JP2K_MARKER::COD;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lcod);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf1 = Scod;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SGCod.prog_order;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf2 = swap_bytes_if_le(SGCod.num_layers);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf1 = SGCod.mc_trans;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.num_decomp;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_width;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_height;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_style;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.wavelet_trans;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       if (Scod & 1)
         for (int i = 0; i <= SPcod.num_decomp; ++i)
         {
-          *(ui8*)buf = SPcod.precinct_size[i];
-          result &= file->write(&buf, 1) == 1;
+          buf1 = SPcod.precinct_size[i];
+          result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
         }
 
       return result;
@@ -916,38 +1101,42 @@ namespace ojph {
       Lcod = num_comps < 257 ? 9 : 10;
       Lcod = (ui16)(Lcod + (Scod & 1 ? 1 + SPcod.num_decomp : 0));
 
-      ui8 buf[4];
+      ui8  buf1;
+      ui16 buf2;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::COC;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lcod);
-      result &= file->write(&buf, 2) == 2;
+      buf2 = JP2K_MARKER::COC;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lcod);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       if (num_comps < 257)
       {
-        *(ui8*)buf = (ui8)comp_idx;
-        result &= file->write(&buf, 1) == 1;
+        buf1 = (ui8)comp_idx;
+        result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       }
       else
       {
-        *(ui16*)buf = swap_byte(comp_idx);
-        result &= file->write(&buf, 2) == 2;
+        buf2 = swap_bytes_if_le(comp_idx);
+        result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       }
-      *(ui8*)buf = Scod;
-      result &= file->write(&buf, 1) == 1;
-      buf[0] = SPcod.num_decomp;
-      buf[1] = SPcod.block_width;
-      buf[2] = SPcod.block_height;
-      buf[3] = SPcod.block_style;
-      result &= file->write(&buf, 4) == 4;
-      *(ui8*)buf = SPcod.wavelet_trans;
-      result &= file->write(&buf, 1) == 1;
+      buf1 = Scod;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.num_decomp;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_width;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_height;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.block_style;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
+      buf1 = SPcod.wavelet_trans;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       if (Scod & 1)
         for (int i = 0; i <= SPcod.num_decomp; ++i)
         {
-          *(ui8*)buf = SPcod.precinct_size[i];
-          result &= file->write(&buf, 1) == 1;
+          buf1 = SPcod.precinct_size[i];
+          result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
         }
 
       return result;
@@ -960,7 +1149,7 @@ namespace ojph {
 
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050071, "error reading COD segment");
-      Lcod = swap_byte(Lcod);
+      Lcod = swap_bytes_if_le(Lcod);
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050072, "error reading COD segment");
       if (file->read(&SGCod.prog_order, 1) != 1)
@@ -968,7 +1157,7 @@ namespace ojph {
       if (file->read(&SGCod.num_layers, 2) != 2)
       { OJPH_ERROR(0x00050074, "error reading COD segment"); }
       else
-        SGCod.num_layers = swap_byte(SGCod.num_layers);
+        SGCod.num_layers = swap_bytes_if_le(SGCod.num_layers);
       if (file->read(&SGCod.mc_trans, 1) != 1)
         OJPH_ERROR(0x00050075, "error reading COD segment");
       if (file->read(&SPcod.num_decomp, 1) != 1)
@@ -994,10 +1183,21 @@ namespace ojph {
         OJPH_ERROR(0x0005007E, "unsupported settings in a COD-SPcod parameter");
 
       ui8 num_decompositions =  get_num_decompositions();
-      if (Scod & 1)
-        for (int i = 0; i <= num_decompositions; ++i)
+      if (Scod & 1) {
+        for (int i = 0; i <= num_decompositions; ++i) {
           if (file->read(&SPcod.precinct_size[i], 1) != 1)
             OJPH_ERROR(0x0005007B, "error reading COD segment");
+          if (i)
+            if ((SPcod.precinct_size[i] & 0x0F) == 0 ||
+              (SPcod.precinct_size[i] >> 4) == 0)
+              OJPH_ERROR(0x0005007F,
+                "Precinct width or height for resolutions other than the"
+                " coarsest must be larger than 1; here, they are %d and %d,"
+                " respectively.",
+                1 << (SPcod.precinct_size[i] & 0x0F),
+                1 << (SPcod.precinct_size[i] >> 4));
+        }
+      }
       if (Lcod != 12 + ((Scod & 1) ? 1 + SPcod.num_decomp : 0))
         OJPH_ERROR(0x0005007C, "error in COD segment length");
     }
@@ -1013,7 +1213,7 @@ namespace ojph {
       this->top_cod = top_cod;
       if (file->read(&Lcod, 2) != 2)
         OJPH_ERROR(0x00050121, "error reading COC segment");
-      Lcod = swap_byte(Lcod);
+      Lcod = swap_bytes_if_le(Lcod);
       if (num_comps < 257) {
         ui8 t;
         if (file->read(&t, 1) != 1)
@@ -1023,7 +1223,7 @@ namespace ojph {
       else {
         if (file->read(&comp_idx, 2) != 2)
           OJPH_ERROR(0x00050123, "error reading COC segment");
-        comp_idx = swap_byte(comp_idx);
+        comp_idx = swap_bytes_if_le(comp_idx);
       }
       if (file->read(&Scod, 1) != 1)
         OJPH_ERROR(0x00050124, "error reading COC segment");
@@ -1053,10 +1253,21 @@ namespace ojph {
         OJPH_ERROR(0x0005012D, "unsupported settings in a COC-SPcoc parameter");
 
       ui8 num_decompositions =  get_num_decompositions();
-      if (Scod & 1)
-        for (int i = 0; i <= num_decompositions; ++i)
+      if (Scod & 1) {
+        for (int i = 0; i <= num_decompositions; ++i) {
           if (file->read(&SPcod.precinct_size[i], 1) != 1)
             OJPH_ERROR(0x0005012A, "error reading COC segment");
+          if (i)
+            if ((SPcod.precinct_size[i] & 0x0F) == 0 ||
+              (SPcod.precinct_size[i] >> 4) == 0)
+              OJPH_ERROR(0x0005012E,
+                "Precinct width or height for resolutions other than the"
+                " coarsest must be larger than 1; here, they are %d and %d,"
+                " respectively.",
+                1 << (SPcod.precinct_size[i] & 0x0F),
+                1 << (SPcod.precinct_size[i] >> 4));
+        }
+      }
       ui32 t = 9;
       t += num_comps < 257 ? 0 : 1;
       t += (Scod & 1) ? 1 + num_decompositions : 0;
@@ -1127,6 +1338,16 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
+    param_cod* param_cod::get_or_add_coc(ui32 comp_idx)
+    {
+      assert(type == COD_MAIN);
+      local::param_cod *p = get_coc(comp_idx);
+      if (p == this)
+        p = add_coc_object(comp_idx);
+      return p;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     //
     //
     //
@@ -1137,142 +1358,137 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void param_qcd::check_validity(const param_siz& siz, const param_cod& cod)
     {
+      assert(this->type == QCD_MAIN);
+
       ui32 num_comps = siz.get_num_components();
       trim_non_existing_components(num_comps);
 
-      // first check that all the component captured by QCD have the same
-      // bit_depth and signedness
-      bool all_same = true;
-      bool other_comps_exist = false;
-      ui32 first_comp = 0xFFFF; // an impossible component
+      // initialize QCD based on the first component that is (a) associated with
+      // COD and (b) does not have a COC, or the first component othewise.
+      ui32 qcd_comp = 0;
+      for (ui32 c = 0; c < num_comps; ++c)
       {
-        ui32 num_decompositions = 0;
-        ui32 bit_depth = 0;
-        bool is_signed = false;
-        ui32 wavelet_kern = param_cod::DWT_IRV97;
-
-        for (ui32 c = 0; c < num_comps; ++c)
+        if (cod.get_coc(c) == &cod && get_qcc(c) == this)
         {
-          if (get_qcc(c) == this) // no qcc defined for component c
+          qcd_comp = c;
+          break;
+        }
+      }
+
+      // check if only the top QCD has qfactor set, if so, check if any
+      // of the first component has COC and qfactor set properly
+      if (this->qfactor != QFACTOR_UNSET)
+      {
+        if (num_comps < 3) // one or two components
+        {
+          for (ui32 i = 0; i < num_comps; ++i)
           {
-            const param_cod *p = cod.get_coc(c);
-            if (bit_depth == 0) // first component captured by QCD
+            param_qcd* q = get_qcc(i);
+            if (q == this)
             {
-              num_decompositions = p->get_num_decompositions();
-              bit_depth = siz.get_bit_depth(c);
-              is_signed = siz.is_signed(c);
-              wavelet_kern = p->get_wavelet_kern();
-              first_comp = c;
-            }
-            else
-            {
-              all_same = all_same
-                && (num_decompositions == p->get_num_decompositions())
-                && (bit_depth == siz.get_bit_depth(c))
-                && (is_signed == siz.is_signed(c))
-                && (wavelet_kern == p->get_wavelet_kern());
+              q = add_qcc_object(i);
+              set_qfactor(i, comp_type::OJPH_COMP_Y, this->qfactor);
             }
           }
-          else
-            other_comps_exist = true;
         }
-      }
-
-      // configure QCD according COD
-      ui32 qcd_num_decompositions;
-      ui32 qcd_bit_depth;
-      bool qcd_is_signed;
-      ui32 qcd_wavelet_kern;
-      {
-        ui32 qcd_component = first_comp != 0xFFFF ? first_comp : 0;
-        bool employing_color_transform = cod.is_employing_color_transform();
-        qcd_num_decompositions = cod.get_num_decompositions();
-        qcd_bit_depth = siz.get_bit_depth(qcd_component);
-        qcd_is_signed = siz.is_signed(qcd_component);
-        qcd_wavelet_kern = cod.get_wavelet_kern();
-        this->num_subbands = 1 + 3 * qcd_num_decompositions;
-        if (qcd_wavelet_kern == param_cod::DWT_REV53)
-          set_rev_quant(qcd_num_decompositions, qcd_bit_depth,
-            qcd_component < 3 ? employing_color_transform : false);
-        else if (qcd_wavelet_kern == param_cod::DWT_IRV97)
+        else if (num_comps >= 3)
         {
-          if (this->base_delta == -1.0f)
-            this->base_delta = 1.0f / (float)(1 << qcd_bit_depth);
-          set_irrev_quant(qcd_num_decompositions);
-        }
-        else
-          assert(0);
-      }
-
-      // if not all the same and captured by QCD, then create QCC for them
-      if (!all_same)
-      {
-        bool employing_color_transform = cod.is_employing_color_transform();
-        for (ui32 c = 0; c < num_comps; ++c)
-        {
-          const param_cod *cp = cod.get_coc(c);
-          if (qcd_num_decompositions == cp->get_num_decompositions()
-              && qcd_bit_depth == siz.get_bit_depth(c)
-              && qcd_is_signed == siz.is_signed(c)
-              && qcd_wavelet_kern == cp->get_wavelet_kern())
-            continue; // captured by QCD
-
-          // Does not match QCD, must have QCC
-          param_qcd *qp = get_qcc(c);
-          if (qp == this) // no QCC was defined, create QCC
-            qp = this->add_qcc_object(c);
-
-          ui32 num_decompositions = cp->get_num_decompositions();
-          qp->num_subbands = 1 + 3 * num_decompositions;
-          ui32 bit_depth = siz.get_bit_depth(c);
-          if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
-            qp->set_rev_quant(num_decompositions, bit_depth,
-              c < 3 ? employing_color_transform : false);
-          else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
-          {
-            if (qp->base_delta == -1.0f)
-              qp->base_delta = 1.0f / (float)(1 << bit_depth);
-            qp->set_irrev_quant(num_decompositions);
+          for (ui32 i = 0; i < num_comps; ++i) {
+            param_qcd* q = get_qcc(i);
+            if (q == this)
+            {
+              q = add_qcc_object(i);
+              ui8 ci = (ui8)(i < 3u ? i : 0u);
+              comp_type t = ojph::param_qcd::ui8_2_comp_type(ci);
+              set_qfactor(i, t, this->qfactor);
+            }
           }
-          else
-            assert(0);
         }
       }
-      else if (other_comps_exist) // Some are captured by QCD
+
+      this->make_quant_steps(qcd_comp, cod, siz);
+
+      // initialize every QCC, creating one for every component that (a) cannot
+      // use QCD and (b) does not already have a QCC
+      // NOTE: Qfactor always creates a QCC and QCD cannot be reused
+      for (ui32 c = 0; c < num_comps; ++c)
       {
-        bool employing_color_transform = cod.is_employing_color_transform();
-        for (ui32 c = 0; c < num_comps; ++c)
+        param_qcd *qcc = this->get_qcc(c);
+        const param_cod *coc = cod.get_coc(c);
+
+        // check if a QCC exists for the component
+        if (qcc == this)
         {
-          param_qcd *qp = get_qcc(c);
-          if (qp == this) // if captured by QCD continue
+          // if none exists, do not create one if QCD can be reused
+          if (!this->is_qcc_needed(c, *coc, siz))
             continue;
-          const param_cod *cp = cod.get_coc(c);
-          ui32 num_decompositions = cp->get_num_decompositions();
-          qp->num_subbands = 1 + 3 * num_decompositions;
-          ui32 bit_depth = siz.get_bit_depth(c);
-          if (cp->get_wavelet_kern() == param_cod::DWT_REV53)
-            qp->set_rev_quant(num_decompositions, bit_depth,
-              c < 3 ? employing_color_transform : false);
-          else if (cp->get_wavelet_kern() == param_cod::DWT_IRV97)
-          {
-            if (qp->base_delta == -1.0f)
-              qp->base_delta = 1.0f / (float)(1 << bit_depth);
-            qp->set_irrev_quant(num_decompositions);
-          }
-          else
-            assert(0);
+
+          qcc = this->add_qcc_object(c);
+          qcc->set_delta(this->base_delta);
         }
+
+        qcc->make_quant_steps(c, *coc, siz);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void param_qcd::set_delta(ui32 comp_idx, float delta)
+    void param_qcd::make_quant_steps(ui32 comp_num, const param_cod &cod,
+                                     const param_siz &siz)
     {
-      assert(type == QCD_MAIN);
-      param_qcd *p = get_qcc(comp_idx);
-      if (p == NULL)
-        p = add_qcc_object(comp_idx);
-      p->set_delta(delta);
+      if (this->is_init)
+        OJPH_ERROR(0x00040001, "Quantization step sizes already initialized.");
+
+      this->is_init = true;
+
+      this->num_decomps = cod.get_num_decompositions();
+      this->bit_depth = siz.get_bit_depth(comp_num);
+      this->is_signed = siz.is_signed(comp_num);
+      this->is_color_trans = cod.is_employing_color_transform();
+      this->wavelet_kern = cod.get_wavelet_kern();
+      this->sampling = siz.get_downsampling(comp_num);
+      this->num_subbands = 1 + 3 * this->num_decomps;
+
+      if (this->wavelet_kern == param_cod::DWT_REV53)
+        this->set_rev_quant(this->num_decomps, this->bit_depth,
+                            comp_num < 3 ? this->is_color_trans : false);
+      else if (this->wavelet_kern == param_cod::DWT_IRV97)
+      {
+        if (this->base_delta == -1.0f)
+        {
+          ui32 t = ojph_min(16, bit_depth);
+          this->base_delta = 1.0f / (float)(1 << t);
+        }
+        else if (qfactor != QFACTOR_UNSET)
+          OJPH_WARN(0x00040002, "qstep for component %d is ignored, because "
+            "qfactor is set.", comp_num);
+
+        this->set_irrev_quant(this->num_decomps);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    bool param_qcd::is_qcc_needed(ui32 comp_num, const param_cod &cod,
+                                  const param_siz &siz)
+    {
+      if (! this->is_init)
+        OJPH_ERROR(0x00040001, "Quantization step sizes not initialized.");
+
+      return this->num_decomps != cod.get_num_decompositions() ||
+              this->bit_depth != siz.get_bit_depth(comp_num) ||
+              this->is_signed != siz.is_signed(comp_num) ||
+              this->is_color_trans != cod.is_employing_color_transform() ||
+              this->wavelet_kern != cod.get_wavelet_kern();
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_qcd::set_qfactor(ui8 qfactor) {
+      assert(this->type == QCD_MAIN);
+
+      if (qfactor < 1 || qfactor > 100)
+        OJPH_ERROR(0x00050181, "Qfactor must be between 1 and 100, "
+          "but was set to %i.", qfactor);
+
+      this->qfactor = qfactor;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1326,42 +1542,73 @@ namespace ojph {
     void param_qcd::set_irrev_quant(ui32 num_decomps)
     {
       int guard_bits = 1;
-      Sqcd = (ui8)((guard_bits<<5)|0x2);//one guard bit, scalar quantization
-      int s = 0;
+      Sqcd = (ui8)((guard_bits<<5)|0x2); //one guard bit, scalar quantization
+
+      float g_c = 1.0f;
+      float delta_ref = base_delta;
+      float power = 1.0f;
+      const float* weights = visual_weights::get_no_weights();
+
+      if (qfactor != QFACTOR_UNSET)
+      {
+        visual_weights::colour_format format =
+          visual_weights::get_format(this->sampling);
+        if (format == visual_weights::VW_COLOUR_FORMAT_ERROR)
+          OJPH_ERROR(0x00050161, "Qfactor can only be used on components "
+            "with 4:4:4, 4:2:2 or 4:2:0 sampling");
+        if (this->ctype == comp_type::OJPH_COMP_Y &&
+          this->sampling.x != 1 && this->sampling.y != 1)
+          OJPH_ERROR(0x00050162, "Qfactor can only be used for a Y or "
+            "luminance component when it is not downsampled.");
+
+        // calculate component gain
+        g_c = visual_weights::get_gain(this->ctype);
+
+        // calculate delta_ref & power
+        delta_ref = visual_weights::get_delta_ref(qfactor, bit_depth, power);
+
+        // find visual weight
+        weights = visual_weights::get_weights(format, this->ctype);
+      }
+
+      // LL band
+      ui32 b = 0;
+      float w_b;
       float gain_l = sqrt_energy_gains::get_gain_l(num_decomps, false);
-      float delta_b = base_delta / (gain_l * gain_l);
-      int exp = 0, mantissa;
-      while (delta_b < 1.0f)
-      { exp++; delta_b *= 2.0f; }
-      //with rounding, there is a risk of becoming equal to 1<<12
-      // but that should not happen in reality
-      mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
-      mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-      SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
+      w_b = visual_weights::get_weight(weights, num_decomps, b);
+      w_b = std::pow(w_b, power);
+      encode_SPqcd(b++, delta_ref / (gain_l * gain_l * g_c * w_b));
+
+      // LL, HL, LH, HH, HL, LH, HH...
       for (ui32 d = num_decomps; d > 0; --d)
       {
+        // compute square root of the enery gain factor W_g
         float gain_l = sqrt_energy_gains::get_gain_l(d, false);
         float gain_h = sqrt_energy_gains::get_gain_h(d - 1, false);
 
-        delta_b = base_delta / (gain_l * gain_h);
-
-        int exp = 0, mantissa;
-        while (delta_b < 1.0f)
-        { exp++; delta_b *= 2.0f; }
-        mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
-        mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
-        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
-
-        delta_b = base_delta / (gain_h * gain_h);
-
-        exp = 0;
-        while (delta_b < 1)
-        { exp++; delta_b *= 2.0f; }
-        mantissa = (int)round(delta_b * (float)(1<<11)) - (1<<11);
-        mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
-        SPqcd.u16[s++] = (ui16)((exp << 11) | mantissa);
+        w_b = visual_weights::get_weight(weights, d, 1);
+        w_b = std::pow(w_b, power);
+        encode_SPqcd(b++, delta_ref / (gain_h * gain_l * g_c * w_b));
+        w_b = visual_weights::get_weight(weights, d, 2);
+        w_b = std::pow(w_b, power);
+        encode_SPqcd(b++, delta_ref / (gain_l * gain_h * g_c * w_b));
+        w_b = visual_weights::get_weight(weights, d, 3);
+        w_b = std::pow(w_b, power);
+        encode_SPqcd(b++, delta_ref / (gain_h * gain_h * g_c * w_b));
       }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_qcd::encode_SPqcd(ui32 subband_index, float delta)
+    {
+      int exp = 0, mantissa;
+      while (delta < 1.0f)
+      { exp++; delta *= 2.0f; }
+      mantissa = (int)round(delta * (float)(1<<11)) - (1<<11);
+      // with rounding, there is a risk that the mantissa becomes
+      // equal to 1<<11
+      mantissa = mantissa < (1<<11) ? mantissa : 0x7FF;
+      SPqcd.u16[subband_index] = (ui16)((exp << 11) | mantissa);
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1401,11 +1648,15 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     float param_qcd::get_irrev_delta(const param_dfs* dfs,
-                                     ui32 num_decompositions,
+                                     ui32 num_decompositions, ui32 comp_num,
                                      ui32 resolution, ui32 subband) const
     {
       float arr[] = { 1.0f, 2.0f, 2.0f, 4.0f };
-      assert((Sqcd & 0x1F) == 2);
+      if ((Sqcd & 0x1F) != 2)
+        OJPH_ERROR(0x00050101, "There is something wrong in the configuration "
+          "of the codestream; for component %d, the codestream defines an "
+          "irreversible transform, for which the codestream provides a "
+          "reversible (no quantization) step sizes in Sqcd/Sqcc.", comp_num);
 
       ui32 idx;
       if (dfs != NULL && dfs->exists())
@@ -1413,7 +1664,7 @@ namespace ojph {
       else
         idx = resolution ? (resolution - 1) * 3 + subband : 0;
       if (idx >= num_subbands) {
-        OJPH_INFO(0x00050101, "Trying to access quantization step size for "
+        OJPH_INFO(0x00050102, "Trying to access quantization step size for "
           "subband %d when the QCD/QCC marker segment specifies "
           "quantization step sizes for %d subbands only.  To continue "
           "decoding, we are using the step size for subband %d, which can "
@@ -1537,28 +1788,29 @@ namespace ojph {
       else
         assert(0);
 
-      char buf[4];
+      ui8  buf1;
+      ui16 buf2;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::QCD;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lqcd);
-      result &= file->write(&buf, 2) == 2;
-      *(ui8*)buf = Sqcd;
-      result &= file->write(&buf, 1) == 1;
+      buf2 = JP2K_MARKER::QCD;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lqcd);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf1 = Sqcd;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
 
       if (irrev == 0)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui8*)buf = SPqcd.u8[i];
-          result &= file->write(&buf, 1) == 1;
+          buf1 = SPqcd.u8[i];
+          result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
         }
       else if (irrev == 2)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui16*)buf = swap_byte(SPqcd.u16[i]);
-          result &= file->write(&buf, 2) == 2;
+          buf2 = swap_bytes_if_le(SPqcd.u16[i]);
+          result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
         }
       else
         assert(0);
@@ -1595,37 +1847,38 @@ namespace ojph {
       else
         assert(0);
 
-      char buf[4];
+      ui8  buf1;
+      ui16 buf2;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::QCC;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lqcd);
-      result &= file->write(&buf, 2) == 2;
+      buf2 = JP2K_MARKER::QCC;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lqcd);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       if (num_comps < 257)
       {
-        *(ui8*)buf = (ui8)comp_idx;
-        result &= file->write(&buf, 1) == 1;
+        buf1 = (ui8)comp_idx;
+        result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       }
       else
       {
-        *(ui16*)buf = swap_byte(comp_idx);
-        result &= file->write(&buf, 2) == 2;
+        buf2 = swap_bytes_if_le(comp_idx);
+        result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       }
-      *(ui8*)buf = Sqcd;
-      result &= file->write(&buf, 1) == 1;
+      buf1 = Sqcd;
+      result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
       if (irrev == 0)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui8*)buf = SPqcd.u8[i];
-          result &= file->write(&buf, 1) == 1;
+          buf1 = SPqcd.u8[i];
+          result &= file->write(&buf1, sizeof(ui8)) == sizeof(ui8);
         }
       else if (irrev == 2)
         for (ui32 i = 0; i < num_subbands; ++i)
         {
-          *(ui16*)buf = swap_byte(SPqcd.u16[i]);
-          result &= file->write(&buf, 2) == 2;
+          buf2 = swap_bytes_if_le(SPqcd.u16[i]);
+          result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
         }
       else
         assert(0);
@@ -1651,12 +1904,15 @@ namespace ojph {
     {
       if (file->read(&Lqcd, 2) != 2)
         OJPH_ERROR(0x00050081, "error reading QCD marker");
-      Lqcd = swap_byte(Lqcd);
+      Lqcd = swap_bytes_if_le(Lqcd);
       if (file->read(&Sqcd, 1) != 1)
         OJPH_ERROR(0x00050082, "error reading QCD marker");
       if ((Sqcd & 0x1F) == 0)
       {
         num_subbands = (Lqcd - 3);
+        if (num_subbands == 0)
+          OJPH_ERROR(0x0005008A, "QCD marker segment that specifies no "
+            "quantization informtion");
         if (num_subbands > 97 || Lqcd != 3 + num_subbands)
           OJPH_ERROR(0x00050083, "wrong Lqcd value of %d in QCD marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
@@ -1674,13 +1930,16 @@ namespace ojph {
       else if ((Sqcd & 0x1F) == 2)
       {
         num_subbands = (Lqcd - 3) / 2;
+        if (num_subbands == 0)
+          OJPH_ERROR(0x0005008B, "QCD marker segment that specifies no "
+            "quantization informtion");
         if (num_subbands > 97 || Lqcd != 3 + 2 * num_subbands)
           OJPH_ERROR(0x00050086, "wrong Lqcd value of %d in QCD marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
         {
           if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x00050087, "error reading QCD marker");
-          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
+          SPqcd.u16[i] = swap_bytes_if_le(SPqcd.u16[i]);
         }
       }
       else
@@ -1692,7 +1951,7 @@ namespace ojph {
     {
       if (file->read(&Lqcd, 2) != 2)
         OJPH_ERROR(0x000500A1, "error reading QCC marker");
-      Lqcd = swap_byte(Lqcd);
+      Lqcd = swap_bytes_if_le(Lqcd);
       if (num_comps < 257)
       {
         ui8 v;
@@ -1704,7 +1963,7 @@ namespace ojph {
       {
         if (file->read(&comp_idx, 2) != 2)
           OJPH_ERROR(0x000500A3, "error reading QCC marker");
-        comp_idx = swap_byte(comp_idx);
+        comp_idx = swap_bytes_if_le(comp_idx);
       }
       if (file->read(&Sqcd, 1) != 1)
         OJPH_ERROR(0x000500A4, "error reading QCC marker");
@@ -1712,6 +1971,9 @@ namespace ojph {
       if ((Sqcd & 0x1F) == 0)
       {
         num_subbands = (Lqcd - offset);
+        if (num_subbands == 0)
+          OJPH_ERROR(0x000500AC, "QCC marker segment that specifies no "
+            "quantization informtion");
         if (num_subbands > 97 || Lqcd != offset + num_subbands)
           OJPH_ERROR(0x000500A5, "wrong Lqcd value of %d in QCC marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
@@ -1729,17 +1991,47 @@ namespace ojph {
       else if ((Sqcd & 0x1F) == 2)
       {
         num_subbands = (Lqcd - offset) / 2;
+        if (num_subbands == 0)
+          OJPH_ERROR(0x000500AD, "QCC marker segment that specifies no "
+            "quantization informtion");
         if (num_subbands > 97 || Lqcd != offset + 2 * num_subbands)
           OJPH_ERROR(0x000500A8, "wrong Lqcc value of %d in QCC marker", Lqcd);
         for (ui32 i = 0; i < num_subbands; ++i)
         {
           if (file->read(&SPqcd.u16[i], 2) != 2)
             OJPH_ERROR(0x000500A9, "error reading QCC marker");
-          SPqcd.u16[i] = swap_byte(SPqcd.u16[i]);
+          SPqcd.u16[i] = swap_bytes_if_le(SPqcd.u16[i]);
         }
       }
       else
         OJPH_ERROR(0x000500AA, "wrong Sqcc value in QCC marker");
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_qcd::set_delta(ui32 comp_idx, float delta)
+    {
+      assert(type == QCD_MAIN);
+      param_qcd *p = get_qcc(comp_idx);
+      if (p == NULL)
+        p = add_qcc_object(comp_idx);
+      p->set_delta(delta);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void param_qcd::set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor)
+    {
+      assert(this->type == QCD_MAIN);
+
+      if (qfactor < 1 || qfactor > 100)
+        OJPH_ERROR(0x00050191, "Qfactor must be between 1 and 100, "
+          "but was set to %i.", qfactor);
+
+      param_qcd *p = get_qcc(comp_idx);
+      if (p == this)
+        p = add_qcc_object(comp_idx);
+
+      p->qfactor = qfactor;
+      p->ctype = ctype;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -1920,20 +2212,20 @@ namespace ojph {
       if (is_any_enabled() == false)
         return true;
 
-      char buf[2];
+      ui16 buf2;
       bool result = true;
       const param_nlt* p = this;
       while (p)
       {
         if (p->enabled)
         {
-          *(ui16*)buf = JP2K_MARKER::NLT;
-          *(ui16*)buf = swap_byte(*(ui16*)buf);
-          result &= file->write(&buf, 2) == 2;
-          *(ui16*)buf = swap_byte(p->Lnlt);
-          result &= file->write(&buf, 2) == 2;
-          *(ui16*)buf = swap_byte(p->Cnlt);
-          result &= file->write(&buf, 2) == 2;
+          buf2 = JP2K_MARKER::NLT;
+          buf2 = swap_bytes_if_le(buf2);
+          result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+          buf2 = swap_bytes_if_le(p->Lnlt);
+          result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+          buf2 = swap_bytes_if_le(p->Cnlt);
+          result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
           result &= file->write(&p->BDnlt, 1) == 1;
           result &= file->write(&p->Tnlt, 1) == 1;
         }
@@ -1945,23 +2237,32 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     void param_nlt::read(infile_base* file)
     {
-      ui8 buf[6];
+      ui16 buf2_len;
+      ui16 buf2_comp;
+      ui8  buf1_BDnlt;
+      ui8  buf1_Tnlt;
 
-      if (file->read(buf, 6) != 6)
+      if (file->read(&buf2_len, sizeof(ui16)) != sizeof(ui16))
         OJPH_ERROR(0x00050141, "error reading NLT marker segment");
+      if (file->read(&buf2_comp, sizeof(ui16)) != sizeof(ui16))
+        OJPH_ERROR(0x00050142, "error reading NLT marker segment");
+      if (file->read(&buf1_BDnlt, sizeof(ui8)) != sizeof(ui8))
+        OJPH_ERROR(0x00050143, "error reading NLT marker segment");
+      if (file->read(&buf1_Tnlt, sizeof(ui8)) != sizeof(ui8))
+        OJPH_ERROR(0x00050144, "error reading NLT marker segment");
 
-      ui16 length = swap_byte(*(ui16*)buf);
-      if (length != 6 || (buf[5] != 3 && buf[5] != 0)) // wrong length or type
-        OJPH_ERROR(0x00050142, "Unsupported NLT type %d\n", buf[5]);
+      ui16 length = swap_bytes_if_le(buf2_len);
+      if (length != 6 || (buf1_Tnlt != 3 && buf1_Tnlt != 0))
+        OJPH_ERROR(0x00050145, "Unsupported NLT type %d\n", buf1_Tnlt);
 
-      ui16 comp = swap_byte(*(ui16*)(buf + 2));
+      ui16 comp = swap_bytes_if_le(buf2_comp);
       param_nlt* p = get_nlt_object(comp);
       if (p == NULL)
         p = add_object(comp);
       p->enabled = true;
       p->Cnlt = comp;
-      p->BDnlt = buf[4];
-      p->Tnlt = buf[5];
+      p->BDnlt = buf1_BDnlt;
+      p->Tnlt = buf1_Tnlt;
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -2041,20 +2342,21 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool param_sot::write(outfile_base *file, ui32 payload_len)
     {
-      char buf[4];
+      ui16 buf2;
+      ui32 buf4;
       bool result = true;
 
       this->Psot = payload_len + 14; //inc. SOT marker, field & SOD
 
-      *(ui16*)buf = JP2K_MARKER::SOT;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lsot);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Isot);
-      result &= file->write(&buf, 2) == 2;
-      *(ui32*)buf = swap_byte(Psot);
-      result &= file->write(&buf, 4) == 4;
+      buf2 = JP2K_MARKER::SOT;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lsot);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Isot);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf4 = swap_bytes_if_le(Psot);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
       result &= file->write(&TPsot, 1) == 1;
       result &= file->write(&TNsot, 1) == 1;
 
@@ -2065,18 +2367,19 @@ namespace ojph {
     bool param_sot::write(outfile_base *file, ui32 payload_len,
                           ui8 TPsot, ui8 TNsot)
     {
-      char buf[4];
+      ui32 buf4;
+      ui16 buf2;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::SOT;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Lsot);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Isot);
-      result &= file->write(&buf, 2) == 2;
-      *(ui32*)buf = swap_byte(payload_len + 14);
-      result &= file->write(&buf, 4) == 4;
+      buf2 = JP2K_MARKER::SOT;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Lsot);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Isot);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf4 = swap_bytes_if_le(payload_len + 14);
+      result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
       result &= file->write(&TPsot, 1) == 1;
       result &= file->write(&TNsot, 1) == 1;
 
@@ -2094,7 +2397,7 @@ namespace ojph {
           Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Lsot = swap_byte(Lsot);
+        Lsot = swap_bytes_if_le(Lsot);
         if (Lsot != 10)
         {
           OJPH_INFO(0x00050092, "error in SOT length");
@@ -2107,7 +2410,7 @@ namespace ojph {
           Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Isot = swap_byte(Isot);
+        Isot = swap_bytes_if_le(Isot);
         if (Isot == 0xFFFF)
         {
           OJPH_INFO(0x00050094, "tile index in SOT marker cannot be 0xFFFF");
@@ -2120,7 +2423,7 @@ namespace ojph {
           Lsot = 0; Isot = 0; Psot = 0; TPsot = 0; TNsot = 0;
           return false;
         }
-        Psot = swap_byte(Psot);
+        Psot = swap_bytes_if_le(Psot);
         if (file->read(&TPsot, 1) != 1)
         {
           OJPH_INFO(0x00050096, "error reading SOT marker");
@@ -2138,17 +2441,17 @@ namespace ojph {
       {
         if (file->read(&Lsot, 2) != 2)
           OJPH_ERROR(0x00050091, "error reading SOT marker");
-        Lsot = swap_byte(Lsot);
+        Lsot = swap_bytes_if_le(Lsot);
         if (Lsot != 10)
           OJPH_ERROR(0x00050092, "error in SOT length");
         if (file->read(&Isot, 2) != 2)
           OJPH_ERROR(0x00050093, "error reading SOT tile index");
-        Isot = swap_byte(Isot);
+        Isot = swap_bytes_if_le(Isot);
         if (Isot == 0xFFFF)
           OJPH_ERROR(0x00050094, "tile index in SOT marker cannot be 0xFFFF");
         if (file->read(&Psot, 4) != 4)
           OJPH_ERROR(0x00050095, "error reading SOT marker");
-        Psot = swap_byte(Psot);
+        Psot = swap_bytes_if_le(Psot);
         if (file->read(&TPsot, 1) != 1)
           OJPH_ERROR(0x00050096, "error reading SOT marker");
         if (file->read(&TNsot, 1) != 1)
@@ -2194,22 +2497,23 @@ namespace ojph {
     bool param_tlm::write(outfile_base *file)
     {
       assert(next_pair_index == num_pairs);
-      char buf[4];
+      ui16 buf2;
+      ui32 buf4;
       bool result = true;
 
-      *(ui16*)buf = JP2K_MARKER::TLM;
-      *(ui16*)buf = swap_byte(*(ui16*)buf);
-      result &= file->write(&buf, 2) == 2;
-      *(ui16*)buf = swap_byte(Ltlm);
-      result &= file->write(&buf, 2) == 2;
+      buf2 = JP2K_MARKER::TLM;
+      buf2 = swap_bytes_if_le(buf2);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+      buf2 = swap_bytes_if_le(Ltlm);
+      result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
       result &= file->write(&Ztlm, 1) == 1;
       result &= file->write(&Stlm, 1) == 1;
       for (ui32 i = 0; i < num_pairs; ++i)
       {
-        *(ui16*)buf = swap_byte(pairs[i].Ttlm);
-        result &= file->write(&buf, 2) == 2;
-        *(ui32*)buf = swap_byte(pairs[i].Ptlm);
-        result &= file->write(&buf, 4) == 4;
+        buf2 = swap_bytes_if_le(pairs[i].Ttlm);
+        result &= file->write(&buf2, sizeof(ui16)) == sizeof(ui16);
+        buf4 = swap_bytes_if_le(pairs[i].Ptlm);
+        result &= file->write(&buf4, sizeof(ui32)) == sizeof(ui32);
       }
       return result;
     }
@@ -2309,16 +2613,19 @@ namespace ojph {
 
       if (file->read(&Ldfs, 2) != 2)
         OJPH_ERROR(0x000500D1, "error reading DFS-Ldfs parameter");
-      Ldfs = swap_byte(Ldfs);
+      Ldfs = swap_bytes_if_le(Ldfs);
       if (file->read(&Sdfs, 2) != 2)
         OJPH_ERROR(0x000500D2, "error reading DFS-Sdfs parameter");
-      Sdfs = swap_byte(Sdfs);
+      Sdfs = swap_bytes_if_le(Sdfs);
       if (Sdfs > 15)
         OJPH_ERROR(0x000500D3, "The DFS-Sdfs parameter is %d, which is "
           "larger than the permissible 15", Sdfs);
       ui8 t, l_Ids = 0;
       if (file->read(&l_Ids, 1) != 1)
         OJPH_ERROR(0x000500D4, "error reading DFS-Ids parameter");
+      if (l_Ids == 0)
+        OJPH_ERROR(0x000500D8,
+          "The value of the Ids member in the DFS marker segment cannot be 0");
       constexpr int max_Ddfs = sizeof(Ddfs) * 4;
       if (l_Ids > max_Ddfs)
         OJPH_INFO(0x000500D5, "The DFS-Ids parameter is %d; while this is "
@@ -2390,27 +2697,25 @@ namespace ojph {
         ui16 v;
         if (file->read(&v, 2) != 2) return false;
         bytes -= 2;
-        K = swap_byte(v);
+        K = swap_bytes_if_le(v);
       }
       else if (coeff_type == 2) { // float
-        union {
-          float f;
-          ui32 i;
-        } v;
-        if (file->read(&v.i, 4) != 4) return false;
+        ui32 i;
+        if (file->read(&i, sizeof(ui32)) != sizeof(ui32)) return false;
         bytes -= 4;
-        v.i = swap_byte(v.i);
-        K = v.f;
+        i = swap_bytes_if_le(i);
+        float f;
+        memcpy(&f, &i, sizeof(float));
+        K = f;
       }
       else if (coeff_type == 3) { // double
-        union {
-          double d;
-          ui64 i;
-        } v;
-        if (file->read(&v.i, 8) != 8) return false;
+        ui64 i;
+        if (file->read(&i, sizeof(ui64)) != sizeof(ui64)) return false;
         bytes -= 8;
-        v.i = swap_byte(v.i);
-        K = (float)v.d;
+        i = swap_bytes_if_le(i);
+        double d;
+        memcpy(&d, &i, sizeof(double));
+        K = (float)d;
       }
       else if (coeff_type == 4) { // 128 bit float
         ui64 v, v1;
@@ -2418,12 +2723,8 @@ namespace ojph {
         bytes -= 8;
         if (file->read(&v1, 8) != 8) return false; // v1 not needed
         bytes -= 8;
-        v = swap_byte(v);
+        v = swap_bytes_if_le(v);
 
-        union {
-          float f;
-          ui32 i;
-        } s;
         // convert the MSB of 128b float to 32b float
         // 32b float has 1 sign bit, 8 exponent (offset 127), 23 mantissa
         // 128b float has 1 sign bit, 15 exponent (offset 16383), 112 mantissa
@@ -2432,11 +2733,13 @@ namespace ojph {
         e += 127;
         e = e & 0xFF;                          // removes MSBs if negative
         e <<= 23;                              // move bits to their location
-        s.i = 0;
-        s.i |= ((ui32)(v >> 32) & 0x80000000); // copy sign bit
-        s.i |= (ui32)e;                        // copy exponent
-        s.i |= (ui32)((v >> 25) & 0x007FFFFF); // copy 23 mantissa
-        K = s.f;
+        ui32 i = 0;
+        i |= ((ui32)(v >> 32) & 0x80000000); // copy sign bit
+        i |= (ui32)e;                        // copy exponent
+        i |= (ui32)((v >> 25) & 0x007FFFFF); // copy 23 mantissa
+        float f;
+        memcpy(&f, &i, sizeof(float));
+        K = f;
       }
       return true;
     }
@@ -2456,7 +2759,7 @@ namespace ojph {
         si16 v;
         if (file->read(&v, 2) != 2) return false;
         bytes -= 2;
-        K = (si16)swap_byte((ui16)v);
+        K = (si16)swap_bytes_if_le((ui16)v);
       }
       else
         return false;
@@ -2471,13 +2774,13 @@ namespace ojph {
 
       if (file->read(&Latk, 2) != 2)
         OJPH_ERROR(0x000500E1, "error reading ATK-Latk parameter");
-      Latk = swap_byte(Latk);
+      Latk = swap_bytes_if_le(Latk);
       si32 bytes = Latk - 2;
       ojph::ui16 temp_Satk;
       if (file->read(&temp_Satk, 2) != 2)
         OJPH_ERROR(0x000500E2, "error reading ATK-Satk parameter");
       bytes -= 2;
-      temp_Satk = swap_byte(temp_Satk);
+      temp_Satk = swap_bytes_if_le(temp_Satk);
       int tmp_idx = temp_Satk & 0xFF;
       if ((top_atk && top_atk->get_atk(tmp_idx) != NULL)
         || tmp_idx == 0 || tmp_idx == 1)
@@ -2523,7 +2826,7 @@ namespace ojph {
           if (file->read(&d[s].rev.Batk, 2) != 2)
             OJPH_ERROR(0x000500EA, "error reading ATK-Batk parameter");
           bytes -= 2;
-          d[s].rev.Batk = (si16)swap_byte((ui16)d[s].rev.Batk);
+          d[s].rev.Batk = (si16)swap_bytes_if_le((ui16)d[s].rev.Batk);
           ui8 LCatk;
           if (file->read(&LCatk, 1) != 1)
             OJPH_ERROR(0x000500EB, "error reading ATK-LCatk parameter");
@@ -2595,7 +2898,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     param_atk* param_atk::add_object()
     {
-      assert(top_atk = NULL);
+      assert(top_atk == NULL);
       param_atk *p = this;
       while (p->next != NULL)
         p = p->next;

--- a/external/OpenJPH/src/core/codestream/ojph_params_local.h
+++ b/external/OpenJPH/src/core/codestream/ojph_params_local.h
@@ -217,21 +217,35 @@ namespace ojph {
         cptr[comp_num].YRsiz = (ui8)downsampling.y;
       }
 
-      void check_validity(const param_cod& cod)
-      {
-        this->cod = &cod;
+      void set_image_extent(point dims) { Xsiz = dims.x; Ysiz = dims.y; }
+      point get_image_extent() const { return point(Xsiz, Ysiz); }
+      void set_tile_size(size s) { XTsiz = s.w; YTsiz = s.h; }
+      size get_tile_size() const { return size(XTsiz, YTsiz); }
+      void set_image_offset(point offset)
+      { XOsiz = offset.x; YOsiz = offset.y; }
+      point get_image_offset() const
+      { return point(XOsiz, YOsiz); }
+      void set_tile_offset(point offset)
+      { XTOsiz = offset.x; YTOsiz = offset.y; }
+      point get_tile_offset() const
+      { return point(XTOsiz, YTOsiz); }
 
-        if (XTsiz == 0 && YTsiz == 0)
-        { XTsiz = Xsiz + XOsiz; YTsiz = Ysiz + YOsiz; }
+      void set_cod(const param_cod& cod) { this->cod = &cod; }
+
+      void check_validity()
+      {
         if (Xsiz == 0 || Ysiz == 0 || XTsiz == 0 || YTsiz == 0)
           OJPH_ERROR(0x00040001,
-            "You cannot set image extent nor tile size to zero");
+            "Image extent and/or tile size cannot be zero");
         if (XTOsiz > XOsiz || YTOsiz > YOsiz)
           OJPH_ERROR(0x00040002,
-            "tile offset has to be smaller than image offset");
+            "Tile offset has to be smaller than the image offset");
         if (XTsiz + XTOsiz <= XOsiz || YTsiz + YTOsiz <= YOsiz)
           OJPH_ERROR(0x00040003,
-            "the top left tile must intersect with the image");
+            "The top left tile must intersect with the image");
+        if (Xsiz <= XOsiz || Ysiz <= YOsiz)
+          OJPH_ERROR(0x00040004,
+            "The image extent must be larger than the image offset");
       }
 
       ui16 get_num_components() const { return Csiz; }
@@ -588,6 +602,9 @@ namespace ojph {
       ////////////////////////////////////////
       param_cod* add_coc_object(ui32 comp_idx);
 
+      ///////////////////////////////////////
+      param_cod* get_or_add_coc(ui32 comp_idx);
+
       ////////////////////////////////////////
       const param_atk* access_atk() const { return atk; }
 
@@ -615,8 +632,15 @@ namespace ojph {
         type = top_cod ? COC_MAIN : COD_MAIN;
         Lcod = 0;
         Scod = 0;
+        SPcod = cod_SPcod();  // SPcod is initialized to default values
         next = NULL;
         atk = NULL;
+        // For COC marker segment:
+        // Lcod will be initialized on writing the marker segment to disk
+        // Scod is initialized to 0
+        // SGcod does not exist in COC
+        // SPcoc is initialized to default values
+        // atk is initialized to NULL
         this->top_cod = top_cod;
         this->comp_idx = comp_idx;
       }
@@ -677,6 +701,14 @@ namespace ojph {
         QCC_TILE  = 4   // not implemented
       };
 
+      ////////////////////////////////////////
+      enum qfactor_const : ui8 {
+        QFACTOR_UNSET = 0
+      };
+
+      ////////////////////////////////////////
+      using comp_type = ojph::param_qcd::comp_type;
+
     public:
       param_qcd(param_qcd* top_qcd = NULL, ui16 comp_idx = OJPH_QCD_DEFAULT)
       { avail = NULL; init(top_qcd, comp_idx); }
@@ -693,21 +725,27 @@ namespace ojph {
       }
 
       void check_validity(const param_siz& siz, const param_cod& cod);
+      void make_quant_steps(ui32 comp_num, const param_cod &cod,
+                            const param_siz &siz);
+      bool is_qcc_needed(ui32 comp_num, const param_cod &cod,
+                         const param_siz &siz);
       void set_delta(float delta) { base_delta = delta; }
-      void set_delta(ui32 comp_idx, float delta);
+      void set_qfactor(ui8 qfactor);
       ui32 get_num_guard_bits() const;
       ui32 get_MAGB() const;
       ui32 get_Kmax(const param_dfs* dfs, ui32 num_decompositions,
                     ui32 resolution, ui32 subband) const;
       ui32 propose_precision(const param_cod* cod) const;
       float get_irrev_delta(const param_dfs* dfs,
-                            ui32 num_decompositions,
+                            ui32 num_decompositions, ui32 comp_num,
                             ui32 resolution, ui32 subband) const;
       bool write(outfile_base *file);
       bool write_qcc(outfile_base *file, ui32 num_comps);
       void read(infile_base *file);
       void read_qcc(infile_base *file, ui32 num_comps);
 
+      void set_delta(ui32 comp_idx, float delta);
+      void set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
       param_qcd* get_qcc(ui32 comp_idx);
       const param_qcd* get_qcc(ui32 comp_idx) const;
       param_qcd* add_qcc_object(ui32 comp_idx);
@@ -717,12 +755,16 @@ namespace ojph {
       ////////////////////////////////////////
       void init(param_qcd* top_qcd, ui16 comp_idx)
       {
+        is_init = false;
         type = top_qcd ? QCC_MAIN : QCD_MAIN;
         Lqcd = 0;
         Sqcd = 0;
         memset(&SPqcd, 0, sizeof(SPqcd));
         num_subbands = 0;
         base_delta = -1.0f;
+        qfactor = QFACTOR_UNSET;
+        ctype = comp_type::OJPH_COMP_Y;
+        sampling = ojph::point(1, 1);
         enabled = true;
         next = NULL;
         this->top_qcd = top_qcd;
@@ -744,6 +786,7 @@ namespace ojph {
       void set_rev_quant(ui32 num_decomps, ui32 bit_depth,
                          bool is_employing_color_transform);
       void set_irrev_quant(ui32 num_decomps);
+      void encode_SPqcd(ui32 subband_index, float delta);
       ui32 get_largest_Kmax() const;
       bool internal_write_qcc(outfile_base *file, ui32 num_comps);
       void trim_non_existing_components(ui32 num_comps);
@@ -755,6 +798,7 @@ namespace ojph {
 
     private: // QCD variables
       qcd_type type;
+      bool is_init;     // have the quantization steps been generated
       ui16 Lqcd;
       ui8 Sqcd;
       union
@@ -763,11 +807,21 @@ namespace ojph {
         ui16 u16[97];
       } SPqcd;
       ui32 num_subbands;  // number of subbands
-      float base_delta;   // base quantization step size -- all other
-                          // step sizes are derived from it.
       bool enabled;       // enabled if two, and ignored if false
       param_qcd *next;    // pointer to create chains of qcc marker segments
       param_qcd *top_qcd; // pointer to the top QCD (this is the default)
+
+      // variables used to generate the quantization step sizes
+      float base_delta;   // base quantization step size -- all other
+                          // step sizes are derived from it.
+      ui8 qfactor;
+      comp_type ctype;
+      bool is_color_trans;
+      ui32 num_decomps;
+      ui32 bit_depth;
+      bool is_signed;
+      ui32 wavelet_kern;
+      ojph::point sampling;
 
     private: // QCC only variables
       ui16 comp_idx;

--- a/external/OpenJPH/src/core/codestream/ojph_resolution.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_resolution.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -57,7 +57,7 @@ namespace ojph {
   {
     //////////////////////////////////////////////////////////////////////////
     void resolution::pre_alloc(codestream* codestream, const rect& res_rect,
-                               const rect& recon_res_rect, 
+                               const rect& recon_res_rect,
                                ui32 comp_num, ui32 res_num)
     {
       mem_fixed_allocator* allocator = codestream->get_allocator();
@@ -150,7 +150,7 @@ namespace ojph {
           tby1 = try1 >> 1;
           re.org.y = tby0;
           re.siz.h = tby1 - tby0;
-          subband::pre_alloc(codestream, re, comp_num, res_num, 
+          subband::pre_alloc(codestream, re, comp_num, res_num,
                              transform_flags);
         }
         else if (ds == param_dfs::HORZ_DWT)
@@ -170,7 +170,7 @@ namespace ojph {
           tbx1 = trx1 >> 1;
           re.org.x = tbx0;
           re.siz.w = tbx1 - tbx0;
-          subband::pre_alloc(codestream, re, comp_num, res_num, 
+          subband::pre_alloc(codestream, re, comp_num, res_num,
                              transform_flags);
         }
         else
@@ -183,7 +183,7 @@ namespace ojph {
         }
       }
       else
-        subband::pre_alloc(codestream, res_rect, comp_num, res_num, 
+        subband::pre_alloc(codestream, res_rect, comp_num, res_num,
                            transform_flags);
 
       //prealloc precincts
@@ -219,7 +219,7 @@ namespace ojph {
             allocator->pre_alloc_data<si32>(width, 1);
             allocator->pre_alloc_data<si32>(width, 1);
           }
-          else 
+          else
           {
             for (ui32 i = 0; i < num_steps; ++i)
               allocator->pre_alloc_data<si64>(width, 1);
@@ -328,7 +328,7 @@ namespace ojph {
               child_res = allocator->post_alloc_obj<resolution>(1);
               child_res->finalize_alloc(codestream, re,
                 skipped_res_for_recon ? recon_res_rect : re, comp_num,
-                res_num - 1, comp_downsamp, next_res_downsamp, 
+                res_num - 1, comp_downsamp, next_res_downsamp,
                 parent_tile_comp, this);
             }
             else
@@ -407,7 +407,7 @@ namespace ojph {
         num_precincts.w -= trx0 >> log_PP.w;
         num_precincts.h = (try1 + (1 << log_PP.h) - 1) >> log_PP.h;
         num_precincts.h -= try0 >> log_PP.h;
-        precincts = 
+        precincts =
           allocator->post_alloc_obj<precinct>((size_t)num_precincts.area());
         ui64 num = num_precincts.area();
         for (ui64 i = 0; i < num; ++i)
@@ -508,7 +508,7 @@ namespace ojph {
               allocator->post_alloc_data<si64>(width, 1), width, 1);
           }
         }
-        else 
+        else
         {
             for (ui32 i = 0; i < num_steps; ++i)
               ssp[i].line->wrap(
@@ -528,7 +528,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     line_buf* resolution::get_line()
-    { 
+    {
       if (vert_even)
       {
         ++cur_line;
@@ -742,11 +742,11 @@ namespace ojph {
               {
                 if (vert_even) { // even
                   if (transform_flags & HORZ_TRX)
-                    rev_horz_syn(atk, aug->line, child_res->pull_line(), 
+                    rev_horz_syn(atk, aug->line, child_res->pull_line(),
                       bands[1].pull_line(), width, horz_even);
                   else
                     memcpy(aug->line->p, child_res->pull_line()->p,
-                      (size_t)width 
+                      (size_t)width
                       * (aug->line->flags & line_buf::LFT_SIZE_MASK));
                   aug->active = true;
                   vert_even = !vert_even;
@@ -755,11 +755,11 @@ namespace ojph {
                 }
                 else {
                   if (transform_flags & HORZ_TRX)
-                    rev_horz_syn(atk, sig->line, bands[2].pull_line(), 
+                    rev_horz_syn(atk, sig->line, bands[2].pull_line(),
                       bands[3].pull_line(), width, horz_even);
                   else
                     memcpy(sig->line->p, bands[2].pull_line()->p,
-                      (size_t)width 
+                      (size_t)width
                       * (sig->line->flags & line_buf::LFT_SIZE_MASK));
                   sig->active = true;
                   vert_even = !vert_even;
@@ -799,7 +799,7 @@ namespace ojph {
                   bands[1].pull_line(), width, horz_even);
               else
                 memcpy(aug->line->p, child_res->pull_line()->p,
-                  (size_t)width 
+                  (size_t)width
                   * (aug->line->flags & line_buf::LFT_SIZE_MASK));
             }
             else
@@ -809,11 +809,11 @@ namespace ojph {
                   bands[3].pull_line(), width, horz_even);
               else
                 memcpy(aug->line->p, bands[2].pull_line()->p,
-                  (size_t)width 
+                  (size_t)width
                   * (aug->line->flags & line_buf::LFT_SIZE_MASK));
               if (aug->line->flags & line_buf::LFT_32BIT)
               {
-                si32* sp = aug->line->i32;                
+                si32* sp = aug->line->i32;
                 for (ui32 i = width; i > 0; --i)
                   *sp++ >>= 1;
               }
@@ -843,9 +843,9 @@ namespace ojph {
               {
                 if (vert_even) { // even
                   if (transform_flags & HORZ_TRX)
-                    irv_horz_syn(atk, aug->line, child_res->pull_line(), 
+                    irv_horz_syn(atk, aug->line, child_res->pull_line(),
                       bands[1].pull_line(), width, horz_even);
-                  else 
+                  else
                     memcpy(aug->line->f32, child_res->pull_line()->f32,
                       width * sizeof(float));
                   aug->active = true;
@@ -859,7 +859,7 @@ namespace ojph {
                 }
                 else {
                   if (transform_flags & HORZ_TRX)
-                    irv_horz_syn(atk, sig->line, bands[2].pull_line(), 
+                    irv_horz_syn(atk, sig->line, bands[2].pull_line(),
                       bands[3].pull_line(), width, horz_even);
                   else
                     memcpy(sig->line->f32, bands[2].pull_line()->f32,
@@ -924,7 +924,7 @@ namespace ojph {
         }
       }
       else
-      { 
+      {
         if (reversible)
         {
           if (transform_flags & HORZ_TRX)

--- a/external/OpenJPH/src/core/codestream/ojph_subband.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_subband.cpp
@@ -3,21 +3,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -127,7 +127,8 @@ namespace ojph {
       this->band_rect = band_rect;
       this->parent = res;
 
-      const param_cod* cdp = codestream->get_coc(parent->get_comp_num());
+      ui32 comp_num = parent->get_comp_num();
+      const param_cod* cdp = codestream->get_coc(comp_num);
       this->reversible = cdp->access_atk()->is_reversible();
       size log_cb = cdp->get_log_block_dims();
       log_PP = cdp->get_log_precinct_size(res_num);
@@ -149,14 +150,14 @@ namespace ojph {
         if (dfs != NULL)
           dfs = dfs->get_dfs(cdp->get_dfs_index());
       }
-      ui32 comp_num = parent->get_comp_num();
       const param_qcd* qcd = codestream->access_qcd()->get_qcc(comp_num);
       ui32 num_decomps = cdp->get_num_decompositions();
       this->K_max = qcd->get_Kmax(dfs, num_decomps, this->res_num, band_num);
       if (!reversible)
       {
-        float d = 
-          qcd->get_irrev_delta(dfs, num_decomps, res_num, subband_num);
+        float d =
+          qcd->get_irrev_delta(dfs, num_decomps,
+            comp_num, res_num, subband_num);
         d /= (float)(1u << (31 - this->K_max));
         delta = d;
         delta_inv = (1.0f/d);
@@ -199,7 +200,7 @@ namespace ojph {
         ui32 cbx1 = ojph_min(tbx1, x_lower_bound + (i + 1) * nominal.w);
         cb_size.w = cbx1 - cbx0;
         blocks[i].finalize_alloc(codestream, this, nominal, cb_size,
-                                 coded_cbs + i, K_max, line_offset, 
+                                 coded_cbs + i, K_max, line_offset,
                                  precision, comp_num);
         line_offset += cb_size.w;
       }
@@ -210,7 +211,7 @@ namespace ojph {
       ui32 width = band_rect.siz.w + 1;
       if (reversible)
       {
-        if (precision <= 32)      
+        if (precision <= 32)
           lines->wrap(allocator->post_alloc_data<si32>(width, 1), width, 1);
         else
           lines->wrap(allocator->post_alloc_data<si64>(width, 1), width, 1);

--- a/external/OpenJPH/src/core/codestream/ojph_tile.cpp
+++ b/external/OpenJPH/src/core/codestream/ojph_tile.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -110,6 +110,7 @@ namespace ojph {
       ui32 recon_ty1 = recon_tile_rect.org.y + recon_tile_rect.siz.h;
 
       ui32 width = 0;
+      rect colour_comp_rect[3];
       for (ui32 i = 0; i < num_comps; ++i)
       {
         point downsamp = szp->get_downsampling(i);
@@ -129,6 +130,9 @@ namespace ojph {
         comp_rect.siz.w = tcx1 - tcx0;
         comp_rect.siz.h = tcy1 - tcy0;
 
+        if (i < 3)
+          colour_comp_rect[i] = comp_rect;
+
         rect recon_comp_rect;
         recon_comp_rect.org.x = recon_tcx0;
         recon_comp_rect.org.y = recon_tcy0;
@@ -147,7 +151,7 @@ namespace ojph {
         for (ui32 i = 0; i < 3; ++i)
           reversible[i] = codestream->get_coc(i)->is_reversible();
         if (reversible[0] != reversible[1] || reversible[1] != reversible[2])
-          OJPH_ERROR(0x000300A2, "When the colour transform is employed. "
+          OJPH_ERROR(0x000300A2, "When the colour transform is employed, "
             "all colour components must undergo either reversible or "
             "irreversible wavelet transform; if not, then it is not clear "
             "what colour transform should be used (reversible or "
@@ -156,6 +160,21 @@ namespace ojph {
             reversible[0] ? "reversible" : "irreversible",
             reversible[1] ? "reversible" : "irreversible",
             reversible[2] ? "reversible" : "irreversible");
+
+        if (colour_comp_rect[0] != colour_comp_rect[1] ||
+          colour_comp_rect[1] != colour_comp_rect[2])
+          OJPH_ERROR(0x000300A3, "When the colour transform is employed, "
+            "the first three colour components must have the same rectangle; "
+            "i.e., the same origin on the canvas and the same width and "
+            "height. The first three components have the following "
+            "origin-size (x,y)-(w,h) values. Component 0 (%d,%d)-(%d,%d), "
+            "Component 1 (%d,%d)-(%d,%d), Component 2 (%d,%d)-(%d,%d)",
+            colour_comp_rect[0].org.x, colour_comp_rect[0].org.y,
+            colour_comp_rect[0].siz.w, colour_comp_rect[0].siz.h,
+            colour_comp_rect[1].org.x, colour_comp_rect[1].org.y,
+            colour_comp_rect[1].siz.w, colour_comp_rect[1].siz.h,
+            colour_comp_rect[2].org.x, colour_comp_rect[2].org.y,
+            colour_comp_rect[2].siz.w, colour_comp_rect[2].siz.h);
 
         allocator->pre_alloc_obj<line_buf>(3);
         if (reversible[0])
@@ -169,7 +188,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void tile::finalize_alloc(codestream *codestream, const rect& tile_rect,
-                              ui32 tile_idx, ui32& offset, 
+                              ui32 tile_idx, ui32& offset,
                               ui32 &num_tileparts)
     {
       //this->parent = codestream;
@@ -252,7 +271,7 @@ namespace ojph {
         ui32 recon_tcx1 = ojph_div_ceil(tx1, recon_downsamp.x);
         ui32 recon_tcy1 = ojph_div_ceil(ty1, recon_downsamp.y);
 
-        line_offsets[i] = 
+        line_offsets[i] =
           recon_tcx0 - ojph_div_ceil(tx0 - offset, recon_downsamp.x);
         comp_rects[i].org.x = tcx0;
         comp_rects[i].org.y = tcy0;
@@ -263,7 +282,7 @@ namespace ojph {
         recon_comp_rects[i].siz.w = recon_tcx1 - recon_tcx0;
         recon_comp_rects[i].siz.h = recon_tcy1 - recon_tcy0;
 
-        comps[i].finalize_alloc(codestream, this, i, comp_rects[i], 
+        comps[i].finalize_alloc(codestream, this, i, comp_rects[i],
           recon_comp_rects[i]);
         width = ojph_max(width, recon_comp_rects[i].siz.w);
 
@@ -274,8 +293,8 @@ namespace ojph {
           OJPH_ERROR(0x000300A1, "Mismatch between Ssiz (bit_depth = %d, "
             "is_signed = %s) from SIZ marker segment, and BDnlt "
             "(bit_depth = %d, is_signed = %s) from NLT marker segment, "
-            "for component %d", i, num_bits[i], 
-            is_signed[i] ? "True" : "False", bd, is ? "True" : "False");
+            "for component %d", num_bits[i],
+            is_signed[i] ? "True" : "False", bd, is ? "True" : "False", i);
         if (result == false)
           nlt_type3[i] = param_nlt::nonlinearity::OJPH_NLT_NO_NLT;
         cur_line[i] = 0;
@@ -311,7 +330,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool tile::push(line_buf *line, ui32 comp_num)
     {
-      constexpr ui8 type3 = 
+      constexpr ui8 type3 =
         param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
 
       assert(comp_num < num_comps);
@@ -334,7 +353,7 @@ namespace ojph {
               tc, 0, shift + 1, comp_width);
           else {
             shift = is_signed[comp_num] ? 0 : -shift;
-            rev_convert(line, line_offsets[comp_num], tc, 0, 
+            rev_convert(line, line_offsets[comp_num], tc, 0,
               shift, comp_width);
           }
         }
@@ -356,11 +375,11 @@ namespace ojph {
         if (reversible[comp_num])
         {
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
-            rev_convert_nlt_type3(line, line_offsets[comp_num], 
-              lines + comp_num, 0, shift + 1, comp_width);            
+            rev_convert_nlt_type3(line, line_offsets[comp_num],
+              lines + comp_num, 0, shift + 1, comp_width);
           else {
             shift = is_signed[comp_num] ? 0 : -shift;
-            rev_convert(line, line_offsets[comp_num], lines + comp_num, 0, 
+            rev_convert(line, line_offsets[comp_num], lines + comp_num, 0,
               shift, comp_width);
           }
 
@@ -379,11 +398,11 @@ namespace ojph {
         {
           if (nlt_type3[comp_num] == type3)
             irv_convert_to_float_nlt_type3(line, line_offsets[comp_num],
-              lines + comp_num, num_bits[comp_num], is_signed[comp_num], 
+              lines + comp_num, num_bits[comp_num], is_signed[comp_num],
               comp_width);
           else
             irv_convert_to_float(line, line_offsets[comp_num],
-              lines + comp_num, num_bits[comp_num], is_signed[comp_num], 
+              lines + comp_num, num_bits[comp_num], is_signed[comp_num],
               comp_width);
           if (comp_num == 2)
           { // irreversible color transform
@@ -404,7 +423,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     bool tile::pull(line_buf* tgt_line, ui32 comp_num)
     {
-      constexpr ui8 type3 = 
+      constexpr ui8 type3 =
         param_nlt::nonlinearity::OJPH_NLT_BINARY_COMPLEMENT_NLT;
 
       assert(comp_num < num_comps);
@@ -413,38 +432,40 @@ namespace ojph {
 
       cur_line[comp_num]++;
 
+      ui32 comp_width = recon_comp_rects[comp_num].siz.w;
+      if (comp_width == 0)
+        return true; // nothing to pull, but not an error
+
       if (!employ_color_transform || num_comps == 1)
       {
         line_buf *src_line = comps[comp_num].pull_line();
-        ui32 comp_width = recon_comp_rects[comp_num].siz.w;
         if (reversible[comp_num])
         {
           si64 shift = (si64)1 << (num_bits[comp_num] - 1);
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
-            rev_convert_nlt_type3(src_line, 0, tgt_line, 
+            rev_convert_nlt_type3(src_line, 0, tgt_line,
               line_offsets[comp_num], shift + 1, comp_width);
           else {
             shift = is_signed[comp_num] ? 0 : shift;
-            rev_convert(src_line, 0, tgt_line, 
+            rev_convert(src_line, 0, tgt_line,
               line_offsets[comp_num], shift, comp_width);
           }
         }
         else
         {
           if (nlt_type3[comp_num] == type3)
-            irv_convert_to_integer_nlt_type3(src_line, tgt_line, 
-              line_offsets[comp_num], num_bits[comp_num], 
+            irv_convert_to_integer_nlt_type3(src_line, tgt_line,
+              line_offsets[comp_num], num_bits[comp_num],
               is_signed[comp_num], comp_width);
           else
-            irv_convert_to_integer(src_line, tgt_line, 
-              line_offsets[comp_num], num_bits[comp_num], 
+            irv_convert_to_integer(src_line, tgt_line,
+              line_offsets[comp_num], num_bits[comp_num],
               is_signed[comp_num], comp_width);
         }
       }
       else
       {
         assert(num_comps >= 3);
-        ui32 comp_width = recon_comp_rects[comp_num].siz.w;
         if (comp_num == 0)
         {
           if (reversible[comp_num])
@@ -465,11 +486,11 @@ namespace ojph {
           else
             src_line = comps[comp_num].pull_line();
           if (is_signed[comp_num] && nlt_type3[comp_num] == type3)
-            rev_convert_nlt_type3(src_line, 0, tgt_line, 
+            rev_convert_nlt_type3(src_line, 0, tgt_line,
               line_offsets[comp_num], shift + 1, comp_width);
           else {
             shift = is_signed[comp_num] ? 0 : shift;
-            rev_convert(src_line, 0, tgt_line, 
+            rev_convert(src_line, 0, tgt_line,
               line_offsets[comp_num], shift, comp_width);
           }
         }
@@ -479,14 +500,14 @@ namespace ojph {
           if (comp_num < 3)
             lbp = lines + comp_num;
           else
-            lbp = comps[comp_num].pull_line();            
+            lbp = comps[comp_num].pull_line();
           if (nlt_type3[comp_num] == type3)
-            irv_convert_to_integer_nlt_type3(lbp, tgt_line, 
-              line_offsets[comp_num], num_bits[comp_num], 
+            irv_convert_to_integer_nlt_type3(lbp, tgt_line,
+              line_offsets[comp_num], num_bits[comp_num],
               is_signed[comp_num], comp_width);
           else
-            irv_convert_to_integer(lbp, tgt_line, 
-              line_offsets[comp_num], num_bits[comp_num], 
+            irv_convert_to_integer(lbp, tgt_line,
+              line_offsets[comp_num], num_bits[comp_num],
               is_signed[comp_num], comp_width);
         }
       }
@@ -511,48 +532,48 @@ namespace ojph {
         tlm->set_next_pair(sot.get_tile_index(), this->num_bytes);
       }
       else if (tilepart_div == OJPH_TILEPART_RESOLUTIONS)
-      { 
+      {
         assert(prog_order != OJPH_PO_PCRL && prog_order != OJPH_PO_CPRL);
         ui32 max_decs = 0;
         for (ui32 c = 0; c < num_comps; ++c)
           max_decs = ojph_max(max_decs, comps[c].get_num_decompositions());
-        for (ui32 r = 0; r <= max_decs; ++r) 
+        for (ui32 r = 0; r <= max_decs; ++r)
         {
           ui32 bytes = 0;
           for (ui32 c = 0; c < num_comps; ++c)
             bytes += comps[c].get_num_bytes(r);
           tlm->set_next_pair(sot.get_tile_index(), bytes);
         }
-      }      
+      }
       else if (tilepart_div == OJPH_TILEPART_COMPONENTS)
       {
         if (prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP)
-        { 
+        {
           ui32 max_decs = 0;
           for (ui32 c = 0; c < num_comps; ++c)
             max_decs = ojph_max(max_decs, comps[c].get_num_decompositions());
-          for (ui32 r = 0; r <= max_decs; ++r) 
+          for (ui32 r = 0; r <= max_decs; ++r)
             for (ui32 c = 0; c < num_comps; ++c)
               if (r <= comps[c].get_num_decompositions())
-                tlm->set_next_pair(sot.get_tile_index(), 
+                tlm->set_next_pair(sot.get_tile_index(),
                                    comps[c].get_num_bytes(r));
         }
         else if (prog_order == OJPH_PO_CPRL)
           for (ui32 c = 0; c < num_comps; ++c)
             tlm->set_next_pair(sot.get_tile_index(), comps[c].get_num_bytes());
-        else 
+        else
           assert(0); // should not be here
       }
-      else 
+      else
       {
         assert(prog_order == OJPH_PO_LRCP || prog_order == OJPH_PO_RLCP);
         ui32 max_decs = 0;
         for (ui32 c = 0; c < num_comps; ++c)
           max_decs = ojph_max(max_decs, comps[c].get_num_decompositions());
-        for (ui32 r = 0; r <= max_decs; ++r) 
+        for (ui32 r = 0; r <= max_decs; ++r)
           for (ui32 c = 0; c < num_comps; ++c)
             if (r <= comps[c].get_num_decompositions())
-              tlm->set_next_pair(sot.get_tile_index(), 
+              tlm->set_next_pair(sot.get_tile_index(),
                                  comps[c].get_num_bytes(r));
       }
     }
@@ -573,7 +594,7 @@ namespace ojph {
           OJPH_ERROR(0x00030081, "Error writing to file");
 
         //write start of data
-        ui16 t = swap_byte(JP2K_MARKER::SOD);
+        ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOD);
         if (!file->write(&t, 2))
           OJPH_ERROR(0x00030082, "Error writing to file");
       }
@@ -588,9 +609,9 @@ namespace ojph {
             for (ui32 c = 0; c < num_comps; ++c)
               comps[c].write_precincts(r, file);
         }
-        else if (tilepart_div == OJPH_TILEPART_RESOLUTIONS) 
+        else if (tilepart_div == OJPH_TILEPART_RESOLUTIONS)
         {
-          for (ui32 r = 0; r <= max_decompositions; ++r) 
+          for (ui32 r = 0; r <= max_decompositions; ++r)
           {
             ui32 bytes = 0;
             for (ui32 c = 0; c < num_comps; ++c)
@@ -601,29 +622,29 @@ namespace ojph {
               OJPH_ERROR(0x00030083, "Error writing to file");
 
             //write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x00030084, "Error writing to file");
-            
+
             //write precincts
             for (ui32 c = 0; c < num_comps; ++c)
-              comps[c].write_precincts(r, file);              
+              comps[c].write_precincts(r, file);
           }
         }
-        else 
+        else
         {
           ui32 num_tileparts = num_comps * (max_decompositions + 1);
           for (ui32 r = 0; r <= max_decompositions; ++r)
             for (ui32 c = 0; c < num_comps; ++c)
               if (r <= comps[c].get_num_decompositions()) {
                 //write tile header
-                if (!sot.write(file, comps[c].get_num_bytes(r), 
+                if (!sot.write(file, comps[c].get_num_bytes(r),
                                (ui8)(c + r * num_comps), (ui8)num_tileparts))
                   OJPH_ERROR(0x00030085, "Error writing to file");
                 //write start of data
-                ui16 t = swap_byte(JP2K_MARKER::SOD);
+                ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOD);
                 if (!file->write(&t, 2))
-                  OJPH_ERROR(0x00030086, "Error writing to file");                
+                  OJPH_ERROR(0x00030086, "Error writing to file");
                 comps[c].write_precincts(r, file);
               }
         }
@@ -642,7 +663,7 @@ namespace ojph {
               OJPH_ERROR(0x00030087, "Error writing to file");
 
             //write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x00030088, "Error writing to file");
           }
@@ -717,7 +738,7 @@ namespace ojph {
               OJPH_ERROR(0x0003008A, "Error writing to file");
 
             //write start of data
-            ui16 t = swap_byte(JP2K_MARKER::SOD);
+            ui16 t = swap_bytes_if_le((ui16)JP2K_MARKER::SOD);
             if (!file->write(&t, 2))
               OJPH_ERROR(0x0003008B, "Error writing to file");
           }

--- a/external/OpenJPH/src/core/coding/ojph_block_common.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_common.cpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -32,6 +33,7 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.cpp
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
@@ -102,9 +104,14 @@ namespace ojph {
 
     /// @brief uvlc_tbl0 contains decoding information for initial row of quads
     ui16 uvlc_tbl0[256+64] = { 0 };
-    /// @brief uvlc_tbl1 contains decoding information for non-initial row of 
+    /// @brief uvlc_tbl1 contains decoding information for non-initial row of
     ///        quads
     ui16 uvlc_tbl1[256] = { 0 };
+    /// @brief uvlc_tbl1_wide: wider UVLC table for non-initial rows.
+    ///        Index = mode(2 bits) * 1024 + vlc_data(10 bits) = 12 bits.
+    ///        Entry bits: [4:0]=total_bits, [12:5]=u_q0, [20:13]=u_q1.
+    ///        total_bits == 0x1F means fallback to original decode path.
+    ui32 uvlc_tbl1_wide[4096] = { 0 };
     /// @brief uvlc_bias contains decoding info. for initial row of quads
     ui8 uvlc_bias[256+64] = { 0 };
     /// @}
@@ -330,6 +337,85 @@ namespace ojph {
     }
 
     //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes uvlc_tbl1_wide: wider UVLC table for non-initial
+     *         rows. Index = mode(2b) * 1024 + vlc(10b). Entry packs
+     *         total_bits[4:0], u_q0[12:5], u_q1[20:13].
+     *         total_bits == 0x1F signals fallback to original decode.
+     */
+    static bool uvlc_init_wide_table()
+    {
+      static const ui8 dec[8] = {
+        3 | (5 << 2) | (5 << 5), //000
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5), //xx1
+        3 | (1 << 2) | (3 << 5), //100
+        1 | (0 << 2) | (1 << 5), //xx1
+        2 | (0 << 2) | (2 << 5), //x10
+        1 | (0 << 2) | (1 << 5)  //xx1
+      };
+
+      for (ui32 idx = 0; idx < 4096; ++idx)
+      {
+        ui32 mode = idx >> 10;       // 2 bits
+        ui32 vlc = idx & 0x3FF;      // 10 bits
+
+        if (mode == 0) {
+          uvlc_tbl1_wide[idx] = 0;
+          continue;
+        }
+
+        if (mode <= 2) // single UVLC (one u_off set)
+        {
+          ui32 d = dec[vlc & 0x7];
+          ui32 prefix_len = d & 0x3;
+          ui32 suffix_len = (d >> 2) & 0x7;
+          ui32 u_pfx = d >> 5;
+          ui32 suffix_val = (vlc >> prefix_len) & ((1u << suffix_len) - 1);
+          ui32 u_val = u_pfx + suffix_val;
+          ui32 total = prefix_len + suffix_len;
+          ui32 u_q0 = (mode == 1) ? u_val : 0;
+          ui32 u_q1 = (mode == 2) ? u_val : 0;
+          uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
+          continue;
+        }
+
+        // mode == 3: both u_off set
+        // Bitstream layout: [prefix0][prefix1][suffix0][suffix1]
+        ui32 d0 = dec[vlc & 0x7];
+        ui32 p0_len = d0 & 0x3;
+        ui32 s0_len = (d0 >> 2) & 0x7;
+        ui32 u0_pfx = d0 >> 5;
+
+        ui32 vlc1 = vlc >> p0_len;  // consume prefix0
+        ui32 d1 = dec[vlc1 & 0x7];
+        ui32 p1_len = d1 & 0x3;
+        ui32 s1_len = (d1 >> 2) & 0x7;
+        ui32 u1_pfx = d1 >> 5;
+
+        ui32 total_prefix = p0_len + p1_len;
+        ui32 total_suffix = s0_len + s1_len;
+        ui32 total = total_prefix + total_suffix;
+
+        if (total > 10) {
+          uvlc_tbl1_wide[idx] = 0x1F; // fallback sentinel
+          continue;
+        }
+
+        // suffixes follow both prefixes in the bitstream
+        ui32 suffix_bits = vlc >> total_prefix;
+        ui32 s0_val = suffix_bits & ((1u << s0_len) - 1);
+        ui32 s1_val = (suffix_bits >> s0_len) & ((1u << s1_len) - 1);
+
+        ui32 u_q0 = u0_pfx + s0_val;
+        ui32 u_q1 = u1_pfx + s1_val;
+        uvlc_tbl1_wide[idx] = total | (u_q0 << 5) | (u_q1 << 13);
+      }
+      return true;
+    }
+
+    //************************************************************************/
     /** @ingroup vlc_decoding_tables_grp
      *  @brief Initializes VLC tables vlc_tbl0 and vlc_tbl1
      */
@@ -340,6 +426,12 @@ namespace ojph {
      *  @brief Initializes UVLC tables uvlc_tbl0 and uvlc_tbl1
      */
     static bool uvlc_tables_initialized = uvlc_init_tables();
+
+    //************************************************************************/
+    /** @ingroup uvlc_decoding_tables_grp
+     *  @brief Initializes wide UVLC table uvlc_tbl1_wide
+     */
+    static bool uvlc_wide_initialized = uvlc_init_wide_table();
 
   } // !namespace local
 } // !namespace ojph

--- a/external/OpenJPH/src/core/coding/ojph_block_common.h
+++ b/external/OpenJPH/src/core/coding/ojph_block_common.h
@@ -5,7 +5,8 @@
 // Copyright (c) 2022, Aous Naman 
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -32,6 +33,7 @@
 // This file is part of the OpenJPH software implementation.
 // File: ojph_block_common.h
 // Author: Aous Naman
+// Author: Osamu Watanabe
 // Date: 13 May 2022
 //***************************************************************************/
 
@@ -44,6 +46,7 @@ namespace ojph{
     extern ui16 vlc_tbl1[1024];
     extern ui16 uvlc_tbl0[256+64];
     extern ui16 uvlc_tbl1[256];
+    extern ui32 uvlc_tbl1_wide[4096];
     extern ui8 uvlc_bias[256+64];
   } // !namespace local
 } // !namespace ojph

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder.h
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder.h
@@ -77,6 +77,12 @@ namespace ojph {
         ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
         ui32 width, ui32 height, ui32 stride, bool stripe_causal);
 
+    // POWER VSX-accelerated decoder
+    bool
+      ojph_decode_codeblock_vsx(ui8* coded_data, ui32* decoded_data,
+        ui32 missing_msbs, ui32 num_passes, ui32 lengths1, ui32 lengths2,
+        ui32 width, ui32 height, ui32 stride, bool stripe_causal);
+
   }
 }
 

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder32.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder32.cpp
@@ -97,7 +97,7 @@ namespace ojph {
 
       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
       if (melp->size > 4) {        // if there is data in the MEL segment
-        val = *(ui32*)melp->data;  // read 32 bits from MEL data
+        val = load_le_ui32(melp->data); // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
@@ -315,7 +315,7 @@ namespace ojph {
       if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
       {
         // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
+        val = load_le_ui32(vlcp->data - 3); // then read 32 bits
         vlcp->data -= 4;          // move data pointer back by 4
         vlcp->size -= 4;          // reduce available byte by 4
       }
@@ -458,7 +458,7 @@ namespace ojph {
       ui32 val = 0;
       if (mrp->size > 3) // If there are 3 byte or more
       { // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(mrp->data - 3); // read 32 bits
+        val = load_le_ui32(mrp->data - 3); // read 32 bits
         mrp->data -= 4;                // move back pointer
         mrp->size -= 4;                // reduce count
       }
@@ -612,7 +612,7 @@ namespace ojph {
 
       ui32 val = 0;
       if (msp->size > 3) {
-        val = *(ui32*)msp->data;  // read 32 bits
+        val = load_le_ui32(msp->data); // read 32 bits
         msp->data += 4;           // increment pointer
         msp->size -= 4;           // reduce size
       }
@@ -1408,13 +1408,13 @@ namespace ojph {
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32*)prev_sig;
-              ui32 ns = *(ui32*)(cur_sig + mstr);
+              ui32 ps = load_le_ui16x2(prev_sig);
+              ui32 ns = load_le_ui16x2(cur_sig + mstr);
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
                 u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32*)cur_sig;
+              ui32 cs = load_le_ui16x2(cur_sig);
               // vertical integration
               ui32 mbr =  cs;                // this sig. info.
               mbr |= (cs & 0x77777777) << 1; //above neighbors
@@ -1566,16 +1566,16 @@ namespace ojph {
 
           for (ui32 y = 0; y < height; y += 4)
           {
-            ui32 *cur_sig = (ui32*)(sigma + (y >> 2) * mstr);
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
             ui32 *dpp = decoded_data + y * stride;
             ui32 half = 1 << (p - 2);
-            for (ui32 i = 0; i < width; i += 8)
+            for (ui32 i = 0; i < width; i += 8, cur_sig += 2)
             {
               //Process one entry from sigma array at a time
               // Each nibble (4 bits) in the sigma array represents 4 rows,
               // and the 32 bits contain 8 columns
               ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-              ui32 sig = *cur_sig++; // 32 bit that will be processed now
+              ui32 sig = load_le_ui16x2(cur_sig); // 32 bits processed now
               ui32 col_mask = 0xFu;  // a mask for a column in sig
               if (sig) // if any of the 32 bits are set
               {

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder64.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder64.cpp
@@ -97,7 +97,7 @@ namespace ojph {
 
       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
       if (melp->size > 4) {        // if there is data in the MEL segment
-        val = *(ui32*)melp->data;  // read 32 bits from MEL data
+        val = load_le_ui32(melp->data); // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
@@ -410,7 +410,7 @@ namespace ojph {
       ui32 val = 0;
       if (mrp->size > 3) // If there are 3 byte or more
       { // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(mrp->data - 3); // read 32 bits
+        val = load_le_ui32(mrp->data - 3); // read 32 bits
         mrp->data -= 4;                // move back pointer
         mrp->size -= 4;                // reduce count
       }
@@ -564,7 +564,7 @@ namespace ojph {
 
       ui32 val = 0;
       if (msp->size > 3) {
-        val = *(ui32*)msp->data;  // read 32 bits
+        val = load_le_ui32(msp->data); // read 32 bits
         msp->data += 4;           // increment pointer
         msp->size -= 4;           // reduce size
       }
@@ -1455,13 +1455,13 @@ namespace ojph {
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32*)prev_sig;
-              ui32 ns = *(ui32*)(cur_sig + mstr);
+              ui32 ps = load_le_ui16x2(prev_sig);
+              ui32 ns = load_le_ui16x2(cur_sig + mstr);
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
                 u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32*)cur_sig;
+              ui32 cs = load_le_ui16x2(cur_sig);
               // vertical integration
               ui32 mbr =  cs;                // this sig. info.
               mbr |= (cs & 0x77777777) << 1; //above neighbors
@@ -1613,16 +1613,16 @@ namespace ojph {
 
           for (ui32 y = 0; y < height; y += 4)
           {
-            ui32 *cur_sig = (ui32*)(sigma + (y >> 2) * mstr);
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
             ui64 *dpp = decoded_data + y * stride;
             ui64 half = 1ULL << (p - 2);
-            for (ui32 i = 0; i < width; i += 8)
+            for (ui32 i = 0; i < width; i += 8, cur_sig += 2)
             {
               //Process one entry from sigma array at a time
               // Each nibble (4 bits) in the sigma array represents 4 rows,
               // and the 32 bits contain 8 columns
               ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-              ui32 sig = *cur_sig++; // 32 bit that will be processed now
+              ui32 sig = load_le_ui16x2(cur_sig); // 32 bits processed now
               ui32 col_mask = 0xFu;  // a mask for a column in sig
               if (sig) // if any of the 32 bits are set
               {

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder_avx2.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder_avx2.cpp
@@ -6,6 +6,7 @@
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
 // Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -100,7 +101,7 @@ namespace ojph {
 
       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
       if (melp->size > 4) {        // if there is data in the MEL segment
-        val = *(ui32*)melp->data;  // read 32 bits from MEL data
+        memcpy(&val, melp->data, 4);  // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
@@ -271,507 +272,349 @@ namespace ojph {
       return t; // return run
     }
 
-    //************************************************************************/
-    /** @brief A structure for reading and unstuffing a segment that grows
-     *         backward, such as VLC and MRP
-     */
-    struct rev_struct {
-      rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
-      {}
-      //storage
-      ui8* data;     //!<pointer to where to read data
-      ui64 tmp;	     //!<temporary buffer of read data
-      ui32 bits;     //!<number of bits stored in tmp
-      int size;      //!<number of bytes left
-      bool unstuff;  //!<true if the last byte is more than 0x8F
-                     //!<then the current byte is unstuffed if it is 0x7F
-    };
 
     //************************************************************************/
-    /** @brief Read and unstuff data from a backwardly-growing segment
+    /** @brief De-stuffs a forward-growing bitstream into a flat buffer
      *
-     *  This reader can read up to 8 bytes from before the VLC segment.
-     *  Care must be taken not read from unreadable memory, causing a
-     *  segmentation fault.
+     *  This replicates, in one pass, the bit production of the frwd_struct
+     *  bitstream reader used by the other block decoders: a byte following
+     *  a 0xFF byte contributes only 7 bits (its MSB -- guaranteed 0 by the
+     *  encoder -- is OR'ed with the following bit), and bits beyond the
+     *  end of the data
+     *  read as X (1s for MagSgn, 0s for SPP).  With the stream flattened,
+     *  bits for any quad can be fetched at an absolute bit position (see
+     *  dfetch), removing the serial fetch/advance state from the decode
+     *  loops.
      *
-     *  Note that there is another subroutine rev_read_mrp that is slightly
-     *  different.  The other one fills zeros when the buffer is exhausted.
-     *  This one basically does not care if the bytes are consumed, because
-     *  any extra data should not be used in the actual decoding.
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
      *
-     *  Unstuffing is needed to prevent sequences more than 0xFF8F from
-     *  appearing in the bits stream; since we are reading backward, we keep
-     *  watch when a value larger than 0x8F appears in the bitstream.
-     *  If the byte following this is 0x7F, we unstuff this byte (ignore the
-     *  MSB of that byte, which should be 0).
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
+     *  @tparam      X is the value fed in when the bitstream is exhausted
+     *  @param [in]  src is a pointer to the start of the bitstream data
+     *  @param [in]  size is the number of bytes in the bitstream data
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch; bytes at or beyond this
+     *               offset hold no stream bits (they read as X)
      */
+    template<int X>
     static inline
-    void rev_read(rev_struct *vlcp)
+    ui32 destuff_frwd(const ui8* src, int size, ui8* dst, ui32 cap)
     {
-      //process 4 bytes at a time
-      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then
-        return;             // reading 32 bits can overflow vlcp->tmp
-      ui32 val = 0;
-      //the next line (the if statement) needs to be tested first
-      if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
+      if (size < 0)
+        size = 0;
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+      const ui8* s = src;
+      const ui8* s_end = src + size;
+      ui64 acc = 0;       // partial output byte, low nb bits are valid
+      ui32 nb = 0;        // number of valid bits in acc; always < 8
+      bool prev_ff = false;
+
+      // fast path; 16 source bytes at a time when they contain no 0xFF
+      while (s + 16 <= s_end && o + 24 <= o_end)
       {
-        // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
-        vlcp->data -= 4;          // move data pointer back by 4
-        vlcp->size -= 4;          // reduce available byte by 4
-      }
-      else if (vlcp->size > 0)
-      { // 4 or less
-        int i = 24;
-        while (vlcp->size > 0) {
-          ui32 v = *vlcp->data--; // read one byte at a time
-          val |= (v << i);        // put byte in its correct location
-          --vlcp->size;
-          i -= 8;
+        __m128i v = _mm_loadu_si128((const __m128i*)s);
+        int ff = _mm_movemask_epi8(_mm_cmpeq_epi8(v, _mm_set1_epi8(-1)));
+        if (ff != 0 || prev_ff)
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui8 b = *s++;
+            acc |= (ui64)b << nb;
+            nb += prev_ff ? 7u : 8u;
+            prev_ff = (b == 0xFFu);
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          continue;
         }
+        ui64 v0, v1;
+        memcpy(&v0, s, 8);
+        memcpy(&v1, s + 8, 8);
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        s += 16;
       }
-
-      __m128i tmp_vec = _mm_set1_epi32((int32_t)val);
-      tmp_vec = _mm_srlv_epi32(tmp_vec, _mm_setr_epi32(24, 16, 8, 0));
-      tmp_vec = _mm_and_si128(tmp_vec, _mm_set1_epi32(0xff));
-
-      __m128i unstuff_vec = _mm_cmpgt_epi32(tmp_vec, _mm_set1_epi32(0x8F));
-      bool unstuff_next = _mm_extract_epi32(unstuff_vec, 3);
-      unstuff_vec = _mm_slli_si128(unstuff_vec, 4);
-      unstuff_vec = _mm_insert_epi32(unstuff_vec, vlcp->unstuff * 0xffffffff, 0);
-
-      __m128i val_7f = _mm_set1_epi32(0x7F);
-      __m128i this_byte_7f = _mm_cmpeq_epi32(_mm_and_si128(tmp_vec, val_7f), val_7f);
-      unstuff_vec = _mm_and_si128(unstuff_vec, this_byte_7f);
-      unstuff_vec = _mm_srli_epi32(unstuff_vec, 31);
-
-      __m128i inc_sum = _mm_sub_epi32(_mm_set1_epi32(8), unstuff_vec);
-      inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 4));
-      inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 8));
-      ui32 total_bits = (ui32)_mm_extract_epi32(inc_sum, 3);
-
-      __m128i final_shift = _mm_slli_si128(inc_sum, 4);
-      tmp_vec = _mm_sllv_epi32(tmp_vec, final_shift);
-      tmp_vec = _mm_or_si128(tmp_vec, _mm_bsrli_si128(tmp_vec, 8));
-
-      ui64 tmp = (ui32)_mm_cvtsi128_si32(tmp_vec) | (ui32)_mm_extract_epi32(tmp_vec, 1);
-
-      vlcp->unstuff = unstuff_next;
-      vlcp->tmp |= tmp << vlcp->bits;
-      vlcp->bits += total_bits;
+      // tail; one byte at a time
+      while (s < s_end && o < o_end)
+      {
+        ui8 b = *s++;
+        acc |= (ui64)b << nb;
+        nb += prev_ff ? 7u : 8u;
+        prev_ff = (b == 0xFFu);
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // fill the bits above nb with X, and pad with X bytes
+      ui32 fill = (X == 0xFF) ? (0xFFu << nb) : 0;
+      *o = (ui8)((ui32)acc | fill);
+      __m256i pad = _mm256_set1_epi8((char)X);
+      _mm256_storeu_si256((__m256i*)(o + 1), pad);
+      _mm256_storeu_si256((__m256i*)(o + 33), pad);
+      return (ui32)(o - dst) + 1;
     }
 
     //************************************************************************/
-    /** @brief Initiates the rev_struct structure and reads a few bytes to
-     *         move the read address to multiple of 4
+    /** @brief Fetches 128 bits from a destuffed MagSgn buffer
      *
-     *  There is another similar rev_init_mrp subroutine.  The difference is
-     *  that this one, rev_init, discards the first 12 bits (they have the
-     *  sum of the lengths of VLC and MEL segments), and first unstuff depends
-     *  on first 4 bits.
+     *  Returns the 128 bits starting at bit position pos of the buffer
+     *  produced by destuff_frwd.  Unlike a stateful bitstream reader,
+     *  this carries no
+     *  serial state; fetches at independent positions can execute out of
+     *  order.  The byte offset is clamped to limit so that positions past
+     *  the end of the stream read as 1s without leaving the buffer.
      *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  dbuf is the destuffed MagSgn buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    __m128i dfetch(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      const ui8* p = dbuf + off;
+      __m128i v = _mm_loadu_si128((const __m128i*)p);
+      __m128i w = _mm_loadu_si128((const __m128i*)(p + 8));
+      int k = (int)(pos & 7);
+      __m128i r = _mm_srl_epi64(v, _mm_cvtsi32_si128(k));
+      __m128i c = _mm_sll_epi64(w, _mm_cvtsi32_si128(64 - k));
+      return _mm_or_si128(r, c);
+    }
+
+    //************************************************************************/
+    /** @brief Fetches at least 57 bits from a destuffed bitstream
+     *
+     *  Scalar counterpart of dfetch; returns the bits starting at bit
+     *  position pos of a buffer produced by destuff_frwd, in the lower
+     *  bits of the result.  Bits above 64 - (pos & 7) are garbage.
+     *
+     *  @param [in]  dbuf is the destuffed bitstream buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    OJPH_FORCE_INLINE
+    ui64 dfetch64(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      ui64 v;
+      memcpy(&v, dbuf + off, 8);
+      return v >> (pos & 7);
+    }
+
+    //************************************************************************/
+    /** @brief Branchless refill of a register-resident bit window
+     *
+     *  Loads 8 bytes from a destuffed buffer and inserts whole bytes
+     *  above the bits remaining in the window, leaving 56 to 63 valid
+     *  bits.  Because the inserted bits land above the remaining ones,
+     *  consumers of the low bits need not wait for the load, keeping it
+     *  off the critical dependency chain.  The read offset is clamped to
+     *  limit so that, when consumption overruns the stream (truncated
+     *  codeblocks), reads come from the zero padding -- the bytes there
+     *  are exactly the fill the stream would produce -- instead of from
+     *  uninitialized buffer memory.
+     *
+     *  @param [in,out]  val is the bit window; its low bits are valid
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in,out]  off is the read offset in the destuffed buffer
+     *  @param [in]      dbuf is the destuffed bitstream buffer
+     *  @param [in]      limit is the clamp offset returned by destuff_vlc
+     */
+    OJPH_FORCE_INLINE
+    void drefill(ui64& val, ui32& bits, ui32& off,
+                 const ui8* dbuf, ui32 limit)
+    {
+      ui64 v;
+      ui32 o = off < limit ? off : limit;
+      memcpy(&v, dbuf + o, 8);
+      val |= v << bits;
+      off += (63 - bits) >> 3;
+      bits |= 56;
+    }
+
+    //************************************************************************/
+    /** @brief Consumes bits from a window refilled by drefill
+     *
+     *  @param [in,out]  val is the bit window
+     *  @param [in,out]  bits is the number of valid bits in val
+     *  @param [in]      num_bits is the number of bits to consume
+     */
+    OJPH_FORCE_INLINE
+    void dconsume(ui64& val, ui32& bits, ui32 num_bits)
+    {
+      val >>= num_bits;
+      bits -= num_bits;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs a backward-growing bitstream into a flat buffer
+     *
+     *  This replicates the bit production of the rev_struct bitstream
+     *  reader used by the other block decoders, for both its VLC and MRP
+     *  variants: reading backward from p, a byte contributes only 7 bits
+     *  (its MSB -- guaranteed 0 by the encoder -- is OR'ed with the
+     *  following bit) when the byte after it in memory is greater than
+     *  0x8F and its own low 7 bits are all 1s.  Bits beyond the end of
+     *  the data read as 0s, matching both readers.  The first byte is
+     *  processed with the caller-provided unstuff state; after that the
+     *  state always equals (p[1] > 0x8F), so the fast path can detect
+     *  stuffing with a pairwise byte comparison within the segment.
+     *
+     *  Writes at most cap + 1 destuffed bytes followed by 64 bytes of
+     *  zero padding; dst must have room for cap + 65 bytes.  cap must be
+     *  no smaller than the maximum number of bits the decoder can consume
+     *  divided by 8, so clipping the data at cap loses no decodable bits.
+     *
+     *  @param [in]  p is a pointer to the last byte of the segment, where
+     *               backward reading starts
+     *  @param [in]  size is the number of bytes in the segment
+     *  @param [in]  unstuff is the initial unstuffing state
+     *  @param [in]  acc holds bits produced by initialization, low nb bits
+     *  @param [in]  nb is the number of valid bits in acc; less than 8
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch/dfetch64; bytes at or beyond
+     *               this offset hold no stream bits (they read as 0s)
+     */
+    static inline
+    ui32 destuff_rev(const ui8* p, int size, bool unstuff,
+                     ui64 acc, ui32 nb, ui8* dst, ui32 cap)
+    {
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+
+      // process the first byte with the caller-provided unstuff state;
+      // afterwards the state is implied by the byte at p[1], which the
+      // fast path checks vectorially (and which stays inside the segment)
+      if (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+
+      // fast path; 16 source bytes at a time when none needs unstuffing
+      while (size >= 16 && o + 24 <= o_end)
+      {
+        __m128i v = _mm_loadu_si128((const __m128i*)(p - 15));
+        __m128i nx = _mm_loadu_si128((const __m128i*)(p - 14));
+        __m128i is7f = _mm_cmpeq_epi8(
+            _mm_and_si128(v, _mm_set1_epi8(0x7F)), _mm_set1_epi8(0x7F));
+        // le8f is 0xFF where the byte after (in memory) is <= 0x8F
+        __m128i le8f = _mm_cmpeq_epi8(
+            _mm_subs_epu8(nx, _mm_set1_epi8((char)0x8F)),
+            _mm_setzero_si128());
+        __m128i stuff = _mm_andnot_si128(le8f, is7f);
+        if (!_mm_testz_si128(stuff, stuff))
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui32 d = *p--;
+            acc |= (ui64)d << nb;
+            nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+            unstuff = d > 0x8F;
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          size -= 16;
+          continue;
+        }
+        __m128i r = _mm_shuffle_epi8(v,
+            _mm_set_epi8(0, 1, 2, 3, 4, 5, 6, 7,
+                         8, 9, 10, 11, 12, 13, 14, 15)); // reverse bytes
+#ifdef OJPH_ARCH_X86_64
+        ui64 v0 = (ui64)_mm_cvtsi128_si64(r);
+        ui64 v1 = (ui64)_mm_extract_epi64(r, 1);
+#else // 32-bit x86 lacks the 64-bit extract intrinsics
+        ui64 v0 = (ui32)_mm_cvtsi128_si32(r)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 1) << 32);
+        ui64 v1 = (ui32)_mm_extract_epi32(r, 2)
+                | ((ui64)(ui32)_mm_extract_epi32(r, 3) << 32);
+#endif
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        p -= 16;
+        size -= 16;
+        unstuff = p[1] > 0x8F;
+      }
+      // tail; one byte at a time
+      while (size > 0 && o < o_end)
+      {
+        ui32 d = *p--;
+        --size;
+        acc |= (ui64)d << nb;
+        nb += 8 - ((unstuff && ((d & 0x7F) == 0x7F)) ? 1u : 0u);
+        unstuff = d > 0x8F;
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // the bits above nb are already 0 = fill; pad with zero bytes
+      *o = (ui8)acc;
+      __m256i z = _mm256_setzero_si256();
+      _mm256_storeu_si256((__m256i*)(o + 1), z);
+      _mm256_storeu_si256((__m256i*)(o + 33), z);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief De-stuffs the VLC segment into a flat buffer
+     *
+     *  Performs the same initialization rev_init does -- the first byte
+     *  contributes only its upper 4 bits (3 bits if its lower 3 bits are
+     *  all 1s) -- then de-stuffs the remaining scup - 2 bytes backward;
+     *  see destuff_rev.
+     *
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
      */
     static inline
-    void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
+    ui32 destuff_vlc(const ui8* data, int lcup, int scup,
+                     ui8* dst, ui32 cap)
     {
-      //first byte has only the upper 4 bits
-      vlcp->data = data + lcup - 2;
-
-      //size can not be larger than this, in fact it should be smaller
-      vlcp->size = scup - 2;
-
-      ui32 d = *vlcp->data--; // read one byte (this is a half byte)
-      vlcp->tmp = d >> 4;    // both initialize and set
-      vlcp->bits = 4 - ((vlcp->tmp & 7) == 7); //check standard
-      vlcp->unstuff = (d | 0xF) > 0x8F; //this is useful for the next byte
-
-      //This code is designed for an architecture that read address should
-      // align to the read size (address multiple of 4 if read size is 4)
-      //These few lines take care of the case where data is not at a multiple
-      // of 4 boundary. It reads 1,2,3 up to 4 bytes from the VLC bitstream.
-      // To read 32 bits, read from (vlcp->data - 3)
-      int num = 1 + (int)(intptr_t(vlcp->data) & 0x3);
-      int tnum = num < vlcp->size ? num : vlcp->size;
-      for (int i = 0; i < tnum; ++i) {
-        ui64 d;
-        d = *vlcp->data--;  // read one byte and move read pointer
-        //check if the last byte was >0x8F (unstuff == true) and this is 0x7F
-        ui32 d_bits = 8 - ((vlcp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-        vlcp->tmp |= d << vlcp->bits; // move data to vlcp->tmp
-        vlcp->bits += d_bits;
-        vlcp->unstuff = d > 0x8F; // for next byte
-      }
-      vlcp->size -= tnum;
-      rev_read(vlcp);  // read another 32 buts
+      const ui8* p = data + lcup - 2;
+      ui32 d = *p; // first byte, only the upper 4 bits are used
+      ui64 acc = d >> 4;
+      ui32 nb = 4 - ((acc & 7) == 7); // check standard
+      bool unstuff = (d | 0xF) > 0x8F;
+      return destuff_rev(p - 1, scup - 2, unstuff, acc, nb, dst, cap);
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
+    /** @brief De-stuffs the MRP segment into a flat buffer
      *
-     *  By the end of this call, vlcp->tmp must have no less than 33 bits
+     *  Performs the same initialization rev_init_mrp does -- reading
+     *  starts at the last byte of the SPP+MRP segments with the unstuff
+     *  state set -- then de-stuffs backward; see destuff_rev.
      *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     */
-    static inline
-    ui32 rev_fetch(rev_struct *vlcp)
-    {
-      if (vlcp->bits < 32)  // if there are less then 32 bits, read more
-      {
-        rev_read(vlcp);     // read 32 bits, but unstuffing might reduce this
-        if (vlcp->bits < 32)// if there is still space in vlcp->tmp for 32 bits
-          rev_read(vlcp);   // read another 32
-      }
-      return (ui32)vlcp->tmp; // return the head (bottom-most) of vlcp->tmp
-    }
-
-    //************************************************************************/
-    /** @brief Consumes num_bits from a rev_struct structure
-     *
-     *  @param [in]  vlcp is a pointer to rev_struct structure
-     *  @param [in]  num_bits is the number of bits to be removed
-     */
-    static inline
-    ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
-    {
-      assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
-      vlcp->tmp >>= num_bits;         // remove bits
-      vlcp->bits -= num_bits;         // decrement the number of bits
-      return (ui32)vlcp->tmp;
-    }
-
-    //************************************************************************/
-    /** @brief Reads and unstuffs from rev_struct
-     *
-     *  This is different than rev_read in that this fills in zeros when the
-     *  the available data is consumed.  The other does not care about the
-     *  values when all data is consumed.
-     *
-     *  See rev_read for more information about unstuffing
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     */
-    static inline
-    void rev_read_mrp(rev_struct *mrp)
-    {
-      //process 4 bytes at a time
-      if (mrp->bits > 32)
-        return;
-      ui32 val = 0;
-      if (mrp->size > 3) // If there are 3 byte or more
-      { // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(mrp->data - 3); // read 32 bits
-        mrp->data -= 4;                // move back pointer
-        mrp->size -= 4;                // reduce count
-      }
-      else if (mrp->size > 0)
-      {
-        int i = 24;
-        while (mrp->size > 0) {
-          ui32 v = *mrp->data--; // read one byte at a time
-          val |= (v << i);       // put byte in its correct location
-          --mrp->size;
-          i -= 8;
-        }
-      }
-
-      //accumulate in tmp, and keep count in bits
-      ui32 bits, tmp = val >> 24;
-
-      //test if the last byte > 0x8F (unstuff must be true) and this is 0x7F
-      bits = 8 - ((mrp->unstuff && (((val >> 24) & 0x7F) == 0x7F)) ? 1 : 0);
-      bool unstuff = (val >> 24) > 0x8F;
-
-      //process the next byte
-      tmp |= ((val >> 16) & 0xFF) << bits;
-      bits += 8 - ((unstuff && (((val >> 16) & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = ((val >> 16) & 0xFF) > 0x8F;
-
-      tmp |= ((val >> 8) & 0xFF) << bits;
-      bits += 8 - ((unstuff && (((val >> 8) & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = ((val >> 8) & 0xFF) > 0x8F;
-
-      tmp |= (val & 0xFF) << bits;
-      bits += 8 - ((unstuff && ((val & 0x7F) == 0x7F)) ? 1 : 0);
-      unstuff = (val & 0xFF) > 0x8F;
-
-      mrp->tmp |= (ui64)tmp << mrp->bits; // move data to mrp pointer
-      mrp->bits += bits;
-      mrp->unstuff = unstuff;             // next byte
-    }
-
-    //************************************************************************/
-    /** @brief Initialized rev_struct structure for MRP segment, and reads
-     *         a number of bytes such that the next 32 bits read are from
-     *         an address that is a multiple of 4. Note this is designed for
-     *         an architecture that read size must be compatible with the
-     *         alignment of the read address
-     *
-     *  There is another similar subroutine rev_init.  This subroutine does
-     *  NOT skip the first 12 bits, and starts with unstuff set to true.
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     *  @param [in]  data is a pointer to byte at the start of the cleanup pass
+     *  @param [in]  data is a pointer to byte at the start of the cleanup
+     *               pass
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  len2 is the length of SPP+MRP segments
+     *  @param [in]  dst is the output buffer, of at least cap + 65 bytes
+     *  @param [in]  cap is the maximum number of destuffed bytes to write
+     *  @return ui32 clamp offset for dfetch64
      */
     static inline
-    void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
+    ui32 destuff_mrp(const ui8* data, int lcup, int len2,
+                     ui8* dst, ui32 cap)
     {
-      mrp->data = data + lcup + len2 - 1;
-      mrp->size = len2;
-      mrp->unstuff = true;
-      mrp->bits = 0;
-      mrp->tmp = 0;
-
-      //This code is designed for an architecture that read address should
-      // align to the read size (address multiple of 4 if read size is 4)
-      //These few lines take care of the case where data is not at a multiple
-      // of 4 boundary.  It reads 1,2,3 up to 4 bytes from the MRP stream
-      int num = 1 + (int)(intptr_t(mrp->data) & 0x3);
-      for (int i = 0; i < num; ++i) {
-        ui64 d;
-        //read a byte, 0 if no more data
-        d = (mrp->size-- > 0) ? *mrp->data-- : 0;
-        //check if unstuffing is needed
-        ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
-        mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
-        mrp->bits += d_bits;
-        mrp->unstuff = d > 0x8F; // for next byte
-      }
-      rev_read_mrp(mrp);
-    }
-
-    //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure
-     *
-     *  By the end of this call, mrp->tmp must have no less than 33 bits
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     */
-    static inline
-    ui32 rev_fetch_mrp(rev_struct *mrp)
-    {
-      if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
-      {
-        rev_read_mrp(mrp);    // read 30-32 bits from mrp
-        if (mrp->bits < 32)   // if there is a space of 32 bits
-          rev_read_mrp(mrp);  // read more
-      }
-      return (ui32)mrp->tmp;  // return the head of mrp->tmp
-    }
-
-    //************************************************************************/
-    /** @brief Consumes num_bits from a rev_struct structure
-     *
-     *  @param [in]  mrp is a pointer to rev_struct structure
-     *  @param [in]  num_bits is the number of bits to be removed
-     */
-    inline ui32 rev_advance_mrp(rev_struct *mrp, ui32 num_bits)
-    {
-      assert(num_bits <= mrp->bits); // we must not consume more than mrp->bits
-      mrp->tmp >>= num_bits;  // discard the lowest num_bits bits
-      mrp->bits -= num_bits;
-      return (ui32)mrp->tmp;  // return data after consumption
-    }
-
-    //************************************************************************/
-    /** @brief State structure for reading and unstuffing of forward-growing
-     *         bitstreams; these are: MagSgn and SPP bitstreams
-     */
-    struct frwd_struct_avx2 {
-      const ui8* data;  //!<pointer to bitstream
-      ui8 tmp[48];      //!<temporary buffer of read data + 16 extra
-      ui32 bits;        //!<number of bits stored in tmp
-      ui32 unstuff;     //!<1 if a bit needs to be unstuffed from next byte
-      int size;         //!<size of data
-    };
-
-    //************************************************************************/
-    /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
-     *
-     *  A template is used to accommodate a different requirement for
-     *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
-     *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
-     *  X controls this value.
-     *
-     *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-     *  in the compressed sequence.  So whenever a value of 0xFF is coded, the
-     *  MSB of the next byte is set 0 and must be ignored during decoding.
-     *
-     *  Reading can go beyond the end of buffer by up to 16 bytes.
-     *
-     *  @tparam       X is the value fed in when the bitstream is exhausted
-     *  @param  [in]  msp is a pointer to frwd_struct_avx2 structure
-     *
-     */
-    template<int X>
-    static inline
-    void frwd_read(frwd_struct_avx2 *msp)
-    {
-      assert(msp->bits <= 128);
-
-      __m128i offset, val, validity, all_xff;
-      val = _mm_loadu_si128((__m128i*)msp->data);
-      int bytes = msp->size >= 16 ? 16 : msp->size;
-      validity = _mm_set1_epi8((char)bytes);
-      msp->data += bytes;
-      msp->size -= bytes;
-      int bits = 128;
-      offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908,0x0706050403020100);
-      validity = _mm_cmpgt_epi8(validity, offset);
-      all_xff = _mm_set1_epi8(-1);
-      if (X == 0xFF) // the compiler should remove this if statement
-      {
-        __m128i t = _mm_xor_si128(validity, all_xff); // complement
-        val = _mm_or_si128(t, val); // fill with 0xFF
-      }
-      else if (X == 0)
-        val = _mm_and_si128(validity, val); // fill with zeros
-      else
-        assert(0);
-
-      __m128i ff_bytes;
-      ff_bytes = _mm_cmpeq_epi8(val, all_xff);
-      ff_bytes = _mm_and_si128(ff_bytes, validity);
-      ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes);
-      flags <<= 1; // unstuff following byte
-      ui32 next_unstuff = flags >> 16;
-      flags |= msp->unstuff;
-      flags &= 0xFFFF;
-      while (flags)
-      { // bit unstuffing occurs on average once every 256 bytes
-        // therefore it is not an issue if it is a bit slow
-        // here we process 16 bytes
-        --bits; // consuming one stuffing bit
-
-        ui32 loc = 31 - count_leading_zeros(flags);
-        flags ^= 1 << loc;
-
-        __m128i m, t, c;
-        t = _mm_set1_epi8((char)loc);
-        m = _mm_cmpgt_epi8(offset, t);
-
-        t = _mm_and_si128(m, val);  // keep bits at locations larger than loc
-        c = _mm_srli_epi64(t, 1);   // 1 bits left
-        t = _mm_srli_si128(t, 8);   // 8 bytes left
-        t = _mm_slli_epi64(t, 63);  // keep the MSB only
-        t = _mm_or_si128(t, c);     // combine the above 3 steps
-
-        val = _mm_or_si128(t, _mm_andnot_si128(m, val));
-      }
-
-      // combine with earlier data
-      assert(msp->bits >= 0 && msp->bits <= 128);
-      int cur_bytes = msp->bits >> 3;
-      int cur_bits = msp->bits & 7;
-      __m128i b1, b2;
-      b1 = _mm_sll_epi64(val, _mm_set1_epi64x(cur_bits));
-      b2 = _mm_slli_si128(val, 8);  // 8 bytes right
-      b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64-cur_bits));
-      b1 = _mm_or_si128(b1, b2);
-      b2 = _mm_loadu_si128((__m128i*)(msp->tmp + cur_bytes));
-      b2 = _mm_or_si128(b1, b2);
-      _mm_storeu_si128((__m128i*)(msp->tmp + cur_bytes), b2);
-
-      int consumed_bits = bits < 128 - cur_bits ? bits : 128 - cur_bits;
-      cur_bytes = (msp->bits + (ui32)consumed_bits + 7) >> 3; // round up
-      int upper = _mm_extract_epi16(val, 7);
-      upper >>= consumed_bits - 128 + 16;
-      msp->tmp[cur_bytes] = (ui8)upper; // copy byte
-
-      msp->bits += (ui32)bits;
-      msp->unstuff = next_unstuff;   // next unstuff
-      assert(msp->unstuff == 0 || msp->unstuff == 1);
-    }
-
-    //************************************************************************/
-    /** @brief Initialize frwd_struct_avx2 struct and reads some bytes
-     *
-     *  @tparam      X is the value fed in when the bitstream is exhausted.
-     *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     *  @param [in]  data is a pointer to the start of data
-     *  @param [in]  size is the number of byte in the bitstream
-     */
-    template<int X>
-    static inline
-    void frwd_init(frwd_struct_avx2 *msp, const ui8* data, int size)
-    {
-      msp->data = data;
-      _mm_storeu_si128((__m128i *)msp->tmp, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 1, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 2, _mm_setzero_si128());
-
-      msp->bits = 0;
-      msp->unstuff = 0;
-      msp->size = size;
-
-      frwd_read<X>(msp); // read 128 bits more
-    }
-
-    //************************************************************************/
-    /** @brief Consume num_bits bits from the bitstream of frwd_struct_avx2
-     *
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     *  @param [in]  num_bits is the number of bit to consume
-     */
-    static inline
-    void frwd_advance(frwd_struct_avx2 *msp, ui32 num_bits)
-    {
-      assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
-      msp->bits -= num_bits;
-
-      __m128i *p = (__m128i*)(msp->tmp + ((num_bits >> 3) & 0x18));
-      num_bits &= 63;
-
-      __m128i v0, v1, c0, c1, t;
-      v0 = _mm_loadu_si128(p);
-      v1 = _mm_loadu_si128(p + 1);
-
-      // shift right by num_bits
-      c0 = _mm_srl_epi64(v0, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v0, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
-      t = _mm_slli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
-
-      _mm_storeu_si128((__m128i*)msp->tmp, c0);
-
-      c1 = _mm_srl_epi64(v1, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c1 = _mm_or_si128(c1, t);
-
-      _mm_storeu_si128((__m128i*)msp->tmp + 1, c1);
-    }
-
-    //************************************************************************/
-    /** @brief Fetches 32 bits from the frwd_struct_avx2 bitstream
-     *
-     *  @tparam      X is the value fed in when the bitstream is exhausted.
-     *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_avx2
-     */
-    template<int X>
-    static inline
-    __m128i frwd_fetch(frwd_struct_avx2 *msp)
-    {
-      if (msp->bits <= 128)
-      {
-        frwd_read<X>(msp);
-        if (msp->bits <= 128) //need to test
-          frwd_read<X>(msp);
-      }
-      __m128i t = _mm_loadu_si128((__m128i*)msp->tmp);
-      return t;
+      return destuff_rev(data + lcup + len2 - 1, len2, true, 0, 0,
+                         dst, cap);
     }
 
     //************************************************************************/
@@ -784,7 +627,10 @@ namespace ojph {
      *  @param vn       used for handling E values (stores v_n values)
      *  @return __m256i decoded two quads
      */
-    static inline __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    OJPH_FORCE_INLINE
+    __m256i decode_two_quad32_avx2(__m256i inf_u_q, __m256i U_q,
+                                   const ui8* dbuf, ui32 limit, ui32& pos,
+                                   ui32 p, __m128i& vn) {
         __m256i row = _mm256_setzero_si256();
 
         // we keeps e_k, e_1, and rho in w2
@@ -810,19 +656,12 @@ namespace ojph {
             __m256i inc_sum = m_n; // inclusive scan
             inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
             inc_sum = _mm256_add_epi32(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-            int total_mn1 = _mm256_extract_epi16(inc_sum, 6);
-            int total_mn2 = _mm256_extract_epi16(inc_sum, 14);
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 6);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 14);
 
-            __m128i ms_vec0 = _mm_setzero_si128();
-            __m128i ms_vec1 = _mm_setzero_si128();
-            if (total_mn1) {
-                ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn1);
-            }
-            if (total_mn2) {
-                ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn2);
-            }
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
 
@@ -898,7 +737,10 @@ namespace ojph {
      *  @return __m128i decoded quad
      */
 
-    static inline __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q, frwd_struct_avx2* magsgn, ui32 p, __m128i& vn) {
+    OJPH_FORCE_INLINE
+    __m256i decode_four_quad16(const __m128i inf_u_q, __m128i U_q,
+                               const ui8* dbuf, ui32 limit, ui32& pos,
+                               ui32 p, __m128i& vn) {
 
         __m256i w0;     // workers
         __m256i insig;  // lanes hold FF's if samples are insignificant
@@ -939,20 +781,13 @@ namespace ojph {
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 2));
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 4));
             inc_sum = _mm256_add_epi16(inc_sum, _mm256_bslli_epi128(inc_sum, 8));
-            int total_mn1 = _mm256_extract_epi16(inc_sum, 7);
-            int total_mn2 = _mm256_extract_epi16(inc_sum, 15);
+            ui32 total_mn1 = (ui32)_mm256_extract_epi16(inc_sum, 7);
+            ui32 total_mn2 = (ui32)_mm256_extract_epi16(inc_sum, 15);
             __m256i ex_sum = _mm256_bslli_epi128(inc_sum, 2); // exclusive scan
 
-            __m128i ms_vec0 = _mm_setzero_si128();
-            __m128i ms_vec1 = _mm_setzero_si128();
-            if (total_mn1) {
-                ms_vec0 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn1);
-            }
-            if (total_mn2) {
-                ms_vec1 = frwd_fetch<0xFF>(magsgn);
-                frwd_advance(magsgn, (ui32)total_mn2);
-            }
+            __m128i ms_vec0 = dfetch(dbuf, limit, pos);
+            __m128i ms_vec1 = dfetch(dbuf, limit, pos + total_mn1);
+            pos += total_mn1 + total_mn2;
 
             __m256i ms_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ms_vec0), ms_vec1, 0x1);
 
@@ -981,29 +816,25 @@ namespace ojph {
             d0 = _mm256_or_si256(d0, d1);
 
             // find location of e_k and mask
-            __m256i shift, t0, t1, Uq0, Uq1;
+            __m256i shift;
             __m256i ones = _mm256_set1_epi16(1);
             __m256i twos = _mm256_set1_epi16(2);
-            __m256i U_q_m1 = _mm256_sub_epi32(U_q_avx, ones);
-            Uq0 = _mm256_and_si256(U_q_m1, _mm256_set_epi32(0, 0, 0, 0x1F, 0, 0, 0, 0x1F));
-            Uq1 = _mm256_bsrli_epi128(U_q_m1, 14);
+            // shift = (2 - e_k) << (U_q - 1); AVX2 has no _mm256_sllv_epi16,
+            // so the variable shift is emulated with a pshufb power-of-two
+            // lookup and a 16-bit multiply.  U_q - 1 <= 14 in this path;
+            // for U_q == 0 the lookup indices have their MSB set, so pshufb
+            // returns 0, the same shift value the former uniform 16-bit
+            // shift emulation produced (it shifted by 31)
+            __m256i kq = _mm256_sub_epi16(U_q_avx, ones);
+            __m256i idx = _mm256_or_si256(kq,
+                _mm256_slli_epi16(_mm256_sub_epi16(kq,
+                                            _mm256_set1_epi16(8)), 8));
+            const __m256i pow2_tbl = _mm256_setr_epi8(
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0,
+                1, 2, 4, 8, 16, 32, 64, (char)128, 0, 0, 0, 0, 0, 0, 0, 0);
+            __m256i pow2 = _mm256_shuffle_epi8(pow2_tbl, idx);
             w0 = _mm256_sub_epi16(twos, w0);
-            t0 = _mm256_and_si256(w0, _mm256_set_epi64x(0, -1, 0, -1));
-            t1 = _mm256_and_si256(w0, _mm256_set_epi64x(-1, 0, -1, 0));
-            {//no _mm256_sllv_epi16 in avx2
-                __m128i t_0_sse = _mm256_castsi256_si128(t0);
-                t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq0));
-                __m128i t_1_sse = _mm256_extracti128_si256(t0 , 0x1);
-                t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq0, 0x1));
-                t0 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-
-                t_0_sse = _mm256_castsi256_si128(t1);
-                t_0_sse = _mm_sll_epi16(t_0_sse, _mm256_castsi256_si128(Uq1));
-                t_1_sse = _mm256_extracti128_si256(t1, 0x1);
-                t_1_sse = _mm_sll_epi16(t_1_sse, _mm256_extracti128_si256(Uq1, 0x1));
-                t1 = _mm256_inserti128_si256(_mm256_castsi128_si256(t_0_sse), t_1_sse, 0x1);
-            }
-            shift = _mm256_or_si256(t0, t1);
+            shift = _mm256_mullo_epi16(w0, pow2);
             ms_vec = _mm256_and_si256(d0, _mm256_sub_epi16(shift, ones));
 
             // next e_1
@@ -1065,6 +896,926 @@ namespace ojph {
      *  @param [in]   stride is the decoded codeblock buffer stride
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 16-bit (4-quad) path.
+     *
+     *  Outlined into its own function so that decode_four_quad16 can be
+     *  force-inlined here without inflating register pressure in the
+     *  much larger ojph_decode_codeblock_avx2 (which also hosts the
+     *  mutually-exclusive 32-bit step-2 path). Returns false on a
+     *  precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_16bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
+    {
+        // reduce bitplane by 16 because we now have 16 bits instead of 32
+        p -= 16;
+
+        const int v_n_size = 512 + 16;
+#ifdef __MINGW64__
+        ui16 v_n_scratch[v_n_size] = {0};
+        ui32 v_n_scratch_32[v_n_size] = {0};
+#else
+        ui16 v_n_scratch[v_n_size];
+        memset(v_n_scratch + (width >> 1) + 4, 0, 8 * sizeof(ui16));
+        ui32 v_n_scratch_32[v_n_size];
+#endif
+
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 < 16) bits
+        const ui32 dbuf_cap = 4096 * 15 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
+
+        {
+          ui16 *sp = scratch;
+          ui16 *vp = v_n_scratch;
+          ui32 *dp = decoded_data;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8) {
+              ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
+              __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
+              if (!_mm_testz_si128(w, w)) {
+                  return false;
+              }
+
+              __m128i vn = _mm_set1_epi16(2);
+              __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+
+              w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+              _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+              __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+              __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+              _mm256_storeu_si256((__m256i*)dp, w0);
+              _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+
+        for (ui32 y = 2; y < height; y += 2) {
+          {
+            // perform 15 - count_leading_zeros(*vp) here
+            ui16 *vp = v_n_scratch;
+            ui32 *vp_32 = v_n_scratch_32;
+
+            ui16* sp = scratch + (y >> 1) * sstr;
+            const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
+            const __m256i avx_31 = _mm256_set1_epi32(31);
+            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
+            const __m256i avx_1 = _mm256_set1_epi32(1);
+            const __m256i avx_0 = _mm256_setzero_si256();
+
+            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8) {
+              __m128i v = _mm_loadu_si128((__m128i*)vp);
+              __m128i v_p1 = _mm_loadu_si128((__m128i*)(vp + 1));
+              v = _mm_or_si128(v, v_p1);
+
+              __m256i v_avx = _mm256_cvtepu16_epi32(v);
+              v_avx = avx2_lzcnt_epi32(v_avx);
+              v_avx = _mm256_sub_epi32(avx_31, v_avx);
+
+              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
+              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
+              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
+              gamma = _mm256_and_si256(gamma, w0);
+              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
+
+              v_avx = _mm256_andnot_si256(gamma, v_avx);
+              v_avx = _mm256_max_epi32(v_avx, avx_1);
+
+              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
+              v_avx = _mm256_add_epi32(inf_u_q, v_avx);
+
+              w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
+              if (!_mm256_testz_si256(w0, w0)) {
+                  return false;
+              }
+
+              _mm256_storeu_si256((__m256i*)vp_32, v_avx);
+            }
+          }
+
+          ui16 *vp = v_n_scratch;
+          ui32* vp_32 = v_n_scratch_32;
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *dp = decoded_data + y * stride;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4) {
+            ////process four quads
+              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
+              __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
+
+            __m128i vn = _mm_set1_epi16(2);
+            __m256i row = decode_four_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+
+            __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
+            _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
+
+            __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
+            __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
+
+            _mm256_storeu_si256((__m256i*)dp, w0);
+            _mm256_storeu_si256((__m256i*)(dp + stride), w1);
+          }
+        }
+        return true;
+    }
+
+    //************************************************************************/
+    /** @brief Step-2 MagSgn decode for the 32-bit (2-quad) path.
+     *
+     *  Outlined for the same reason as decode_cb_step2_16bit: it keeps the
+     *  always-inlined decode_two_quad32_avx2 kernel in its own register
+     *  allocation scope, isolated from step-1 and from the 16-bit path.
+     *  Returns false on a precision-overflow error, true otherwise.
+     */
+    OJPH_NO_INLINE
+    bool decode_cb_step2_32bit(ui16* scratch, ui32* decoded_data,
+                               ui8* coded_data, ui32 width, ui32 height,
+                               ui32 stride, ui32 sstr, ui32 p, ui32 mmsbp2,
+                               int lcup, int scup)
+    {
+        const int v_n_size = 512 + 16;
+#ifdef __MINGW64__
+        ui32 v_n_scratch[2 * v_n_size] = {0};
+#else
+        ui32 v_n_scratch[2 * v_n_size];
+        memset(v_n_scratch + (width >> 1) + 2, 0, 14 * sizeof(ui32));
+#endif
+
+        // maximum consumable MagSgn bits: 4096 samples x (mmsbp2 <= 32) bits
+        const ui32 dbuf_cap = 4096 * 32 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup, dbuf, dbuf_cap);
+        ui32 pos = 0;
+
+        const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
+
+        {
+          ui16 *sp = scratch;
+          ui32 *vp = v_n_scratch;
+          ui32 *dp = decoded_data;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
+          {
+            __m128i vn = _mm_set1_epi32(2);
+
+            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
+            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i U_q = _mm256_srli_epi32(inf_u_q, 16);
+            __m256i w = _mm256_cmpgt_epi32(U_q, avx_mmsbp2);
+            if (!_mm256_testz_si256(w, w)) {
+                return false;
+            }
+
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
+            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
+
+            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
+            w0 = _mm_or_si128(w0, vn);
+            _mm_storeu_si128((__m128i*)vp, w0);
+          }
+        }
+
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          {
+            // perform 31 - count_leading_zeros(*vp) here
+            ui32 *vp = v_n_scratch;
+            ui16* sp = scratch + (y >> 1) * sstr;
+
+            const __m256i avx_31 = _mm256_set1_epi32(31);
+            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
+            const __m256i avx_1 = _mm256_set1_epi32(1);
+            const __m256i avx_0 = _mm256_setzero_si256();
+
+            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16) {
+              __m256i v = _mm256_loadu_si256((__m256i*)vp);
+              __m256i v_p1 = _mm256_loadu_si256((__m256i*)(vp + 1));
+              v = _mm256_or_si256(v, v_p1);
+              v = avx2_lzcnt_epi32(v);
+              v = _mm256_sub_epi32(avx_31, v);
+
+              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
+              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
+              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
+              gamma = _mm256_and_si256(gamma, w0);
+              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
+
+              v = _mm256_andnot_si256(gamma, v);
+              v = _mm256_max_epi32(v, avx_1);
+
+              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
+              v = _mm256_add_epi32(inf_u_q, v);
+
+              w0 = _mm256_cmpgt_epi32(v, avx_mmsbp2);
+              if (!_mm256_testz_si256(w0, w0)) {
+                  return false;
+              }
+
+              _mm256_storeu_si256((__m256i*)(vp + v_n_size), v);
+            }
+          }
+
+          ui32 *vp = v_n_scratch;
+          ui16 *sp = scratch + (y >> 1) * sstr;
+          ui32 *dp = decoded_data + y * stride;
+          vp[0] = 2; // for easy calculation of emax
+
+          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4) {
+            //process two quads
+            __m128i vn = _mm_set1_epi32(2);
+
+            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
+            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i U_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)(vp + v_n_size)));
+            U_q = _mm256_permutevar8x32_epi32(U_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
+
+            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
+            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
+            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
+
+            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
+            w0 = _mm_or_si128(w0, vn);
+            _mm_storeu_si128((__m128i*)vp, w0);
+          }
+        }
+        return true;
+    }
+
+    //************************************************************************/
+    /** @brief Significance-Propagation and Magnitude-Refinement passes.
+     *
+     *  Outlined from ojph_decode_codeblock_avx2 so the (lossless cleanup-only)
+     *  common path does not pay the register-allocation cost of this ~375-line
+     *  block. Only runs when num_passes > 1.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_spp_mrp(ui16* scratch, ui32* decoded_data, ui8* coded_data,
+                           ui32 width, ui32 height, ui32 stride, ui32 sstr,
+                           ui32 p, ui32 num_passes, ui32 lengths1,
+                           ui32 lengths2, bool stripe_causal)
+    {
+        // We use scratch again, we can divide it into multiple regions
+        // sigma holds all the significant samples, and it cannot
+        // be modified after it is set.  it will be used during the
+        // Magnitude Refinement Pass
+        ui16* const sigma = scratch;
+
+        ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
+                                         // ui16 contains 4 columns
+        mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
+
+        // We re-arrange quad significance, where each 4 consecutive
+        // bits represent one quad, into column significance, where,
+        // each 4 consequtive bits represent one column of 4 rows
+        {
+          ui32 y;
+
+          const __m128i mask_3 = _mm_set1_epi32(0x30);
+          const __m128i mask_C = _mm_set1_epi32(0xC0);
+          const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
+          for (y = 0; y < height; y += 4)
+          {
+            ui16* sp = scratch + (y >> 1) * sstr;
+            ui16* dp = sigma + (y >> 2) * mstr;
+            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
+            {
+              __m128i s0, s1, u3, uC, t0, t1;
+
+              s0 = _mm_loadu_si128((__m128i*)(sp));
+              u3 = _mm_and_si128(s0, mask_3);
+              u3 = _mm_srli_epi32(u3, 4);
+              uC = _mm_and_si128(s0, mask_C);
+              uC = _mm_srli_epi32(uC, 2);
+              t0 = _mm_or_si128(u3, uC);
+
+              s1 = _mm_loadu_si128((__m128i*)(sp + sstr));
+              u3 = _mm_and_si128(s1, mask_3);
+              u3 = _mm_srli_epi32(u3, 2);
+              uC = _mm_and_si128(s1, mask_C);
+              t1 = _mm_or_si128(u3, uC);
+
+              __m128i r = _mm_or_si128(t0, t1);
+              r = _mm_shuffle_epi8(r, shuffle_mask);
+
+              ui32 t = (ui32)_mm_extract_epi32(r, 0);
+              memcpy(dp, &t, 4);
+            }
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+          {
+            // reset one row after the codeblock
+            ui16* dp = sigma + (y >> 2) * mstr;
+            __m128i zero = _mm_setzero_si128();
+            for (ui32 x = 0; x < width; x += 32, dp += 8)
+              _mm_storeu_si128((__m128i*)dp, zero);
+            dp[0] = 0; // set an extra entry on the right with 0
+          }
+        }
+
+        // We perform Significance Propagation Pass here
+        {
+          // This stores significance information of the previous
+          // 4 rows.  Significance information in this array includes
+          // all signicant samples in bitplane p - 1; that is,
+          // significant samples for bitplane p (discovered during the
+          // cleanup pass and stored in sigma) and samples that have recently
+          // became significant (during the SPP) in bitplane p-1.
+          // We store enough for the widest row, containing 1024 columns,
+          // which is equivalent to 256 of ui16, since each stores 4 columns.
+          // We add an extra 8 entries, just in case we need more
+          ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
+
+          // maximum consumable SPP bits: 4096 samples x 2 bits (one
+          // significance bit and one sign bit per sample)
+          const ui32 spp_cap = 4096 * 2 / 8;
+          ui8 spp_buf[spp_cap + 72];
+          ui32 spp_limit = destuff_frwd<0>(coded_data + lengths1,
+                                           (int)lengths2, spp_buf, spp_cap);
+          ui32 spp_pos = 0;
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui32 pattern = 0xFFFFu; // a pattern needed samples
+            if (height - y < 4) {
+              pattern = 0x7777u;
+              if (height - y < 3) {
+                pattern = 0x3333u;
+                if (height - y < 2)
+                  pattern = 0x1111u;
+              }
+            }
+
+            // prev holds sign. info. for the previous quad, together
+            // with the rows on top of it and below it.
+            ui32 prev = 0;
+            ui16 *prev_sig = prev_row_sig;
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            for (ui32 x = 0; x < width; x += 4, dpp += 4, ++cur_sig, ++prev_sig)
+            {
+              // only rows and columns inside the stripe are included
+              si32 s = (si32)x + 4 - (si32)width;
+              s = ojph_max(s, 0);
+              pattern = pattern >> (s * 4);
+
+              // We first find locations that need to be tested (potential
+              // SPP members); these location will end up in mbr
+              // In each iteration, we produce 16 bits because cwd can have
+              // up to 16 bits of significance information, followed by the
+              // corresponding 16 bits of sign information; therefore, it is
+              // sufficient to fetch 32 bit data per loop.
+
+              // Althougth we are interested in 16 bits only, we load 32 bits.
+              // For the 16 bits we are producing, we need the next 4 bits --
+              // We need data for at least 5 columns out of 8.
+              // Therefore loading 32 bits is easier than loading 16 bits
+              // twice.
+              ui32 ps, ns, cs;
+              memcpy(&ps, prev_sig, 4);
+              memcpy(&ns, cur_sig + mstr, 4);
+              ui32 u = (ps & 0x88888888) >> 3; // the row on top
+              if (!stripe_causal)
+                u |= (ns & 0x11111111) << 3;   // the row below
+
+              memcpy(&cs, cur_sig, 4);
+              // vertical integration
+              ui32 mbr =  cs;                // this sig. info.
+              mbr |= (cs & 0x77777777) << 1; //above neighbors
+              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
+              mbr |= u;
+              // horizontal integration
+              ui32 t = mbr;
+              mbr |= t << 4;      // neighbors on the left
+              mbr |= t >> 4;      // neighbors on the right
+              mbr |= prev >> 12;  // significance of previous group
+
+              // remove outside samples, and already significant samples
+              mbr &= pattern;
+              mbr &= ~cs;
+
+              // find samples that become significant during the SPP
+              ui32 new_sig = mbr;
+              if (new_sig)
+              {
+                ui64 cwd = dfetch64(spp_buf, spp_limit, spp_pos);
+
+                ui32 cnt = 0;
+                ui32 col_mask = 0xFu;
+                ui32 inv_sig = ~cs & pattern;
+                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
+                {
+                  if ((col_mask & new_sig) == 0)
+                    continue;
+
+                  //scan one column
+                  ui32 sample_mask = 0x1111u & col_mask;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x33u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0x76u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xECu << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+
+                  sample_mask <<= 1;
+                  if (new_sig & sample_mask)
+                  {
+                    new_sig &= ~sample_mask;
+                    if (cwd & 1)
+                    {
+                      ui32 t = 0xC8u << i;
+                      new_sig |= t & inv_sig;
+                    }
+                    cwd >>= 1; ++cnt;
+                  }
+                }
+
+                if (new_sig)
+                {
+                  // the sign bits sit right after the cnt consumed bits
+                  // of cwd; no reassembly is needed
+
+                  // Spread new_sig, such that each bit is in one byte with a
+                  // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
+                  __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
+                  new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                  new_sig_vec = _mm_and_si128(new_sig_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+
+                  // find cumulative sums
+                  // to find which bit in cwd we should extract
+                  __m128i inc_sum = new_sig_vec; // inclusive scan
+                  inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
+                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
+                  cnt += (ui32)_mm_extract_epi16(inc_sum, 7) >> 8;
+                  // exclusive scan
+                  __m128i ex_sum = _mm_bslli_si128(inc_sum, 1);
+
+                  // Spread cwd, such that each bit is in one byte
+                  // with a value of 0 or 1.
+                  __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
+                  cwd_vec = _mm_shuffle_epi8(cwd_vec,
+                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                  cwd_vec = _mm_and_si128(cwd_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  cwd_vec = _mm_cmpeq_epi8(cwd_vec,
+                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  cwd_vec = _mm_abs_epi8(cwd_vec);
+
+                  // Obtain bit from cwd_vec correspondig to ex_sum
+                  // Basically, collect needed bits from cwd_vec
+                  __m128i v = _mm_shuffle_epi8(cwd_vec, ex_sum);
+
+                  // load data and set spp coefficients
+                  __m128i m =
+                    _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
+                  __m128i val = _mm_set1_epi32(3 << (p - 2));
+                  ui32 *dp = dpp;
+                  for (int c = 0; c < 4; ++ c) {
+                    __m128i s0, s0_ns, s0_val;
+                    // load coefficients
+                    s0 = _mm_load_si128((__m128i*)dp);
+
+                    // epi32 is -1 only for coefficient that
+                    // are changed during the SPP
+                    s0_ns = _mm_shuffle_epi8(new_sig_vec, m);
+                    s0_ns = _mm_cmpeq_epi32(s0_ns, _mm_set1_epi32(0xFF));
+
+                    // obtain sign for coefficients in SPP
+                    s0_val = _mm_shuffle_epi8(v, m);
+                    s0_val = _mm_slli_epi32(s0_val, 31);
+                    s0_val = _mm_or_si128(s0_val, val);
+                    s0_val = _mm_and_si128(s0_val, s0_ns);
+
+                    // update vector
+                    s0 = _mm_or_si128(s0, s0_val);
+                    // store coefficients
+                    _mm_store_si128((__m128i*)dp, s0);
+                    // prepare for next row
+                    dp += stride;
+                    m = _mm_add_epi32(m, _mm_set1_epi32(1));
+                  }
+                }
+                spp_pos += cnt;
+              }
+
+              new_sig |= cs;
+              *prev_sig = (ui16)(new_sig);
+
+              // vertical integration for the new sig. info.
+              t = new_sig;
+              new_sig |= (t & 0x7777) << 1; //above neighbors
+              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
+              // add sig. info. from the row on top and below
+              prev = new_sig | u;
+              // we need only the bits in 0xF000
+              prev &= 0xF000;
+            }
+          }
+        }
+
+        // We perform Magnitude Refinement Pass here
+        if (num_passes > 2)
+        {
+          // de-stuff the MRP segment; consumption is at most 1 bit per
+          // sample = 512 bytes, so 1024 bytes always suffice
+          const ui32 mrp_cap = 1024;
+          ui8 mrp_buf[mrp_cap + 72];
+          ui32 mrp_limit = destuff_mrp(coded_data, (int)lengths1,
+                                       (int)lengths2, mrp_buf, mrp_cap);
+          ui32 mrp_pos = 0;
+
+          for (ui32 y = 0; y < height; y += 4)
+          {
+            ui16 *cur_sig = sigma + (y >> 2) * mstr;
+            ui32 *dpp = decoded_data + y * stride;
+            for (ui32 i = 0; i < width; i += 4, dpp += 4)
+            {
+              //Process one entry from sigma array at a time
+              // Each nibble (4 bits) in the sigma array represents 4 rows,
+              ui64 cwd = dfetch64(mrp_buf, mrp_limit, mrp_pos);
+              ui16 sig = *cur_sig++; // 16 bit that will be processed now
+              int total_bits = 0;
+              if (sig) // if any of the 32 bits are set
+              {
+                // We work on 4 rows, with 4 samples each, since
+                // data is 32 bit (4 bytes)
+
+                // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
+                __m128i sig_vec = _mm_set1_epi16((si16)sig);
+                sig_vec = _mm_shuffle_epi8(sig_vec,
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                sig_vec = _mm_and_si128(sig_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                sig_vec = _mm_cmpeq_epi8(sig_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                sig_vec = _mm_abs_epi8(sig_vec);
+
+                // find cumulative sums
+                // to find which bit in cwd we should extract
+                __m128i inc_sum = sig_vec; // inclusive scan
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
+                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
+                total_bits = _mm_extract_epi16(inc_sum, 7) >> 8;
+                __m128i ex_sum = _mm_bslli_si128(inc_sum, 1); // exclusive scan
+
+                // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
+                // cwd_vec. Then, convert these to a form suitable
+                // for coefficient modifications; in particular, a value
+                // of 0 is presented as binary 11, and a value of 1 is
+                // represented as binary 01
+                __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
+                cwd_vec = _mm_shuffle_epi8(cwd_vec,
+                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
+                cwd_vec = _mm_and_si128(cwd_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
+                  _mm_set1_epi64x((si64)0x8040201008040201));
+                cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
+                cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
+                cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
+
+                // load data and insert the mrp bit
+                __m128i m =
+                  _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
+                ui32 *dp = dpp;
+                for (int c = 0; c < 4; ++c) {
+                  __m128i s0, s0_sig, s0_idx, s0_val;
+                  // load coefficients
+                  s0 = _mm_load_si128((__m128i*)dp);
+                  // find significant samples in this row
+                  s0_sig = _mm_shuffle_epi8(sig_vec, m);
+                  s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
+                  // get MRP bit index, and MRP pattern
+                  s0_idx = _mm_shuffle_epi8(ex_sum, m);
+                  s0_val = _mm_shuffle_epi8(cwd_vec, s0_idx);
+                  // keep data from significant samples only
+                  s0_val = _mm_andnot_si128(s0_sig, s0_val);
+                  // move mrp bits to correct position, and employ
+                  s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
+                  s0 = _mm_xor_si128(s0, s0_val);
+                  // store coefficients
+                  _mm_store_si128((__m128i*)dp, s0);
+                  // prepare for next row
+                  dp += stride;
+                  m = _mm_add_epi32(m, _mm_set1_epi32(1));
+                }
+              }
+              // consume data according to the number of bits set
+              mrp_pos += (ui32)total_bits;
+            }
+          }
+        }
+    }
+
+    //************************************************************************/
+    /** @brief Step-1: decode the VLC and MEL segments into the scratch buffer.
+     *
+     *  Outlined so the serial scalar VLC/MEL chain gets its own register
+     *  allocation, isolated from the step-2 / SPP-MRP code paths.
+     */
+    OJPH_NO_INLINE
+    void decode_cb_step1_vlc(ui16* scratch, ui8* coded_data, int lcup,
+                             int scup, ui32 width, ui32 height, ui32 sstr)
+    {
+        // init structures
+        dec_mel_st mel;
+        mel_init(&mel, coded_data, lcup, scup);
+
+        // de-stuff the VLC segment; its size is at most scup - 1 < 4095
+        // bytes (scup is a 12-bit value), and consumption per quad pair is
+        // at most 7 + 7 + 30 bits, so 4096 bytes always suffice
+        const ui32 vlc_cap = 4096;
+        ui8 vlc_buf[vlc_cap + 72];
+        ui32 vlc_limit = destuff_vlc(coded_data, lcup, scup,
+                                     vlc_buf, vlc_cap);
+        ui32 vlc_off = 0;
+        ui32 vlc_bits = 0;
+
+        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
+                                     // data represented as runs of 0 events
+                                     // See mel_decode description
+
+        ui64 vlc_val = 0;
+        ui32 c_q = 0;
+        ui16 *sp = scratch;
+        //initial quad row
+        for (ui32 x = 0; x < width; sp += 4)
+        {
+          // decode VLC
+          /////////////
+
+          // first quad
+          drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // Is the run terminated in 1? if so, use decoded VLC code,
+            // otherwise, discard decoded data, since we will decoded again
+            // using a different context
+            t0 = (run == -1) ? t0 : 0;
+
+            // is run -1 or -2? this means a run has been consumed
+            if (run < 0)
+              run = mel_get_run(&mel);  // get another run
+          }
+          //run -= (c_q == 0) ? 2 : 0;
+          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[0] = t0;
+          x += 2;
+
+          // prepare context for the next quad; eqn. 1 in ITU T.814
+          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
+
+          //remove data from vlc stream (0 bits are removed if vlc is not used)
+          dconsume(vlc_val, vlc_bits, t0 & 0x7u);
+
+          //second quad
+          ui16 t1 = 0;
+
+          //decode VLC using the context c_q and the head of VLC bitstream
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
+
+          // if context is zero, use one MEL event
+          if (c_q == 0 && x < width) //zero context
+          {
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            // if event is 0, discard decoded t1
+            t1 = (run == -1) ? t1 : 0;
+
+            if (run < 0) // have we consumed all events in a run
+              run = mel_get_run(&mel); // if yes, then get another run
+          }
+          t1 = x < width ? t1 : 0;
+          //run -= (c_q == 0 && x < width) ? 2 : 0;
+          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+          sp[2] = t1;
+          x += 2;
+
+          //prepare context for the next quad, eqn. 1 in ITU T.814
+          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
+
+          //remove data from vlc stream, if qinf is not used, cwdlen is 0
+          dconsume(vlc_val, vlc_bits, t1 & 0x7u);
+
+          // decode u
+          /////////////
+          // uvlc_mode is made up of u_offset bits from the quad pair
+          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
+          {                     // the MEL run of events
+            run -= 2; //subtract 2, since events number if multiplied by 2
+
+            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
+                                                 // is 0x40
+
+            if (run < 0)//if run is consumed (run is -1 or -2), get another run
+              run = mel_get_run(&mel);
+          }
+          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
+          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
+          //if (run < 0)
+          //  run = mel_get_run(&mel);  // get another run
+
+          //decode uvlc_mode to get u for both quads
+          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
+          //remove total prefix length
+          dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
+          uvlc_entry >>= 3;
+          //extract suffixes for quad 0 and 1
+          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
+          ui32 tmp = (ui32)vlc_val & ((1u << len) - 1); //suffix value, 2 quads
+          dconsume(vlc_val, vlc_bits, len);
+          uvlc_entry >>= 4;
+          // quad 0 length
+          len = uvlc_entry & 0x7; // quad 0 suffix length
+          uvlc_entry >>= 3;
+          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
+          sp[1] = u_q;
+          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
+          sp[3] = u_q;
+        }
+        sp[0] = sp[1] = 0;
+
+        //non initial quad rows
+        for (ui32 y = 2; y < height; y += 2)
+        {
+          c_q = 0;                                // context
+          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
+
+          for (ui32 x = 0; x < width; sp += 4)
+          {
+            // decode VLC
+            /////////////
+
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
+
+            // first quad
+            drefill(vlc_val, vlc_bits, vlc_off, vlc_buf, vlc_limit);
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0) //zero context
+            {
+              run -= 2; //subtract 2, since events number is multiplied by 2
+
+              // Is the run terminated in 1? if so, use decoded VLC code,
+              // otherwise, discard decoded data, since we will decoded again
+              // using a different context
+              t0 = (run == -1) ? t0 : 0;
+
+              // is run -1 or -2? this means a run has been consumed
+              if (run < 0)
+                run = mel_get_run(&mel);  // get another run
+            }
+            //run -= (c_q == 0) ? 2 : 0;
+            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[0] = t0;
+            x += 2;
+
+            // prepare context for the next quad; eqn. 2 in ITU T.814
+            // sigma_q (w, sw)
+            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[0 - (si32)sstr] & 0x80;
+            // sigma_q (n, ne, nf)
+            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
+            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
+
+            //remove data from vlc stream (0 bits are removed if vlc is unused)
+            dconsume(vlc_val, vlc_bits, t0 & 0x7u);
+
+            //second quad
+            ui16 t1 = 0;
+
+            //decode VLC using the context c_q and the head of VLC bitstream
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
+
+            // if context is zero, use one MEL event
+            if (c_q == 0 && x < width) //zero context
+            {
+              run -= 2; //subtract 2, since events number if multiplied by 2
+
+              // if event is 0, discard decoded t1
+              t1 = (run == -1) ? t1 : 0;
+
+              if (run < 0) // have we consumed all events in a run
+                run = mel_get_run(&mel); // if yes, then get another run
+            }
+            t1 = x < width ? t1 : 0;
+            //run -= (c_q == 0 && x < width) ? 2 : 0;
+            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
+            //if (run < 0)
+            //  run = mel_get_run(&mel);  // get another run
+            sp[2] = t1;
+            x += 2;
+
+            // partial c_q, will be completed when we process the next quad
+            // sigma_q (w, sw)
+            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
+            // sigma_q (nw)
+            c_q |= sp[2 - (si32)sstr] & 0x80;
+
+            //remove data from vlc stream, if qinf is not used, cwdlen is 0
+            dconsume(vlc_val, vlc_bits, t1 & 0x7u);
+
+            // decode u using wide UVLC table
+            /////////////
+            ui32 uvlc_mode = (((t0 >> 3) & 1u) | (((t1 >> 3) & 1u) << 1));
+            ui32 uvlc_entry =
+              uvlc_tbl1_wide[(uvlc_mode << 10) | (vlc_val & 0x3FF)];
+            ui32 total_bits = uvlc_entry & 0x1F;
+            if (total_bits < 0x1F) {
+              sp[1] = (ui16)((uvlc_entry >> 5) & 0xFF);
+              sp[3] = (ui16)((uvlc_entry >> 13) & 0xFF);
+              dconsume(vlc_val, vlc_bits, total_bits);
+            } else {
+              uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
+              uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
+              dconsume(vlc_val, vlc_bits, uvlc_entry & 0x7u);
+              uvlc_entry >>= 3;
+              ui32 len = uvlc_entry & 0xF;
+              ui32 tmp = (ui32)vlc_val & ((1u << len) - 1);
+              dconsume(vlc_val, vlc_bits, len);
+              uvlc_entry >>= 4;
+              len = uvlc_entry & 0x7;
+              uvlc_entry >>= 3;
+              sp[1] = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+              sp[3] = (ui16)((uvlc_entry >> 3) + (tmp >> len));
+            }
+          }
+          sp[0] = sp[1] = 0;
+        }
+    }
+
     bool ojph_decode_codeblock_avx2(ui8* coded_data, ui32* decoded_data,
                                     ui32 missing_msbs, ui32 num_passes,
                                     ui32 lengths1, ui32 lengths2,
@@ -1159,8 +1910,6 @@ namespace ojph {
       // Each entry in UVLC contains u_q
       // One extra row to handle the case of SPP propagating downwards
       // when codeblock width is 4
-      ui16 scratch[8 * 513] = {0};          // 8+ kB
-
       // We need an extra two entries (one inf and one u_q) beyond
       // the last column.
       // If the block width is 4 (2 quads), then we use sstr of 8
@@ -1168,6 +1917,16 @@ namespace ojph {
       // sstr is 16 (enough for 8 quads). For a width of 16 (8
       // quads), we use 24 (enough for 12 quads).
       ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
+
+#ifdef __MINGW64__
+      ui16 scratch[8 * 513] = {0};
+#else
+      ui16 scratch[8 * 513];
+      ui32 quad_rows = (height + 1u) >> 1;
+      size_t scratch_zero = (size_t)(quad_rows + 1) * sstr;
+      if (scratch_zero > 8 * 513) scratch_zero = 8 * 513;
+      memset(scratch, 0, scratch_zero * sizeof(ui16));
+#endif
 
       assert((stride & 0x3) == 0);
 
@@ -1179,244 +1938,8 @@ namespace ojph {
       // This information should be sufficient for the next step.
       // In step 2, we decode the MagSgn segment.
 
-      // step 1 decoding VLC and MEL segments
-      {
-        // init structures
-        dec_mel_st mel;
-        mel_init(&mel, coded_data, lcup, scup);
-        rev_struct vlc;
-        rev_init(&vlc, coded_data, lcup, scup);
-
-        int run = mel_get_run(&mel); // decode runs of events from MEL bitstrm
-                                     // data represented as runs of 0 events
-                                     // See mel_decode description
-
-        ui32 vlc_val;
-        ui32 c_q = 0;
-        ui16 *sp = scratch;
-        //initial quad row
-        for (ui32 x = 0; x < width; sp += 4)
-        {
-          // decode VLC
-          /////////////
-
-          // first quad
-          vlc_val = rev_fetch(&vlc);
-
-          //decode VLC using the context c_q and the head of VLC bitstream
-          ui16 t0 = vlc_tbl0[ c_q + (vlc_val & 0x7F) ];
-
-          // if context is zero, use one MEL event
-          if (c_q == 0) //zero context
-          {
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            // Is the run terminated in 1? if so, use decoded VLC code,
-            // otherwise, discard decoded data, since we will decoded again
-            // using a different context
-            t0 = (run == -1) ? t0 : 0;
-
-            // is run -1 or -2? this means a run has been consumed
-            if (run < 0)
-              run = mel_get_run(&mel);  // get another run
-          }
-          //run -= (c_q == 0) ? 2 : 0;
-          //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-          sp[0] = t0;
-          x += 2;
-
-          // prepare context for the next quad; eqn. 1 in ITU T.814
-          c_q = ((t0 & 0x10U) << 3) | ((t0 & 0xE0U) << 2);
-
-          //remove data from vlc stream (0 bits are removed if vlc is not used)
-          vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-          //second quad
-          ui16 t1 = 0;
-
-          //decode VLC using the context c_q and the head of VLC bitstream
-          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
-
-          // if context is zero, use one MEL event
-          if (c_q == 0 && x < width) //zero context
-          {
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            // if event is 0, discard decoded t1
-            t1 = (run == -1) ? t1 : 0;
-
-            if (run < 0) // have we consumed all events in a run
-              run = mel_get_run(&mel); // if yes, then get another run
-          }
-          t1 = x < width ? t1 : 0;
-          //run -= (c_q == 0 && x < width) ? 2 : 0;
-          //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-          sp[2] = t1;
-          x += 2;
-
-          //prepare context for the next quad, eqn. 1 in ITU T.814
-          c_q = ((t1 & 0x10U) << 3) | ((t1 & 0xE0U) << 2);
-
-          //remove data from vlc stream, if qinf is not used, cwdlen is 0
-          vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-          // decode u
-          /////////////
-          // uvlc_mode is made up of u_offset bits from the quad pair
-          ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-          if (uvlc_mode == 0xc0)// if both u_offset are set, get an event from
-          {                     // the MEL run of events
-            run -= 2; //subtract 2, since events number if multiplied by 2
-
-            uvlc_mode += (run == -1) ? 0x40 : 0; // increment uvlc_mode by
-                                                 // is 0x40
-
-            if (run < 0)//if run is consumed (run is -1 or -2), get another run
-              run = mel_get_run(&mel);
-          }
-          //run -= (uvlc_mode == 0xc0) ? 2 : 0;
-          //uvlc_mode += (uvlc_mode == 0xc0 && run == -1) ? 0x40 : 0;
-          //if (run < 0)
-          //  run = mel_get_run(&mel);  // get another run
-
-          //decode uvlc_mode to get u for both quads
-          ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
-          //remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-          uvlc_entry >>= 3;
-          //extract suffixes for quad 0 and 1
-          ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
-          ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
-          vlc_val = rev_advance(&vlc, len);
-          ojph_unused(vlc_val); //static code analysis: unused value
-          uvlc_entry >>= 4;
-          // quad 0 length
-          len = uvlc_entry & 0x7; // quad 0 suffix length
-          uvlc_entry >>= 3;
-          ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
-          sp[1] = u_q;
-          u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
-          sp[3] = u_q;
-        }
-        sp[0] = sp[1] = 0;
-
-        //non initial quad rows
-        for (ui32 y = 2; y < height; y += 2)
-        {
-          c_q = 0;                                // context
-          ui16 *sp = scratch + (y >> 1) * sstr;   // this row of quads
-
-          for (ui32 x = 0; x < width; sp += 4)
-          {
-            // decode VLC
-            /////////////
-
-            // sigma_q (n, ne, nf)
-            c_q |= ((sp[0 - (si32)sstr] & 0xA0U) << 2);
-            c_q |= ((sp[2 - (si32)sstr] & 0x20U) << 4);
-
-            // first quad
-            vlc_val = rev_fetch(&vlc);
-
-            //decode VLC using the context c_q and the head of VLC bitstream
-            ui16 t0 = vlc_tbl1[ c_q + (vlc_val & 0x7F) ];
-
-            // if context is zero, use one MEL event
-            if (c_q == 0) //zero context
-            {
-              run -= 2; //subtract 2, since events number is multiplied by 2
-
-              // Is the run terminated in 1? if so, use decoded VLC code,
-              // otherwise, discard decoded data, since we will decoded again
-              // using a different context
-              t0 = (run == -1) ? t0 : 0;
-
-              // is run -1 or -2? this means a run has been consumed
-              if (run < 0)
-                run = mel_get_run(&mel);  // get another run
-            }
-            //run -= (c_q == 0) ? 2 : 0;
-            //t0 = (c_q != 0 || run == -1) ? t0 : 0;
-            //if (run < 0)
-            //  run = mel_get_run(&mel);  // get another run
-            sp[0] = t0;
-            x += 2;
-
-            // prepare context for the next quad; eqn. 2 in ITU T.814
-            // sigma_q (w, sw)
-            c_q = ((t0 & 0x40U) << 2) | ((t0 & 0x80U) << 1);
-            // sigma_q (nw)
-            c_q |= sp[0 - (si32)sstr] & 0x80;
-            // sigma_q (n, ne, nf)
-            c_q |= ((sp[2 - (si32)sstr] & 0xA0U) << 2);
-            c_q |= ((sp[4 - (si32)sstr] & 0x20U) << 4);
-
-            //remove data from vlc stream (0 bits are removed if vlc is unused)
-            vlc_val = rev_advance(&vlc, t0 & 0x7);
-
-            //second quad
-            ui16 t1 = 0;
-
-            //decode VLC using the context c_q and the head of VLC bitstream
-            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
-
-            // if context is zero, use one MEL event
-            if (c_q == 0 && x < width) //zero context
-            {
-              run -= 2; //subtract 2, since events number if multiplied by 2
-
-              // if event is 0, discard decoded t1
-              t1 = (run == -1) ? t1 : 0;
-
-              if (run < 0) // have we consumed all events in a run
-                run = mel_get_run(&mel); // if yes, then get another run
-            }
-            t1 = x < width ? t1 : 0;
-            //run -= (c_q == 0 && x < width) ? 2 : 0;
-            //t1 = (c_q != 0 || run == -1) ? t1 : 0;
-            //if (run < 0)
-            //  run = mel_get_run(&mel);  // get another run
-            sp[2] = t1;
-            x += 2;
-
-            // partial c_q, will be completed when we process the next quad
-            // sigma_q (w, sw)
-            c_q = ((t1 & 0x40U) << 2) | ((t1 & 0x80U) << 1);
-            // sigma_q (nw)
-            c_q |= sp[2 - (si32)sstr] & 0x80;
-
-            //remove data from vlc stream, if qinf is not used, cwdlen is 0
-            vlc_val = rev_advance(&vlc, t1 & 0x7);
-
-            // decode u
-            /////////////
-            // uvlc_mode is made up of u_offset bits from the quad pair
-            ui32 uvlc_mode = ((t0 & 0x8U) << 3) | ((t1 & 0x8U) << 4);
-            ui32 uvlc_entry = uvlc_tbl1[uvlc_mode + (vlc_val & 0x3F)];
-            //remove total prefix length
-            vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
-            uvlc_entry >>= 3;
-            //extract suffixes for quad 0 and 1
-            ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
-            ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
-            vlc_val = rev_advance(&vlc, len);
-            ojph_unused(vlc_val); //static code analysis: unused value
-            uvlc_entry >>= 4;
-            // quad 0 length
-            len = uvlc_entry & 0x7; // quad 0 suffix length
-            uvlc_entry >>= 3;
-            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
-            sp[1] = u_q;
-            u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
-            sp[3] = u_q;
-          }
-          sp[0] = sp[1] = 0;
-        }
-      }
+      // step 1: decode VLC and MEL segments into scratch
+      decode_cb_step1_vlc(scratch, coded_data, lcup, scup, width, height, sstr);
 
       // step2 we decode magsgn
       // mmsbp2 equals K_max + 1 (we decode up to K_max bits + 1 sign bit)
@@ -1428,613 +1951,22 @@ namespace ojph {
       // path, but we are not doing this here.
       if (mmsbp2 >= 16)
       {
-        // We allocate a scratch row for storing v_n values.
-        // We have 512 quads horizontally.
-        // We may go beyond the last entry by up to 4 entries.
-        // Here we allocate additional 8 entries.
-        // There are two rows in this structure, the bottom
-        // row is used to store processed entries.
-        const int v_n_size = 512 + 16;
-        ui32 v_n_scratch[2 * v_n_size] = {0}; // 4+ kB
-
-        frwd_struct_avx2 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-        const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
-
-        {
-          ui16 *sp = scratch;
-          ui32 *vp = v_n_scratch;
-          ui32 *dp = decoded_data;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
-          {
-            __m128i vn = _mm_set1_epi32(2);
-
-            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
-            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-            __m256i U_q = _mm256_srli_epi32(inf_u_q, 16);
-            __m256i w = _mm256_cmpgt_epi32(U_q, avx_mmsbp2);
-            if (!_mm256_testz_si256(w, w)) {
-                return false;
-            }
-
-            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q, &magsgn, p, vn);
-            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
-            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
-            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
-
-            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
-          }
-        }
-
-        for (ui32 y = 2; y < height; y += 2)
-        {
-          {
-            // perform 31 - count_leading_zeros(*vp) here
-            ui32 *vp = v_n_scratch;
-            ui16* sp = scratch + (y >> 1) * sstr;
-
-            const __m256i avx_31 = _mm256_set1_epi32(31);
-            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
-            const __m256i avx_1 = _mm256_set1_epi32(1);
-            const __m256i avx_0 = _mm256_setzero_si256();
-
-            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16) {
-              __m256i v = _mm256_loadu_si256((__m256i*)vp);
-              __m256i v_p1 = _mm256_loadu_si256((__m256i*)(vp + 1));
-              v = _mm256_or_si256(v, v_p1);
-              v = avx2_lzcnt_epi32(v);
-              v = _mm256_sub_epi32(avx_31, v);
-
-              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
-              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
-              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
-              gamma = _mm256_and_si256(gamma, w0);
-              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
-
-              v = _mm256_andnot_si256(gamma, v);
-              v = _mm256_max_epi32(v, avx_1);
-
-              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
-              v = _mm256_add_epi32(inf_u_q, v);
-
-              w0 = _mm256_cmpgt_epi32(v, avx_mmsbp2);
-              if (!_mm256_testz_si256(w0, w0)) {
-                  return false;
-              }
-
-              _mm256_storeu_si256((__m256i*)(vp + v_n_size), v);
-            }
-          }
-
-          ui32 *vp = v_n_scratch;
-          ui16 *sp = scratch + (y >> 1) * sstr;
-          ui32 *dp = decoded_data + y * stride;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4) {
-            //process two quads
-            __m128i vn = _mm_set1_epi32(2);
-
-            __m256i inf_u_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)sp));
-            inf_u_q = _mm256_permutevar8x32_epi32(inf_u_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-            __m256i U_q = _mm256_castsi128_si256(_mm_loadl_epi64((__m128i*)(vp + v_n_size)));
-            U_q = _mm256_permutevar8x32_epi32(U_q, _mm256_setr_epi32(0, 0, 0, 0, 1, 1, 1, 1));
-
-            __m256i row = decode_two_quad32_avx2(inf_u_q, U_q,  &magsgn, p, vn);
-            row = _mm256_permutevar8x32_epi32(row, _mm256_setr_epi32(0, 2, 4, 6, 1, 3, 5, 7));
-            _mm_store_si128((__m128i*)dp, _mm256_castsi256_si128(row));
-            _mm_store_si128((__m128i*)(dp + stride), _mm256_extracti128_si256(row, 0x1));
-
-            __m128i w0 = _mm_cvtsi32_si128(*(int const*)vp);
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
-          }
-        }
+        if (!decode_cb_step2_32bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
       }
       else {
-
-        // reduce bitplane by 16 because we now have 16 bits instead of 32
-        p -= 16;
-
-        // We allocate a scratch row for storing v_n values.
-        // We have 512 quads horizontally.
-        // We may go beyond the last entry by up to 8 entries.
-        // Therefore we allocate additional 8 entries.
-        // There are two rows in this structure, the bottom
-        // row is used to store processed entries.
-        const int v_n_size = 512 + 16;
-        ui16 v_n_scratch[v_n_size] = {0}; // 1+ kB
-        ui32 v_n_scratch_32[v_n_size] = {0}; // 2+ kB
-
-        frwd_struct_avx2 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
-
-        {
-          ui16 *sp = scratch;
-          ui16 *vp = v_n_scratch;
-          ui32 *dp = decoded_data;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8) {
-              ////process four quads
-              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              __m128i U_q = _mm_srli_epi32(inf_u_q, 16);
-              __m128i w = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              if (!_mm_testz_si128(w, w)) {
-                  return false;
-              }
-
-              __m128i vn = _mm_set1_epi16(2);
-              __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-              w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
-              _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
-
-              __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-              __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-              _mm256_storeu_si256((__m256i*)dp, w0);
-              _mm256_storeu_si256((__m256i*)(dp + stride), w1);
-          }
-        }
-
-        for (ui32 y = 2; y < height; y += 2) {
-          {
-            // perform 15 - count_leading_zeros(*vp) here
-            ui16 *vp = v_n_scratch;
-            ui32 *vp_32 = v_n_scratch_32;
-
-            ui16* sp = scratch + (y >> 1) * sstr;
-            const __m256i avx_mmsbp2 = _mm256_set1_epi32((int)mmsbp2);
-            const __m256i avx_31 = _mm256_set1_epi32(31);
-            const __m256i avx_f0 = _mm256_set1_epi32(0xF0);
-            const __m256i avx_1 = _mm256_set1_epi32(1);
-            const __m256i avx_0 = _mm256_setzero_si256();
-
-            for (ui32 x = 0; x <= width; x += 16, vp += 8, sp += 16, vp_32 += 8) {
-              __m128i v = _mm_loadu_si128((__m128i*)vp);
-              __m128i v_p1 = _mm_loadu_si128((__m128i*)(vp + 1));
-              v = _mm_or_si128(v, v_p1);
-
-              __m256i v_avx = _mm256_cvtepu16_epi32(v);
-              v_avx = avx2_lzcnt_epi32(v_avx);
-              v_avx = _mm256_sub_epi32(avx_31, v_avx);
-
-              __m256i inf_u_q = _mm256_loadu_si256((__m256i*)sp);
-              __m256i gamma = _mm256_and_si256(inf_u_q, avx_f0);
-              __m256i w0 = _mm256_sub_epi32(gamma, avx_1);
-              gamma = _mm256_and_si256(gamma, w0);
-              gamma = _mm256_cmpeq_epi32(gamma, avx_0);
-
-              v_avx = _mm256_andnot_si256(gamma, v_avx);
-              v_avx = _mm256_max_epi32(v_avx, avx_1);
-
-              inf_u_q = _mm256_srli_epi32(inf_u_q, 16);
-              v_avx = _mm256_add_epi32(inf_u_q, v_avx);
-
-              w0 = _mm256_cmpgt_epi32(v_avx, avx_mmsbp2);
-              if (!_mm256_testz_si256(w0, w0)) {
-                  return false;
-              }
-
-              _mm256_storeu_si256((__m256i*)vp_32, v_avx);
-            }
-          }
-
-          ui16 *vp = v_n_scratch;
-          ui32* vp_32 = v_n_scratch_32;
-          ui16 *sp = scratch + (y >> 1) * sstr;
-          ui32 *dp = decoded_data + y * stride;
-          vp[0] = 2; // for easy calculation of emax
-
-          for (ui32 x = 0; x < width; x += 8, sp += 8, vp += 4, dp += 8, vp_32 += 4) {
-            ////process four quads
-              __m128i inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              __m128i U_q = _mm_loadu_si128((__m128i*)vp_32);
-
-            __m128i vn = _mm_set1_epi16(2);
-            __m256i row = decode_four_quad16(inf_u_q, U_q, &magsgn, p, vn);
-
-            __m128i w = _mm_cvtsi32_si128(*(unsigned short const*)(vp));
-            _mm_storeu_si128((__m128i*)vp, _mm_or_si128(w, vn));
-
-            __m256i  w0 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1, 0x0D0C, -1, 0x0908, -1, 0x0504, -1, 0x0100, -1));
-            __m256i  w1 = _mm256_shuffle_epi8(row, _mm256_set_epi16(0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1, 0x0F0E, -1, 0x0B0A, -1, 0x0706, -1, 0x0302, -1));
-
-            _mm256_storeu_si256((__m256i*)dp, w0);
-            _mm256_storeu_si256((__m256i*)(dp + stride), w1);
-          }
-        }
-
-        // increase bitplane back by 16 because we need to process 32 bits
-        p += 16;
+        if (!decode_cb_step2_16bit(scratch, decoded_data, coded_data,
+                                   width, height, stride, sstr, p, mmsbp2,
+                                   lcup, scup))
+          return false;
       }
 
       if (num_passes > 1)
-      {
-        // We use scratch again, we can divide it into multiple regions
-        // sigma holds all the significant samples, and it cannot
-        // be modified after it is set.  it will be used during the
-        // Magnitude Refinement Pass
-        ui16* const sigma = scratch;
-
-        ui32 mstr = (width + 3u) >> 2;   // divide by 4, since each
-                                         // ui16 contains 4 columns
-        mstr = ((mstr + 2u) + 7u) & ~7u; // multiples of 8
-
-        // We re-arrange quad significance, where each 4 consecutive
-        // bits represent one quad, into column significance, where,
-        // each 4 consequtive bits represent one column of 4 rows
-        {
-          ui32 y;
-
-          const __m128i mask_3 = _mm_set1_epi32(0x30);
-          const __m128i mask_C = _mm_set1_epi32(0xC0);
-          const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
-          for (y = 0; y < height; y += 4)
-          {
-            ui16* sp = scratch + (y >> 1) * sstr;
-            ui16* dp = sigma + (y >> 2) * mstr;
-            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
-            {
-              __m128i s0, s1, u3, uC, t0, t1;
-
-              s0 = _mm_loadu_si128((__m128i*)(sp));
-              u3 = _mm_and_si128(s0, mask_3);
-              u3 = _mm_srli_epi32(u3, 4);
-              uC = _mm_and_si128(s0, mask_C);
-              uC = _mm_srli_epi32(uC, 2);
-              t0 = _mm_or_si128(u3, uC);
-
-              s1 = _mm_loadu_si128((__m128i*)(sp + sstr));
-              u3 = _mm_and_si128(s1, mask_3);
-              u3 = _mm_srli_epi32(u3, 2);
-              uC = _mm_and_si128(s1, mask_C);
-              t1 = _mm_or_si128(u3, uC);
-
-              __m128i r = _mm_or_si128(t0, t1);
-              r = _mm_shuffle_epi8(r, shuffle_mask);
-
-              *(ui32*)dp = (ui32)_mm_extract_epi32(r, 0);
-            }
-            dp[0] = 0; // set an extra entry on the right with 0
-          }
-          {
-            // reset one row after the codeblock
-            ui16* dp = sigma + (y >> 2) * mstr;
-            __m128i zero = _mm_setzero_si128();
-            for (ui32 x = 0; x < width; x += 32, dp += 8)
-              _mm_storeu_si128((__m128i*)dp, zero);
-            dp[0] = 0; // set an extra entry on the right with 0
-          }
-        }
-
-        // We perform Significance Propagation Pass here
-        {
-          // This stores significance information of the previous
-          // 4 rows.  Significance information in this array includes
-          // all signicant samples in bitplane p - 1; that is,
-          // significant samples for bitplane p (discovered during the
-          // cleanup pass and stored in sigma) and samples that have recently
-          // became significant (during the SPP) in bitplane p-1.
-          // We store enough for the widest row, containing 1024 columns,
-          // which is equivalent to 256 of ui16, since each stores 4 columns.
-          // We add an extra 8 entries, just in case we need more
-          ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
-
-          frwd_struct_avx2 sigprop;
-          frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
-
-          for (ui32 y = 0; y < height; y += 4)
-          {
-            ui32 pattern = 0xFFFFu; // a pattern needed samples
-            if (height - y < 4) {
-              pattern = 0x7777u;
-              if (height - y < 3) {
-                pattern = 0x3333u;
-                if (height - y < 2)
-                  pattern = 0x1111u;
-              }
-            }
-
-            // prev holds sign. info. for the previous quad, together
-            // with the rows on top of it and below it.
-            ui32 prev = 0;
-            ui16 *prev_sig = prev_row_sig;
-            ui16 *cur_sig = sigma + (y >> 2) * mstr;
-            ui32 *dpp = decoded_data + y * stride;
-            for (ui32 x = 0; x < width; x += 4, dpp += 4, ++cur_sig, ++prev_sig)
-            {
-              // only rows and columns inside the stripe are included
-              si32 s = (si32)x + 4 - (si32)width;
-              s = ojph_max(s, 0);
-              pattern = pattern >> (s * 4);
-
-              // We first find locations that need to be tested (potential
-              // SPP members); these location will end up in mbr
-              // In each iteration, we produce 16 bits because cwd can have
-              // up to 16 bits of significance information, followed by the
-              // corresponding 16 bits of sign information; therefore, it is
-              // sufficient to fetch 32 bit data per loop.
-
-              // Althougth we are interested in 16 bits only, we load 32 bits.
-              // For the 16 bits we are producing, we need the next 4 bits --
-              // We need data for at least 5 columns out of 8.
-              // Therefore loading 32 bits is easier than loading 16 bits
-              // twice.
-              ui32 ps = *(ui32*)prev_sig;
-              ui32 ns = *(ui32*)(cur_sig + mstr);
-              ui32 u = (ps & 0x88888888) >> 3; // the row on top
-              if (!stripe_causal)
-                u |= (ns & 0x11111111) << 3;   // the row below
-
-              ui32 cs = *(ui32*)cur_sig;
-              // vertical integration
-              ui32 mbr =  cs;                // this sig. info.
-              mbr |= (cs & 0x77777777) << 1; //above neighbors
-              mbr |= (cs & 0xEEEEEEEE) >> 1; //below neighbors
-              mbr |= u;
-              // horizontal integration
-              ui32 t = mbr;
-              mbr |= t << 4;      // neighbors on the left
-              mbr |= t >> 4;      // neighbors on the right
-              mbr |= prev >> 12;  // significance of previous group
-
-              // remove outside samples, and already significant samples
-              mbr &= pattern;
-              mbr &= ~cs;
-
-              // find samples that become significant during the SPP
-              ui32 new_sig = mbr;
-              if (new_sig)
-              {
-                __m128i cwd_vec = frwd_fetch<0>(&sigprop);
-                ui32 cwd = (ui32)_mm_extract_epi16(cwd_vec, 0);
-
-                ui32 cnt = 0;
-                ui32 col_mask = 0xFu;
-                ui32 inv_sig = ~cs & pattern;
-                for (int i = 0; i < 16; i += 4, col_mask <<= 4)
-                {
-                  if ((col_mask & new_sig) == 0)
-                    continue;
-
-                  //scan one column
-                  ui32 sample_mask = 0x1111u & col_mask;
-                  if (new_sig & sample_mask)
-                  {
-                    new_sig &= ~sample_mask;
-                    if (cwd & 1)
-                    {
-                      ui32 t = 0x33u << i;
-                      new_sig |= t & inv_sig;
-                    }
-                    cwd >>= 1; ++cnt;
-                  }
-
-                  sample_mask <<= 1;
-                  if (new_sig & sample_mask)
-                  {
-                    new_sig &= ~sample_mask;
-                    if (cwd & 1)
-                    {
-                      ui32 t = 0x76u << i;
-                      new_sig |= t & inv_sig;
-                    }
-                    cwd >>= 1; ++cnt;
-                  }
-
-                  sample_mask <<= 1;
-                  if (new_sig & sample_mask)
-                  {
-                    new_sig &= ~sample_mask;
-                    if (cwd & 1)
-                    {
-                      ui32 t = 0xECu << i;
-                      new_sig |= t & inv_sig;
-                    }
-                    cwd >>= 1; ++cnt;
-                  }
-
-                  sample_mask <<= 1;
-                  if (new_sig & sample_mask)
-                  {
-                    new_sig &= ~sample_mask;
-                    if (cwd & 1)
-                    {
-                      ui32 t = 0xC8u << i;
-                      new_sig |= t & inv_sig;
-                    }
-                    cwd >>= 1; ++cnt;
-                  }
-                }
-
-                if (new_sig)
-                {
-                  cwd |= (ui32)_mm_extract_epi16(cwd_vec, 1) << (16 - cnt);
-
-                  // Spread new_sig, such that each bit is in one byte with a
-                  // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
-                  __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
-                  new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
-                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                  new_sig_vec = _mm_and_si128(new_sig_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-
-                  // find cumulative sums
-                  // to find which bit in cwd we should extract
-                  __m128i inc_sum = new_sig_vec; // inclusive scan
-                  inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                  cnt += (ui32)_mm_extract_epi16(inc_sum, 7) >> 8;
-                  // exclusive scan
-                  __m128i ex_sum = _mm_bslli_si128(inc_sum, 1);
-
-                  // Spread cwd, such that each bit is in one byte
-                  // with a value of 0 or 1.
-                  cwd_vec = _mm_set1_epi16((si16)cwd);
-                  cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                  cwd_vec = _mm_and_si128(cwd_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  cwd_vec = _mm_abs_epi8(cwd_vec);
-
-                  // Obtain bit from cwd_vec correspondig to ex_sum
-                  // Basically, collect needed bits from cwd_vec
-                  __m128i v = _mm_shuffle_epi8(cwd_vec, ex_sum);
-
-                  // load data and set spp coefficients
-                  __m128i m =
-                    _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
-                  __m128i val = _mm_set1_epi32(3 << (p - 2));
-                  ui32 *dp = dpp;
-                  for (int c = 0; c < 4; ++ c) {
-                    __m128i s0, s0_ns, s0_val;
-                    // load coefficients
-                    s0 = _mm_load_si128((__m128i*)dp);
-
-                    // epi32 is -1 only for coefficient that
-                    // are changed during the SPP
-                    s0_ns = _mm_shuffle_epi8(new_sig_vec, m);
-                    s0_ns = _mm_cmpeq_epi32(s0_ns, _mm_set1_epi32(0xFF));
-
-                    // obtain sign for coefficients in SPP
-                    s0_val = _mm_shuffle_epi8(v, m);
-                    s0_val = _mm_slli_epi32(s0_val, 31);
-                    s0_val = _mm_or_si128(s0_val, val);
-                    s0_val = _mm_and_si128(s0_val, s0_ns);
-
-                    // update vector
-                    s0 = _mm_or_si128(s0, s0_val);
-                    // store coefficients
-                    _mm_store_si128((__m128i*)dp, s0);
-                    // prepare for next row
-                    dp += stride;
-                    m = _mm_add_epi32(m, _mm_set1_epi32(1));
-                  }
-                }
-                frwd_advance(&sigprop, cnt);
-              }
-
-              new_sig |= cs;
-              *prev_sig = (ui16)(new_sig);
-
-              // vertical integration for the new sig. info.
-              t = new_sig;
-              new_sig |= (t & 0x7777) << 1; //above neighbors
-              new_sig |= (t & 0xEEEE) >> 1; //below neighbors
-              // add sig. info. from the row on top and below
-              prev = new_sig | u;
-              // we need only the bits in 0xF000
-              prev &= 0xF000;
-            }
-          }
-        }
-
-        // We perform Magnitude Refinement Pass here
-        if (num_passes > 2)
-        {
-          rev_struct magref;
-          rev_init_mrp(&magref, coded_data, (int)lengths1, (int)lengths2);
-
-          for (ui32 y = 0; y < height; y += 4)
-          {
-            ui16 *cur_sig = sigma + (y >> 2) * mstr;
-            ui32 *dpp = decoded_data + y * stride;
-            for (ui32 i = 0; i < width; i += 4, dpp += 4)
-            {
-              //Process one entry from sigma array at a time
-              // Each nibble (4 bits) in the sigma array represents 4 rows,
-              ui32 cwd = rev_fetch_mrp(&magref); // get 32 bit data
-              ui16 sig = *cur_sig++; // 16 bit that will be processed now
-              int total_bits = 0;
-              if (sig) // if any of the 32 bits are set
-              {
-                // We work on 4 rows, with 4 samples each, since
-                // data is 32 bit (4 bytes)
-
-                // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
-                __m128i sig_vec = _mm_set1_epi16((si16)sig);
-                sig_vec = _mm_shuffle_epi8(sig_vec,
-                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                sig_vec = _mm_and_si128(sig_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                sig_vec = _mm_cmpeq_epi8(sig_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                sig_vec = _mm_abs_epi8(sig_vec);
-
-                // find cumulative sums
-                // to find which bit in cwd we should extract
-                __m128i inc_sum = sig_vec; // inclusive scan
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                total_bits = _mm_extract_epi16(inc_sum, 7) >> 8;
-                __m128i ex_sum = _mm_bslli_si128(inc_sum, 1); // exclusive scan
-
-                // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
-                // cwd_vec. Then, convert these to a form suitable
-                // for coefficient modifications; in particular, a value
-                // of 0 is presented as binary 11, and a value of 1 is
-                // represented as binary 01
-                __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
-                cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                cwd_vec = _mm_and_si128(cwd_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
-                cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
-                cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
-
-                // load data and insert the mrp bit
-                __m128i m =
-                  _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
-                ui32 *dp = dpp;
-                for (int c = 0; c < 4; ++c) {
-                  __m128i s0, s0_sig, s0_idx, s0_val;
-                  // load coefficients
-                  s0 = _mm_load_si128((__m128i*)dp);
-                  // find significant samples in this row
-                  s0_sig = _mm_shuffle_epi8(sig_vec, m);
-                  s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
-                  // get MRP bit index, and MRP pattern
-                  s0_idx = _mm_shuffle_epi8(ex_sum, m);
-                  s0_val = _mm_shuffle_epi8(cwd_vec, s0_idx);
-                  // keep data from significant samples only
-                  s0_val = _mm_andnot_si128(s0_sig, s0_val);
-                  // move mrp bits to correct position, and employ
-                  s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
-                  s0 = _mm_xor_si128(s0, s0_val);
-                  // store coefficients
-                  _mm_store_si128((__m128i*)dp, s0);
-                  // prepare for next row
-                  dp += stride;
-                  m = _mm_add_epi32(m, _mm_set1_epi32(1));
-                }
-              }
-              // consume data according to the number of bits set
-              rev_advance_mrp(&magref, (ui32)total_bits);
-            }
-          }
-        }
-      }
+        decode_cb_spp_mrp(scratch, decoded_data, coded_data, width, height,
+                          stride, sstr, p, num_passes, lengths1, lengths2,
+                          stripe_causal);
 
       return true;
     }

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder_vsx.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder_vsx.cpp
@@ -30,18 +30,15 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //***************************************************************************/
 // This file is part of the OpenJPH software implementation.
-// File: ojph_block_decoder_ssse3.cpp
+// File: ojph_block_decoder_vsx.cpp
 // Author: Aous Naman
 // Date: 13 May 2022
 //***************************************************************************/
 
 //***************************************************************************/
-/** @file ojph_block_decoder_ssse3.cpp
- *  @brief implements a faster HTJ2K block decoder using ssse3
+/** @file ojph_block_decoder_vsx.cpp
+ *  @brief implements a faster HTJ2K block decoder using POWER VSX simd
  */
-
-#include "ojph_arch.h"
-#if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
 #include <string>
 #include <iostream>
@@ -50,12 +47,21 @@
 #include <cstring>
 #include "ojph_block_common.h"
 #include "ojph_block_decoder.h"
+#include "ojph_arch.h"
 #include "ojph_message.h"
 
-#include <immintrin.h>
+#include "ojph_simd_vsx.h"
 
 namespace ojph {
   namespace local {
+
+    //************************************************************************/
+    /** @brief Macros that help with typing and space
+     */
+    #define OJPH_REPEAT2(a) a,a
+    #define OJPH_REPEAT4(a) a,a,a,a
+    #define OJPH_REPEAT8(a) a,a,a,a,a,a,a,a
+    #define OJPH_REPEAT16(a) a,a,a,a,a,a,a,a,a,a,a,a,a,a,a,a
 
     //************************************************************************/
     /** @brief MEL state structure for reading and decoding the MEL bitstream
@@ -581,7 +587,7 @@ namespace ojph {
     /** @brief State structure for reading and unstuffing of forward-growing
      *         bitstreams; these are: MagSgn and SPP bitstreams
      */
-    struct frwd_struct_ssse3 {
+    struct frwd_struct {
       const ui8* data;  //!<pointer to bitstream
       ui8 tmp[48];      //!<temporary buffer of read data + 16 extra
       ui32 bits;        //!<number of bits stored in tmp
@@ -598,45 +604,45 @@ namespace ojph {
      *  X controls this value.
      *
      *  Unstuffing prevent sequences that are more than 0xFF7F from appearing
-     *  in the compressed sequence.  So whenever a value of 0xFF is coded, the
+     *  in the conpressed sequence.  So whenever a value of 0xFF is coded, the
      *  MSB of the next byte is set 0 and must be ignored during decoding.
      *
      *  Reading can go beyond the end of buffer by up to 16 bytes.
      *
      *  @tparam       X is the value fed in when the bitstream is exhausted
-     *  @param  [in]  msp is a pointer to frwd_struct_ssse3 structure
+     *  @param  [in]  msp is a pointer to frwd_struct structure
      *
      */
     template<int X>
     static inline
-    void frwd_read(frwd_struct_ssse3 *msp)
+    void frwd_read(frwd_struct *msp)
     {
       assert(msp->bits <= 128);
 
-      __m128i offset, val, validity, all_xff;
-      val = _mm_loadu_si128((__m128i*)msp->data);
+      v128_t offset, val, validity, all_xff;
+      val = vsx_v128_load(msp->data);
       int bytes = msp->size >= 16 ? 16 : msp->size;
-      validity = _mm_set1_epi8((char)bytes);
+      validity = vsx_i8x16_splat((signed char)bytes);
       msp->data += bytes;
       msp->size -= bytes;
       int bits = 128;
-      offset = _mm_set_epi64x(0x0F0E0D0C0B0A0908,0x0706050403020100);
-      validity = _mm_cmpgt_epi8(validity, offset);
-      all_xff = _mm_set1_epi8(-1);
+      offset = vsx_i64x2_const(0x0706050403020100,0x0F0E0D0C0B0A0908);
+      validity = vsx_i8x16_gt(validity, offset);
+      all_xff = vsx_i8x16_const(OJPH_REPEAT16(-1));
       if (X == 0xFF) // the compiler should remove this if statement
       {
-        __m128i t = _mm_xor_si128(validity, all_xff); // complement
-        val = _mm_or_si128(t, val); // fill with 0xFF
+        v128_t t = vsx_v128_xor(validity, all_xff); // complement
+        val = vsx_v128_or(t, val); // fill with 0xFF
       }
       else if (X == 0)
-        val = _mm_and_si128(validity, val); // fill with zeros
+        val = vsx_v128_and(validity, val); // fill with zeros
       else
         assert(0);
 
-      __m128i ff_bytes;
-      ff_bytes = _mm_cmpeq_epi8(val, all_xff);
-      ff_bytes = _mm_and_si128(ff_bytes, validity);
-      ui32 flags = (ui32)_mm_movemask_epi8(ff_bytes);
+      v128_t ff_bytes;
+      ff_bytes = vsx_i8x16_eq(val, all_xff);
+      ff_bytes = vsx_v128_and(ff_bytes, validity);
+      ui32 flags = (ui32)vsx_i8x16_bitmask(ff_bytes);
       flags <<= 1; // unstuff following byte
       ui32 next_unstuff = flags >> 16;
       flags |= msp->unstuff;
@@ -650,36 +656,38 @@ namespace ojph {
         ui32 loc = 31 - count_leading_zeros(flags);
         flags ^= 1 << loc;
 
-        __m128i m, t, c;
-        t = _mm_set1_epi8((char)loc);
-        m = _mm_cmpgt_epi8(offset, t);
+        v128_t m, t, c;
+        t = vsx_i8x16_splat((signed char)loc);
+        m = vsx_i8x16_gt(offset, t);
 
-        t = _mm_and_si128(m, val);  // keep bits at locations larger than loc
-        c = _mm_srli_epi64(t, 1);   // 1 bits left
-        t = _mm_srli_si128(t, 8);   // 8 bytes left
-        t = _mm_slli_epi64(t, 63);  // keep the MSB only
-        t = _mm_or_si128(t, c);     // combine the above 3 steps
+        t = vsx_v128_and(m, val);    // keep bits at locations larger than loc
+        c = vsx_u64x2_shr(t, 1);     // 1 bits left
+        t = vsx_i64x2_shuffle(t, vsx_i64x2_const(0, 0), 1, 2);
+        t = vsx_i64x2_shl(t, 63);    // keep the MSB only
+        t = vsx_v128_or(t, c);       // combine the above 3 steps
 
-        val = _mm_or_si128(t, _mm_andnot_si128(m, val));
+        val = vsx_v128_or(t, vsx_v128_andnot(val, m));
       }
 
       // combine with earlier data
       assert(msp->bits >= 0 && msp->bits <= 128);
       int cur_bytes = msp->bits >> 3;
-      int cur_bits = msp->bits & 7;
-      __m128i b1, b2;
-      b1 = _mm_sll_epi64(val, _mm_set1_epi64x(cur_bits));
-      b2 = _mm_slli_si128(val, 8);  // 8 bytes right
-      b2 = _mm_srl_epi64(b2, _mm_set1_epi64x(64-cur_bits));
-      b1 = _mm_or_si128(b1, b2);
-      b2 = _mm_loadu_si128((__m128i*)(msp->tmp + cur_bytes));
-      b2 = _mm_or_si128(b1, b2);
-      _mm_storeu_si128((__m128i*)(msp->tmp + cur_bytes), b2);
+      int cur_bits = (int)(msp->bits & 7);
+      v128_t b1, b2;
+      b1 = vsx_i64x2_shl(val, cur_bits);
+      //next shift 8 bytes right
+      b2 = vsx_i64x2_shuffle(vsx_i64x2_const(0, 0), val, 1, 2);
+      b2 = vsx_u64x2_shr(b2, 64 - cur_bits);
+      b2 = (cur_bits > 0) ? b2 : vsx_i64x2_const(0, 0);
+      b1 = vsx_v128_or(b1, b2);
+      b2 = vsx_v128_load(msp->tmp + cur_bytes);
+      b2 = vsx_v128_or(b1, b2);
+      vsx_v128_store(msp->tmp + cur_bytes, b2);
 
-      int consumed_bits = bits < 128 - cur_bits ? bits : 128 - cur_bits;
-      cur_bytes = (msp->bits + (ui32)consumed_bits + 7) >> 3; // round up
-      int upper = _mm_extract_epi16(val, 7);
-      upper >>= consumed_bits - 128 + 16;
+      ui32 consumed_bits = (ui32)(bits < 128-cur_bits ? bits : 128-cur_bits);
+      cur_bytes = (msp->bits + consumed_bits + 7) >> 3; // round up
+      int upper = vsx_u16x8_extract_lane(val, 7);
+      upper >>= consumed_bits + 16 - 128;
       msp->tmp[cur_bytes] = (ui8)upper; // copy byte
 
       msp->bits += (ui32)bits;
@@ -688,22 +696,22 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief Initialize frwd_struct_ssse3 struct and reads some bytes
+    /** @brief Initialize frwd_struct struct and reads some bytes
      *
      *  @tparam      X is the value fed in when the bitstream is exhausted.
      *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_ssse3
+     *  @param [in]  msp is a pointer to frwd_struct
      *  @param [in]  data is a pointer to the start of data
      *  @param [in]  size is the number of byte in the bitstream
      */
     template<int X>
     static inline
-    void frwd_init(frwd_struct_ssse3 *msp, const ui8* data, int size)
+    void frwd_init(frwd_struct *msp, const ui8* data, int size)
     {
       msp->data = data;
-      _mm_storeu_si128((__m128i *)msp->tmp, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 1, _mm_setzero_si128());
-      _mm_storeu_si128((__m128i *)msp->tmp + 2, _mm_setzero_si128());
+      vsx_v128_store(msp->tmp, vsx_i64x2_const(0, 0));
+      vsx_v128_store(msp->tmp + 16, vsx_i64x2_const(0, 0));
+      vsx_v128_store(msp->tmp + 32, vsx_i64x2_const(0, 0));
 
       msp->bits = 0;
       msp->unstuff = 0;
@@ -713,53 +721,56 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief Consume num_bits bits from the bitstream of frwd_struct_ssse3
+    /** @brief Consume num_bits bits from the bitstream of frwd_struct
      *
-     *  @param [in]  msp is a pointer to frwd_struct_ssse3
+     *  @param [in]  msp is a pointer to frwd_struct
      *  @param [in]  num_bits is the number of bit to consume
      */
     static inline
-    void frwd_advance(frwd_struct_ssse3 *msp, ui32 num_bits)
+    void frwd_advance(frwd_struct *msp, ui32 num_bits)
     {
       assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
       msp->bits -= num_bits;
 
-      __m128i *p = (__m128i*)(msp->tmp + ((num_bits >> 3) & 0x18));
+      v128_t *p = (v128_t*)(msp->tmp + ((num_bits >> 3) & 0x18));
       num_bits &= 63;
 
-      __m128i v0, v1, c0, c1, t;
-      v0 = _mm_loadu_si128(p);
-      v1 = _mm_loadu_si128(p + 1);
+      v128_t v0, v1, c0, c1, t;
+      v0 = vsx_v128_load(p);
+      v1 = vsx_v128_load(p + 1);
 
       // shift right by num_bits
-      c0 = _mm_srl_epi64(v0, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v0, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
-      t = _mm_slli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c0 = _mm_or_si128(c0, t);
+      c0 = vsx_u64x2_shr(v0, (int)num_bits);
+      t = vsx_i64x2_shuffle(v0, vsx_i64x2_const(0, 0), 1, 2);
+      t = vsx_i64x2_shl(t, 64 - (int)num_bits);
+      t = (num_bits > 0) ? t : vsx_i64x2_const(0, 0);
+      c0 = vsx_v128_or(c0, t);
+      t = vsx_i64x2_shuffle(vsx_i64x2_const(0, 0), v1, 1, 2);
+      t = vsx_i64x2_shl(t, 64 - (int)num_bits);
+      t = (num_bits > 0) ? t : vsx_i64x2_const(0, 0);
+      c0 = vsx_v128_or(c0, t);
 
-      _mm_storeu_si128((__m128i*)msp->tmp, c0);
+      vsx_v128_store(msp->tmp, c0);
 
-      c1 = _mm_srl_epi64(v1, _mm_set1_epi64x(num_bits));
-      t = _mm_srli_si128(v1, 8);
-      t = _mm_sll_epi64(t, _mm_set1_epi64x(64 - num_bits));
-      c1 = _mm_or_si128(c1, t);
+      c1 = vsx_u64x2_shr(v1, (int)num_bits);
+      t = vsx_i64x2_shuffle(v1, vsx_i64x2_const(0, 0), 1, 2);
+      t = vsx_i64x2_shl(t, 64 - (int)num_bits);
+      t = (num_bits > 0) ? t : vsx_i64x2_const(0, 0);
+      c1 = vsx_v128_or(c1, t);
 
-      _mm_storeu_si128((__m128i*)msp->tmp + 1, c1);
+      vsx_v128_store(msp->tmp + 16, c1);
     }
 
     //************************************************************************/
-    /** @brief Fetches 32 bits from the frwd_struct_ssse3 bitstream
+    /** @brief Fetches 32 bits from the frwd_struct bitstream
      *
      *  @tparam      X is the value fed in when the bitstream is exhausted.
      *               See frwd_read regarding the template
-     *  @param [in]  msp is a pointer to frwd_struct_ssse3
+     *  @param [in]  msp is a pointer to frwd_struct
      */
     template<int X>
     static inline
-    __m128i frwd_fetch(frwd_struct_ssse3 *msp)
+    v128_t frwd_fetch(frwd_struct *msp)
     {
       if (msp->bits <= 128)
       {
@@ -767,8 +778,111 @@ namespace ojph {
         if (msp->bits <= 128) //need to test
           frwd_read<X>(msp);
       }
-      __m128i t = _mm_loadu_si128((__m128i*)msp->tmp);
+      v128_t t = vsx_v128_load(msp->tmp);
       return t;
+    }
+
+    //************************************************************************/
+    /** @brief Destuffs a bitstream into a contiguous buffer, upfront
+     *
+     *  Removes bit stuffing once for the whole stream, so that fetching
+     *  bits at a given position later needs no serial state; this keeps
+     *  the per-quad bit-consumption chain in general-purpose registers
+     *  (pos += bits) instead of shifting a vector-resident window, which
+     *  on POWER costs vector stores/reloads through the stack.
+     *
+     *  @tparam      X is the value fed in when the bitstream is exhausted
+     *  @param [in]  src is a pointer to the start of the bitstream
+     *  @param [in]  size is the number of bytes in the bitstream
+     *  @param [in]  dst is the destination buffer, of capacity cap + 72
+     *  @param [in]  cap is the destination capacity, excluding padding
+     *  @return      the clamp offset; bytes at or beyond this offset hold
+     *               no stream bits (they read as X)
+     */
+    template<int X>
+    static inline
+    ui32 destuff_frwd(const ui8* src, int size, ui8* dst, ui32 cap)
+    {
+      if (size < 0)
+        size = 0;
+      ui8* o = dst;
+      ui8* o_end = dst + cap;
+      const ui8* s = src;
+      const ui8* s_end = src + size;
+      ui64 acc = 0;       // partial output byte, low nb bits are valid
+      ui32 nb = 0;        // number of valid bits in acc; always < 8
+      bool prev_ff = false;
+
+      // fast path; 16 source bytes at a time when they contain no 0xFF
+      while (s + 16 <= s_end && o + 24 <= o_end)
+      {
+        v128_t v = vsx_v128_load(s);
+        if (vec_any_eq((vsx_v_u8)v, vec_splats((unsigned char)0xFF))
+            || prev_ff)
+        { // process these 16 bytes one at a time
+          for (int i = 0; i < 16; ++i) {
+            ui8 b = *s++;
+            acc |= (ui64)b << nb;
+            nb += prev_ff ? 7u : 8u;
+            prev_ff = (b == 0xFFu);
+            if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+          }
+          continue;
+        }
+        ui64 v0, v1;
+        memcpy(&v0, s, 8);
+        memcpy(&v1, s + 8, 8);
+        ui64 w0 = acc | (v0 << nb);
+        ui64 w1 = (v1 << nb) | (nb ? (v0 >> (64 - nb)) : 0);
+        memcpy(o, &w0, 8);
+        memcpy(o + 8, &w1, 8);
+        acc = nb ? (v1 >> (64 - nb)) : 0;
+        o += 16;
+        s += 16;
+      }
+      // tail; one byte at a time
+      while (s < s_end && o < o_end)
+      {
+        ui8 b = *s++;
+        acc |= (ui64)b << nb;
+        nb += prev_ff ? 7u : 8u;
+        prev_ff = (b == 0xFFu);
+        if (nb >= 8) { *o++ = (ui8)acc; acc >>= 8; nb -= 8; }
+      }
+      // fill the bits above nb with X, and pad with X bytes
+      ui32 fill = (X == 0xFF) ? (0xFFu << nb) : 0;
+      *o = (ui8)((ui32)acc | fill);
+      memset(o + 1, X, 64);
+      return (ui32)(o - dst) + 1;
+    }
+
+    //************************************************************************/
+    /** @brief Fetches 128 bits from a destuffed bitstream buffer
+     *
+     *  Returns the 128 bits starting at bit position pos of the buffer
+     *  produced by destuff_frwd.  Carries no serial state; fetches at
+     *  independent positions can execute out of order.  The byte offset
+     *  is clamped to limit so that positions past the end of the stream
+     *  read from the padding without leaving the buffer.
+     *
+     *  @param [in]  dbuf is the destuffed bitstream buffer
+     *  @param [in]  limit is the clamp offset returned by destuff_frwd
+     *  @param [in]  pos is the absolute bit position to fetch from
+     */
+    static inline
+    v128_t vsx_dfetch(const ui8* dbuf, ui32 limit, ui32 pos)
+    {
+      ui32 off = pos >> 3;
+      off = off < limit ? off : limit;
+      const ui8* p = dbuf + off;
+      v128_t v = vsx_v128_load(p);
+      v128_t w = vsx_v128_load(p + 8);
+      int k = (int)(pos & 7);
+      v128_t r = vsx_u64x2_shr(v, k);
+      // shift left by 64 - k without branching on k == 0; vector shifts
+      // are modulo 64, so the shift is split into 1 and 63 - k
+      v128_t c = vsx_i64x2_shl(vsx_i64x2_shl(w, 1), 63 - k);
+      return vsx_v128_or(r, c);
     }
 
     //************************************************************************/
@@ -781,102 +895,108 @@ namespace ojph {
      *  @param magsgn   structure for forward data buffer
      *  @param p        bitplane at which we are decoding
      *  @param vn       used for handling E values (stores v_n values)
-     *  @return __m128i decoded quad
+     *  @return v128_t decoded quad
      */
     template <int N>
     static inline
-    __m128i decode_one_quad32(const __m128i inf_u_q, __m128i U_q,
-                              frwd_struct_ssse3* magsgn, ui32 p, __m128i& vn)
+    v128_t decode_one_quad32(const v128_t inf_u_q, v128_t U_q,
+                              frwd_struct* magsgn, ui32 p, v128_t& vn)
     {
-      __m128i w0;    // workers
-      __m128i insig; // lanes hold FF's if samples are insignificant
-      __m128i flags; // lanes hold e_k, e_1, and rho
-      __m128i row;   // decoded row
+      v128_t w0;    // workers
+      v128_t insig; // lanes hold FF's if samples are insignificant
+      v128_t flags; // lanes hold e_k, e_1, and rho
+      v128_t row;   // decoded row
 
-      row = _mm_setzero_si128();
-      w0 = _mm_shuffle_epi32(inf_u_q, _MM_SHUFFLE(N, N, N, N));
+      row = vsx_i64x2_const(0, 0);
+      w0 = vsx_i32x4_shuffle(inf_u_q, inf_u_q, N, N, N, N);
       // we keeps e_k, e_1, and rho in w2
-      flags = _mm_and_si128(w0, _mm_set_epi32(0x8880, 0x4440, 0x2220, 0x1110));
-      insig = _mm_cmpeq_epi32(flags, _mm_setzero_si128());
-      if (_mm_movemask_epi8(insig) != 0xFFFF) //are all insignificant?
+      flags = vsx_v128_and(w0, vsx_i32x4_const(0x1110,0x2220,0x4440,0x8880));
+      insig = vsx_i32x4_eq(flags, vsx_i64x2_const(0, 0));
+      if (vsx_i8x16_bitmask(insig) != 0xFFFF) //are all insignificant?
       {
-        U_q = _mm_shuffle_epi32(U_q, _MM_SHUFFLE(N, N, N, N));
-        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1,1,2,2,4,4,8,8));
-        __m128i ms_vec = frwd_fetch<0xFF>(magsgn);
+        U_q = vsx_i32x4_shuffle(U_q, U_q, N, N, N, N);
+        flags = vsx_i16x8_mul(flags, vsx_i16x8_const(8,8,4,4,2,2,1,1));
+        v128_t ms_vec = frwd_fetch<0xFF>(magsgn);
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
         // 0x8000, e_1 in 0x800, and rho in 0x80
 
         // next e_k and m_n
-        __m128i m_n;
-        w0 = _mm_srli_epi32(flags, 15); // e_k
-        m_n = _mm_sub_epi32(U_q, w0);
-        m_n = _mm_andnot_si128(insig, m_n);
+        v128_t m_n;
+        w0 = vsx_u32x4_shr(flags, 15); // e_k
+        m_n = vsx_i32x4_sub(U_q, w0);
+        m_n = vsx_v128_andnot(m_n, insig);
 
         // find cumulative sums
         // to find at which bit in ms_vec the sample starts
-        __m128i inc_sum = m_n; // inclusive scan
-        inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 4));
-        inc_sum = _mm_add_epi32(inc_sum, _mm_bslli_si128(inc_sum, 8));
-        int total_mn = _mm_extract_epi16(inc_sum, 6);
-        __m128i ex_sum = _mm_bslli_si128(inc_sum, 4); // exclusive scan
+        v128_t ex_sum, shfl, inc_sum = m_n; // inclusive scan
+        shfl = vsx_i32x4_shuffle(vsx_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
+        inc_sum = vsx_i32x4_add(inc_sum, shfl);
+        shfl = vsx_i64x2_shuffle(vsx_i64x2_const(0,0), inc_sum, 1, 2);
+        inc_sum = vsx_i32x4_add(inc_sum, shfl);
+        int total_mn = vsx_u16x8_extract_lane(inc_sum, 6);
+        ex_sum = vsx_i32x4_shuffle(vsx_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
 
         // find the starting byte and starting bit
-        __m128i byte_idx = _mm_srli_epi32(ex_sum, 3);
-        __m128i bit_idx = _mm_and_si128(ex_sum, _mm_set1_epi32(7));
-        byte_idx = _mm_shuffle_epi8(byte_idx,
-          _mm_set_epi32(0x0C0C0C0C, 0x08080808, 0x04040404, 0x00000000));
-        byte_idx = _mm_add_epi32(byte_idx, _mm_set1_epi32(0x03020100));
-        __m128i d0 = _mm_shuffle_epi8(ms_vec, byte_idx);
-        byte_idx = _mm_add_epi32(byte_idx, _mm_set1_epi32(0x01010101));
-        __m128i d1 = _mm_shuffle_epi8(ms_vec, byte_idx);
+        v128_t byte_idx = vsx_u32x4_shr(ex_sum, 3);
+        v128_t bit_idx =
+          vsx_v128_and(ex_sum, vsx_i32x4_const(OJPH_REPEAT4(7)));
+        byte_idx = vsx_i8x16_swizzle(byte_idx,
+          vsx_i32x4_const(0x00000000, 0x04040404, 0x08080808, 0x0C0C0C0C));
+        byte_idx =
+          vsx_i32x4_add(byte_idx, vsx_i32x4_const(OJPH_REPEAT4(0x03020100)));
+        v128_t d0 = vsx_i8x16_swizzle(ms_vec, byte_idx);
+        byte_idx =
+          vsx_i32x4_add(byte_idx, vsx_i32x4_const(OJPH_REPEAT4(0x01010101)));
+        v128_t d1 = vsx_i8x16_swizzle(ms_vec, byte_idx);
 
         // shift samples values to correct location
-        bit_idx = _mm_or_si128(bit_idx, _mm_slli_epi32(bit_idx, 16));
-        __m128i bit_shift = _mm_shuffle_epi8(
-          _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
-                       1, 3, 7, 15, 31, 63, 127, -1), bit_idx);
-        bit_shift = _mm_add_epi16(bit_shift, _mm_set1_epi16(0x0101));
-        d0 = _mm_mullo_epi16(d0, bit_shift);
-        d0 = _mm_srli_epi16(d0, 8); // we should have 8 bits in the LSB
-        d1 = _mm_mullo_epi16(d1, bit_shift);
-        d1 = _mm_and_si128(d1, _mm_set1_epi32((si32)0xFF00FF00)); // 8 in MSB
-        d0 = _mm_or_si128(d0, d1);
+        bit_idx = vsx_v128_or(bit_idx, vsx_i32x4_shl(bit_idx, 16));
+        v128_t bit_shift = vsx_i8x16_swizzle(
+          vsx_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
+                           -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
+        bit_shift =
+          vsx_i16x8_add(bit_shift, vsx_i16x8_const(OJPH_REPEAT8(0x0101)));
+        d0 = vsx_i16x8_mul(d0, bit_shift);
+        d0 = vsx_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
+        d1 = vsx_i16x8_mul(d1, bit_shift);
+        d1 =  // 8 in MSB
+          vsx_v128_and(d1, vsx_u32x4_const(OJPH_REPEAT4(0xFF00FF00)));
+        d0 = vsx_v128_or(d0, d1);
 
         // find location of e_k and mask
-        __m128i shift;
-        __m128i ones = _mm_set1_epi32(1);
-        __m128i twos = _mm_set1_epi32(2);
-        __m128i U_q_m1 = _mm_sub_epi32(U_q, ones);
-        U_q_m1 = _mm_and_si128(U_q_m1, _mm_set_epi32(0,0,0,0x1F));
-        w0 = _mm_sub_epi32(twos, w0);
-        shift = _mm_sll_epi32(w0, U_q_m1); // U_q_m1 must be no more than 31
-        ms_vec = _mm_and_si128(d0, _mm_sub_epi32(shift, ones));
+        v128_t shift;
+        v128_t ones = vsx_i32x4_const(OJPH_REPEAT4(1));
+        v128_t twos = vsx_i32x4_const(OJPH_REPEAT4(2));
+        ui32 U_q_m1 = vsx_u32x4_extract_lane(U_q, 0) - 1u;
+        w0 = vsx_i32x4_sub(twos, w0);
+        shift = vsx_i32x4_shl(w0, (int)U_q_m1);
+        ms_vec = vsx_v128_and(d0, vsx_i32x4_sub(shift, ones));
 
         // next e_1
-        w0 = _mm_and_si128(flags, _mm_set1_epi32(0x800));
-        w0 = _mm_cmpeq_epi32(w0, _mm_setzero_si128());
-        w0 = _mm_andnot_si128(w0, shift);  // e_1 in correct position
-        ms_vec = _mm_or_si128(ms_vec, w0); // e_1
-        w0 = _mm_slli_epi32(ms_vec, 31);   // sign
-        ms_vec = _mm_or_si128(ms_vec, ones); // bin center
-        __m128i tvn = ms_vec;
-        ms_vec = _mm_add_epi32(ms_vec, twos);// + 2
-        ms_vec = _mm_slli_epi32(ms_vec, (si32)p - 1);
-        ms_vec = _mm_or_si128(ms_vec, w0); // sign
-        row = _mm_andnot_si128(insig, ms_vec); // significant only
+        w0 = vsx_v128_and(flags, vsx_i32x4_const(OJPH_REPEAT4(0x800)));
+        w0 = vsx_i32x4_eq(w0, vsx_i64x2_const(0, 0));
+        w0 = vsx_v128_andnot(shift, w0);  // e_1 in correct position
+        ms_vec = vsx_v128_or(ms_vec, w0); // e_1
+        w0 = vsx_i32x4_shl(ms_vec, 31);   // sign
+        ms_vec = vsx_v128_or(ms_vec, ones); // bin center
+        v128_t tvn = ms_vec;
+        ms_vec = vsx_i32x4_add(ms_vec, twos);// + 2
+        ms_vec = vsx_i32x4_shl(ms_vec, (int)p - 1);
+        ms_vec = vsx_v128_or(ms_vec, w0); // sign
+        row = vsx_v128_andnot(ms_vec, insig); // significant only
 
-        ms_vec = _mm_andnot_si128(insig, tvn); // significant only
+        ms_vec = vsx_v128_andnot(tvn, insig); // significant only
         if (N == 0) // the compiler should remove one
-          tvn = _mm_shuffle_epi8(ms_vec,
-            _mm_set_epi32(-1, -1, 0x0F0E0D0C, 0x07060504));
+          tvn = vsx_i8x16_swizzle(ms_vec,
+            vsx_i32x4_const(0x07060504, 0x0F0E0D0C, -1, -1));
         else if (N == 1)
-          tvn = _mm_shuffle_epi8(ms_vec,
-            _mm_set_epi32(-1, 0x0F0E0D0C, 0x07060504, -1));
+          tvn = vsx_i8x16_swizzle(ms_vec,
+            vsx_i32x4_const(-1, 0x07060504, 0x0F0E0D0C, -1));
         else
           assert(0);
-        vn = _mm_or_si128(vn, tvn);
+        vn = vsx_v128_or(vn, tvn);
 
         if (total_mn)
           frwd_advance(magsgn, (ui32)total_mn);
@@ -892,113 +1012,123 @@ namespace ojph {
      *  @param magsgn   structure for forward data buffer
      *  @param p        bitplane at which we are decoding
      *  @param vn       used for handling E values (stores v_n values)
-     *  @return __m128i decoded quad
+     *  @return v128_t decoded quad
      */
     static inline
-    __m128i decode_two_quad16(const __m128i inf_u_q, __m128i U_q,
-                              frwd_struct_ssse3* magsgn, ui32 p, __m128i& vn)
+    v128_t decode_two_quad16(const v128_t inf_u_q, v128_t U_q,
+                              const ui8* dbuf, ui32 limit, ui32& pos,
+                              ui32 p, v128_t& vn)
     {
-      __m128i w0;     // workers
-      __m128i insig;  // lanes hold FF's if samples are insignificant
-      __m128i flags;  // lanes hold e_k, e_1, and rho
-      __m128i row;    // decoded row
+      v128_t w0;     // workers
+      v128_t insig;  // lanes hold FF's if samples are insignificant
+      v128_t flags;  // lanes hold e_k, e_1, and rho
+      v128_t row;    // decoded row
 
-      row = _mm_setzero_si128();
-      w0 = _mm_shuffle_epi8(inf_u_q,
-        _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
-                      0x0100, 0x0100, 0x0100, 0x0100));
+      row = vsx_i64x2_const(0, 0);
+      w0 = vsx_i8x16_swizzle(inf_u_q,
+        vsx_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
+                         0x0504, 0x0504, 0x0504, 0x0504));
       // we keeps e_k, e_1, and rho in w2
-      flags = _mm_and_si128(w0,
-        _mm_set_epi16((si16)0x8880, 0x4440, 0x2220, 0x1110,
-                      (si16)0x8880, 0x4440, 0x2220, 0x1110));
-      insig = _mm_cmpeq_epi16(flags, _mm_setzero_si128());
-      if (_mm_movemask_epi8(insig) != 0xFFFF) //are all insignificant?
+      flags = vsx_v128_and(w0,
+        vsx_u16x8_const(0x1110, 0x2220, 0x4440, 0x8880,
+                         0x1110, 0x2220, 0x4440, 0x8880));
+      insig = vsx_i16x8_eq(flags, vsx_i64x2_const(0, 0));
+      if (vsx_i8x16_bitmask(insig) != 0xFFFF) //are all insignificant?
       {
-        U_q = _mm_shuffle_epi8(U_q,
-          _mm_set_epi16(0x0504, 0x0504, 0x0504, 0x0504,
-                        0x0100, 0x0100, 0x0100, 0x0100));
-        flags = _mm_mullo_epi16(flags, _mm_set_epi16(1,2,4,8,1,2,4,8));
-        __m128i ms_vec = frwd_fetch<0xFF>(magsgn);
+        U_q = vsx_i8x16_swizzle(U_q,
+          vsx_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
+                           0x0504, 0x0504, 0x0504, 0x0504));
+        flags = vsx_i16x8_mul(flags, vsx_i16x8_const(8,4,2,1,8,4,2,1));
+        v128_t ms_vec = vsx_dfetch(dbuf, limit, pos);
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
         // 0x8000, e_1 in 0x800, and rho in 0x80
 
         // next e_k and m_n
-        __m128i m_n;
-        w0 = _mm_srli_epi16(flags, 15); // e_k
-        m_n = _mm_sub_epi16(U_q, w0);
-        m_n = _mm_andnot_si128(insig, m_n);
+        v128_t m_n;
+        w0 = vsx_u16x8_shr(flags, 15); // e_k
+        m_n = vsx_i16x8_sub(U_q, w0);
+        m_n = vsx_v128_andnot(m_n, insig);
 
         // find cumulative sums
         // to find at which bit in ms_vec the sample starts
-        __m128i inc_sum = m_n; // inclusive scan
-        inc_sum = _mm_add_epi16(inc_sum, _mm_bslli_si128(inc_sum, 2));
-        inc_sum = _mm_add_epi16(inc_sum, _mm_bslli_si128(inc_sum, 4));
-        inc_sum = _mm_add_epi16(inc_sum, _mm_bslli_si128(inc_sum, 8));
-        int total_mn = _mm_extract_epi16(inc_sum, 7);
-        __m128i ex_sum = _mm_bslli_si128(inc_sum, 2); // exclusive scan
+        v128_t ex_sum, shfl, inc_sum = m_n; // inclusive scan
+        shfl = vsx_i16x8_shuffle(vsx_i64x2_const(0,0),
+          inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
+        inc_sum = vsx_i16x8_add(inc_sum, shfl);
+        shfl = vsx_i32x4_shuffle(vsx_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
+        inc_sum = vsx_i16x8_add(inc_sum, shfl);
+        shfl = vsx_i64x2_shuffle(vsx_i64x2_const(0,0), inc_sum, 1, 2);
+        inc_sum = vsx_i16x8_add(inc_sum, shfl);
+        int total_mn = vsx_u16x8_extract_lane(inc_sum, 7);
+        ex_sum = vsx_i16x8_shuffle(vsx_i64x2_const(0,0),
+          inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
 
         // find the starting byte and starting bit
-        __m128i byte_idx = _mm_srli_epi16(ex_sum, 3);
-        __m128i bit_idx = _mm_and_si128(ex_sum, _mm_set1_epi16(7));
-        byte_idx = _mm_shuffle_epi8(byte_idx,
-          _mm_set_epi16(0x0E0E, 0x0C0C, 0x0A0A, 0x0808,
-                        0x0606, 0x0404, 0x0202, 0x0000));
-        byte_idx = _mm_add_epi16(byte_idx, _mm_set1_epi16(0x0100));
-        __m128i d0 = _mm_shuffle_epi8(ms_vec, byte_idx);
-        byte_idx = _mm_add_epi16(byte_idx, _mm_set1_epi16(0x0101));
-        __m128i d1 = _mm_shuffle_epi8(ms_vec, byte_idx);
+        v128_t byte_idx = vsx_u16x8_shr(ex_sum, 3);
+        v128_t bit_idx =
+          vsx_v128_and(ex_sum, vsx_i16x8_const(OJPH_REPEAT8(7)));
+        byte_idx = vsx_i8x16_swizzle(byte_idx,
+          vsx_i16x8_const(0x0000, 0x0202, 0x0404, 0x0606,
+                           0x0808, 0x0A0A, 0x0C0C, 0x0E0E));
+        byte_idx =
+          vsx_i16x8_add(byte_idx, vsx_i16x8_const(OJPH_REPEAT8(0x0100)));
+        v128_t d0 = vsx_i8x16_swizzle(ms_vec, byte_idx);
+        byte_idx =
+          vsx_i16x8_add(byte_idx, vsx_i16x8_const(OJPH_REPEAT8(0x0101)));
+        v128_t d1 = vsx_i8x16_swizzle(ms_vec, byte_idx);
 
         // shift samples values to correct location
-        __m128i bit_shift = _mm_shuffle_epi8(
-          _mm_set_epi8(1, 3, 7, 15, 31, 63, 127, -1,
-                       1, 3, 7, 15, 31, 63, 127, -1), bit_idx);
-        bit_shift = _mm_add_epi16(bit_shift, _mm_set1_epi16(0x0101));
-        d0 = _mm_mullo_epi16(d0, bit_shift);
-        d0 = _mm_srli_epi16(d0, 8); // we should have 8 bits in the LSB
-        d1 = _mm_mullo_epi16(d1, bit_shift);
-        d1 = _mm_and_si128(d1, _mm_set1_epi16((si16)0xFF00)); // 8 in MSB
-        d0 = _mm_or_si128(d0, d1);
+        v128_t bit_shift = vsx_i8x16_swizzle(
+          vsx_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
+                           -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
+        bit_shift =
+          vsx_i16x8_add(bit_shift, vsx_i16x8_const(OJPH_REPEAT8(0x0101)));
+        d0 = vsx_i16x8_mul(d0, bit_shift);
+        d0 = vsx_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
+        d1 = vsx_i16x8_mul(d1, bit_shift);
+        d1 = // 8 in MSB
+          vsx_v128_and(d1, vsx_i16x8_const(OJPH_REPEAT8((si16)0xFF00)));
+        d0 = vsx_v128_or(d0, d1);
 
         // find location of e_k and mask
-        __m128i shift, t0, t1, Uq0, Uq1;
-        __m128i ones = _mm_set1_epi16(1);
-        __m128i twos = _mm_set1_epi16(2);
-        __m128i U_q_m1 = _mm_sub_epi32(U_q, ones);
-        Uq0 = _mm_and_si128(U_q_m1, _mm_set_epi32(0,0,0,0x1F));
-        Uq1 = _mm_bsrli_si128(U_q_m1, 14);
-        w0 = _mm_sub_epi16(twos, w0);
-        t0 = _mm_and_si128(w0, _mm_set_epi64x(0, -1));
-        t1 = _mm_and_si128(w0, _mm_set_epi64x(-1, 0));
-        t0 = _mm_sll_epi16(t0, Uq0);
-        t1 = _mm_sll_epi16(t1, Uq1);
-        shift = _mm_or_si128(t0, t1);
-        ms_vec = _mm_and_si128(d0, _mm_sub_epi16(shift, ones));
+        v128_t shift, t0, t1;
+        v128_t ones = vsx_i16x8_const(OJPH_REPEAT8(1));
+        v128_t twos = vsx_i16x8_const(OJPH_REPEAT8(2));
+        v128_t U_q_m1 = vsx_i32x4_sub(U_q, ones);
+        ui32 Uq0 = vsx_u16x8_extract_lane(U_q_m1, 0);
+        ui32 Uq1 = vsx_u16x8_extract_lane(U_q_m1, 4);
+        w0 = vsx_i16x8_sub(twos, w0);
+        t0 = vsx_v128_and(w0, vsx_i64x2_const(-1, 0));
+        t1 = vsx_v128_and(w0, vsx_i64x2_const(0, -1));
+        t0 = vsx_i32x4_shl(t0, (int)Uq0);
+        t1 = vsx_i32x4_shl(t1, (int)Uq1);
+        shift = vsx_v128_or(t0, t1);
+        ms_vec = vsx_v128_and(d0, vsx_i16x8_sub(shift, ones));
 
         // next e_1
-        w0 = _mm_and_si128(flags, _mm_set1_epi16(0x800));
-        w0 = _mm_cmpeq_epi16(w0, _mm_setzero_si128());
-        w0 = _mm_andnot_si128(w0, shift);  // e_1 in correct position
-        ms_vec = _mm_or_si128(ms_vec, w0); // e_1
-        w0 = _mm_slli_epi16(ms_vec, 15);   // sign
-        ms_vec = _mm_or_si128(ms_vec, ones); // bin center
-        __m128i tvn = ms_vec;
-        ms_vec = _mm_add_epi16(ms_vec, twos);// + 2
-        ms_vec = _mm_slli_epi16(ms_vec, (si32)p - 1);
-        ms_vec = _mm_or_si128(ms_vec, w0); // sign
-        row = _mm_andnot_si128(insig, ms_vec); // significant only
+        w0 = vsx_v128_and(flags, vsx_i16x8_const(OJPH_REPEAT8(0x800)));
+        w0 = vsx_i16x8_eq(w0, vsx_i64x2_const(0, 0));
+        w0 = vsx_v128_andnot(shift, w0);  // e_1 in correct position
+        ms_vec = vsx_v128_or(ms_vec, w0); // e_1
+        w0 = vsx_i16x8_shl(ms_vec, 15);   // sign
+        ms_vec = vsx_v128_or(ms_vec, ones); // bin center
+        v128_t tvn = ms_vec;
+        ms_vec = vsx_i16x8_add(ms_vec, twos);// + 2
+        ms_vec = vsx_i16x8_shl(ms_vec, (int)p - 1);
+        ms_vec = vsx_v128_or(ms_vec, w0); // sign
+        row = vsx_v128_andnot(ms_vec, insig); // significant only
 
-        ms_vec = _mm_andnot_si128(insig, tvn); // significant only
-        w0 = _mm_shuffle_epi8(ms_vec,
-          _mm_set_epi16(-1, -1, -1, -1, -1, -1, 0x0706, 0x0302));
-        vn = _mm_or_si128(vn, w0);
-        w0 = _mm_shuffle_epi8(ms_vec,
-          _mm_set_epi16(-1, -1, -1, -1, -1, 0x0F0E, 0x0B0A, -1));
-        vn = _mm_or_si128(vn, w0);
+        ms_vec = vsx_v128_andnot(tvn, insig); // significant only
+        w0 = vsx_i8x16_swizzle(ms_vec,
+          vsx_i16x8_const(0x0302, 0x0706, -1, -1, -1, -1, -1, -1));
+        vn = vsx_v128_or(vn, w0);
+        w0 = vsx_i8x16_swizzle(ms_vec,
+          vsx_i16x8_const(-1, 0x0B0A, 0x0F0E, -1, -1, -1, -1, -1));
+        vn = vsx_v128_or(vn, w0);
 
-        if (total_mn)
-          frwd_advance(magsgn, (ui32)total_mn);
+        pos += (ui32)total_mn;
       }
       return row;
     }
@@ -1021,11 +1151,11 @@ namespace ojph {
      *  @param [in]   stride is the decoded codeblock buffer stride
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
-    bool ojph_decode_codeblock_ssse3(ui8* coded_data, ui32* decoded_data,
-                                     ui32 missing_msbs, ui32 num_passes,
-                                     ui32 lengths1, ui32 lengths2,
-                                     ui32 width, ui32 height, ui32 stride,
-                                     bool stripe_causal)
+    bool ojph_decode_codeblock_vsx(ui8* coded_data, ui32* decoded_data,
+                                    ui32 missing_msbs, ui32 num_passes,
+                                    ui32 lengths1, ui32 lengths2,
+                                    ui32 width, ui32 height, ui32 stride,
+                                    bool stripe_causal)
     {
       static bool insufficient_precision = false;
       static bool modify_code = false;
@@ -1035,14 +1165,14 @@ namespace ojph {
       {
         OJPH_WARN(0x00010001, "A malformed codeblock that has more than "
                               "one coding pass, but zero length for "
-                              "2nd and potential 3rd pass.");
+                              "2nd and potential 3rd pass.\n");
         num_passes = 1;
       }
 
       if (num_passes > 3)
       {
         OJPH_WARN(0x00010002, "We do not support more than 3 coding passes; "
-                              "This codeblocks has %d passes.",
+                              "This codeblocks has %d passes.\n",
                               num_passes);
         return false;
       }
@@ -1054,7 +1184,7 @@ namespace ojph {
           insufficient_precision = true;
           OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
                                 "codeblock. This message will not be "
-                                "displayed again.");
+                                "displayed again.\n");
         }
         return false;
       }
@@ -1065,7 +1195,7 @@ namespace ojph {
           OJPH_WARN(0x00010004, "Not enough precision to decode the cleanup "
                                 "pass. The code can be modified to support "
                                 "this case. This message will not be "
-                                "displayed again.");
+                                "displayed again.\n");
         }
          return false;         // 32 bits are not enough to decode this
        }
@@ -1078,7 +1208,7 @@ namespace ojph {
             OJPH_WARN(0x00010005, "Not enough precision to decode the SgnProp "
                                   "nor MagRef passes; both will be skipped. "
                                   "This message will not be displayed "
-                                  "again.");
+                                  "again.\n");
           }
         }
       }
@@ -1088,7 +1218,7 @@ namespace ojph {
 
       if (lengths1 < 2)
       {
-        OJPH_WARN(0x00010006, "Wrong codeblock length.");
+        OJPH_WARN(0x00010006, "Wrong codeblock length.\n");
         return false;
       }
 
@@ -1363,7 +1493,7 @@ namespace ojph {
             // quad 0 length
             len = uvlc_entry & 0x7; // quad 0 suffix length
             uvlc_entry >>= 3;
-            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFFU << len)));
+            ui16 u_q = (ui16)((uvlc_entry & 7) + (tmp & ~(0xFU << len))); //u_q
             sp[1] = u_q;
             u_q = (ui16)((uvlc_entry >> 3) + (tmp >> len)); // u_q
             sp[3] = u_q;
@@ -1391,7 +1521,7 @@ namespace ojph {
         const int v_n_size = 512 + 8;
         ui32 v_n_scratch[2 * v_n_size] = {0}; // 4+ kB
 
-        frwd_struct_ssse3 magsgn;
+        frwd_struct magsgn;
         frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
 
         {
@@ -1403,34 +1533,35 @@ namespace ojph {
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
             //here we process two quads
-            __m128i w0, w1; // workers
-            __m128i inf_u_q, U_q;
+            v128_t w0, w1; // workers
+            v128_t inf_u_q, U_q;
             // determine U_q
             {
-              inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              U_q = _mm_srli_epi32(inf_u_q, 16);
+              inf_u_q = vsx_v128_load(sp);
+              U_q = vsx_u32x4_shr(inf_u_q, 16);
 
-              w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              int i = _mm_movemask_epi8(w0);
+              w0 = vsx_i32x4_gt(U_q, vsx_u32x4_splat(mmsbp2));
+              ui32 i = (ui32)vsx_i8x16_bitmask(w0);
               if (i & 0xFF) // only the lower two U_q
                 return false;
             }
 
-            __m128i vn = _mm_set1_epi32(2);
-            __m128i row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
-            __m128i row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i*)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi32(0,0,0,-1));
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
+            v128_t vn = vsx_i32x4_const(OJPH_REPEAT4(2));
+            v128_t row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
+            v128_t row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
+            w0 = vsx_v128_load(vp);
+            w0 = vsx_v128_and(w0, vsx_i32x4_const(-1,0,0,0));
+            w0 = vsx_v128_or(w0, vn);
+            vsx_v128_store(vp, w0);
 
             //interleave in ssse3 style
-            w0 = _mm_unpacklo_epi32(row0, row1);
-            w1 = _mm_unpackhi_epi32(row0, row1);
-            row0 = _mm_unpacklo_epi32(w0, w1);
-            row1 = _mm_unpackhi_epi32(w0, w1);
-            _mm_store_si128((__m128i*)dp, row0);
-            _mm_store_si128((__m128i*)(dp + stride), row1);
+
+            w0 = vsx_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
+            w1 = vsx_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
+            row0 = vsx_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
+            row1 = vsx_i32x4_shuffle(w0, w1, 2, 6, 3, 7);
+            vsx_v128_store(dp, row0);
+            vsx_v128_store(dp + stride, row1);
           }
         }
 
@@ -1439,37 +1570,37 @@ namespace ojph {
           {
             // perform 31 - count_leading_zeros(*vp) here
             ui32 *vp = v_n_scratch;
-            const __m128i lut_lo = _mm_set_epi8(
-              4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 31
+            const v128_t lut_lo = vsx_i8x16_const(
+              31, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4
             );
-            const __m128i lut_hi = _mm_set_epi8(
-              0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 31
+            const v128_t lut_hi = vsx_i8x16_const(
+              31, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0
             );
-            const __m128i nibble_mask = _mm_set1_epi8(0x0F);
-            const __m128i byte_offset8 = _mm_set1_epi16(8);
-            const __m128i byte_offset16 = _mm_set1_epi16(16);
-            const __m128i cc = _mm_set1_epi32(31);
+            const v128_t nibble_mask = vsx_i8x16_const(OJPH_REPEAT16(0x0F));
+            const v128_t byte_offset8 = vsx_i16x8_const(OJPH_REPEAT8(8));
+            const v128_t byte_offset16 = vsx_i16x8_const(OJPH_REPEAT8(16));
+            const v128_t cc = vsx_i32x4_const(OJPH_REPEAT4(31));
             for (ui32 x = 0; x <= width; x += 8, vp += 4)
             {
-              __m128i v, t; // workers
-              v = _mm_loadu_si128((__m128i*)vp);
+              v128_t v, t; // workers
+              v = vsx_v128_load(vp);
 
-              t = _mm_and_si128(nibble_mask, v);
-              v = _mm_and_si128(_mm_srli_epi16(v, 4), nibble_mask);
-              t = _mm_shuffle_epi8(lut_lo, t);
-              v = _mm_shuffle_epi8(lut_hi, v);
-              v = _mm_min_epu8(v, t);
+              t = vsx_v128_and(nibble_mask, v);
+              v = vsx_v128_and(vsx_u16x8_shr(v, 4), nibble_mask);
+              t = vsx_i8x16_swizzle(lut_lo, t);
+              v = vsx_i8x16_swizzle(lut_hi, v);
+              v = vsx_u8x16_min(v, t);
 
-              t = _mm_srli_epi16(v, 8);
-              v = _mm_or_si128(v, byte_offset8);
-              v = _mm_min_epu8(v, t);
+              t = vsx_u16x8_shr(v, 8);
+              v = vsx_v128_or(v, byte_offset8);
+              v = vsx_u8x16_min(v, t);
 
-              t = _mm_srli_epi32(v, 16);
-              v = _mm_or_si128(v, byte_offset16);
-              v = _mm_min_epu8(v, t);
+              t = vsx_u32x4_shr(v, 16);
+              v = vsx_v128_or(v, byte_offset16);
+              v = vsx_u8x16_min(v, t);
 
-              v = _mm_sub_epi16(cc, v);
-              _mm_storeu_si128((__m128i*)(vp + v_n_size), v);
+              v = vsx_i16x8_sub(cc, v);
+              vsx_v128_store(vp + v_n_size, v);
             }
           }
 
@@ -1481,50 +1612,51 @@ namespace ojph {
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
             //process two quads
-            __m128i w0, w1; // workers
-            __m128i inf_u_q, U_q;
+            v128_t w0, w1; // workers
+            v128_t inf_u_q, U_q;
             // determine U_q
             {
-              __m128i gamma, emax, kappa, u_q; // needed locally
+              v128_t gamma, emax, kappa, u_q; // needed locally
 
-              inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              gamma = _mm_and_si128(inf_u_q, _mm_set1_epi32(0xF0));
-              w0 = _mm_sub_epi32(gamma, _mm_set1_epi32(1));
-              gamma = _mm_and_si128(gamma, w0);
-              gamma = _mm_cmpeq_epi32(gamma, _mm_setzero_si128());
+              inf_u_q = vsx_v128_load(sp);
+              gamma =
+                vsx_v128_and(inf_u_q, vsx_i32x4_const(OJPH_REPEAT4(0xF0)));
+              w0 = vsx_i32x4_sub(gamma, vsx_i32x4_const(OJPH_REPEAT4(1)));
+              gamma = vsx_v128_and(gamma, w0);
+              gamma = vsx_i32x4_eq(gamma, vsx_i64x2_const(0, 0));
 
-              emax = _mm_loadu_si128((__m128i*)(vp + v_n_size));
-              w0 = _mm_bsrli_si128(emax, 4);
-              emax = _mm_max_epi16(w0, emax); // no max_epi32 in ssse3
-              emax = _mm_andnot_si128(gamma, emax);
+              emax = vsx_v128_load(vp + v_n_size);
+              w0 = vsx_i32x4_shuffle(emax, vsx_i64x2_const(0,0), 1, 2, 3, 4);
+              emax = vsx_i16x8_max(w0, emax); // no max_epi32 in ssse3
+              emax = vsx_v128_andnot(emax, gamma);
 
-              kappa = _mm_set1_epi32(1);
-              kappa = _mm_max_epi16(emax, kappa); // no max_epi32 in ssse3
+              kappa = vsx_i32x4_const(OJPH_REPEAT4(1));
+              kappa = vsx_i16x8_max(emax, kappa); // no max_epi32 in ssse3
 
-              u_q = _mm_srli_epi32(inf_u_q, 16);
-              U_q = _mm_add_epi32(u_q, kappa);
+              u_q = vsx_u32x4_shr(inf_u_q, 16);
+              U_q = vsx_i32x4_add(u_q, kappa);
 
-              w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              int i = _mm_movemask_epi8(w0);
+              w0 = vsx_i32x4_gt(U_q, vsx_u32x4_splat(mmsbp2));
+              ui32 i = (ui32)vsx_i8x16_bitmask(w0);
               if (i & 0xFF) // only the lower two U_q
                 return false;
             }
 
-            __m128i vn = _mm_set1_epi32(2);
-            __m128i row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
-            __m128i row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i*)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi32(0,0,0,-1));
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
+            v128_t vn = vsx_i32x4_const(OJPH_REPEAT4(2));
+            v128_t row0 = decode_one_quad32<0>(inf_u_q, U_q, &magsgn, p, vn);
+            v128_t row1 = decode_one_quad32<1>(inf_u_q, U_q, &magsgn, p, vn);
+            w0 = vsx_v128_load(vp);
+            w0 = vsx_v128_and(w0, vsx_i32x4_const(-1,0,0,0));
+            w0 = vsx_v128_or(w0, vn);
+            vsx_v128_store(vp, w0);
 
             //interleave in ssse3 style
-            w0 = _mm_unpacklo_epi32(row0, row1);
-            w1 = _mm_unpackhi_epi32(row0, row1);
-            row0 = _mm_unpacklo_epi32(w0, w1);
-            row1 = _mm_unpackhi_epi32(w0, w1);
-            _mm_store_si128((__m128i*)dp, row0);
-            _mm_store_si128((__m128i*)(dp + stride), row1);
+            w0 = vsx_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
+            w1 = vsx_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
+            row0 = vsx_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
+            row1 = vsx_i32x4_shuffle(w0, w1, 2, 6, 3, 7);
+            vsx_v128_store(dp, row0);
+            vsx_v128_store(dp + stride, row1);
           }
         }
       }
@@ -1542,8 +1674,13 @@ namespace ojph {
         const int v_n_size = 512 + 8;
         ui16 v_n_scratch[2 * v_n_size] = {0}; // 2+ kB
 
-        frwd_struct_ssse3 magsgn;
-        frwd_init<0xFF>(&magsgn, coded_data, lcup - scup);
+        // destuff the MagSgn bitstream upfront; per-quad consumption then
+        // advances a bit position in a GPR (see destuff_frwd)
+        const ui32 dbuf_cap = 4096 * 15 / 8;
+        ui8 dbuf[dbuf_cap + 72];
+        ui32 limit = destuff_frwd<0xFF>(coded_data, lcup - scup,
+                                        dbuf, dbuf_cap);
+        ui32 pos = 0;
 
         {
           ui16 *sp = scratch;
@@ -1554,35 +1691,35 @@ namespace ojph {
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
             //here we process two quads
-            __m128i w0, w1; // workers
-            __m128i inf_u_q, U_q;
+            v128_t w0, w1; // workers
+            v128_t inf_u_q, U_q;
             // determine U_q
             {
-              inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              U_q = _mm_srli_epi32(inf_u_q, 16);
+              inf_u_q = vsx_v128_load(sp);
+              U_q = vsx_u32x4_shr(inf_u_q, 16);
 
-              w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              int i = _mm_movemask_epi8(w0);
+              w0 = vsx_i32x4_gt(U_q, vsx_u32x4_splat(mmsbp2));
+              ui32 i = (ui32)vsx_i8x16_bitmask(w0);
               if (i & 0xFF) // only the lower two U_q
                 return false;
             }
 
-            __m128i vn = _mm_set1_epi16(2);
-            __m128i row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i*)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi16(0,0,0,0,0,0,0,-1));
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
+            v128_t vn = vsx_i16x8_const(OJPH_REPEAT8(2));
+            v128_t row = decode_two_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            w0 = vsx_v128_load(vp);
+            w0 = vsx_v128_and(w0, vsx_i16x8_const(-1,0,0,0,0,0,0,0));
+            w0 = vsx_v128_or(w0, vn);
+            vsx_v128_store(vp, w0);
 
             //interleave in ssse3 style
-            w0 = _mm_shuffle_epi8(row,
-              _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
-                            0x0504, -1, 0x0100, -1));
-            _mm_store_si128((__m128i*)dp, w0);
-            w1 = _mm_shuffle_epi8(row,
-              _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
-                            0x0706, -1, 0x0302, -1));
-            _mm_store_si128((__m128i*)(dp + stride), w1);
+            w0 = vsx_i8x16_swizzle(row,
+              vsx_i16x8_const(-1, 0x0100, -1, 0x0504,
+                               -1, 0x0908, -1, 0x0D0C));
+            vsx_v128_store(dp, w0);
+            w1 = vsx_i8x16_swizzle(row,
+              vsx_i16x8_const(-1, 0x0302, -1, 0x0706,
+                               -1, 0x0B0A, -1, 0x0F0E));
+            vsx_v128_store(dp + stride, w1);
           }
         }
 
@@ -1591,32 +1728,32 @@ namespace ojph {
           {
             // perform 15 - count_leading_zeros(*vp) here
             ui16 *vp = v_n_scratch;
-            const __m128i lut_lo = _mm_set_epi8(
-              4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 7, 15
+            const v128_t lut_lo = vsx_i8x16_const(
+              15, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4
             );
-            const __m128i lut_hi = _mm_set_epi8(
-              0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3, 15
+            const v128_t lut_hi = vsx_i8x16_const(
+              15, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0
             );
-            const __m128i nibble_mask = _mm_set1_epi8(0x0F);
-            const __m128i byte_offset8 = _mm_set1_epi16(8);
-            const __m128i cc = _mm_set1_epi16(15);
+            const v128_t nibble_mask = vsx_i8x16_const(OJPH_REPEAT16(0x0F));
+            const v128_t byte_offset8 = vsx_i16x8_const(OJPH_REPEAT8(8));
+            const v128_t cc = vsx_i16x8_const(OJPH_REPEAT8(15));
             for (ui32 x = 0; x <= width; x += 16, vp += 8)
             {
-              __m128i v, t; // workers
-              v = _mm_loadu_si128((__m128i*)vp);
+              v128_t v, t; // workers
+              v = vsx_v128_load(vp);
 
-              t = _mm_and_si128(nibble_mask, v);
-              v = _mm_and_si128(_mm_srli_epi16(v, 4), nibble_mask);
-              t = _mm_shuffle_epi8(lut_lo, t);
-              v = _mm_shuffle_epi8(lut_hi, v);
-              v = _mm_min_epu8(v, t);
+              t = vsx_v128_and(nibble_mask, v);
+              v = vsx_v128_and(vsx_u16x8_shr(v, 4), nibble_mask);
+              t = vsx_i8x16_swizzle(lut_lo, t);
+              v = vsx_i8x16_swizzle(lut_hi, v);
+              v = vsx_u8x16_min(v, t);
 
-              t = _mm_srli_epi16(v, 8);
-              v = _mm_or_si128(v, byte_offset8);
-              v = _mm_min_epu8(v, t);
+              t = vsx_u16x8_shr(v, 8);
+              v = vsx_v128_or(v, byte_offset8);
+              v = vsx_u8x16_min(v, t);
 
-              v = _mm_sub_epi16(cc, v);
-              _mm_storeu_si128((__m128i*)(vp + v_n_size), v);
+              v = vsx_i16x8_sub(cc, v);
+              vsx_v128_store(vp + v_n_size, v);
             }
           }
 
@@ -1628,53 +1765,55 @@ namespace ojph {
           for (ui32 x = 0; x < width; x += 4, sp += 4, vp += 2, dp += 4)
           {
             //process two quads
-            __m128i w0, w1; // workers
-            __m128i inf_u_q, U_q;
+            v128_t w0, w1; // workers
+            v128_t inf_u_q, U_q;
             // determine U_q
             {
-              __m128i gamma, emax, kappa, u_q; // needed locally
+              v128_t gamma, emax, kappa, u_q; // needed locally
 
-              inf_u_q = _mm_loadu_si128((__m128i*)sp);
-              gamma = _mm_and_si128(inf_u_q, _mm_set1_epi32(0xF0));
-              w0 = _mm_sub_epi32(gamma, _mm_set1_epi32(1));
-              gamma = _mm_and_si128(gamma, w0);
-              gamma = _mm_cmpeq_epi32(gamma, _mm_setzero_si128());
+              inf_u_q = vsx_v128_load(sp);
+              gamma =
+                vsx_v128_and(inf_u_q, vsx_i32x4_const(OJPH_REPEAT4(0xF0)));
+              w0 = vsx_i32x4_sub(gamma, vsx_i32x4_const(OJPH_REPEAT4(1)));
+              gamma = vsx_v128_and(gamma, w0);
+              gamma = vsx_i32x4_eq(gamma, vsx_i64x2_const(0, 0));
 
-              emax = _mm_loadu_si128((__m128i*)(vp + v_n_size));
-              w0 = _mm_bsrli_si128(emax, 2);
-              emax = _mm_max_epi16(w0, emax); // no max_epi32 in ssse3
-              emax = _mm_shuffle_epi8(emax,
-                _mm_set_epi16(-1, 0x0706, -1, 0x0504,
-                              -1, 0x0302, -1, 0x0100));
-              emax = _mm_andnot_si128(gamma, emax);
+              emax = vsx_v128_load(vp + v_n_size);
+              w0 = vsx_i16x8_shuffle(emax,
+                vsx_i64x2_const(0, 0), 1, 2, 3, 4, 5, 6, 7, 8);
+              emax = vsx_i16x8_max(w0, emax); // no max_epi32 in ssse3
+              emax = vsx_i8x16_swizzle(emax,
+                vsx_i16x8_const(0x0100, -1, 0x0302, -1,
+                                 0x0504, -1, 0x0706, -1));
+              emax = vsx_v128_andnot(emax, gamma);
 
-              kappa = _mm_set1_epi32(1);
-              kappa = _mm_max_epi16(emax, kappa); // no max_epi32 in ssse3
+              kappa = vsx_i32x4_const(OJPH_REPEAT4(1));
+              kappa = vsx_i16x8_max(emax, kappa); // no max_epi32 in ssse3
 
-              u_q = _mm_srli_epi32(inf_u_q, 16);
-              U_q = _mm_add_epi32(u_q, kappa);
+              u_q = vsx_u32x4_shr(inf_u_q, 16);
+              U_q = vsx_i32x4_add(u_q, kappa);
 
-              w0 = _mm_cmpgt_epi32(U_q, _mm_set1_epi32((int)mmsbp2));
-              int i = _mm_movemask_epi8(w0);
+              w0 = vsx_i32x4_gt(U_q, vsx_u32x4_splat(mmsbp2));
+              ui32 i = (ui32)vsx_i8x16_bitmask(w0);
               if (i & 0xFF) // only the lower two U_q
                 return false;
             }
 
-            __m128i vn = _mm_set1_epi16(2);
-            __m128i row = decode_two_quad16(inf_u_q, U_q, &magsgn, p, vn);
-            w0 = _mm_loadu_si128((__m128i*)vp);
-            w0 = _mm_and_si128(w0, _mm_set_epi16(0,0,0,0,0,0,0,-1));
-            w0 = _mm_or_si128(w0, vn);
-            _mm_storeu_si128((__m128i*)vp, w0);
+            v128_t vn = vsx_i16x8_const(OJPH_REPEAT8(2));
+            v128_t row = decode_two_quad16(inf_u_q, U_q, dbuf, limit, pos, p, vn);
+            w0 = vsx_v128_load(vp);
+            w0 = vsx_v128_and(w0, vsx_i16x8_const(-1,0,0,0,0,0,0,0));
+            w0 = vsx_v128_or(w0, vn);
+            vsx_v128_store(vp, w0);
 
-            w0 = _mm_shuffle_epi8(row,
-              _mm_set_epi16(0x0D0C, -1, 0x0908, -1,
-                            0x0504, -1, 0x0100, -1));
-            _mm_store_si128((__m128i*)dp, w0);
-            w1 = _mm_shuffle_epi8(row,
-              _mm_set_epi16(0x0F0E, -1, 0x0B0A, -1,
-                            0x0706, -1, 0x0302, -1));
-            _mm_store_si128((__m128i*)(dp + stride), w1);
+            w0 = vsx_i8x16_swizzle(row,
+              vsx_i16x8_const(-1, 0x0100, -1, 0x0504,
+                               -1, 0x0908, -1, 0x0D0C));
+            vsx_v128_store(dp, w0);
+            w1 = vsx_i8x16_swizzle(row,
+              vsx_i16x8_const(-1, 0x0302, -1, 0x0706,
+                               -1, 0x0B0A, -1, 0x0F0E));
+            vsx_v128_store(dp + stride, w1);
           }
         }
 
@@ -1700,44 +1839,43 @@ namespace ojph {
         {
           ui32 y;
 
-          const __m128i mask_3 = _mm_set1_epi32(0x30);
-          const __m128i mask_C = _mm_set1_epi32(0xC0);
-          const __m128i shuffle_mask = _mm_set_epi32(-1, -1, -1, 0x0C080400);
+          const v128_t mask_3 = vsx_i32x4_const(OJPH_REPEAT4(0x30));
+          const v128_t mask_C = vsx_i32x4_const(OJPH_REPEAT4(0xC0));
+          const v128_t shuffle_mask = vsx_i32x4_const(0x0C080400,-1,-1,-1);
           for (y = 0; y < height; y += 4)
           {
             ui16* sp = scratch + (y >> 1) * sstr;
             ui16* dp = sigma + (y >> 2) * mstr;
             for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
             {
-              __m128i s0, s1, u3, uC, t0, t1;
+              v128_t s0, s1, u3, uC, t0, t1;
 
-              s0 = _mm_loadu_si128((__m128i*)(sp));
-              u3 = _mm_and_si128(s0, mask_3);
-              u3 = _mm_srli_epi32(u3, 4);
-              uC = _mm_and_si128(s0, mask_C);
-              uC = _mm_srli_epi32(uC, 2);
-              t0 = _mm_or_si128(u3, uC);
+              s0 = vsx_v128_load(sp);
+              u3 = vsx_v128_and(s0, mask_3);
+              u3 = vsx_u32x4_shr(u3, 4);
+              uC = vsx_v128_and(s0, mask_C);
+              uC = vsx_u32x4_shr(uC, 2);
+              t0 = vsx_v128_or(u3, uC);
 
-              s1 = _mm_loadu_si128((__m128i*)(sp + sstr));
-              u3 = _mm_and_si128(s1, mask_3);
-              u3 = _mm_srli_epi32(u3, 2);
-              uC = _mm_and_si128(s1, mask_C);
-              t1 = _mm_or_si128(u3, uC);
+              s1 = vsx_v128_load(sp + sstr);
+              u3 = vsx_v128_and(s1, mask_3);
+              u3 = vsx_u32x4_shr(u3, 2);
+              uC = vsx_v128_and(s1, mask_C);
+              t1 = vsx_v128_or(u3, uC);
 
-              __m128i r = _mm_or_si128(t0, t1);
-              r = _mm_shuffle_epi8(r, shuffle_mask);
+              v128_t r = vsx_v128_or(t0, t1);
+              r = vsx_i8x16_swizzle(r, shuffle_mask);
 
-              dp[0] = (ui16)_mm_extract_epi16(r, 0);
-              dp[1] = (ui16)_mm_extract_epi16(r, 1);
+              vsx_v128_store32_lane(dp, r, 0);
             }
             dp[0] = 0; // set an extra entry on the right with 0
           }
           {
             // reset one row after the codeblock
             ui16* dp = sigma + (y >> 2) * mstr;
-            __m128i zero = _mm_setzero_si128();
+            v128_t zero = vsx_i64x2_const(0, 0);
             for (ui32 x = 0; x < width; x += 32, dp += 8)
-              _mm_storeu_si128((__m128i*)dp, zero);
+              vsx_v128_store(dp, zero);
             dp[0] = 0; // set an extra entry on the right with 0
           }
         }
@@ -1755,7 +1893,7 @@ namespace ojph {
           // We add an extra 8 entries, just in case we need more
           ui16 prev_row_sig[256 + 8] = {0}; // 528 Bytes
 
-          frwd_struct_ssse3 sigprop;
+          frwd_struct sigprop;
           frwd_init<0>(&sigprop, coded_data + lengths1, (int)lengths2);
 
           for (ui32 y = 0; y < height; y += 4)
@@ -1821,8 +1959,8 @@ namespace ojph {
               ui32 new_sig = mbr;
               if (new_sig)
               {
-                __m128i cwd_vec = frwd_fetch<0>(&sigprop);
-                ui32 cwd = (ui32)_mm_extract_epi16(cwd_vec, 0);
+                v128_t cwd_vec = frwd_fetch<0>(&sigprop);
+                ui32 cwd = vsx_u32x4_extract_lane(cwd_vec, 0);
 
                 ui32 cnt = 0;
                 ui32 col_mask = 0xFu;
@@ -1884,73 +2022,81 @@ namespace ojph {
 
                 if (new_sig)
                 {
-                  cwd |= (ui32)_mm_extract_epi16(cwd_vec, 1) << (16 - cnt);
-
                   // Spread new_sig, such that each bit is in one byte with a
                   // value of 0 if new_sig bit is 0, and 0xFF if new_sig is 1
-                  __m128i new_sig_vec = _mm_set1_epi16((si16)new_sig);
-                  new_sig_vec = _mm_shuffle_epi8(new_sig_vec,
-                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                  new_sig_vec = _mm_and_si128(new_sig_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  new_sig_vec = _mm_cmpeq_epi8(new_sig_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
+                  v128_t new_sig_vec = vsx_i16x8_splat((si16)new_sig);
+                  new_sig_vec = vsx_i8x16_swizzle(new_sig_vec,
+                    vsx_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
+                  new_sig_vec = vsx_v128_and(new_sig_vec,
+                    vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                  new_sig_vec = vsx_i8x16_eq(new_sig_vec,
+                    vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
 
                   // find cumulative sums
                   // to find which bit in cwd we should extract
-                  __m128i inc_sum = new_sig_vec; // inclusive scan
-                  inc_sum = _mm_abs_epi8(inc_sum); // cvrt to 0 or 1
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                  inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                  cnt += (ui32)_mm_extract_epi16(inc_sum, 7) >> 8;
+                  v128_t ex_sum, shfl, inc_sum = new_sig_vec; // inclusive scan
+                  inc_sum = vsx_i8x16_abs(inc_sum); // cvrt to 0 or 1
+                  shfl = vsx_i8x16_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                    15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
+                  inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                  shfl = vsx_i16x8_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                    7, 8, 9, 10, 11, 12, 13, 14);
+                  inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                  shfl = vsx_i32x4_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                    3, 4, 5, 6);
+                  inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                  shfl = vsx_i64x2_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                    1, 2);
+                  inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                  cnt += vsx_u8x16_extract_lane(inc_sum, 15);
                   // exclusive scan
-                  __m128i ex_sum = _mm_bslli_si128(inc_sum, 1);
+                  ex_sum = vsx_i8x16_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                    15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
 
                   // Spread cwd, such that each bit is in one byte
                   // with a value of 0 or 1.
-                  cwd_vec = _mm_set1_epi16((si16)cwd);
-                  cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                    _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                  cwd_vec = _mm_and_si128(cwd_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                    _mm_set1_epi64x((si64)0x8040201008040201));
-                  cwd_vec = _mm_abs_epi8(cwd_vec);
+                  cwd_vec = vsx_i16x8_splat((si16)cwd);
+                  cwd_vec = vsx_i8x16_swizzle(cwd_vec,
+                    vsx_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
+                  cwd_vec = vsx_v128_and(cwd_vec,
+                    vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                  cwd_vec = vsx_i8x16_eq(cwd_vec,
+                    vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                  cwd_vec = vsx_i8x16_abs(cwd_vec);
 
                   // Obtain bit from cwd_vec correspondig to ex_sum
                   // Basically, collect needed bits from cwd_vec
-                  __m128i v = _mm_shuffle_epi8(cwd_vec, ex_sum);
+                  v128_t v = vsx_i8x16_swizzle(cwd_vec, ex_sum);
 
                   // load data and set spp coefficients
-                  __m128i m =
-                    _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
-                  __m128i val = _mm_set1_epi32(3 << (p - 2));
+                  v128_t m = vsx_i8x16_const(
+                    0,-1,-1,-1,4,-1,-1,-1,8,-1,-1,-1,12,-1,-1,-1);
+                  v128_t val = vsx_i32x4_splat(3 << (p - 2));
                   ui32 *dp = dpp;
                   for (int c = 0; c < 4; ++ c) {
-                    __m128i s0, s0_ns, s0_val;
+                    v128_t s0, s0_ns, s0_val;
                     // load coefficients
-                    s0 = _mm_load_si128((__m128i*)dp);
+                    s0 = vsx_v128_load(dp);
 
                     // epi32 is -1 only for coefficient that
                     // are changed during the SPP
-                    s0_ns = _mm_shuffle_epi8(new_sig_vec, m);
-                    s0_ns = _mm_cmpeq_epi32(s0_ns, _mm_set1_epi32(0xFF));
+                    s0_ns = vsx_i8x16_swizzle(new_sig_vec, m);
+                    s0_ns = vsx_i32x4_eq(s0_ns,
+                      vsx_i32x4_const(OJPH_REPEAT4(0xFF)));
 
                     // obtain sign for coefficients in SPP
-                    s0_val = _mm_shuffle_epi8(v, m);
-                    s0_val = _mm_slli_epi32(s0_val, 31);
-                    s0_val = _mm_or_si128(s0_val, val);
-                    s0_val = _mm_and_si128(s0_val, s0_ns);
+                    s0_val = vsx_i8x16_swizzle(v, m);
+                    s0_val = vsx_i32x4_shl(s0_val, 31);
+                    s0_val = vsx_v128_or(s0_val, val);
+                    s0_val = vsx_v128_and(s0_val, s0_ns);
 
                     // update vector
-                    s0 = _mm_or_si128(s0, s0_val);
+                    s0 = vsx_v128_or(s0, s0_val);
                     // store coefficients
-                    _mm_store_si128((__m128i*)dp, s0);
+                    vsx_v128_store(dp, s0);
                     // prepare for next row
                     dp += stride;
-                    m = _mm_add_epi32(m, _mm_set1_epi32(1));
+                    m = vsx_i32x4_add(m, vsx_i32x4_const(OJPH_REPEAT4(1)));
                   }
                 }
                 frwd_advance(&sigprop, cnt);
@@ -1994,65 +2140,77 @@ namespace ojph {
                 // data is 32 bit (4 bytes)
 
                 // spread the 16 bits in sig to 0 or 1 bytes in sig_vec
-                __m128i sig_vec = _mm_set1_epi16((si16)sig);
-                sig_vec = _mm_shuffle_epi8(sig_vec,
-                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                sig_vec = _mm_and_si128(sig_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                sig_vec = _mm_cmpeq_epi8(sig_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                sig_vec = _mm_abs_epi8(sig_vec);
+                v128_t sig_vec = vsx_i16x8_splat((si16)sig);
+                sig_vec = vsx_i8x16_swizzle(sig_vec,
+                  vsx_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
+                sig_vec = vsx_v128_and(sig_vec,
+                  vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                sig_vec = vsx_i8x16_eq(sig_vec,
+                  vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                sig_vec = vsx_i8x16_abs(sig_vec);
 
                 // find cumulative sums
                 // to find which bit in cwd we should extract
-                __m128i inc_sum = sig_vec; // inclusive scan
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 1));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 2));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 4));
-                inc_sum = _mm_add_epi8(inc_sum, _mm_bslli_si128(inc_sum, 8));
-                total_bits = _mm_extract_epi16(inc_sum, 7) >> 8;
-                __m128i ex_sum = _mm_bslli_si128(inc_sum, 1); // exclusive scan
+                v128_t ex_sum, shfl, inc_sum = sig_vec; // inclusive scan
+                shfl = vsx_i8x16_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                  15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
+                inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                shfl = vsx_i16x8_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                  7, 8, 9, 10, 11, 12, 13, 14);
+                inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                shfl = vsx_i32x4_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                  3, 4, 5, 6);
+                inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                shfl = vsx_i64x2_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                  1, 2);
+                inc_sum = vsx_i8x16_add(inc_sum, shfl);
+                total_bits = vsx_u8x16_extract_lane(inc_sum, 15);
+                // exclusive scan
+                ex_sum = vsx_i8x16_shuffle(vsx_i64x2_const(0,0), inc_sum,
+                  15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
 
                 // Spread the 16 bits in cwd to inverted 0 or 1 bytes in
                 // cwd_vec. Then, convert these to a form suitable
                 // for coefficient modifications; in particular, a value
                 // of 0 is presented as binary 11, and a value of 1 is
                 // represented as binary 01
-                __m128i cwd_vec = _mm_set1_epi16((si16)cwd);
-                cwd_vec = _mm_shuffle_epi8(cwd_vec,
-                  _mm_set_epi8(1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0));
-                cwd_vec = _mm_and_si128(cwd_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                cwd_vec = _mm_cmpeq_epi8(cwd_vec,
-                  _mm_set1_epi64x((si64)0x8040201008040201));
-                cwd_vec = _mm_add_epi8(cwd_vec, _mm_set1_epi8(1));
-                cwd_vec = _mm_add_epi8(cwd_vec, cwd_vec);
-                cwd_vec = _mm_or_si128(cwd_vec, _mm_set1_epi8(1));
+                v128_t cwd_vec = vsx_i16x8_splat((si16)cwd);
+                cwd_vec = vsx_i8x16_swizzle(cwd_vec,
+                  vsx_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
+                cwd_vec = vsx_v128_and(cwd_vec,
+                  vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                cwd_vec = vsx_i8x16_eq(cwd_vec,
+                  vsx_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
+                cwd_vec =
+                  vsx_i8x16_add(cwd_vec, vsx_i8x16_const(OJPH_REPEAT16(1)));
+                cwd_vec = vsx_i8x16_add(cwd_vec, cwd_vec);
+                cwd_vec =
+                  vsx_v128_or(cwd_vec, vsx_i8x16_const(OJPH_REPEAT16(1)));
 
                 // load data and insert the mrp bit
-                __m128i m =
-                  _mm_set_epi8(-1,-1,-1,12,-1,-1,-1,8,-1,-1,-1,4,-1,-1,-1,0);
+                v128_t m = vsx_i8x16_const(0,-1,-1,-1,4,-1,-1,-1,
+                                            8,-1,-1,-1,12,-1,-1,-1);
                 ui32 *dp = dpp;
                 for (int c = 0; c < 4; ++c) {
-                  __m128i s0, s0_sig, s0_idx, s0_val;
+                  v128_t s0, s0_sig, s0_idx, s0_val;
                   // load coefficients
-                  s0 = _mm_load_si128((__m128i*)dp);
+                  s0 = vsx_v128_load(dp);
                   // find significant samples in this row
-                  s0_sig = _mm_shuffle_epi8(sig_vec, m);
-                  s0_sig = _mm_cmpeq_epi8(s0_sig, _mm_setzero_si128());
+                  s0_sig = vsx_i8x16_swizzle(sig_vec, m);
+                  s0_sig = vsx_i8x16_eq(s0_sig, vsx_i64x2_const(0, 0));
                   // get MRP bit index, and MRP pattern
-                  s0_idx = _mm_shuffle_epi8(ex_sum, m);
-                  s0_val = _mm_shuffle_epi8(cwd_vec, s0_idx);
+                  s0_idx = vsx_i8x16_swizzle(ex_sum, m);
+                  s0_val = vsx_i8x16_swizzle(cwd_vec, s0_idx);
                   // keep data from significant samples only
-                  s0_val = _mm_andnot_si128(s0_sig, s0_val);
+                  s0_val = vsx_v128_andnot(s0_val, s0_sig);
                   // move mrp bits to correct position, and employ
-                  s0_val = _mm_slli_epi32(s0_val, (si32)p - 2);
-                  s0 = _mm_xor_si128(s0, s0_val);
+                  s0_val = vsx_i32x4_shl(s0_val, (int)p - 2);
+                  s0 = vsx_v128_xor(s0, s0_val);
                   // store coefficients
-                  _mm_store_si128((__m128i*)dp, s0);
+                  vsx_v128_store(dp, s0);
                   // prepare for next row
                   dp += stride;
-                  m = _mm_add_epi32(m, _mm_set1_epi32(1));
+                  m = vsx_i32x4_add(m, vsx_i32x4_const(OJPH_REPEAT4(1)));
                 }
               }
               // consume data according to the number of bits set
@@ -2066,5 +2224,3 @@ namespace ojph {
     }
   }
 }
-
-#endif

--- a/external/OpenJPH/src/core/coding/ojph_block_decoder_wasm.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_decoder_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2022, Aous Naman 
+// Copyright (c) 2022, Aous Naman
 // Copyright (c) 2022, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2022, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -69,7 +69,7 @@ namespace ojph {
      *  A number of events is decoded from the MEL bitstream ahead of time
      *  and stored in run/num_runs.
      *  Each run represents the number of zero events before a one event.
-     */ 
+     */
     struct dec_mel_st {
       dec_mel_st() : data(NULL), tmp(0), bits(0), size(0), unstuff(false),
         k(0), num_runs(0), runs(0)
@@ -89,7 +89,7 @@ namespace ojph {
 
     //************************************************************************/
     /** @brief Reads and unstuffs the MEL bitstream
-     * 
+     *
      *  This design needs more bytes in the codeblock buffer than the length
      *  of the cleanup pass by up to 2 bytes.
      *
@@ -107,14 +107,14 @@ namespace ojph {
 
       ui32 val = 0xFFFFFFFF;       // feed in 0xFF if buffer is exhausted
       if (melp->size > 4) {        // if there is data in the MEL segment
-        val = *(ui32*)melp->data;  // read 32 bits from MEL data
+        memcpy(&val, melp->data, sizeof(val)); // read 32 bits from MEL data
         melp->data += 4;           // advance pointer
         melp->size -= 4;           // reduce counter
       }
       else if (melp->size > 0)
       { // 4 or less
         int i = 0;
-        while (melp->size > 1) {   
+        while (melp->size > 1) {
           ui32 v = *melp->data++;    // read one byte at a time
           ui32 m = ~(0xFFu << i);    // mask of location
           val = (val & m) | (v << i);// put one byte in its correct location
@@ -122,21 +122,21 @@ namespace ojph {
           i += 8;
         }
         // size equal to 1
-        ui32 v = *melp->data++;    // the one before the last is different 
+        ui32 v = *melp->data++;    // the one before the last is different
         v |= 0xF;                  // MEL and VLC segments can overlap
         ui32 m = ~(0xFFu << i);
         val = (val & m) | (v << i);
         --melp->size;
       }
-      
+
       // next we unstuff them before adding them to the buffer
       int bits = 32 - melp->unstuff; // number of bits in val, subtract 1 if
-                                     // the previously read byte requires 
+                                     // the previously read byte requires
                                      // unstuffing
 
       // data is unstuffed and accumulated in t
       // bits has the number of bits in t
-      ui32 t = val & 0xFF; 
+      ui32 t = val & 0xFF;
       bool unstuff = ((val & 0xFF) == 0xFF); // true if we need unstuffing
       bits -= unstuff; // there is one less bit in t if unstuffing is needed
       t = t << (8 - unstuff); // move up to make room for the next byte
@@ -163,14 +163,14 @@ namespace ojph {
 
     //************************************************************************/
     /** @brief Decodes unstuffed MEL segment bits stored in tmp to runs
-     * 
+     *
      *  Runs are stored in "runs" and the number of runs in "num_runs".
-     *  Each run represents a number of zero events that may or may not 
+     *  Each run represents a number of zero events that may or may not
      *  terminate in a 1 event.
      *  Each run is stored in 7 bits.  The LSB is 1 if the run terminates in
-     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating 
-     *  with 1, contain the number of consecutive 0 zero events * 2; for the 
-     *  case terminating with 0, they store (number of consecutive 0 zero 
+     *  a 1 event, 0 otherwise.  The next 6 bits, for the case terminating
+     *  with 1, contain the number of consecutive 0 zero events * 2; for the
+     *  case terminating with 0, they store (number of consecutive 0 zero
      *  events - 1) * 2.
      *  A total of 6 bits (made up of 1 + 5) should have been enough.
      *
@@ -195,7 +195,7 @@ namespace ojph {
         int run = 0;
         if (melp->tmp & (1ull<<63)) //The next bit to decode (stored in MSB)
         { //one is found
-          run = 1 << eval;  
+          run = 1 << eval;
           run--; // consecutive runs of 0 events - 1
           melp->k = melp->k + 1 < 12 ? melp->k + 1 : 12;//increment, max is 12
           melp->tmp <<= 1; // consume one bit from tmp
@@ -213,14 +213,14 @@ namespace ojph {
         eval = melp->num_runs * 7;           // 7 bits per run
         melp->runs &= ~((ui64)0x3F << eval); // 6 bits are sufficient
         melp->runs |= ((ui64)run) << eval;   // store the value in runs
-        melp->num_runs++;                    // increment count  
+        melp->num_runs++;                    // increment count
       }
     }
 
     //************************************************************************/
     /** @brief Initiates a dec_mel_st structure for MEL decoding and reads
      *         some bytes in order to get the read address to a multiple
-     *         of 4 
+     *         of 4
      *
      *  @param [in]  melp is a pointer to dec_mel_st structure
      *  @param [in]  bbuf is a pointer to byte buffer
@@ -235,7 +235,7 @@ namespace ojph {
       melp->tmp = 0;                   //
       melp->unstuff = false;           // no unstuffing
       melp->size = scup - 1;           // size is the length of MEL+VLC-1
-      melp->k = 0;                     // 0 for state 
+      melp->k = 0;                     // 0 for state
       melp->num_runs = 0;              // num_runs is 0
       melp->runs = 0;                  //
 
@@ -253,7 +253,7 @@ namespace ojph {
         int d_bits = 8 - melp->unstuff; //if unstuffing is needed, reduce by 1
         melp->tmp = (melp->tmp << d_bits) | d; //store bits in tmp
         melp->bits += d_bits;  //increment tmp by number of bits
-        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs 
+        melp->unstuff = ((d & 0xFF) == 0xFF); //true of next byte needs
                                               //unstuffing
       }
       melp->tmp <<= (64 - melp->bits); //push all the way up so the first bit
@@ -265,7 +265,7 @@ namespace ojph {
      *         MEL segment is decoded
      *
      * @param [in]  melp is a pointer to dec_mel_st structure
-     */    
+     */
     static inline
     int mel_get_run(dec_mel_st *melp)
     {
@@ -281,7 +281,7 @@ namespace ojph {
     //************************************************************************/
     /** @brief A structure for reading and unstuffing a segment that grows
      *         backward, such as VLC and MRP
-     */ 
+     */
     struct rev_struct {
       rev_struct() : data(NULL), tmp(0), bits(0), size(0), unstuff(false)
       {}
@@ -298,41 +298,41 @@ namespace ojph {
     /** @brief Read and unstuff data from a backwardly-growing segment
      *
      *  This reader can read up to 8 bytes from before the VLC segment.
-     *  Care must be taken not read from unreadable memory, causing a 
+     *  Care must be taken not read from unreadable memory, causing a
      *  segmentation fault.
-     * 
+     *
      *  Note that there is another subroutine rev_read_mrp that is slightly
      *  different.  The other one fills zeros when the buffer is exhausted.
      *  This one basically does not care if the bytes are consumed, because
      *  any extra data should not be used in the actual decoding.
      *
-     *  Unstuffing is needed to prevent sequences more than 0xFF8F from 
+     *  Unstuffing is needed to prevent sequences more than 0xFF8F from
      *  appearing in the bits stream; since we are reading backward, we keep
-     *  watch when a value larger than 0x8F appears in the bitstream. 
-     *  If the byte following this is 0x7F, we unstuff this byte (ignore the 
+     *  watch when a value larger than 0x8F appears in the bitstream.
+     *  If the byte following this is 0x7F, we unstuff this byte (ignore the
      *  MSB of that byte, which should be 0).
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline 
+    static inline
     void rev_read(rev_struct *vlcp)
     {
       //process 4 bytes at a time
-      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then 
+      if (vlcp->bits > 32)  // if there are more than 32 bits in tmp, then
         return;             // reading 32 bits can overflow vlcp->tmp
       ui32 val = 0;
       //the next line (the if statement) needs to be tested first
       if (vlcp->size > 3)  // if there are more than 3 bytes left in VLC
       {
         // (vlcp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(vlcp->data - 3); // then read 32 bits
+        memcpy(&val, vlcp->data - 3, sizeof(val)); // then read 32 bits
         vlcp->data -= 4;          // move data pointer back by 4
         vlcp->size -= 4;          // reduce available byte by 4
       }
       else if (vlcp->size > 0)
       { // 4 or less
         int i = 24;
-        while (vlcp->size > 0) {   
+        while (vlcp->size > 0) {
           ui32 v = *vlcp->data--; // read one byte at a time
           val |= (v << i);        // put byte in its correct location
           --vlcp->size;
@@ -367,7 +367,7 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief Initiates the rev_struct structure and reads a few bytes to 
+    /** @brief Initiates the rev_struct structure and reads a few bytes to
      *         move the read address to multiple of 4
      *
      *  There is another similar rev_init_mrp subroutine.  The difference is
@@ -380,7 +380,7 @@ namespace ojph {
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  scup is the length of MEL+VLC segments
      */
-    static inline 
+    static inline
     void rev_init(rev_struct *vlcp, ui8* data, int lcup, int scup)
     {
       //first byte has only the upper 4 bits
@@ -415,13 +415,13 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure
      *
      *  By the end of this call, vlcp->tmp must have no less than 33 bits
      *
      *  @param [in]  vlcp is a pointer to rev_struct structure
      */
-    static inline 
+    static inline
     ui32 rev_fetch(rev_struct *vlcp)
     {
       if (vlcp->bits < 32)  // if there are less then 32 bits, read more
@@ -439,7 +439,7 @@ namespace ojph {
      *  @param [in]  vlcp is a pointer to rev_struct structure
      *  @param [in]  num_bits is the number of bits to be removed
      */
-    static inline 
+    static inline
     ui32 rev_advance(rev_struct *vlcp, ui32 num_bits)
     {
       assert(num_bits <= vlcp->bits); // vlcp->tmp must have more than num_bits
@@ -459,7 +459,7 @@ namespace ojph {
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline 
+    static inline
     void rev_read_mrp(rev_struct *mrp)
     {
       //process 4 bytes at a time
@@ -468,14 +468,14 @@ namespace ojph {
       ui32 val = 0;
       if (mrp->size > 3) // If there are 3 byte or more
       { // (mrp->data - 3) move pointer back to read 32 bits at once
-        val = *(ui32*)(mrp->data - 3); // read 32 bits
+        memcpy(&val, mrp->data - 3, sizeof(val)); // read 32 bits
         mrp->data -= 4;                // move back pointer
         mrp->size -= 4;                // reduce count
       }
       else if (mrp->size > 0)
       {
         int i = 24;
-        while (mrp->size > 0) {   
+        while (mrp->size > 0) {
           ui32 v = *mrp->data--; // read one byte at a time
           val |= (v << i);       // put byte in its correct location
           --mrp->size;
@@ -515,7 +515,7 @@ namespace ojph {
      *         an architecture that read size must be compatible with the
      *         alignment of the read address
      *
-     *  There is another similar subroutine rev_init.  This subroutine does 
+     *  There is another similar subroutine rev_init.  This subroutine does
      *  NOT skip the first 12 bits, and starts with unstuff set to true.
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
@@ -523,7 +523,7 @@ namespace ojph {
      *  @param [in]  lcup is the length of MagSgn+MEL+VLC segments
      *  @param [in]  len2 is the length of SPP+MRP segments
      */
-    static inline 
+    static inline
     void rev_init_mrp(rev_struct *mrp, ui8* data, int lcup, int len2)
     {
       mrp->data = data + lcup + len2 - 1;
@@ -540,7 +540,7 @@ namespace ojph {
       for (int i = 0; i < num; ++i) {
         ui64 d;
         //read a byte, 0 if no more data
-        d = (mrp->size-- > 0) ? *mrp->data-- : 0; 
+        d = (mrp->size-- > 0) ? *mrp->data-- : 0;
         //check if unstuffing is needed
         ui32 d_bits = 8 - ((mrp->unstuff && ((d & 0x7F) == 0x7F)) ? 1 : 0);
         mrp->tmp |= d << mrp->bits; // move data to vlcp->tmp
@@ -551,13 +551,13 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief Retrieves 32 bits from the head of a rev_struct structure 
+    /** @brief Retrieves 32 bits from the head of a rev_struct structure
      *
      *  By the end of this call, mrp->tmp must have no less than 33 bits
      *
      *  @param [in]  mrp is a pointer to rev_struct structure
      */
-    static inline 
+    static inline
     ui32 rev_fetch_mrp(rev_struct *mrp)
     {
       if (mrp->bits < 32) // if there are less than 32 bits in mrp->tmp
@@ -584,7 +584,7 @@ namespace ojph {
     }
 
     //************************************************************************/
-    /** @brief State structure for reading and unstuffing of forward-growing 
+    /** @brief State structure for reading and unstuffing of forward-growing
      *         bitstreams; these are: MagSgn and SPP bitstreams
      */
     struct frwd_struct {
@@ -597,7 +597,7 @@ namespace ojph {
 
     //************************************************************************/
     /** @brief Read and unstuffs 16 bytes from forward-growing bitstream
-     *  
+     *
      *  A template is used to accommodate a different requirement for
      *  MagSgn and SPP bitstreams; in particular, when MagSgn bitstream is
      *  consumed, 0xFF's are fed, while when SPP is exhausted 0's are fed in.
@@ -614,7 +614,7 @@ namespace ojph {
      *
      */
     template<int X>
-    static inline 
+    static inline
     void frwd_read(frwd_struct *msp)
     {
       assert(msp->bits <= 128);
@@ -635,19 +635,19 @@ namespace ojph {
         val = wasm_v128_or(t, val); // fill with 0xFF
       }
       else if (X == 0)
-        val = wasm_v128_and(validity, val); // fill with zeros 
+        val = wasm_v128_and(validity, val); // fill with zeros
       else
         assert(0);
 
       v128_t ff_bytes;
       ff_bytes = wasm_i8x16_eq(val, all_xff);
       ff_bytes = wasm_v128_and(ff_bytes, validity);
-      ui32 flags = wasm_i8x16_bitmask(ff_bytes); 
+      ui32 flags = wasm_i8x16_bitmask(ff_bytes);
       flags <<= 1; // unstuff following byte
       ui32 next_unstuff = flags >> 16;
       flags |= msp->unstuff;
       flags &= 0xFFFF;
-      while (flags) 
+      while (flags)
       { // bit unstuffing occurs on average once every 256 bytes
         // therefore it is not an issue if it is a bit slow
         // here we process 16 bytes
@@ -665,7 +665,7 @@ namespace ojph {
         t = wasm_i64x2_shuffle(t, wasm_i64x2_const(0, 0), 1, 2);
         t = wasm_i64x2_shl(t, 63);    // keep the MSB only
         t = wasm_v128_or(t, c);       // combine the above 3 steps
-                                    
+
         val = wasm_v128_or(t, wasm_v128_andnot(val, m));
       }
 
@@ -697,7 +697,7 @@ namespace ojph {
 
     //************************************************************************/
     /** @brief Initialize frwd_struct struct and reads some bytes
-     *  
+     *
      *  @tparam      X is the value fed in when the bitstream is exhausted.
      *               See frwd_read regarding the template
      *  @param [in]  msp is a pointer to frwd_struct
@@ -705,7 +705,7 @@ namespace ojph {
      *  @param [in]  size is the number of byte in the bitstream
      */
     template<int X>
-    static inline 
+    static inline
     void frwd_init(frwd_struct *msp, const ui8* data, int size)
     {
       msp->data = data;
@@ -726,7 +726,7 @@ namespace ojph {
      *  @param [in]  msp is a pointer to frwd_struct
      *  @param [in]  num_bits is the number of bit to consume
      */
-    static inline 
+    static inline
     void frwd_advance(frwd_struct *msp, ui32 num_bits)
     {
       assert(num_bits > 0 && num_bits <= msp->bits && num_bits < 128);
@@ -795,7 +795,7 @@ namespace ojph {
      *  @return v128_t decoded quad
      */
     template <int N>
-    static inline 
+    static inline
     v128_t decode_one_quad32(const v128_t inf_u_q, v128_t U_q,
                               frwd_struct* magsgn, ui32 p, v128_t& vn)
     {
@@ -813,7 +813,7 @@ namespace ojph {
       {
         U_q = wasm_i32x4_shuffle(U_q, U_q, N, N, N, N);
         flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8,8,4,4,2,2,1,1));
-        v128_t ms_vec = frwd_fetch<0xFF>(magsgn); 
+        v128_t ms_vec = frwd_fetch<0xFF>(magsgn);
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -837,14 +837,14 @@ namespace ojph {
 
         // find the starting byte and starting bit
         v128_t byte_idx = wasm_u32x4_shr(ex_sum, 3);
-        v128_t bit_idx = 
+        v128_t bit_idx =
           wasm_v128_and(ex_sum, wasm_i32x4_const(OJPH_REPEAT4(7)));
-        byte_idx = wasm_i8x16_swizzle(byte_idx, 
+        byte_idx = wasm_i8x16_swizzle(byte_idx,
           wasm_i32x4_const(0x00000000, 0x04040404, 0x08080808, 0x0C0C0C0C));
-        byte_idx = 
+        byte_idx =
           wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x03020100)));
         v128_t d0 = wasm_i8x16_swizzle(ms_vec, byte_idx);
-        byte_idx = 
+        byte_idx =
           wasm_i32x4_add(byte_idx, wasm_i32x4_const(OJPH_REPEAT4(0x01010101)));
         v128_t d1 = wasm_i8x16_swizzle(ms_vec, byte_idx);
 
@@ -853,7 +853,7 @@ namespace ojph {
         v128_t bit_shift = wasm_i8x16_swizzle(
           wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
                            -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
-        bit_shift = 
+        bit_shift =
           wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         d0 = wasm_i16x8_mul(d0, bit_shift);
         d0 = wasm_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
@@ -886,10 +886,10 @@ namespace ojph {
 
         ms_vec = wasm_v128_andnot(tvn, insig); // significant only
         if (N == 0) // the compiler should remove one
-          tvn = wasm_i8x16_swizzle(ms_vec, 
+          tvn = wasm_i8x16_swizzle(ms_vec,
             wasm_i32x4_const(0x07060504, 0x0F0E0D0C, -1, -1));
         else if (N == 1)
-          tvn = wasm_i8x16_swizzle(ms_vec, 
+          tvn = wasm_i8x16_swizzle(ms_vec,
             wasm_i32x4_const(-1, 0x07060504, 0x0F0E0D0C, -1));
         else
           assert(0);
@@ -911,8 +911,8 @@ namespace ojph {
      *  @param vn       used for handling E values (stores v_n values)
      *  @return v128_t decoded quad
      */
-    static inline 
-    v128_t decode_two_quad16(const v128_t inf_u_q, v128_t U_q, 
+    static inline
+    v128_t decode_two_quad16(const v128_t inf_u_q, v128_t U_q,
                               frwd_struct* magsgn, ui32 p, v128_t& vn)
     {
       v128_t w0;     // workers
@@ -921,21 +921,21 @@ namespace ojph {
       v128_t row;    // decoded row
 
       row = wasm_i64x2_const(0, 0);
-      w0 = wasm_i8x16_swizzle(inf_u_q, 
+      w0 = wasm_i8x16_swizzle(inf_u_q,
         wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
                          0x0504, 0x0504, 0x0504, 0x0504));
       // we keeps e_k, e_1, and rho in w2
-      flags = wasm_v128_and(w0, 
-        wasm_u16x8_const(0x1110, 0x2220, 0x4440, 0x8880, 
+      flags = wasm_v128_and(w0,
+        wasm_u16x8_const(0x1110, 0x2220, 0x4440, 0x8880,
                          0x1110, 0x2220, 0x4440, 0x8880));
       insig = wasm_i16x8_eq(flags, wasm_i64x2_const(0, 0));
       if (wasm_i8x16_bitmask(insig) != 0xFFFF) //are all insignificant?
       {
-        U_q = wasm_i8x16_swizzle(U_q, 
-          wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100, 
+        U_q = wasm_i8x16_swizzle(U_q,
+          wasm_i16x8_const(0x0100, 0x0100, 0x0100, 0x0100,
                            0x0504, 0x0504, 0x0504, 0x0504));
         flags = wasm_i16x8_mul(flags, wasm_i16x8_const(8,4,2,1,8,4,2,1));
-        v128_t ms_vec = frwd_fetch<0xFF>(magsgn); 
+        v128_t ms_vec = frwd_fetch<0xFF>(magsgn);
 
         // U_q holds U_q for this quad
         // flags has e_k, e_1, and rho such that e_k is sitting in the
@@ -950,7 +950,7 @@ namespace ojph {
         // find cumulative sums
         // to find at which bit in ms_vec the sample starts
         v128_t ex_sum, shfl, inc_sum = m_n; // inclusive scan
-        shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), 
+        shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0),
           inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
         inc_sum = wasm_i16x8_add(inc_sum, shfl);
         shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 3, 4, 5, 6);
@@ -958,20 +958,20 @@ namespace ojph {
         shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 1, 2);
         inc_sum = wasm_i16x8_add(inc_sum, shfl);
         int total_mn = wasm_u16x8_extract_lane(inc_sum, 7);
-        ex_sum = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), 
+        ex_sum = wasm_i16x8_shuffle(wasm_i64x2_const(0,0),
           inc_sum, 7, 8, 9, 10, 11, 12, 13, 14);
 
         // find the starting byte and starting bit
         v128_t byte_idx = wasm_u16x8_shr(ex_sum, 3);
-        v128_t bit_idx = 
+        v128_t bit_idx =
           wasm_v128_and(ex_sum, wasm_i16x8_const(OJPH_REPEAT8(7)));
-        byte_idx = wasm_i8x16_swizzle(byte_idx, 
-          wasm_i16x8_const(0x0000, 0x0202, 0x0404, 0x0606, 
+        byte_idx = wasm_i8x16_swizzle(byte_idx,
+          wasm_i16x8_const(0x0000, 0x0202, 0x0404, 0x0606,
                            0x0808, 0x0A0A, 0x0C0C, 0x0E0E));
-        byte_idx = 
+        byte_idx =
           wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0100)));
         v128_t d0 = wasm_i8x16_swizzle(ms_vec, byte_idx);
-        byte_idx = 
+        byte_idx =
           wasm_i16x8_add(byte_idx, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         v128_t d1 = wasm_i8x16_swizzle(ms_vec, byte_idx);
 
@@ -979,13 +979,13 @@ namespace ojph {
         v128_t bit_shift = wasm_i8x16_swizzle(
           wasm_i8x16_const(-1, 127, 63, 31, 15, 7, 3, 1,
                            -1, 127, 63, 31, 15, 7, 3, 1), bit_idx);
-        bit_shift = 
+        bit_shift =
           wasm_i16x8_add(bit_shift, wasm_i16x8_const(OJPH_REPEAT8(0x0101)));
         d0 = wasm_i16x8_mul(d0, bit_shift);
         d0 = wasm_u16x8_shr(d0, 8); // we should have 8 bits in the LSB
         d1 = wasm_i16x8_mul(d1, bit_shift);
         d1 = // 8 in MSB
-          wasm_v128_and(d1, wasm_i16x8_const(OJPH_REPEAT8((si16)0xFF00))); 
+          wasm_v128_and(d1, wasm_i16x8_const(OJPH_REPEAT8((si16)0xFF00)));
         d0 = wasm_v128_or(d0, d1);
 
         // find location of e_k and mask
@@ -1017,10 +1017,10 @@ namespace ojph {
         row = wasm_v128_andnot(ms_vec, insig); // significant only
 
         ms_vec = wasm_v128_andnot(tvn, insig); // significant only
-        w0 = wasm_i8x16_swizzle(ms_vec, 
+        w0 = wasm_i8x16_swizzle(ms_vec,
           wasm_i16x8_const(0x0302, 0x0706, -1, -1, -1, -1, -1, -1));
         vn = wasm_v128_or(vn, w0);
-        w0 = wasm_i8x16_swizzle(ms_vec, 
+        w0 = wasm_i8x16_swizzle(ms_vec,
           wasm_i16x8_const(-1, 0x0B0A, 0x0F0E, -1, -1, -1, -1, -1));
         vn = wasm_v128_or(vn, w0);
 
@@ -1043,9 +1043,9 @@ namespace ojph {
      *  @param [in]   lengths1 is the length of cleanup pass
      *  @param [in]   lengths2 is the length of refinement passes (either SPP
      *                only or SPP+MRP)
-     *  @param [in]   width is the decoded codeblock width 
+     *  @param [in]   width is the decoded codeblock width
      *  @param [in]   height is the decoded codeblock height
-     *  @param [in]   stride is the decoded codeblock buffer stride 
+     *  @param [in]   stride is the decoded codeblock buffer stride
      *  @param [in]   stripe_causal is true for stripe causal mode
      */
     bool ojph_decode_codeblock_wasm(ui8* coded_data, ui32* decoded_data,
@@ -1076,7 +1076,7 @@ namespace ojph {
 
       if (missing_msbs > 30) // p < 0
       {
-        if (insufficient_precision == false) 
+        if (insufficient_precision == false)
         {
           insufficient_precision = true;
           OJPH_WARN(0x00010003, "32 bits are not enough to decode this "
@@ -1084,7 +1084,7 @@ namespace ojph {
                                 "displayed again.\n");
         }
         return false;
-      }       
+      }
       else if (missing_msbs == 30) // p == 0
       { // not enough precision to decode and set the bin center to 1
         if (modify_code == false) {
@@ -1127,16 +1127,16 @@ namespace ojph {
       if (scup < 2 || scup > lcup || scup > 4079) //something is wrong
         return false;
 
-      // The temporary storage scratch holds two types of data in an 
+      // The temporary storage scratch holds two types of data in an
       // interleaved fashion. The interleaving allows us to use one
       // memory pointer.
       // We have one entry for a decoded VLC code, and one entry for UVLC.
-      // Entries are 16 bits each, corresponding to one quad, 
-      // but since we want to use XMM registers of the SSE family 
+      // Entries are 16 bits each, corresponding to one quad,
+      // but since we want to use XMM registers of the SSE family
       // of SIMD; we allocated 16 bytes or more per quad row; that is,
       // the width is no smaller than 16 bytes (or 8 entries), and the
       // height is 512 quads
-      // Each VLC entry contains, in the following order, starting 
+      // Each VLC entry contains, in the following order, starting
       // from MSB
       // e_k (4bits), e_1 (4bits), rho (4bits), useless for step 2 (4bits)
       // Each entry in UVLC contains u_q
@@ -1145,10 +1145,10 @@ namespace ojph {
       ui16 scratch[8 * 513] = {0};          // 8+ kB
 
       // We need an extra two entries (one inf and one u_q) beyond
-      // the last column. 
-      // If the block width is 4 (2 quads), then we use sstr of 8 
-      // (enough for 4 quads). If width is 8 (4 quads) we use 
-      // sstr is 16 (enough for 8 quads). For a width of 16 (8 
+      // the last column.
+      // If the block width is 4 (2 quads), then we use sstr of 8
+      // (enough for 4 quads). If width is 8 (4 quads) we use
+      // sstr is 16 (enough for 8 quads). For a width of 16 (8
       // quads), we use 24 (enough for 12 quads).
       ui32 sstr = ((width + 2u) + 7u) & ~7u; // multiples of 8
 
@@ -1157,11 +1157,11 @@ namespace ojph {
       ui32 mmsbp2 = missing_msbs + 2;
 
       // The cleanup pass is decoded in two steps; in step one,
-      // the VLC and MEL segments are decoded, generating a record that 
+      // the VLC and MEL segments are decoded, generating a record that
       // has 2 bytes per quad. The 2 bytes contain, u, rho, e^1 & e^k.
       // This information should be sufficient for the next step.
       // In step 2, we decode the MagSgn segment.
-      
+
       // step 1 decoding VLC and MEL segments
       {
         // init structures
@@ -1194,20 +1194,20 @@ namespace ojph {
           {
             run -= 2; //subtract 2, since events number if multiplied by 2
 
-            // Is the run terminated in 1? if so, use decoded VLC code, 
-            // otherwise, discard decoded data, since we will decoded again 
+            // Is the run terminated in 1? if so, use decoded VLC code,
+            // otherwise, discard decoded data, since we will decoded again
             // using a different context
             t0 = (run == -1) ? t0 : 0;
 
             // is run -1 or -2? this means a run has been consumed
-            if (run < 0) 
+            if (run < 0)
               run = mel_get_run(&mel);  // get another run
           }
           //run -= (c_q == 0) ? 2 : 0;
           //t0 = (c_q != 0 || run == -1) ? t0 : 0;
           //if (run < 0)
           //  run = mel_get_run(&mel);  // get another run
-          sp[0] = t0; 
+          sp[0] = t0;
           x += 2;
 
           // prepare context for the next quad; eqn. 1 in ITU T.814
@@ -1220,7 +1220,7 @@ namespace ojph {
           ui16 t1 = 0;
 
           //decode VLC using the context c_q and the head of VLC bitstream
-          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)]; 
+          t1 = vlc_tbl0[c_q + (vlc_val & 0x7F)];
 
           // if context is zero, use one MEL event
           if (c_q == 0 && x < width) //zero context
@@ -1246,7 +1246,7 @@ namespace ojph {
 
           //remove data from vlc stream, if qinf is not used, cwdlen is 0
           vlc_val = rev_advance(&vlc, t1 & 0x7);
-          
+
           // decode u
           /////////////
           // uvlc_mode is made up of u_offset bits from the quad pair
@@ -1269,8 +1269,8 @@ namespace ojph {
           //decode uvlc_mode to get u for both quads
           ui32 uvlc_entry = uvlc_tbl0[uvlc_mode + (vlc_val & 0x3F)];
           //remove total prefix length
-          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7); 
-          uvlc_entry >>= 3; 
+          vlc_val = rev_advance(&vlc, uvlc_entry & 0x7);
+          uvlc_entry >>= 3;
           //extract suffixes for quad 0 and 1
           ui32 len = uvlc_entry & 0xF;           //suffix length for 2 quads
           ui32 tmp = vlc_val & ((1 << len) - 1); //suffix value for 2 quads
@@ -1280,9 +1280,9 @@ namespace ojph {
           len = uvlc_entry & 0x7; // quad 0 suffix length
           uvlc_entry >>= 3;
           ui16 u_q = (ui16)(1 + (uvlc_entry&7) + (tmp&~(0xFFU<<len))); //kap. 1
-          sp[1] = u_q; 
+          sp[1] = u_q;
           u_q = (ui16)(1 + (uvlc_entry >> 3) + (tmp >> len));  //kappa == 1
-          sp[3] = u_q; 
+          sp[3] = u_q;
         }
         sp[0] = sp[1] = 0;
 
@@ -1312,13 +1312,13 @@ namespace ojph {
             {
               run -= 2; //subtract 2, since events number is multiplied by 2
 
-              // Is the run terminated in 1? if so, use decoded VLC code, 
-              // otherwise, discard decoded data, since we will decoded again 
+              // Is the run terminated in 1? if so, use decoded VLC code,
+              // otherwise, discard decoded data, since we will decoded again
               // using a different context
               t0 = (run == -1) ? t0 : 0;
 
               // is run -1 or -2? this means a run has been consumed
-              if (run < 0) 
+              if (run < 0)
                 run = mel_get_run(&mel);  // get another run
             }
             //run -= (c_q == 0) ? 2 : 0;
@@ -1344,7 +1344,7 @@ namespace ojph {
             ui16 t1 = 0;
 
             //decode VLC using the context c_q and the head of VLC bitstream
-            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)]; 
+            t1 = vlc_tbl1[ c_q + (vlc_val & 0x7F)];
 
             // if context is zero, use one MEL event
             if (c_q == 0 && x < width) //zero context
@@ -1362,7 +1362,7 @@ namespace ojph {
             //t1 = (c_q != 0 || run == -1) ? t1 : 0;
             //if (run < 0)
             //  run = mel_get_run(&mel);  // get another run
-            sp[2] = t1; 
+            sp[2] = t1;
             x += 2;
 
             // partial c_q, will be completed when we process the next quad
@@ -1373,7 +1373,7 @@ namespace ojph {
 
             //remove data from vlc stream, if qinf is not used, cwdlen is 0
             vlc_val = rev_advance(&vlc, t1 & 0x7);
-          
+
             // decode u
             /////////////
             // uvlc_mode is made up of u_offset bits from the quad pair
@@ -1449,10 +1449,10 @@ namespace ojph {
             w0 = wasm_v128_load(vp);
             w0 = wasm_v128_and(w0, wasm_i32x4_const(-1,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);            
+            wasm_v128_store(vp, w0);
 
-            //interleave in ssse3 style 
-                 
+            //interleave in ssse3 style
+
             w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
             w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
             row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
@@ -1516,7 +1516,7 @@ namespace ojph {
               v128_t gamma, emax, kappa, u_q; // needed locally
 
               inf_u_q = wasm_v128_load(sp);
-              gamma = 
+              gamma =
                 wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
               w0 = wasm_i32x4_sub(gamma, wasm_i32x4_const(OJPH_REPEAT4(1)));
               gamma = wasm_v128_and(gamma, w0);
@@ -1524,7 +1524,7 @@ namespace ojph {
 
               emax = wasm_v128_load(vp + v_n_size);
               w0 = wasm_i32x4_shuffle(emax, wasm_i64x2_const(0,0), 1, 2, 3, 4);
-              emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3              
+              emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3
               emax = wasm_v128_andnot(emax, gamma);
 
               kappa = wasm_i32x4_const(OJPH_REPEAT4(1));
@@ -1545,19 +1545,19 @@ namespace ojph {
             w0 = wasm_v128_load(vp);
             w0 = wasm_v128_and(w0, wasm_i32x4_const(-1,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);  
+            wasm_v128_store(vp, w0);
 
             //interleave in ssse3 style
-            w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5); 
-            w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7); 
-            row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5); 
-            row1 = wasm_i32x4_shuffle(w0, w1, 2, 6, 3, 7); 
+            w0 = wasm_i32x4_shuffle(row0, row1, 0, 4, 1, 5);
+            w1 = wasm_i32x4_shuffle(row0, row1, 2, 6, 3, 7);
+            row0 = wasm_i32x4_shuffle(w0, w1, 0, 4, 1, 5);
+            row1 = wasm_i32x4_shuffle(w0, w1, 2, 6, 3, 7);
             wasm_v128_store(dp, row0);
             wasm_v128_store(dp + stride, row1);
           }
         }
       }
-      else 
+      else
       {
         // reduce bitplane by 16 because we now have 16 bits instead of 32
         p -= 16;
@@ -1601,15 +1601,15 @@ namespace ojph {
             w0 = wasm_v128_load(vp);
             w0 = wasm_v128_and(w0, wasm_i16x8_const(-1,0,0,0,0,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);  
+            wasm_v128_store(vp, w0);
 
-            //interleave in ssse3 style 
-            w0 = wasm_i8x16_swizzle(row, 
-              wasm_i16x8_const(-1, 0x0100, -1, 0x0504, 
+            //interleave in ssse3 style
+            w0 = wasm_i8x16_swizzle(row,
+              wasm_i16x8_const(-1, 0x0100, -1, 0x0504,
                                -1, 0x0908, -1, 0x0D0C));
             wasm_v128_store(dp, w0);
-            w1 = wasm_i8x16_swizzle(row, 
-              wasm_i16x8_const(-1, 0x0302, -1, 0x0706, 
+            w1 = wasm_i8x16_swizzle(row,
+              wasm_i16x8_const(-1, 0x0302, -1, 0x0706,
                                -1, 0x0B0A, -1, 0x0F0E));
             wasm_v128_store(dp + stride, w1);
           }
@@ -1664,18 +1664,18 @@ namespace ojph {
               v128_t gamma, emax, kappa, u_q; // needed locally
 
               inf_u_q = wasm_v128_load(sp);
-              gamma = 
+              gamma =
                 wasm_v128_and(inf_u_q, wasm_i32x4_const(OJPH_REPEAT4(0xF0)));
               w0 = wasm_i32x4_sub(gamma, wasm_i32x4_const(OJPH_REPEAT4(1)));
               gamma = wasm_v128_and(gamma, w0);
               gamma = wasm_i32x4_eq(gamma, wasm_i64x2_const(0, 0));
 
               emax = wasm_v128_load(vp + v_n_size);
-              w0 = wasm_i16x8_shuffle(emax, 
+              w0 = wasm_i16x8_shuffle(emax,
                 wasm_i64x2_const(0, 0), 1, 2, 3, 4, 5, 6, 7, 8);
               emax = wasm_i16x8_max(w0, emax); // no max_epi32 in ssse3
-              emax = wasm_i8x16_swizzle(emax, 
-                wasm_i16x8_const(0x0100, -1, 0x0302, -1, 
+              emax = wasm_i8x16_swizzle(emax,
+                wasm_i16x8_const(0x0100, -1, 0x0302, -1,
                                  0x0504, -1, 0x0706, -1));
               emax = wasm_v128_andnot(emax, gamma);
 
@@ -1696,14 +1696,14 @@ namespace ojph {
             w0 = wasm_v128_load(vp);
             w0 = wasm_v128_and(w0, wasm_i16x8_const(-1,0,0,0,0,0,0,0));
             w0 = wasm_v128_or(w0, vn);
-            wasm_v128_store(vp, w0);  
+            wasm_v128_store(vp, w0);
 
-            w0 = wasm_i8x16_swizzle(row, 
-              wasm_i16x8_const(-1, 0x0100, -1, 0x0504, 
+            w0 = wasm_i8x16_swizzle(row,
+              wasm_i16x8_const(-1, 0x0100, -1, 0x0504,
                                -1, 0x0908, -1, 0x0D0C));
             wasm_v128_store(dp, w0);
-            w1 = wasm_i8x16_swizzle(row, 
-              wasm_i16x8_const(-1, 0x0302, -1, 0x0706, 
+            w1 = wasm_i8x16_swizzle(row,
+              wasm_i16x8_const(-1, 0x0302, -1, 0x0706,
                                -1, 0x0B0A, -1, 0x0F0E));
             wasm_v128_store(dp + stride, w1);
           }
@@ -1717,7 +1717,7 @@ namespace ojph {
       {
         // We use scratch again, we can divide it into multiple regions
         // sigma holds all the significant samples, and it cannot
-        // be modified after it is set.  it will be used during the 
+        // be modified after it is set.  it will be used during the
         // Magnitude Refinement Pass
         ui16* const sigma = scratch;
 
@@ -1734,11 +1734,11 @@ namespace ojph {
           const v128_t mask_3 = wasm_i32x4_const(OJPH_REPEAT4(0x30));
           const v128_t mask_C = wasm_i32x4_const(OJPH_REPEAT4(0xC0));
           const v128_t shuffle_mask = wasm_i32x4_const(0x0C080400,-1,-1,-1);
-          for (y = 0; y < height; y += 4) 
+          for (y = 0; y < height; y += 4)
           {
             ui16* sp = scratch + (y >> 1) * sstr;
             ui16* dp = sigma + (y >> 2) * mstr;
-            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2) 
+            for (ui32 x = 0; x < width; x += 8, sp += 8, dp += 2)
             {
               v128_t s0, s1, u3, uC, t0, t1;
 
@@ -1825,13 +1825,13 @@ namespace ojph {
               // We need data for at least 5 columns out of 8.
               // Therefore loading 32 bits is easier than loading 16 bits
               // twice.
-              ui32 ps = *(ui32*)prev_sig;
-              ui32 ns = *(ui32*)(cur_sig + mstr);
+              ui32 ps; memcpy(&ps, prev_sig, sizeof(ps));
+              ui32 ns; memcpy(&ns, cur_sig + mstr, sizeof(ns));
               ui32 u = (ps & 0x88888888) >> 3; // the row on top
               if (!stripe_causal)
                 u |= (ns & 0x11111111) << 3;   // the row below
 
-              ui32 cs = *(ui32*)cur_sig;
+              ui32 cs; memcpy(&cs, cur_sig, sizeof(cs));
               // vertical integration
               ui32 mbr =  cs;                // this sig. info.
               mbr |= (cs & 0x77777777) << 1; //above neighbors
@@ -1927,17 +1927,17 @@ namespace ojph {
                   // find cumulative sums
                   // to find which bit in cwd we should extract
                   v128_t ex_sum, shfl, inc_sum = new_sig_vec; // inclusive scan
-                  inc_sum = wasm_i8x16_abs(inc_sum); // cvrt to 0 or 1                  
+                  inc_sum = wasm_i8x16_abs(inc_sum); // cvrt to 0 or 1
                   shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
                     15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum,
                     7, 8, 9, 10, 11, 12, 13, 14);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum,
                     3, 4, 5, 6);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                  shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                  shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum,
                     1, 2);
                   inc_sum = wasm_i8x16_add(inc_sum, shfl);
                   cnt += wasm_u8x16_extract_lane(inc_sum, 15);
@@ -1973,7 +1973,7 @@ namespace ojph {
                     // epi32 is -1 only for coefficient that
                     // are changed during the SPP
                     s0_ns = wasm_i8x16_swizzle(new_sig_vec, m);
-                    s0_ns = wasm_i32x4_eq(s0_ns, 
+                    s0_ns = wasm_i32x4_eq(s0_ns,
                       wasm_i32x4_const(OJPH_REPEAT4(0xFF)));
 
                     // obtain sign for coefficients in SPP
@@ -2047,13 +2047,13 @@ namespace ojph {
                 shfl = wasm_i8x16_shuffle(wasm_i64x2_const(0,0), inc_sum,
                   15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                shfl = wasm_i16x8_shuffle(wasm_i64x2_const(0,0), inc_sum,
                   7, 8, 9, 10, 11, 12, 13, 14);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                shfl = wasm_i32x4_shuffle(wasm_i64x2_const(0,0), inc_sum,
                   3, 4, 5, 6);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
-                shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum, 
+                shfl = wasm_i64x2_shuffle(wasm_i64x2_const(0,0), inc_sum,
                   1, 2);
                 inc_sum = wasm_i8x16_add(inc_sum, shfl);
                 total_bits = wasm_u8x16_extract_lane(inc_sum, 15);
@@ -2069,14 +2069,14 @@ namespace ojph {
                 v128_t cwd_vec = wasm_i16x8_splat((si16)cwd);
                 cwd_vec = wasm_i8x16_swizzle(cwd_vec,
                   wasm_i8x16_const(0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1));
-                cwd_vec = wasm_v128_and(cwd_vec, 
+                cwd_vec = wasm_v128_and(cwd_vec,
                   wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
-                cwd_vec = wasm_i8x16_eq(cwd_vec, 
+                cwd_vec = wasm_i8x16_eq(cwd_vec,
                   wasm_u64x2_const(OJPH_REPEAT2(0x8040201008040201)));
-                cwd_vec = 
+                cwd_vec =
                   wasm_i8x16_add(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
                 cwd_vec = wasm_i8x16_add(cwd_vec, cwd_vec);
-                cwd_vec = 
+                cwd_vec =
                   wasm_v128_or(cwd_vec, wasm_i8x16_const(OJPH_REPEAT16(1)));
 
                 // load data and insert the mrp bit
@@ -2085,7 +2085,7 @@ namespace ojph {
                 ui32 *dp = dpp;
                 for (int c = 0; c < 4; ++c) {
                   v128_t s0, s0_sig, s0_idx, s0_val;
-                  // load coefficients                  
+                  // load coefficients
                   s0 = wasm_v128_load(dp);
                   // find significant samples in this row
                   s0_sig = wasm_i8x16_swizzle(sig_vec, m);

--- a/external/OpenJPH/src/core/coding/ojph_block_encoder.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_encoder.cpp
@@ -44,6 +44,7 @@
 #include <cstring>
 #include <cstdint>
 #include <climits>
+#include <mutex>
 
 #include "ojph_mem.h"
 #include "ojph_arch.h"
@@ -254,16 +255,15 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static bool tables_initialized = false;
-
-    /////////////////////////////////////////////////////////////////////////
     bool initialize_block_encoder_tables() {
-      if (!tables_initialized) {
+      static bool tables_initialized = false;
+      static std::once_flag tables_initialized_flag;
+      std::call_once(tables_initialized_flag, []() {
         memset(vlc_tbl0, 0, 2048 * sizeof(ui16));
         memset(vlc_tbl1, 0, 2048 * sizeof(ui16));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-      }
+      });
       return tables_initialized;
     }
 

--- a/external/OpenJPH/src/core/coding/ojph_block_encoder_avx2.cpp
+++ b/external/OpenJPH/src/core/coding/ojph_block_encoder_avx2.cpp
@@ -6,6 +6,7 @@
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
 // Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -34,6 +35,14 @@
 // File: ojph_block_encoder_avx2.cpp
 //***************************************************************************/
 
+// Apple Clang on Intel produces corrupt bitstreams with several of the
+// scalar optimizations below (branchless VLC drain, 64-bit MagSgn, etc.)
+// for reasons not yet identified. Since this file is x86-only, the guard
+// does not affect Apple Silicon builds (which use NEON, not AVX2).
+#if defined(__apple_build_version__)
+#include "ojph_block_encoder_avx2_apple.h"
+#else
+
 #include "ojph_arch.h"
 #if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
@@ -42,6 +51,7 @@
 #include <cstdint>
 #include <climits>
 #include <immintrin.h>
+#include <mutex>
 
 #include "ojph_mem.h"
 #include "ojph_arch.h"
@@ -71,6 +81,8 @@ namespace ojph {
     static ui32 vlc_tbl1[2048];
 
     //UVLC encoding
+    static ui32 uvlc_tbl_pair1[33 * 33];
+    static ui32 uvlc_tbl_pair2[33 * 33];
     static ui32 ulvc_cwd_pre[33];
     static int ulvc_cwd_pre_len[33];
     static ui32 ulvc_cwd_suf[33];
@@ -221,16 +233,66 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    static bool tables_initialized = false;
+    static void uvlc_init_pair_tables()
+    {
+      for (int uq0 = 0; uq0 < 33; ++uq0) {
+        for (int uq1 = 0; uq1 < 33; ++uq1) {
+          ui32 cwd; int len;
+
+          cwd = 0; len = 0;
+          if (uq0 > 2 && uq1 > 2) {
+            cwd |= ulvc_cwd_pre[uq0 - 2];
+            len += ulvc_cwd_pre_len[uq0 - 2];
+            cwd |= ulvc_cwd_pre[uq1 - 2] << len;
+            len += ulvc_cwd_pre_len[uq1 - 2];
+            cwd |= ulvc_cwd_suf[uq0 - 2] << len;
+            len += ulvc_cwd_suf_len[uq0 - 2];
+            cwd |= ulvc_cwd_suf[uq1 - 2] << len;
+            len += ulvc_cwd_suf_len[uq1 - 2];
+          } else if (uq0 > 2 && uq1 > 0) {
+            cwd |= ulvc_cwd_pre[uq0];
+            len += ulvc_cwd_pre_len[uq0];
+            cwd |= (ui32)(uq1 - 1) << len;
+            len += 1;
+            cwd |= ulvc_cwd_suf[uq0] << len;
+            len += ulvc_cwd_suf_len[uq0];
+          } else {
+            cwd |= ulvc_cwd_pre[uq0];
+            len += ulvc_cwd_pre_len[uq0];
+            cwd |= ulvc_cwd_pre[uq1] << len;
+            len += ulvc_cwd_pre_len[uq1];
+            cwd |= ulvc_cwd_suf[uq0] << len;
+            len += ulvc_cwd_suf_len[uq0];
+            cwd |= ulvc_cwd_suf[uq1] << len;
+            len += ulvc_cwd_suf_len[uq1];
+          }
+          uvlc_tbl_pair1[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
+
+          cwd = 0; len = 0;
+          cwd |= ulvc_cwd_pre[uq0];
+          len += ulvc_cwd_pre_len[uq0];
+          cwd |= ulvc_cwd_pre[uq1] << len;
+          len += ulvc_cwd_pre_len[uq1];
+          cwd |= ulvc_cwd_suf[uq0] << len;
+          len += ulvc_cwd_suf_len[uq0];
+          cwd |= ulvc_cwd_suf[uq1] << len;
+          len += ulvc_cwd_suf_len[uq1];
+          uvlc_tbl_pair2[uq0 * 33 + uq1] = (cwd << 5) | (ui32)len;
+        }
+      }
+    }
 
     /////////////////////////////////////////////////////////////////////////
     bool initialize_block_encoder_tables_avx2() {
-      if (!tables_initialized) {
+      static bool tables_initialized = false;
+      static std::once_flag tables_initialized_flag;
+      std::call_once(tables_initialized_flag, []() {
         memset(vlc_tbl0, 0, 2048 * sizeof(ui32));
         memset(vlc_tbl1, 0, 2048 * sizeof(ui32));
         tables_initialized = vlc_init_tables();
         tables_initialized = tables_initialized && uvlc_init_tables();
-      }
+        uvlc_init_pair_tables();
+      });
       return tables_initialized;
     }
 
@@ -265,16 +327,20 @@ namespace ojph {
       melp->threshold = 1; // this is 1 << mel_exp[melp->k];
     }
 
+    static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
+
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    mel_emit_bit(mel_struct* melp, int v)
+    mel_emit_bits(mel_struct* melp, ui32 bits, int num_bits)
     {
-      melp->tmp = (melp->tmp << 1) + v;
-      melp->remaining_bits--;
-      if (melp->remaining_bits == 0) {
-        melp->buf[melp->pos++] = (ui8)melp->tmp;
-        melp->remaining_bits = (melp->tmp == 0xFF ? 7 : 8);
-        melp->tmp = 0;
+      melp->tmp = (melp->tmp << num_bits) | (int)bits;
+      melp->remaining_bits -= num_bits;
+      if (melp->remaining_bits <= 0) {
+        int excess = -melp->remaining_bits;
+        ui8 byte = (ui8)(melp->tmp >> excess);
+        melp->buf[melp->pos++] = byte;
+        melp->tmp &= (1 << excess) - 1;
+        melp->remaining_bits += 8 - (byte == 0xFF);
       }
     }
 
@@ -282,33 +348,59 @@ namespace ojph {
     static inline void
     mel_encode(mel_struct* melp, bool bit)
     {
-      //MEL exponent
-      static const int mel_exp[13] = {0,0,0,1,1,1,2,2,2,3,3,4,5};
-
       if (bit == false) {
         ++melp->run;
         if (melp->run >= melp->threshold) {
-          mel_emit_bit(melp, 1);
+          mel_emit_bits(melp, 1, 1);
           melp->run = 0;
           melp->k = ojph_min(12, melp->k + 1);
           melp->threshold = 1 << mel_exp[melp->k];
         }
       } else {
-        mel_emit_bit(melp, 0);
         int t = mel_exp[melp->k];
-        while (t > 0) {
-          mel_emit_bit(melp, (melp->run >> --t) & 1);
-        }
+        mel_emit_bits(melp, (ui32)melp->run & ((1u << t) - 1), t + 1);
         melp->run = 0;
         melp->k = ojph_max(0, melp->k - 1);
         melp->threshold = 1 << mel_exp[melp->k];
       }
     }
 
+    //////////////////////////////////////////////////////////////////////////
+    // static inline void
+    // mel_advance_run(mel_struct* melp, ui32 n)
+    // {
+    //   ui32 remaining = n;
+    //   while (remaining > 0) {
+    //     ui32 space = (ui32)melp->threshold - (ui32)melp->run;
+    //     if (remaining >= space) {
+    //       remaining -= space;
+    //       mel_emit_bits(melp, 1, 1);
+    //       melp->run = 0;
+    //       melp->k = ojph_min(12, melp->k + 1);
+    //       melp->threshold = 1 << mel_exp[melp->k];
+    //     } else {
+    //       melp->run += (int)remaining;
+    //       remaining = 0;
+    //     }
+    //   }
+    // }
+
+    //////////////////////////////////////////////////////////////////////////
+    // static inline void
+    // mel_encode_significance(mel_struct* melp)
+    // {
+    //   int t = mel_exp[melp->k];
+    //   mel_emit_bits(melp, melp->run & ((1u << t) - 1), t + 1);
+    //   melp->run = 0;
+    //   melp->k = ojph_max(0, melp->k - 1);
+    //   melp->threshold = 1 << mel_exp[melp->k];
+    // }
+
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct vlc_struct_avx2 {
+
+    struct vlc_struct {
       //storage
       ui8* buf;      //pointer to data buffer
       ui32 pos;      //position of next writing within buf
@@ -321,7 +413,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct_avx2* vlcp, ui32 buffer_size, ui8* data)
+    vlc_init(vlc_struct* vlcp, ui32 buffer_size, ui8* data)
     {
       vlcp->buf = data + buffer_size - 1; //points to last byte
       vlcp->pos = 1;                      //locations will be all -pos
@@ -335,39 +427,40 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_encode(vlc_struct_avx2* vlcp, ui32 cwd, int cwd_len)
+    vlc_drain(vlc_struct* vlcp)
     {
-      vlcp->tmp |= (ui64)cwd << vlcp->used_bits;
-      vlcp->used_bits += cwd_len;
-
       while (vlcp->used_bits >= 8) {
-          ui8 tmp;
+        int escape = (int)vlcp->last_greater_than_8F;
+        int is_7f = (int)((vlcp->tmp & 0x7F) == 0x7F);
+        int need_stuff = (escape & is_7f) != 0 ? 1 : 0;
+        int bits = 8 - need_stuff;
 
-          if (unlikely(vlcp->last_greater_than_8F)) {
-              tmp = vlcp->tmp & 0x7F;
+        ui8 byte = (ui8)(vlcp->tmp & ((1u << bits) - 1));
+        *(vlcp->buf - vlcp->pos) = byte;
+        vlcp->pos++;
+        vlcp->tmp >>= bits;
+        vlcp->used_bits -= bits;
+        vlcp->last_greater_than_8F = byte > 0x8F;
+      }
+    }
 
-              if (likely(tmp != 0x7F)) {
-                  tmp = vlcp->tmp & 0xFF;
-                  *(vlcp->buf - vlcp->pos) = tmp;
-                  vlcp->last_greater_than_8F = tmp > 0x8F;
-                  vlcp->tmp >>= 8;
-                  vlcp->used_bits -= 8;
-              } else {
-                  *(vlcp->buf - vlcp->pos) = tmp;
-                  vlcp->last_greater_than_8F = false;
-                  vlcp->tmp >>= 7;
-                  vlcp->used_bits -= 7;
-              }
-
-          } else {
-              tmp = vlcp->tmp & 0xFF;
-              *(vlcp->buf - vlcp->pos) = tmp;
-              vlcp->last_greater_than_8F = tmp > 0x8F;
-              vlcp->tmp >>= 8;
-              vlcp->used_bits -= 8;
-          }
-
-          vlcp->pos++;
+    //////////////////////////////////////////////////////////////////////////
+    static inline void
+    vlc_encode(vlc_struct* vlcp, ui64 cwd, int cwd_len)
+    {
+      while (true) {
+        int avail = 64 - vlcp->used_bits;
+        if (likely(avail > 0 && cwd_len <= avail)) {
+          vlcp->tmp |= cwd << vlcp->used_bits;
+          vlcp->used_bits += cwd_len;
+          return;
+        }
+        if (likely(avail > 0)) // available space smaller than needed
+          vlcp->tmp |= cwd << vlcp->used_bits;
+        vlcp->used_bits = 64;
+        vlc_drain(vlcp);
+        cwd >>= avail;
+        cwd_len -= avail;
       }
     }
 
@@ -375,10 +468,10 @@ namespace ojph {
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx2* vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct* vlcp)
     {
       if (melp->run > 0)
-        mel_emit_bit(melp, 1);
+        mel_emit_bits(melp, 1, 1);
 
       if (vlcp->last_greater_than_8F && (vlcp->tmp & 0x7f) == 0x7f) {
         *(vlcp->buf - vlcp->pos) = 0x7f;
@@ -416,15 +509,16 @@ namespace ojph {
 /////////////////////////////////////////////////////////////////////////
 //
 /////////////////////////////////////////////////////////////////////////
+
     struct ms_struct {
       //storage
-      ui8* buf;      //pointer to data buffer
-      ui32 pos;      //position of next writing within buf
-      ui32 buf_size; //size of buffer, which we must not exceed
+      ui8* buf;        //pointer to data buffer
+      ui32 pos;        //position of next writing within buf
+      ui32 buf_size;   //size of buffer, which we must not exceed
 
-      int max_bits;  //maximum number of bits that can be store in tmp
-      int used_bits; //number of occupied bits in tmp
-      ui32 tmp;      //temporary storage of coded bits
+      int used_bits;   //number of occupied bits in tmp
+      ui64 tmp;        //temporary storage of coded bits (64-bit accumulator)
+      bool last_was_ff;//true if the last written byte was 0xFF
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -434,51 +528,129 @@ namespace ojph {
       msp->buf = data;
       msp->pos = 0;
       msp->buf_size = buffer_size;
-      msp->max_bits = 8;
       msp->used_bits = 0;
       msp->tmp = 0;
+      msp->last_was_ff = false;
     }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    ms_encode(ms_struct* msp, ui64 cwd, int cwd_len)
+    ms_drain(ms_struct* msp)
     {
-      while (cwd_len > 0)
-      {
-        if (msp->pos >= msp->buf_size)
-          OJPH_ERROR(0x00020005, "magnitude sign encoder's buffer is full");
-        int t = ojph_min(msp->max_bits - msp->used_bits, cwd_len);
-        msp->tmp |= ((ui32)(cwd & ((1U << t) - 1))) << msp->used_bits;
-        msp->used_bits += t;
-        cwd >>= t;
-        cwd_len -= t;
-        if (msp->used_bits >= msp->max_bits)
-        {
-          msp->buf[msp->pos++] = (ui8)msp->tmp;
-          msp->max_bits = (msp->tmp == 0xFF) ? 7 : 8;
-          msp->tmp = 0;
-          msp->used_bits = 0;
+      if (msp->last_was_ff) {
+        if (msp->used_bits < 7)
+          return;
+        msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
+        msp->tmp >>= 7;
+        msp->used_bits -= 7;
+        msp->last_was_ff = false;
+      }
+
+      while (msp->used_bits >= 8) {
+        int n_bytes = msp->used_bits >> 3;
+        if (n_bytes > 8) n_bytes = 8;
+
+        ui64 word = msp->tmp;
+        ui64 valid_mask = (n_bytes < 8)
+                        ? (1ULL << (n_bytes * 8)) - 1 : ~(ui64)0;
+
+        ui64 w = ~word;
+        ui64 ff_detect = (w - 0x0101010101010101ULL) & ~w
+                       & 0x8080808080808080ULL;
+        ff_detect &= valid_mask;
+
+        if (likely(ff_detect == 0)) {
+          memcpy(msp->buf + msp->pos, &word, (size_t)n_bytes);
+          msp->pos += (ui32)n_bytes;
+          if (n_bytes < 8)
+            msp->tmp >>= (n_bytes * 8);
+          else
+            msp->tmp = 0;
+          msp->used_bits -= n_bytes * 8;
+        } else {
+          int ff_pos = (int)(count_trailing_zeros(ff_detect) >> 3);
+          int safe = ff_pos + 1;
+          memcpy(msp->buf + msp->pos, &word, (size_t)safe);
+          msp->pos += (ui32)safe;
+          int bits = safe * 8;
+          if (bits < 64)
+            msp->tmp >>= bits;
+          else
+            msp->tmp = 0;
+          msp->used_bits -= bits;
+
+          if (msp->used_bits >= 7) {
+            msp->buf[msp->pos++] = (ui8)(msp->tmp & 0x7F);
+            msp->tmp >>= 7;
+            msp->used_bits -= 7;
+            msp->last_was_ff = false;
+          } else {
+            msp->last_was_ff = true;
+            return;
+          }
         }
       }
     }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline void
+    ms_encode_nodefer(ms_struct* msp, ui64 cwd, int cwd_len)
+    {
+      while (true) {
+        int avail = 64 - msp->used_bits;
+        if (likely(avail > 0 && cwd_len <= avail)) {
+          msp->tmp |= cwd << msp->used_bits;
+          msp->used_bits += cwd_len;
+          return;
+        }
+        if (likely(avail > 0)) // available space smaller than needed
+          msp->tmp |= cwd << msp->used_bits;
+        msp->used_bits = 64;
+        ms_drain(msp);
+        cwd >>= avail;
+        cwd_len -= avail;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // static inline void
+    // ms_encode(ms_struct* msp, ui64 cwd, int cwd_len)
+    // {
+    //   int avail = 64 - msp->used_bits;
+    //   if (likely(cwd_len <= avail)) {
+    //     msp->tmp |= cwd << msp->used_bits;
+    //     msp->used_bits += cwd_len;
+    //   } else {
+    //     msp->tmp |= (cwd & ((1ULL << avail) - 1)) << msp->used_bits;
+    //     msp->used_bits = 64;
+    //     ms_drain(msp);
+    //     cwd >>= avail;
+    //     cwd_len -= avail;
+    //     msp->tmp |= cwd << msp->used_bits;
+    //     msp->used_bits += cwd_len;
+    //   }
+    //   ms_drain(msp);
+    // }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
     ms_terminate(ms_struct* msp)
     {
+      ms_drain(msp);
       if (msp->used_bits)
       {
-        int t = msp->max_bits - msp->used_bits; //unused bits
-        msp->tmp |= (0xFF & ((1U << t) - 1)) << msp->used_bits;
-        msp->used_bits += t;
-        if (msp->tmp != 0xFF)
+        int max_bits = msp->last_was_ff ? 7 : 8;
+        int t = max_bits - msp->used_bits;
+        ui32 byte = (ui32)(msp->tmp & ((1ULL << msp->used_bits) - 1));
+        byte |= (0xFFu & ((1u << t) - 1)) << msp->used_bits;
+        if (byte != 0xFF)
         {
           if (msp->pos >= msp->buf_size)
             OJPH_ERROR(0x00020006, "magnitude sign encoder's buffer is full");
-          msp->buf[msp->pos++] = (ui8)msp->tmp;
+          msp->buf[msp->pos++] = (ui8)byte;
         }
       }
-      else if (msp->max_bits == 7)
+      else if (msp->last_was_ff)
         msp->pos--;
     }
 
@@ -665,23 +837,10 @@ static void proc_ms_encode(ms_struct *msp,
     m_vec[3] = _mm256_and_si256(mask, tmp);
 
     rotate_matrix(m_vec);
-    /* s_vec from
-     * s_vec[0]:[0, 0], [0, 2] ... [0,14], [0, 16], [0, 18] ... [0,30]
-     * s_vec[1]:[1, 0], [1, 2] ... [1,14], [1, 16], [1, 18] ... [1,30]
-     * s_vec[2]:[0, 1], [0, 3] ... [0,15], [0, 17], [0, 19] ... [0,31]
-     * s_vec[3]:[1, 1], [1, 3] ... [1,15], [1, 17], [1, 19] ... [1,31]
-     * to
-     * s_vec[0]:[0, 0], [1, 0], [0, 1], [1, 1], [0, 2], [1, 2]...[0, 7], [1, 7]
-     * s_vec[1]:[0, 8], [1, 8], [0, 9], [1, 9], [0,10], [1,10]...[0,15], [1,15]
-     * s_vec[2]:[0,16], [1,16], [0,17], [1,17], [0,18], [1,18]...[0,23], [1,23]
-     * s_vec[3]:[0,24], [1,24], [0,25], [1,25], [0,26], [1,26]...[0,31], [1,31]
-     */
     rotate_matrix(s_vec);
 
     ui32 cwd[8];
     int cwd_len[8];
-    ui64 _cwd = 0;
-    int _cwd_len = 0;
 
     /* Each iteration process 8 bytes * 2 lines */
     for (ui32 i = 0; i < 4; ++i) {
@@ -694,15 +853,32 @@ static void proc_ms_encode(ms_struct *msp,
         tmp = _mm256_and_si256(tmp, s_vec[i]);
         _mm256_storeu_si256((__m256i*)cwd, tmp);
 
-        for (ui32 j = 0; j < 4; ++j) {
-            ui32 idx = j * 2;
-            _cwd     = cwd[idx];
-            _cwd_len = cwd_len[idx];
-            _cwd     |= ((ui64)cwd[idx + 1]) << _cwd_len;
-            _cwd_len += cwd_len[idx + 1];
-            ms_encode(msp, _cwd, _cwd_len);
+        for (ui32 j = 0; j < 4; j += 2) {
+            ui32 idx0 = j * 2;
+            ui64 _cwd     = cwd[idx0];
+            int  _cwd_len = cwd_len[idx0];
+            _cwd     |= ((ui64)cwd[idx0 + 1]) << _cwd_len;
+            _cwd_len += cwd_len[idx0 + 1];
+
+            ui32 idx1 = (j + 1) * 2;
+            int len1 = cwd_len[idx1] + cwd_len[idx1 + 1];
+            if (likely(_cwd_len + len1 <= 64)) {
+                _cwd     |= ((ui64)cwd[idx1]) << _cwd_len;
+                _cwd_len += cwd_len[idx1];
+                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
+                _cwd_len += cwd_len[idx1 + 1];
+                ms_encode_nodefer(msp, _cwd, _cwd_len);
+            } else {
+                ms_encode_nodefer(msp, _cwd, _cwd_len);
+                _cwd     = cwd[idx1];
+                _cwd_len = cwd_len[idx1];
+                _cwd     |= ((ui64)cwd[idx1 + 1]) << _cwd_len;
+                _cwd_len += cwd_len[idx1 + 1];
+                ms_encode_nodefer(msp, _cwd, _cwd_len);
+            }
         }
     }
+    ms_drain(msp);
 }
 
 static __m256i cal_eps_vec(__m256i *eq_vec, __m256i &u_q_vec,
@@ -806,7 +982,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     auto tmp = _mm256_permutevar8x32_epi32(lcxp1_vec, right_shift);
 
 #ifdef OJPH_ARCH_X86_64
-    tmp = _mm256_insert_epi64(tmp, 
+    tmp = _mm256_insert_epi64(tmp,
       _mm_cvtsi128_si64(_mm256_castsi256_si128(cx_val_vec[x + 1])), 3);
 #elif (defined OJPH_ARCH_I386)
     int lsb = _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1]));
@@ -817,7 +993,7 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
     #error Error unsupport compiler
 #endif
     tmp = _mm256_slli_epi32(tmp, 2);
-    auto tmp1 = _mm256_insert_epi32(lcxp1_vec, 
+    auto tmp1 = _mm256_insert_epi32(lcxp1_vec,
       _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1])), 7);
     tmp = _mm256_add_epi32(tmp1, tmp);
 
@@ -830,8 +1006,6 @@ static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
 
     return _mm256_or_si256(tmp, tmp1);
 }
-
-using fn_proc_cq = __m256i (*)(ui32, __m256i *, __m256i &, const __m256i);
 
 static void proc_mel_encode1(mel_struct *melp, __m256i &cq_vec,
                              __m256i &rho_vec, __m256i u_q_vec, ui32 ignore,
@@ -882,133 +1056,183 @@ static void proc_mel_encode2(mel_struct *melp, __m256i &cq_vec,
 {
     ojph_unused(u_q_vec);
     ojph_unused(right_shift);
-    int32_t mel_need_encode[8];
-    int32_t mel_bit[8];
 
-    /* Prepare mel_encode params */
-    /* if (c_q[i] == 0) { */
-    _mm256_storeu_si256((__m256i*)mel_need_encode, _mm256_cmpeq_epi32(cq_vec, ZERO));
-    /*   mel_encode(&mel, rho[i] != 0); */
-    _mm256_storeu_si256((__m256i*)mel_bit, _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
-    /* } */
+    __m256i need = _mm256_cmpeq_epi32(cq_vec, ZERO);
+    ui32 mask = (ui32)_mm256_movemask_epi8(need);
+    mask &= 0x88888888;
 
     ui32 i_max = 8 - (ignore / 2);
+    if (i_max < 8)
+        mask &= (1u << (i_max * 4)) - 1;
 
-    for (ui32 i = 0; i < i_max; ++i) {
-        if (mel_need_encode[i]) {
-            mel_encode(melp, mel_bit[i]);
-        }
+    if (mask == 0)
+        return;
+
+    int32_t mel_bit[8];
+    _mm256_storeu_si256((__m256i*)mel_bit,
+        _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
+
+    while (mask) {
+        ui32 bit_pos = (ui32)count_trailing_zeros(mask);
+        ui32 i = bit_pos / 4;
+        mel_encode(melp, mel_bit[i]);
+        mask &= mask - 1;
     }
 }
 
 using fn_proc_mel_encode = void (*)(mel_struct *, __m256i &, __m256i &,
                                     __m256i, ui32, const __m256i);
 
-static void proc_vlc_encode1(vlc_struct_avx2 *vlcp, ui32 *tuple,
-                             ui32 *u_q, ui32 ignore)
+static inline void
+build_vlc_uvlc_pair(ui32 *tuple, ui32 *u_q, ui32 i,
+                    const ui32 *uvlc_tbl, ui64 &val, int &size)
+{
+    val = tuple[i + 0] >> 4;
+    size = tuple[i + 0] & 7;
+
+    val |= (ui64)(tuple[i + 1] >> 4) << size;
+    size += tuple[i + 1] & 7;
+
+    ui32 entry = uvlc_tbl[u_q[i] * 33 + u_q[i + 1]];
+    val |= (ui64)(entry >> 5) << size;
+    size += entry & 0x1F;
+}
+
+static void proc_vlc_encode(vlc_struct *vlcp, ui32 *tuple,
+                            ui32 *u_q, ui32 ignore, const ui32 *uvlc_tbl)
 {
     ui32 i_max = 8 - (ignore / 2);
 
-    for (ui32 i = 0; i < i_max; i += 2) {
-        /* 7 bits */
-        ui32 val = tuple[i + 0] >> 4;
-        int size = tuple[i + 0] & 7;
-
-        if (i + 1 < i_max) {
-            /* 7 bits */
-            val |= (tuple[i + 1] >> 4) << size;
-            size += tuple[i + 1] & 7;
-        }
-
-        if (u_q[i] > 2 && u_q[i + 1] > 2) {
-            /* 3 bits */
-            val |= (ulvc_cwd_pre[u_q[i] - 2]) << size;
-            size += ulvc_cwd_pre_len[u_q[i] - 2];
-
-            /* 3 bits */
-            val |= (ulvc_cwd_pre[u_q[i + 1] - 2]) << size;
-            size += ulvc_cwd_pre_len[u_q[i + 1] - 2];
-
-            /* 5 bits */
-            val |= (ulvc_cwd_suf[u_q[i] - 2]) << size;
-            size += ulvc_cwd_suf_len[u_q[i] - 2];
-
-            /* 5 bits */
-            val |= (ulvc_cwd_suf[u_q[i + 1] - 2]) << size;
-            size += ulvc_cwd_suf_len[u_q[i + 1] - 2];
-
-        } else if (u_q[i] > 2 && u_q[i + 1] > 0) {
-            /* 3 bits */
-            val |= (ulvc_cwd_pre[u_q[i]]) << size;
-            size += ulvc_cwd_pre_len[u_q[i]];
-
-            /* 1 bit */
-            val |= (u_q[i + 1] - 1) << size;
-            size += 1;
-
-            /* 5 bits */
-            val |= (ulvc_cwd_suf[u_q[i]]) << size;
-            size += ulvc_cwd_suf_len[u_q[i]];
-
-        } else {
-            /* 3 bits */
-            val |= (ulvc_cwd_pre[u_q[i]]) << size;
-            size += ulvc_cwd_pre_len[u_q[i]];
-
-            /* 3 bits */
-            val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
-            size += ulvc_cwd_pre_len[u_q[i + 1]];
-
-            /* 5 bits */
-            val |= (ulvc_cwd_suf[u_q[i]]) << size;
-            size += ulvc_cwd_suf_len[u_q[i]];
-
-            /* 5 bits */
-            val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
-            size += ulvc_cwd_suf_len[u_q[i + 1]];
-        }
-
+    ui32 i = 0;
+    for (; i + 2 < i_max; i += 4) {
+        ui64 val1; int size1;
+        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val1, size1);
+        ui64 val2; int size2;
+        build_vlc_uvlc_pair(tuple, u_q, i + 2, uvlc_tbl, val2, size2);
+        vlc_encode(vlcp, val1 | (val2 << size1), size1 + size2);
+    }
+    if (i < i_max) {
+        ui64 val; int size;
+        build_vlc_uvlc_pair(tuple, u_q, i, uvlc_tbl, val, size);
         vlc_encode(vlcp, val, size);
     }
 }
 
-static void proc_vlc_encode2(vlc_struct_avx2 *vlcp, ui32 *tuple,
-                             ui32 *u_q, ui32 ignore)
+template<int PASS>
+OJPH_FORCE_INLINE void encode_x_loop(
+    ui32 *sp, ui32 stride, ui32 height, ui32 y,
+    ui32 n_loop, ui32 _width, ui32 ignore, ui32 p,
+    mel_struct &mel, vlc_struct &vlc, ms_struct &ms,
+    __m256i *e_val_vec, __m256i &prev_e_val_vec,
+    __m256i *cx_val_vec, __m256i &prev_cx_val_vec,
+    ui32 &prev_cq,
+    const __m256i &right_shift, const __m256i &left_shift)
 {
-    ui32 i_max = 8 - (ignore / 2);
+    ui32 *vlc_tbl = (PASS == 1) ? vlc_tbl0 : vlc_tbl1;
 
-    for (ui32 i = 0; i < i_max; i += 2) {
-        /* 7 bits */
-        ui32 val = tuple[i + 0] >> 4;
-        int size = tuple[i + 0] & 7;
+    __m256i tmp, tmp1;
+    __m256i eq_vec[4];
+    __m256i s_vec[4];
+    __m256i src_vec[4];
 
-        if (i + 1 < i_max) {
-            /* 7 bits */
-            val |= (tuple[i + 1] >> 4) << size;
-            size += tuple[i + 1] & 7;
+    /* 16 bytes per iteration */
+    for (ui32 x = 0; x < n_loop; ++x) {
+
+        /* t = sp[i]; */
+        if ((x == (n_loop - 1)) && (_width % 16)) {
+            ui32 tmp_buf[16] = { 0 };
+            memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
+            src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+            src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+            if (y + 1 < height) {
+                memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
+                src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+            }
+            else {
+                src_vec[1] = ZERO;
+                src_vec[3] = ZERO;
+            }
+        }
+        else {
+            src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
+            src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
+
+            if (y + 1 < height) {
+                src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
+                src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
+            }
+            else {
+                src_vec[1] = ZERO;
+                src_vec[3] = ZERO;
+            }
+            sp += 16;
         }
 
-        /* 3 bits */
-        val |= ulvc_cwd_pre[u_q[i]] << size;
-        size += ulvc_cwd_pre_len[u_q[i]];
+        __m256i rho_vec, e_qmax_vec;
+        proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
 
-        /* 3 bits */
-        val |= (ulvc_cwd_pre[u_q[i + 1]]) << size;
-        size += ulvc_cwd_pre_len[u_q[i + 1]];
+        // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
+        tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
+        tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
 
-        /* 5 bits */
-        val |= (ulvc_cwd_suf[u_q[i + 0]]) << size;
-        size += ulvc_cwd_suf_len[u_q[i + 0]];
+        auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
+        max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
 
-        /* 5 bits */
-        val |= (ulvc_cwd_suf[u_q[i + 1]]) << size;
-        size += ulvc_cwd_suf_len[u_q[i + 1]];
+        // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
+        tmp = _mm256_max_epi32(max_e_vec, ONE);
+        tmp1 = _mm256_sub_epi32(rho_vec, ONE);
+        tmp1 = _mm256_and_si256(rho_vec, tmp1);
 
-        vlc_encode(vlcp, val, size);
+        auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
+        auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
+        auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
+        const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
+
+        if (PASS == 1)
+            tmp = proc_cq1(x, cx_val_vec, rho_vec, right_shift);
+        else
+            tmp = proc_cq2(x, cx_val_vec, rho_vec, right_shift);
+
+        auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
+        cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
+        prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
+
+        update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
+        update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
+
+        /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
+        /* u_q[i] = Uq[i] - kappa[i]; */
+        auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
+        auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
+
+        auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
+        __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
+        ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
+
+        if (PASS == 1)
+            proc_mel_encode1(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
+                             right_shift);
+        else
+            proc_mel_encode2(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
+                             right_shift);
+
+        proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
+
+        ui32 u_q[10];
+        ui32 tuple[10];
+        tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
+        _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
+        _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
+        {
+          ui32 i_max = 8 - (_ignore / 2);
+          if (i_max & 1) { tuple[i_max] = 0; u_q[i_max] = 0; }
+          tuple[8] = 0; u_q[8] = 0;
+        }
+        proc_vlc_encode(&vlc, tuple, u_q, _ignore,
+            (PASS == 1) ? uvlc_tbl_pair1 : uvlc_tbl_pair2);
     }
 }
-
-using fn_proc_vlc_encode = void (*)(vlc_struct_avx2 *, ui32 *, ui32 *, ui32);
 
 void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
                                 ui32 num_passes, ui32 _width, ui32 height,
@@ -1032,7 +1256,7 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     mel_struct mel;
     mel_init(&mel, mel_size, mel_buf);
-    vlc_struct_avx2 vlc;
+    vlc_struct vlc;
     vlc_init(&vlc, vlc_size, vlc_buf);
     ms_struct ms;
     ms_init(&ms, ms_size, ms_buf);
@@ -1059,9 +1283,9 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
     ui32 n_loop = (width + 15) / 16;
 
     __m256i e_val_vec[65];
-    for (ui32 i = 0; i <ojph_min(64, n_loop); ++i) {
+    for (ui32 i = 0; i < ojph_min(64, n_loop); ++i)
         e_val_vec[i] = ZERO;
-    }
+
     __m256i prev_e_val_vec = ZERO;
 
     __m256i cx_val_vec[65];
@@ -1069,21 +1293,14 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
     ui32 prev_cq = 0;
 
-    __m256i eq_vec[4];
-    __m256i s_vec[4];
-    __m256i src_vec[4];
-
-    ui32 *vlc_tbl = vlc_tbl0;
-    fn_proc_cq proc_cq = proc_cq1;
-    fn_proc_mel_encode proc_mel_encode = proc_mel_encode1;
-    fn_proc_vlc_encode proc_vlc_encode = proc_vlc_encode1;
+    __m256i tmp;
 
     /* 2 lines per iteration */
     for (ui32 y = 0; y < height; y += 2)
     {
         e_val_vec[n_loop] = prev_e_val_vec;
         /* lcxp[0] = (ui8)((rho[0] & 8) >> 3); */
-        __m256i tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
+        tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
         cx_val_vec[n_loop] = _mm256_srli_epi32(tmp, 3);
 
         prev_e_val_vec = ZERO;
@@ -1091,119 +1308,27 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 
         ui32 *sp = buf + y * stride;
 
-        /* 16 bytes per iteration */
-        for (ui32 x = 0; x < n_loop; ++x) {
-
-            /* t = sp[i]; */
-            if ((x == (n_loop - 1)) && (_width % 16)) {
-                ui32 tmp_buf[16] = { 0 };
-                memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
-                src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-                src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-                if (y + 1 < height) {
-                    memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
-                    src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
-                    src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
-                }
-                else {
-                    src_vec[1] = ZERO;
-                    src_vec[3] = ZERO;
-                }
-            }
-            else {
-                src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
-                src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
-
-                if (y + 1 < height) {
-                    src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
-                    src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
-                }
-                else {
-                    src_vec[1] = ZERO;
-                    src_vec[3] = ZERO;
-                }
-                sp += 16;
-            }
-
-            /* src_vec layout:
-             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5],.[0, 6],.[0, 7]
-             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5],.[1, 6],.[1, 7]
-             * src_vec[2]:[0, 8],[0, 9],[0,10],[0,11],[0,12],[0,13],.[0,14], [0,15]
-             * src_vec[3]:[1, 8],[1, 9],[1,10],[1,11],[1,12],[1,13],.[1,14], [1,15]
-             */
-            __m256i rho_vec, e_qmax_vec;
-            proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
-
-            // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
-            tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
-            tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
-
-            auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
-            max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
-
-            // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
-            tmp = _mm256_max_epi32(max_e_vec, ONE);
-            __m256i tmp1 = _mm256_sub_epi32(rho_vec, ONE);
-            tmp1 = _mm256_and_si256(rho_vec, tmp1);
-
-            auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
-            auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
-            auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
-            const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
-
-            /* cq[1 - 16] = cq_vec
-             * cq[0] = prev_cq_vec[0]
-             */
-            tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
-
-            auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
-            cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
-            prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
-
-            update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
-            update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
-
-            /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
-            /* u_q[i] = Uq[i] - kappa[i]; */
-            auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
-            auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
-
-            auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
-            __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
-            ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
-
-            proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
-                            right_shift);
-
-            proc_ms_encode(&ms, tuple_vec, uq_vec, rho_vec, s_vec);
-
-            // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
-            // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
-            ui32 u_q[8];
-            ui32 tuple[8];
-            /* The tuple is scaled by 4 due to:
-             * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
-             * So in the vlc_encode, the tuple will only be scaled by 2.
-             */
-            tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
-            _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
-            _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
-
-            proc_vlc_encode(&vlc, tuple, u_q, _ignore);
-        }
+        if (y == 0)
+            encode_x_loop<1>(sp, stride, height, y, n_loop, _width,
+                             ignore, p, mel, vlc, ms,
+                             e_val_vec, prev_e_val_vec,
+                             cx_val_vec, prev_cx_val_vec, prev_cq,
+                             right_shift, left_shift);
+        else
+            encode_x_loop<2>(sp, stride, height, y, n_loop, _width,
+                             ignore, p, mel, vlc, ms,
+                             e_val_vec, prev_e_val_vec,
+                             cx_val_vec, prev_cx_val_vec, prev_cq,
+                             right_shift, left_shift);
 
         tmp = _mm256_permutevar8x32_epi32(cx_val_vec[0], right_shift);
         tmp = _mm256_slli_epi32(tmp, 2);
         tmp = _mm256_add_epi32(tmp, cx_val_vec[0]);
         prev_cq = (ui32)_mm_cvtsi128_si32(_mm256_castsi256_si128(tmp));
-
-        proc_cq = proc_cq2;
-        vlc_tbl = vlc_tbl1;
-        proc_mel_encode = proc_mel_encode2;
-        proc_vlc_encode = proc_vlc_encode2;
     }
 
     ms_terminate(&ms);
+    vlc_drain(&vlc);
     terminate_mel_vlc(&mel, &vlc);
 
     //copy to elastic
@@ -1227,3 +1352,4 @@ void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
 } /* namespace ojph */
 
 #endif
+#endif // !defined(__apple_build_version__)

--- a/external/OpenJPH/src/core/coding/ojph_block_encoder_avx2_apple.h
+++ b/external/OpenJPH/src/core/coding/ojph_block_encoder_avx2_apple.h
@@ -5,7 +5,8 @@
 // Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// Copyright (c) 2023, Intel Corporation
+// Copyright (c) 2024, Intel Corporation
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -31,11 +32,11 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //***************************************************************************/
 // This file is part of the OpenJPH software implementation.
-// File: ojph_block_encoder_avx512.cpp
+// File: ojph_block_encoder_avx2.cpp
 //***************************************************************************/
 
 #include "ojph_arch.h"
-#if defined(OJPH_ARCH_X86_64)
+#if defined(OJPH_ARCH_I386) || defined(OJPH_ARCH_X86_64)
 
 #include <cassert>
 #include <cstring>
@@ -45,6 +46,7 @@
 #include <mutex>
 
 #include "ojph_mem.h"
+#include "ojph_arch.h"
 #include "ojph_block_encoder.h"
 #include "ojph_message.h"
 
@@ -221,7 +223,7 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    bool initialize_block_encoder_tables_avx512() {
+    bool initialize_block_encoder_tables_avx2() {
       static bool tables_initialized = false;
       static std::once_flag tables_initialized_flag;
       std::call_once(tables_initialized_flag, []() {
@@ -307,7 +309,7 @@ namespace ojph {
     /////////////////////////////////////////////////////////////////////////
     //
     /////////////////////////////////////////////////////////////////////////
-    struct vlc_struct_avx512 {
+    struct vlc_struct_avx2 {
       //storage
       ui8* buf;      //pointer to data buffer
       ui32 pos;      //position of next writing within buf
@@ -320,7 +322,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_init(vlc_struct_avx512* vlcp, ui32 buffer_size, ui8* data)
+    vlc_init(vlc_struct_avx2* vlcp, ui32 buffer_size, ui8* data)
     {
       vlcp->buf = data + buffer_size - 1; //points to last byte
       vlcp->pos = 1;                      //locations will be all -pos
@@ -334,7 +336,7 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    vlc_encode(vlc_struct_avx512* vlcp, ui32 cwd, int cwd_len)
+    vlc_encode(vlc_struct_avx2* vlcp, ui32 cwd, int cwd_len)
     {
       vlcp->tmp |= (ui64)cwd << vlcp->used_bits;
       vlcp->used_bits += cwd_len;
@@ -374,7 +376,7 @@ namespace ojph {
     //
     //////////////////////////////////////////////////////////////////////////
     static inline void
-    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx512* vlcp)
+    terminate_mel_vlc(mel_struct* melp, vlc_struct_avx2* vlcp)
     {
       if (melp->run > 0)
         mel_emit_bit(melp, 1);
@@ -481,117 +483,112 @@ namespace ojph {
         msp->pos--;
     }
 
-#define ZERO _mm512_setzero_epi32()
-#define ONE  _mm512_set1_epi32(1)
+#define ZERO _mm256_setzero_si256()
+#define ONE  _mm256_set1_epi32(1)
 
-#if 0
-static void print_epi32(const char *msg, __m512i &val)
-{
-    uint32_t A[16] = {0};
+// https://stackoverflow.com/a/58827596
+inline __m256i avx2_lzcnt_epi32(__m256i v) {
+    // prevent value from being rounded up to the next power of two
+    v = _mm256_andnot_si256(_mm256_srli_epi32(v, 8), v);  // keep 8 MSB
 
-    _mm512_store_epi32(A, val);
+    v = _mm256_castps_si256(_mm256_cvtepi32_ps(v));    // convert an integer to float
+    v = _mm256_srli_epi32(v, 23);                   // shift down the exponent
+    v = _mm256_subs_epu16(_mm256_set1_epi32(158), v);  // undo bias
+    v = _mm256_min_epi16(v, _mm256_set1_epi32(32));    // clamp at 32
 
-    printf("%s: ", msg);
-    for (int i = 0; i < 16; ++i) {
-        printf("%X ", A[i]);
-    }
-    printf("\n");
+    return v;
 }
-#endif
 
-static void proc_pixel(__m512i *src_vec, ui32 p,
-                       __m512i *eq_vec, __m512i *s_vec,
-                       __m512i &rho_vec, __m512i &e_qmax_vec)
+inline __m256i avx2_cmpneq_epi32(__m256i v, __m256i v2) {
+    return _mm256_xor_si256(_mm256_cmpeq_epi32(v, v2), _mm256_set1_epi32((int32_t)0xffffffff));
+}
+
+static void proc_pixel(__m256i *src_vec, ui32 p,
+                       __m256i *eq_vec, __m256i *s_vec,
+                       __m256i &rho_vec, __m256i &e_qmax_vec)
 {
-    __m512i val_vec[4];
-    __m512i _eq_vec[4];
-    __m512i _s_vec[4];
-    __m512i _rho_vec[4];
-    ui16 val_mask[4];
+    __m256i val_vec[4];
+    __m256i _eq_vec[4];
+    __m256i _s_vec[4];
+    __m256i _rho_vec[4];
 
     for (ui32 i = 0; i < 4; ++i) {
         /* val = t + t; //multiply by 2 and get rid of sign */
-        val_vec[i] = _mm512_add_epi32(src_vec[i], src_vec[i]);
+        val_vec[i] = _mm256_add_epi32(src_vec[i], src_vec[i]);
 
         /* val >>= p;  // 2 \mu_p + x */
-        val_vec[i] = _mm512_srli_epi32(val_vec[i], p);
+        val_vec[i] = _mm256_srli_epi32(val_vec[i], (int)p);
 
         /* val &= ~1u; // 2 \mu_p */
-        val_vec[i] = _mm512_and_epi32(val_vec[i], _mm512_set1_epi32((int)~1u));
+        val_vec[i] = _mm256_and_si256(val_vec[i], _mm256_set1_epi32((int)~1u));
 
         /* if (val) { */
-        val_mask[i] = _mm512_cmpneq_epi32_mask(val_vec[i], ZERO);
+        const __m256i val_notmask = avx2_cmpneq_epi32(val_vec[i], ZERO);
 
         /*   rho[i] = 1 << i;
          *   rho is processed below.
          */
 
         /*   e_q[i] = 32 - (int)count_leading_ZEROs(--val); //2\mu_p - 1 */
-        val_vec[i] = _mm512_mask_sub_epi32(ZERO, val_mask[i], val_vec[i], ONE);
-        _eq_vec[i] = _mm512_mask_lzcnt_epi32(ZERO, val_mask[i], val_vec[i]);
-        _eq_vec[i] = _mm512_mask_sub_epi32(ZERO, val_mask[i],
-                                           _mm512_set1_epi32(32), _eq_vec[i]);
+        val_vec[i] = _mm256_sub_epi32(val_vec[i], ONE);
+        _eq_vec[i] = avx2_lzcnt_epi32(val_vec[i]);
+        _eq_vec[i] = _mm256_sub_epi32(_mm256_set1_epi32(32), _eq_vec[i]);
 
         /*   e_qmax[i] = ojph_max(e_qmax[i], e_q[j]);
          *   e_qmax is processed below
          */
 
         /*   s[0] = --val + (t >> 31); //v_n = 2(\mu_p-1) + s_n */
-        val_vec[i] = _mm512_mask_sub_epi32(ZERO, val_mask[i], val_vec[i], ONE);
-        _s_vec[i] = _mm512_mask_srli_epi32(ZERO, val_mask[i], src_vec[i], 31);
-        _s_vec[i] =
-          _mm512_mask_add_epi32(ZERO, val_mask[i], _s_vec[i], val_vec[i]);
+        val_vec[i] = _mm256_sub_epi32(val_vec[i], ONE);
+        _s_vec[i] = _mm256_srli_epi32(src_vec[i], 31);
+        _s_vec[i] = _mm256_add_epi32(_s_vec[i], val_vec[i]);
+
+        _eq_vec[i] = _mm256_and_si256(_eq_vec[i], val_notmask);
+        _s_vec[i] = _mm256_and_si256(_s_vec[i], val_notmask);
+        val_vec[i] = _mm256_srli_epi32(val_notmask, 31);
         /* } */
     }
 
-    val_vec[0] = _mm512_mask_mov_epi32(ZERO, val_mask[0], ONE);
-    val_vec[1] = _mm512_mask_mov_epi32(ZERO, val_mask[1], ONE);
-    val_vec[2] = _mm512_mask_mov_epi32(ZERO, val_mask[2], ONE);
-    val_vec[3] = _mm512_mask_mov_epi32(ZERO, val_mask[3], ONE);
-    e_qmax_vec = ZERO;
-
-    const __m512i idx[2] = {
-        _mm512_set_epi32(14, 12, 10, 8, 6, 4, 2, 0, 14, 12, 10, 8, 6, 4, 2, 0),
-        _mm512_set_epi32(15, 13, 11, 9, 7, 5, 3, 1, 15, 13, 11, 9, 7, 5, 3, 1),
-    };
+    const __m256i idx = _mm256_set_epi32(7, 5, 3, 1, 6, 4, 2, 0);
 
     /* Reorder from
-     * *_vec[0]:[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5]...[0,14], [0,15]
-     * *_vec[1]:[1, 0], [1, 1], [1, 2], [1, 3], [1, 4], [1, 5]...[1,14], [1,15]
-     * *_vec[2]:[0,16], [0,17], [0,18], [0,19], [0,20], [0,21]...[0,30], [0,31]
-     * *_vec[3]:[1,16], [1,17], [1,18], [1,19], [1,20], [1,21]...[1,30], [1,31]
+     * *_vec[0]:[0, 0], [0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7]
+     * *_vec[1]:[1, 0], [1, 1], [1, 2], [1, 3], [1, 4], [1, 5],.[1, 6], [1, 7]
+     * *_vec[2]:[0, 8], [0, 9], [0,10], [0,11], [0,12], [0,13], [0,14], [0,15]
+     * *_vec[3]:[1, 8], [1, 9], [1,10], [1,11], [1,12], [1,13], [1,14], [1,15]
      * to
-     * *_vec[0]:[0, 0], [0, 2] ... [0,14], [0,16], [0,18] ... [0,30]
-     * *_vec[1]:[1, 0], [1, 2] ... [1,14], [1,16], [1,18] ... [1,30]
-     * *_vec[2]:[0, 1], [0, 3] ... [0,15], [0,17], [0,19] ... [0,31]
-     * *_vec[3]:[1, 1], [1, 3] ... [1,15], [1,17], [1,19] ... [1,31]
+     * *_vec[0]:[0, 0], [0, 2], [0, 4], [0, 6], [0, 8], [0,10], [0,12], [0,14]
+     * *_vec[1]:[1, 0], [1, 2], [1, 4], [1, 6], [1, 8], [1,10], [1,12], [1,14]
+     * *_vec[2]:[0, 1], [0, 3], [0, 5], [0, 7], [0, 9], [0,11], [0,13], [0,15]
+     * *_vec[3]:[1, 1], [1, 3], [1, 5], [1, 7], [1, 9], [1,11], [1,13], [1,15]
      */
-    for (ui32 i = 0; i < 4; ++i) {
-        ui32 e_idx = i >> 1;
-        ui32 o_idx = i & 0x1;
+    __m256i tmp1, tmp2;
+    for (ui32 i = 0; i < 2; ++i) {
+        tmp1 = _mm256_permutevar8x32_epi32(_eq_vec[0 + i], idx);
+        tmp2 = _mm256_permutevar8x32_epi32(_eq_vec[2 + i], idx);
+        eq_vec[0 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (0 << 0) + (2 << 4));
+        eq_vec[2 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (1 << 0) + (3 << 4));
 
-        eq_vec[i] = _mm512_permutexvar_epi32(idx[e_idx], _eq_vec[o_idx]);
-        eq_vec[i] = _mm512_mask_permutexvar_epi32(eq_vec[i], 0xFF00,
-                                                  idx[e_idx],
-                                                  _eq_vec[o_idx + 2]);
+        tmp1 = _mm256_permutevar8x32_epi32(_s_vec[0 + i], idx);
+        tmp2 = _mm256_permutevar8x32_epi32(_s_vec[2 + i], idx);
+        s_vec[0 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (0 << 0) + (2 << 4));
+        s_vec[2 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (1 << 0) + (3 << 4));
 
-        s_vec[i] = _mm512_permutexvar_epi32(idx[e_idx], _s_vec[o_idx]);
-        s_vec[i] = _mm512_mask_permutexvar_epi32(s_vec[i], 0xFF00,
-                                                 idx[e_idx],
-                                                 _s_vec[o_idx + 2]);
-
-        _rho_vec[i] = _mm512_permutexvar_epi32(idx[e_idx], val_vec[o_idx]);
-        _rho_vec[i] = _mm512_mask_permutexvar_epi32(_rho_vec[i], 0xFF00,
-                                                    idx[e_idx],
-                                                    val_vec[o_idx + 2]);
-        _rho_vec[i] = _mm512_slli_epi32(_rho_vec[i], i);
-
-        e_qmax_vec = _mm512_max_epi32(e_qmax_vec, eq_vec[i]);
+        tmp1 = _mm256_permutevar8x32_epi32(val_vec[0 + i], idx);
+        tmp2 = _mm256_permutevar8x32_epi32(val_vec[2 + i], idx);
+        _rho_vec[0 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (0 << 0) + (2 << 4));
+        _rho_vec[2 + i] = _mm256_permute2x128_si256(tmp1, tmp2, (1 << 0) + (3 << 4));
     }
 
-    rho_vec = _mm512_or_epi32(_rho_vec[0], _rho_vec[1]);
-    rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[2]);
-    rho_vec = _mm512_or_epi32(rho_vec, _rho_vec[3]);
+    e_qmax_vec = _mm256_max_epi32(eq_vec[0], eq_vec[1]);
+    e_qmax_vec = _mm256_max_epi32(e_qmax_vec, eq_vec[2]);
+    e_qmax_vec = _mm256_max_epi32(e_qmax_vec, eq_vec[3]);
+    _rho_vec[1] = _mm256_slli_epi32(_rho_vec[1], 1);
+    _rho_vec[2] = _mm256_slli_epi32(_rho_vec[2], 2);
+    _rho_vec[3] = _mm256_slli_epi32(_rho_vec[3], 3);
+    rho_vec = _mm256_or_si256(_rho_vec[0], _rho_vec[1]);
+    rho_vec = _mm256_or_si256(rho_vec, _rho_vec[2]);
+    rho_vec = _mm256_or_si256(rho_vec, _rho_vec[3]);
 }
 
 /* from [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, ...]
@@ -607,69 +604,66 @@ static void proc_pixel(__m512i *src_vec, ui32 p,
  *
  *      [..]
  */
-static void rotate_matrix(__m512i *matrix)
+static void rotate_matrix(__m256i *matrix)
 {
-    __m512i _matrix[4];
-    _matrix[0] = _mm512_unpacklo_epi32(matrix[0], matrix[1]);
-    _matrix[1] = _mm512_unpackhi_epi32(matrix[0], matrix[1]);
-    _matrix[2] = _mm512_unpacklo_epi32(matrix[2], matrix[3]);
-    _matrix[3] = _mm512_unpackhi_epi32(matrix[2], matrix[3]);
+    __m256i tmp1 = _mm256_unpacklo_epi32(matrix[0], matrix[1]);
+    __m256i tmp2 = _mm256_unpacklo_epi32(matrix[2], matrix[3]);
+    __m256i tmp3 = _mm256_unpackhi_epi32(matrix[0], matrix[1]);
+    __m256i tmp4 = _mm256_unpackhi_epi32(matrix[2], matrix[3]);
 
-    matrix[0] = _mm512_unpacklo_epi64(_matrix[0], _matrix[2]);
-    matrix[1] = _mm512_unpackhi_epi64(_matrix[0], _matrix[2]);
-    matrix[2] = _mm512_unpacklo_epi64(_matrix[1], _matrix[3]);
-    matrix[3] = _mm512_unpackhi_epi64(_matrix[1], _matrix[3]);
+    matrix[0] = _mm256_unpacklo_epi64(tmp1, tmp2);
+    matrix[1] = _mm256_unpacklo_epi64(tmp3, tmp4);
+    matrix[2] = _mm256_unpackhi_epi64(tmp1, tmp2);
+    matrix[3] = _mm256_unpackhi_epi64(tmp3, tmp4);
 
-    _matrix[0] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0x88);
-    _matrix[1] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0x88);
-    _matrix[2] = _mm512_shuffle_i32x4(matrix[0], matrix[1], 0xDD);
-    _matrix[3] = _mm512_shuffle_i32x4(matrix[2], matrix[3], 0xDD);
+    tmp1 = _mm256_permute2x128_si256(matrix[0], matrix[2], 0x20);
+    matrix[2] = _mm256_permute2x128_si256(matrix[0], matrix[2], 0x31);
+    matrix[0] = tmp1;
 
-    matrix[0] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0x88);
-    matrix[1] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0x88);
-    matrix[2] = _mm512_shuffle_i32x4(_matrix[0], _matrix[1], 0xDD);
-    matrix[3] = _mm512_shuffle_i32x4(_matrix[2], _matrix[3], 0xDD);
+    tmp1 = _mm256_permute2x128_si256(matrix[1], matrix[3], 0x20);
+    matrix[3] = _mm256_permute2x128_si256(matrix[1], matrix[3], 0x31);
+    matrix[1] = tmp1;
 }
 
 static void proc_ms_encode(ms_struct *msp,
-                           __m512i &tuple_vec,
-                           __m512i &uq_vec,
-                           __m512i &rho_vec,
-                           __m512i *s_vec)
+                           __m256i &tuple_vec,
+                           __m256i &uq_vec,
+                           __m256i &rho_vec,
+                           __m256i *s_vec)
 {
-    __m512i m_vec[4];
+    __m256i m_vec[4];
 
     /* Prepare parameters for ms_encode */
     /* m = (rho[i] & 1) ? Uq[i] - ((tuple[i] & 1) >> 0) : 0; */
-    auto tmp = _mm512_and_epi32(tuple_vec, ONE);
-    tmp = _mm512_sub_epi32(uq_vec, tmp);
-    auto tmp1 = _mm512_and_epi32(rho_vec, ONE);
-    auto mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-    m_vec[0] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+    auto tmp = _mm256_and_si256(tuple_vec, ONE);
+    tmp = _mm256_sub_epi32(uq_vec, tmp);
+    auto tmp1 = _mm256_and_si256(rho_vec, ONE);
+    auto mask = avx2_cmpneq_epi32(tmp1, ZERO);
+    m_vec[0] = _mm256_and_si256(mask, tmp);
 
     /* m = (rho[i] & 2) ? Uq[i] - ((tuple[i] & 2) >> 1) : 0; */
-    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(2));
-    tmp = _mm512_srli_epi32(tmp, 1);
-    tmp = _mm512_sub_epi32(uq_vec, tmp);
-    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
-    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-    m_vec[1] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+    tmp = _mm256_and_si256(tuple_vec, _mm256_set1_epi32(2));
+    tmp = _mm256_srli_epi32(tmp, 1);
+    tmp = _mm256_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(2));
+    mask = avx2_cmpneq_epi32(tmp1, ZERO);
+    m_vec[1] = _mm256_and_si256(mask, tmp);
 
     /* m = (rho[i] & 4) ? Uq[i] - ((tuple[i] & 4) >> 2) : 0; */
-    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(4));
-    tmp = _mm512_srli_epi32(tmp, 2);
-    tmp = _mm512_sub_epi32(uq_vec, tmp);
-    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
-    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-    m_vec[2] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+    tmp = _mm256_and_si256(tuple_vec, _mm256_set1_epi32(4));
+    tmp = _mm256_srli_epi32(tmp, 2);
+    tmp = _mm256_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(4));
+    mask = avx2_cmpneq_epi32(tmp1, ZERO);
+    m_vec[2] = _mm256_and_si256(mask, tmp);
 
     /* m = (rho[i] & 8) ? Uq[i] - ((tuple[i] & 8) >> 3) : 0; */
-    tmp = _mm512_and_epi32(tuple_vec, _mm512_set1_epi32(8));
-    tmp = _mm512_srli_epi32(tmp, 3);
-    tmp = _mm512_sub_epi32(uq_vec, tmp);
-    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
-    mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-    m_vec[3] = _mm512_mask_mov_epi32(ZERO, mask, tmp);
+    tmp = _mm256_and_si256(tuple_vec, _mm256_set1_epi32(8));
+    tmp = _mm256_srli_epi32(tmp, 3);
+    tmp = _mm256_sub_epi32(uq_vec, tmp);
+    tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(8));
+    mask = avx2_cmpneq_epi32(tmp1, ZERO);
+    m_vec[3] = _mm256_and_si256(mask, tmp);
 
     rotate_matrix(m_vec);
     /* s_vec from
@@ -685,8 +679,8 @@ static void proc_ms_encode(ms_struct *msp,
      */
     rotate_matrix(s_vec);
 
-    ui32 cwd[16];
-    int cwd_len[16];
+    ui32 cwd[8];
+    int cwd_len[8];
     ui64 _cwd = 0;
     int _cwd_len = 0;
 
@@ -695,13 +689,13 @@ static void proc_ms_encode(ms_struct *msp,
         /* cwd = s[i * 4 + 0] & ((1U << m) - 1)
          * cwd_len = m
          */
-        _mm512_storeu_si512(cwd_len, m_vec[i]);
-        tmp = _mm512_sllv_epi32(ONE, m_vec[i]);
-        tmp = _mm512_sub_epi32(tmp, ONE);
-        tmp = _mm512_and_epi32(tmp, s_vec[i]);
-        _mm512_storeu_si512(cwd, tmp);
+        _mm256_storeu_si256((__m256i *)cwd_len, m_vec[i]);
+        tmp = _mm256_sllv_epi32(ONE, m_vec[i]);
+        tmp = _mm256_sub_epi32(tmp, ONE);
+        tmp = _mm256_and_si256(tmp, s_vec[i]);
+        _mm256_storeu_si256((__m256i*)cwd, tmp);
 
-        for (ui32 j = 0; j < 8; ++j) {
+        for (ui32 j = 0; j < 4; ++j) {
             ui32 idx = j * 2;
             _cwd     = cwd[idx];
             _cwd_len = cwd_len[idx];
@@ -712,8 +706,8 @@ static void proc_ms_encode(ms_struct *msp,
     }
 }
 
-static __m512i cal_eps_vec(__m512i *eq_vec, __m512i &u_q_vec,
-                           __m512i &e_qmax_vec)
+static __m256i cal_eps_vec(__m256i *eq_vec, __m256i &u_q_vec,
+                           __m256i &e_qmax_vec)
 {
     /* if (u_q[i] > 0) {
      *     eps[i] |= (e_q[i * 4 + 0] == e_qmax[i]);
@@ -722,188 +716,199 @@ static __m512i cal_eps_vec(__m512i *eq_vec, __m512i &u_q_vec,
      *     eps[i] |= (e_q[i * 4 + 3] == e_qmax[i]) << 3;
      * }
      */
-    auto u_q_mask = _mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
+    auto u_q_mask = _mm256_cmpgt_epi32(u_q_vec, ZERO);
 
-    auto mask = _mm512_cmpeq_epi32_mask(eq_vec[0], e_qmax_vec);
-    auto tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-    auto eps_vec = _mm512_mask_mov_epi32(ZERO, u_q_mask, tmp);
+    auto mask = _mm256_cmpeq_epi32(eq_vec[0], e_qmax_vec);
+    auto eps_vec = _mm256_srli_epi32(mask, 31);
 
-    mask = _mm512_cmpeq_epi32_mask(eq_vec[1], e_qmax_vec);
-    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-    tmp = _mm512_slli_epi32(tmp, 1);
-    eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+    mask = _mm256_cmpeq_epi32(eq_vec[1], e_qmax_vec);
+    auto tmp = _mm256_srli_epi32(mask, 31);
+    tmp = _mm256_slli_epi32(tmp, 1);
+    eps_vec = _mm256_or_si256(eps_vec, tmp);
 
-    mask = _mm512_cmpeq_epi32_mask(eq_vec[2], e_qmax_vec);
-    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-    tmp = _mm512_slli_epi32(tmp, 2);
-    eps_vec = _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+    mask = _mm256_cmpeq_epi32(eq_vec[2], e_qmax_vec);
+    tmp = _mm256_srli_epi32(mask, 31);
+    tmp = _mm256_slli_epi32(tmp, 2);
+    eps_vec = _mm256_or_si256(eps_vec, tmp);
 
-    mask = _mm512_cmpeq_epi32_mask(eq_vec[3], e_qmax_vec);
-    tmp = _mm512_mask_mov_epi32(ZERO, mask, ONE);
-    tmp = _mm512_slli_epi32(tmp, 3);
+    mask = _mm256_cmpeq_epi32(eq_vec[3], e_qmax_vec);
+    tmp = _mm256_srli_epi32(mask, 31);
+    tmp = _mm256_slli_epi32(tmp, 3);
+    eps_vec = _mm256_or_si256(eps_vec, tmp);
 
-    return  _mm512_mask_or_epi32(ZERO, u_q_mask, eps_vec, tmp);
+    return  _mm256_and_si256(u_q_mask, eps_vec);
 }
 
-static void update_lep(ui32 x, __m512i &prev_e_val_vec,
-                       __m512i *eq_vec, __m512i *e_val_vec,
-                       const __m512i left_shift)
+static void update_lep(ui32 x, __m256i &prev_e_val_vec,
+                       __m256i *eq_vec, __m256i *e_val_vec,
+                       const __m256i left_shift)
 {
     /* lep[0] = ojph_max(lep[0], (ui8)e_q[1]); lep++;
      * lep[0] = (ui8)e_q[3];
      * Compare e_q[1] with e_q[3] of the prevous round.
      */
-    auto tmp = _mm512_mask_permutexvar_epi32(prev_e_val_vec, 0xFFFE,
-                                             left_shift, eq_vec[3]);
-    prev_e_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                   eq_vec[3]);
-    e_val_vec[x] = _mm512_max_epi32(eq_vec[1], tmp);
+    auto tmp = _mm256_permutevar8x32_epi32(eq_vec[3], left_shift);
+    tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(prev_e_val_vec)), 0);
+    prev_e_val_vec = _mm256_insert_epi32(ZERO, _mm256_extract_epi32(eq_vec[3], 7), 0);
+    e_val_vec[x] = _mm256_max_epi32(eq_vec[1], tmp);
 }
 
 
-static void update_lcxp(ui32 x, __m512i &prev_cx_val_vec,
-                        __m512i &rho_vec, __m512i *cx_val_vec,
-                        const __m512i left_shift)
+static void update_lcxp(ui32 x, __m256i &prev_cx_val_vec,
+                        __m256i &rho_vec, __m256i *cx_val_vec,
+                        const __m256i left_shift)
 {
     /* lcxp[0] = (ui8)(lcxp[0] | (ui8)((rho[0] & 2) >> 1)); lcxp++;
      * lcxp[0] = (ui8)((rho[0] & 8) >> 3);
      * Or (rho[0] & 2) and (rho[0] of the previous round & 8).
      */
-    auto tmp = _mm512_mask_permutexvar_epi32(prev_cx_val_vec, 0xFFFE,
-                                             left_shift, rho_vec);
-    prev_cx_val_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                    rho_vec);
+    auto tmp = _mm256_permutevar8x32_epi32(rho_vec, left_shift);
+    tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(prev_cx_val_vec)), 0);
+    prev_cx_val_vec = _mm256_insert_epi32(ZERO, _mm256_extract_epi32(rho_vec, 7), 0);
 
-    tmp = _mm512_and_epi32(tmp, _mm512_set1_epi32(8));
-    tmp = _mm512_srli_epi32(tmp, 3);
+    tmp = _mm256_and_si256(tmp, _mm256_set1_epi32(8));
+    tmp = _mm256_srli_epi32(tmp, 3);
 
-    auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(2));
-    tmp1 = _mm512_srli_epi32(tmp1, 1);
-    cx_val_vec[x] = _mm512_or_epi32(tmp, tmp1);
+    auto tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(2));
+    tmp1 = _mm256_srli_epi32(tmp1, 1);
+    cx_val_vec[x] = _mm256_or_si256(tmp, tmp1);
 }
 
-static __m512i cal_tuple(__m512i &cq_vec, __m512i &rho_vec,
-                         __m512i &eps_vec, ui32 *vlc_tbl)
+static __m256i cal_tuple(__m256i &cq_vec, __m256i &rho_vec,
+                         __m256i &eps_vec, ui32 *vlc_tbl)
 {
     /* tuple[i] = vlc_tbl1[(c_q[i] << 8) + (rho[i] << 4) + eps[i]]; */
-    auto tmp = _mm512_slli_epi32(cq_vec, 8);
-    auto tmp1 = _mm512_slli_epi32(rho_vec, 4);
-    tmp = _mm512_add_epi32(tmp, tmp1);
-    tmp = _mm512_add_epi32(tmp, eps_vec);
-    return _mm512_i32gather_epi32(tmp, vlc_tbl, 4);
+    auto tmp = _mm256_slli_epi32(cq_vec, 8);
+    auto tmp1 = _mm256_slli_epi32(rho_vec, 4);
+    tmp = _mm256_add_epi32(tmp, tmp1);
+    tmp = _mm256_add_epi32(tmp, eps_vec);
+    return _mm256_i32gather_epi32((const int *)vlc_tbl, tmp, 4);
 }
 
-static __m512i proc_cq1(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
-                        const __m512i right_shift)
+static __m256i proc_cq1(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
+                        const __m256i right_shift)
 {
     ojph_unused(x);
     ojph_unused(cx_val_vec);
     ojph_unused(right_shift);
 
     /* c_q[i + 1] = (rho[i] >> 1) | (rho[i] & 1); */
-    auto tmp = _mm512_srli_epi32(rho_vec, 1);
-    auto tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(1));
-    return _mm512_or_epi32(tmp, tmp1);
+    auto tmp = _mm256_srli_epi32(rho_vec, 1);
+    auto tmp1 = _mm256_and_si256(rho_vec, ONE);
+    return _mm256_or_si256(tmp, tmp1);
 }
 
-static __m512i proc_cq2(ui32 x, __m512i *cx_val_vec, __m512i &rho_vec,
-                        const __m512i right_shift)
+static __m256i proc_cq2(ui32 x, __m256i *cx_val_vec, __m256i &rho_vec,
+                        const __m256i right_shift)
 {
     // c_q[i + 1] = (lcxp[i + 1] + (lcxp[i + 2] << 2))
     //            | (((rho[i] & 4) >> 1) | ((rho[i] & 8) >> 2));
-    auto lcxp1_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x]);
-    auto lcxp2_vec = _mm512_permutexvar_epi32(right_shift, cx_val_vec[x + 1]);
-    auto tmp = _mm512_permutexvar_epi32(right_shift, lcxp1_vec);
-    tmp = _mm512_mask_permutexvar_epi32(tmp, 0xC000, right_shift, lcxp2_vec);
-    tmp = _mm512_slli_epi32(tmp, 2);
-    auto tmp1 = _mm512_mask_mov_epi32(lcxp1_vec, 0x8000, lcxp2_vec);
-    tmp = _mm512_add_epi32(tmp1, tmp);
+    auto lcxp1_vec = _mm256_permutevar8x32_epi32(cx_val_vec[x], right_shift);
+    auto tmp = _mm256_permutevar8x32_epi32(lcxp1_vec, right_shift);
 
-    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(4));
-    tmp1 = _mm512_srli_epi32(tmp1, 1);
-    tmp = _mm512_or_epi32(tmp, tmp1);
+#ifdef OJPH_ARCH_X86_64
+    tmp = _mm256_insert_epi64(tmp, 
+      _mm_cvtsi128_si64(_mm256_castsi256_si128(cx_val_vec[x + 1])), 3);
+#elif (defined OJPH_ARCH_I386)
+    int lsb = _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1]));
+    tmp = _mm256_insert_epi32(tmp, lsb, 6);
+    int msb = _mm_extract_epi32(_mm256_castsi256_si128(cx_val_vec[x + 1]), 1);
+    tmp = _mm256_insert_epi32(tmp, msb, 7);
+#else
+    #error Error unsupport compiler
+#endif
+    tmp = _mm256_slli_epi32(tmp, 2);
+    auto tmp1 = _mm256_insert_epi32(lcxp1_vec, 
+      _mm_cvtsi128_si32(_mm256_castsi256_si128(cx_val_vec[x + 1])), 7);
+    tmp = _mm256_add_epi32(tmp1, tmp);
 
-    tmp1 = _mm512_and_epi32(rho_vec, _mm512_set1_epi32(8));
-    tmp1 = _mm512_srli_epi32(tmp1, 2);
+    tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(4));
+    tmp1 = _mm256_srli_epi32(tmp1, 1);
+    tmp = _mm256_or_si256(tmp, tmp1);
 
-    return _mm512_or_epi32(tmp, tmp1);
+    tmp1 = _mm256_and_si256(rho_vec, _mm256_set1_epi32(8));
+    tmp1 = _mm256_srli_epi32(tmp1, 2);
+
+    return _mm256_or_si256(tmp, tmp1);
 }
 
-using fn_proc_cq = __m512i (*)(ui32, __m512i *, __m512i &, const __m512i);
+using fn_proc_cq = __m256i (*)(ui32, __m256i *, __m256i &, const __m256i);
 
-static void proc_mel_encode1(mel_struct *melp, __m512i &cq_vec,
-                             __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
-                             const __m512i right_shift)
+static void proc_mel_encode1(mel_struct *melp, __m256i &cq_vec,
+                             __m256i &rho_vec, __m256i u_q_vec, ui32 ignore,
+                             const __m256i right_shift)
 {
+    int32_t mel_need_encode[8];
+    int32_t mel_need_encode2[8];
+    int32_t mel_bit[8];
+    int32_t mel_bit2[8];
     /* Prepare mel_encode params */
     /* if (c_q[i] == 0) { */
-    auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
+    _mm256_storeu_si256((__m256i *)mel_need_encode, _mm256_cmpeq_epi32(cq_vec, ZERO));
     /*   mel_encode(&mel, rho[i] != 0); */
-    auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
+    _mm256_storeu_si256((__m256i*)mel_bit, _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
     /* } */
 
     /*   mel_encode(&mel, ojph_min(u_q[i], u_q[i + 1]) > 2); */
-    auto tmp = _mm512_permutexvar_epi32(right_shift, u_q_vec);
-    auto tmp1 = _mm512_min_epi32(u_q_vec, tmp);
-    auto mel_bit2 = (ui16)_mm512_cmpgt_epi32_mask(tmp1, _mm512_set1_epi32(2));
+    auto tmp = _mm256_permutevar8x32_epi32(u_q_vec, right_shift);
+    auto tmp1 = _mm256_min_epi32(u_q_vec, tmp);
+    _mm256_storeu_si256((__m256i*)mel_bit2, _mm256_srli_epi32(_mm256_cmpgt_epi32(tmp1, _mm256_set1_epi32(2)), 31));
 
     /* if (u_q[i] > 0 && u_q[i + 1] > 0) { } */
-    auto mel_need_encode2 = (ui16)_mm512_cmpgt_epi32_mask(u_q_vec, ZERO);
-    mel_need_encode2 =
-      mel_need_encode2 & (ui16)_mm512_cmpgt_epi32_mask(tmp, ZERO);
+    auto need_encode2 = _mm256_cmpgt_epi32(u_q_vec, ZERO);
+    _mm256_storeu_si256((__m256i*)mel_need_encode2, _mm256_and_si256(need_encode2, _mm256_cmpgt_epi32(tmp, ZERO)));
 
-    ui32 i_max = 16 - (ignore / 2);
+    ui32 i_max = 8 - (ignore / 2);
 
     for (ui32 i = 0; i < i_max; i += 2) {
-        auto mask = 1 << i;
-        if (0 != (mel_need_encode & mask)) {
-            mel_encode(melp, mel_bit & mask);
+        if (mel_need_encode[i]) {
+            mel_encode(melp, mel_bit[i]);
         }
 
         if (i + 1 < i_max) {
-            auto mask = 1 << (i + 1);
-            if (0 != (mel_need_encode & mask)) {
-                mel_encode(melp, mel_bit & mask);
+            if (mel_need_encode[i + 1]) {
+                mel_encode(melp, mel_bit[i + 1]);
             }
         }
 
-        if (0 != (mel_need_encode2 & mask)) {
-            mel_encode(melp, mel_bit2 & mask);
+        if (mel_need_encode2[i]) {
+            mel_encode(melp, mel_bit2[i]);
         }
     }
 }
 
-static void proc_mel_encode2(mel_struct *melp, __m512i &cq_vec,
-                             __m512i &rho_vec, __m512i u_q_vec, ui32 ignore,
-                             const __m512i right_shift)
+static void proc_mel_encode2(mel_struct *melp, __m256i &cq_vec,
+                             __m256i &rho_vec, __m256i u_q_vec, ui32 ignore,
+                             const __m256i right_shift)
 {
     ojph_unused(u_q_vec);
     ojph_unused(right_shift);
+    int32_t mel_need_encode[8];
+    int32_t mel_bit[8];
 
     /* Prepare mel_encode params */
     /* if (c_q[i] == 0) { */
-    auto mel_need_encode = _mm512_cmpeq_epi32_mask(cq_vec, ZERO);
+    _mm256_storeu_si256((__m256i*)mel_need_encode, _mm256_cmpeq_epi32(cq_vec, ZERO));
     /*   mel_encode(&mel, rho[i] != 0); */
-    auto mel_bit = _mm512_cmpneq_epi32_mask(rho_vec, ZERO);
+    _mm256_storeu_si256((__m256i*)mel_bit, _mm256_srli_epi32(avx2_cmpneq_epi32(rho_vec, ZERO), 31));
     /* } */
 
-    ui32 i_max = 16 - (ignore / 2);
+    ui32 i_max = 8 - (ignore / 2);
 
     for (ui32 i = 0; i < i_max; ++i) {
-        auto mask = 1 << i;
-        if (0 != (mel_need_encode & mask)) {
-            mel_encode(melp, mel_bit & mask);
+        if (mel_need_encode[i]) {
+            mel_encode(melp, mel_bit[i]);
         }
     }
 }
 
-using fn_proc_mel_encode = void (*)(mel_struct *, __m512i &, __m512i &,
-                                    __m512i, ui32, const __m512i);
+using fn_proc_mel_encode = void (*)(mel_struct *, __m256i &, __m256i &,
+                                    __m256i, ui32, const __m256i);
 
-static void proc_vlc_encode1(vlc_struct_avx512 *vlcp, ui32 *tuple,
+static void proc_vlc_encode1(vlc_struct_avx2 *vlcp, ui32 *tuple,
                              ui32 *u_q, ui32 ignore)
 {
-    ui32 i_max = 16 - (ignore / 2);
+    ui32 i_max = 8 - (ignore / 2);
 
     for (ui32 i = 0; i < i_max; i += 2) {
         /* 7 bits */
@@ -968,10 +973,10 @@ static void proc_vlc_encode1(vlc_struct_avx512 *vlcp, ui32 *tuple,
     }
 }
 
-static void proc_vlc_encode2(vlc_struct_avx512 *vlcp, ui32 *tuple,
+static void proc_vlc_encode2(vlc_struct_avx2 *vlcp, ui32 *tuple,
                              ui32 *u_q, ui32 ignore)
 {
-    ui32 i_max = 16 - (ignore / 2);
+    ui32 i_max = 8 - (ignore / 2);
 
     for (ui32 i = 0; i < i_max; i += 2) {
         /* 7 bits */
@@ -1004,17 +1009,17 @@ static void proc_vlc_encode2(vlc_struct_avx512 *vlcp, ui32 *tuple,
     }
 }
 
-using fn_proc_vlc_encode = void (*)(vlc_struct_avx512 *, ui32 *, ui32 *, ui32);
+using fn_proc_vlc_encode = void (*)(vlc_struct_avx2 *, ui32 *, ui32 *, ui32);
 
-void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
-                                  ui32 num_passes, ui32 _width, ui32 height,
-                                  ui32 stride, ui32* lengths,
-                                  ojph::mem_elastic_allocator *elastic,
-                                  ojph::coded_lists *& coded)
+void ojph_encode_codeblock_avx2(ui32* buf, ui32 missing_msbs,
+                                ui32 num_passes, ui32 _width, ui32 height,
+                                ui32 stride, ui32* lengths,
+                                ojph::mem_elastic_allocator *elastic,
+                                ojph::coded_lists *& coded)
 {
     ojph_unused(num_passes);                      //currently not used
 
-    ui32 width = (_width + 31) & ~31u;
+    ui32 width = (_width + 15) & ~15u;
     ui32 ignore = width - _width;
     const int ms_size = (16384 * 16 + 14) / 15; //more than enough
     const int mel_vlc_size = 3072;              //more than enough
@@ -1028,12 +1033,12 @@ void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
 
     mel_struct mel;
     mel_init(&mel, mel_size, mel_buf);
-    vlc_struct_avx512 vlc;
+    vlc_struct_avx2 vlc;
     vlc_init(&vlc, vlc_size, vlc_buf);
     ms_struct ms;
     ms_init(&ms, ms_size, ms_buf);
 
-    ui32 p = 30 - missing_msbs;
+    const ui32 p = 30 - missing_msbs;
 
     //e_val: E values for a line (these are the highest set bit)
     //cx_val: is the context values
@@ -1044,36 +1049,30 @@ void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
     //For a 1024 pixels, we need 512 bytes, the 2 extra,
     // one for the non-existing earlier quad, and one for beyond the
     // the end
-    const __m512i right_shift = _mm512_set_epi32(
-      0, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
+    const __m256i right_shift = _mm256_set_epi32(
+        0, 7, 6, 5, 4, 3, 2, 1
     );
 
-    const __m512i left_shift = _mm512_set_epi32(
-      14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 15
+    const __m256i left_shift = _mm256_set_epi32(
+        6, 5, 4, 3, 2, 1, 0, 7
     );
 
-    __m512i e_val_vec[33];
-    for (ui32 i = 0; i < 32; ++i) {
+    ui32 n_loop = (width + 15) / 16;
+
+    __m256i e_val_vec[65];
+    for (ui32 i = 0; i <ojph_min(64, n_loop); ++i) {
         e_val_vec[i] = ZERO;
     }
-    __m512i prev_e_val_vec = ZERO;
+    __m256i prev_e_val_vec = ZERO;
 
-    __m512i cx_val_vec[33];
-    __m512i prev_cx_val_vec = ZERO;
+    __m256i cx_val_vec[65];
+    __m256i prev_cx_val_vec = ZERO;
 
-    __m512i prev_cq_vec = ZERO;
+    ui32 prev_cq = 0;
 
-    __m512i tmp;
-    __m512i tmp1;
-
-    __m512i eq_vec[4];
-    __m512i s_vec[4];
-    __m512i src_vec[4];
-    __m512i rho_vec;
-    __m512i e_qmax_vec;
-    __m512i kappa_vec;
-
-    ui32 n_loop = (width + 31) / 32;
+    __m256i eq_vec[4];
+    __m256i s_vec[4];
+    __m256i src_vec[4];
 
     ui32 *vlc_tbl = vlc_tbl0;
     fn_proc_cq proc_cq = proc_cq1;
@@ -1085,82 +1084,93 @@ void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
     {
         e_val_vec[n_loop] = prev_e_val_vec;
         /* lcxp[0] = (ui8)((rho[0] & 8) >> 3); */
-        tmp = _mm512_and_epi32(prev_cx_val_vec, _mm512_set1_epi32(8));
-        tmp = _mm512_srli_epi32(tmp, 3);
-        cx_val_vec[n_loop] = tmp;
+        __m256i tmp = _mm256_and_si256(prev_cx_val_vec, _mm256_set1_epi32(8));
+        cx_val_vec[n_loop] = _mm256_srli_epi32(tmp, 3);
 
         prev_e_val_vec = ZERO;
         prev_cx_val_vec = ZERO;
 
         ui32 *sp = buf + y * stride;
 
-        /* 32 bytes per iteration */
+        /* 16 bytes per iteration */
         for (ui32 x = 0; x < n_loop; ++x) {
 
-            // mask to stop loading unnecessary data
-            si32 true_x = (si32)x << 5;
-            ui32 mask32 = 0xFFFFFFFFu;
-            si32 entries = true_x + 32 - (si32)_width;
-            mask32 >>= ((entries >= 0) ? entries : 0);
-            __mmask16 load_mask0 = _cvtu32_mask16(mask32);
-            __mmask16 load_mask1 = _cvtu32_mask16(mask32 >> 16);
-
             /* t = sp[i]; */
-            src_vec[0] = _mm512_maskz_loadu_epi32(load_mask0, sp);
-            src_vec[2] = _mm512_maskz_loadu_epi32(load_mask1, sp + 16);
-
-            if (y + 1 < height) {
-                src_vec[1] = _mm512_maskz_loadu_epi32(load_mask0, sp + stride);
-                src_vec[3] =
-                  _mm512_maskz_loadu_epi32(load_mask1, sp + 16 + stride);
-            } else {
-                src_vec[1] = ZERO;
-                src_vec[3] = ZERO;
+            if ((x == (n_loop - 1)) && (_width % 16)) {
+                ui32 tmp_buf[16] = { 0 };
+                memcpy(tmp_buf, sp, (_width % 16) * sizeof(ui32));
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                if (y + 1 < height) {
+                    memcpy(tmp_buf, sp + stride, (_width % 16) * sizeof(ui32));
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(tmp_buf));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(tmp_buf + 8));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
             }
-            sp += 32;
+            else {
+                src_vec[0] = _mm256_loadu_si256((__m256i*)(sp));
+                src_vec[2] = _mm256_loadu_si256((__m256i*)(sp + 8));
+
+                if (y + 1 < height) {
+                    src_vec[1] = _mm256_loadu_si256((__m256i*)(sp + stride));
+                    src_vec[3] = _mm256_loadu_si256((__m256i*)(sp + 8 + stride));
+                }
+                else {
+                    src_vec[1] = ZERO;
+                    src_vec[3] = ZERO;
+                }
+                sp += 16;
+            }
 
             /* src_vec layout:
-             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5]...[0,15]
-             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5]...[1,15]
-             * src_vec[2]:[0,16],[0,17],[0,18],[0,19],[0,20],[0,21]...[0,31]
-             * src_vec[3]:[1,16],[1,17],[1,18],[1,19],[1,20],[1,21]...[1,31]
+             * src_vec[0]:[0, 0],[0, 1],[0, 2],[0, 3],[0, 4],[0, 5],.[0, 6],.[0, 7]
+             * src_vec[1]:[1, 0],[1, 1],[1, 2],[1, 3],[1, 4],[1, 5],.[1, 6],.[1, 7]
+             * src_vec[2]:[0, 8],[0, 9],[0,10],[0,11],[0,12],[0,13],.[0,14], [0,15]
+             * src_vec[3]:[1, 8],[1, 9],[1,10],[1,11],[1,12],[1,13],.[1,14], [1,15]
              */
+            __m256i rho_vec, e_qmax_vec;
             proc_pixel(src_vec, p, eq_vec, s_vec, rho_vec, e_qmax_vec);
 
             // max_e[(i + 1) % num] = ojph_max(lep[i + 1], lep[i + 2]) - 1;
-            tmp = _mm512_permutexvar_epi32(right_shift, e_val_vec[x]);
-            tmp = _mm512_mask_permutexvar_epi32(tmp, 0x8000, right_shift,
-                                                e_val_vec[x + 1]);
-            auto mask = _mm512_cmpgt_epi32_mask(e_val_vec[x], tmp);
-            auto max_e_vec = _mm512_mask_mov_epi32(tmp, mask, e_val_vec[x]);
-            max_e_vec = _mm512_sub_epi32(max_e_vec, ONE);
+            tmp = _mm256_permutevar8x32_epi32(e_val_vec[x], right_shift);
+            tmp = _mm256_insert_epi32(tmp, _mm_cvtsi128_si32(_mm256_castsi256_si128(e_val_vec[x + 1])), 7);
+
+            auto max_e_vec = _mm256_max_epi32(tmp, e_val_vec[x]);
+            max_e_vec = _mm256_sub_epi32(max_e_vec, ONE);
 
             // kappa[i] = (rho[i] & (rho[i] - 1)) ? ojph_max(1, max_e[i]) : 1;
-            tmp = _mm512_max_epi32(max_e_vec, ONE);
-            tmp1 = _mm512_sub_epi32(rho_vec, ONE);
-            tmp1 = _mm512_and_epi32(rho_vec, tmp1);
-            mask = _mm512_cmpneq_epi32_mask(tmp1, ZERO);
-            kappa_vec = _mm512_mask_mov_epi32(ONE, mask, tmp);
+            tmp = _mm256_max_epi32(max_e_vec, ONE);
+            __m256i tmp1 = _mm256_sub_epi32(rho_vec, ONE);
+            tmp1 = _mm256_and_si256(rho_vec, tmp1);
+
+            auto cmp = _mm256_cmpeq_epi32(tmp1, ZERO);
+            auto kappa_vec1_ = _mm256_and_si256(cmp, ONE);
+            auto kappa_vec2_ = _mm256_and_si256(_mm256_xor_si256(cmp, _mm256_set1_epi32((int32_t)0xffffffff)), tmp);
+            const __m256i kappa_vec = _mm256_max_epi32(kappa_vec1_, kappa_vec2_);
 
             /* cq[1 - 16] = cq_vec
              * cq[0] = prev_cq_vec[0]
              */
             tmp = proc_cq(x, cx_val_vec, rho_vec, right_shift);
-            auto cq_vec = _mm512_mask_permutexvar_epi32(prev_cq_vec, 0xFFFE,
-                                                        left_shift, tmp);
-            prev_cq_vec = _mm512_mask_permutexvar_epi32(ZERO, 0x1, left_shift,
-                                                        tmp);
+
+            auto cq_vec = _mm256_permutevar8x32_epi32(tmp, left_shift);
+            cq_vec = _mm256_insert_epi32(cq_vec, prev_cq, 0);
+            prev_cq = (ui32)_mm256_extract_epi32(tmp, 7);
 
             update_lep(x, prev_e_val_vec, eq_vec, e_val_vec, left_shift);
             update_lcxp(x, prev_cx_val_vec, rho_vec, cx_val_vec, left_shift);
 
             /* Uq[i] = ojph_max(e_qmax[i], kappa[i]); */
             /* u_q[i] = Uq[i] - kappa[i]; */
-            auto uq_vec = _mm512_max_epi32(kappa_vec, e_qmax_vec);
-            auto u_q_vec = _mm512_sub_epi32(uq_vec, kappa_vec);
+            auto uq_vec = _mm256_max_epi32(kappa_vec, e_qmax_vec);
+            auto u_q_vec = _mm256_sub_epi32(uq_vec, kappa_vec);
 
             auto eps_vec = cal_eps_vec(eq_vec, u_q_vec, e_qmax_vec);
-            __m512i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
+            __m256i tuple_vec = cal_tuple(cq_vec, rho_vec, eps_vec, vlc_tbl);
             ui32 _ignore = ((n_loop - 1) == x) ? ignore : 0;
 
             proc_mel_encode(&mel, cq_vec, rho_vec, u_q_vec, _ignore,
@@ -1170,21 +1180,23 @@ void ojph_encode_codeblock_avx512(ui32* buf, ui32 missing_msbs,
 
             // vlc_encode(&vlc, tuple[i*2+0] >> 8, (tuple[i*2+0] >> 4) & 7);
             // vlc_encode(&vlc, tuple[i*2+1] >> 8, (tuple[i*2+1] >> 4) & 7);
-            ui32 u_q[16];
-            ui32 tuple[16];
+            ui32 u_q[8];
+            ui32 tuple[8];
             /* The tuple is scaled by 4 due to:
              * vlc_encode(&vlc, tuple0 >> 8, (tuple0 >> 4) & 7, true);
              * So in the vlc_encode, the tuple will only be scaled by 2.
              */
-            tuple_vec = _mm512_srli_epi32(tuple_vec, 4);
-            _mm512_storeu_si512(tuple, tuple_vec);
-            _mm512_storeu_si512(u_q, u_q_vec);
+            tuple_vec = _mm256_srli_epi32(tuple_vec, 4);
+            _mm256_storeu_si256((__m256i*)tuple, tuple_vec);
+            _mm256_storeu_si256((__m256i*)u_q, u_q_vec);
+
             proc_vlc_encode(&vlc, tuple, u_q, _ignore);
         }
 
-        tmp = _mm512_permutexvar_epi32(right_shift, cx_val_vec[0]);
-        tmp = _mm512_slli_epi32(tmp, 2);
-        prev_cq_vec = _mm512_maskz_add_epi32(0x1, tmp, cx_val_vec[0]);
+        tmp = _mm256_permutevar8x32_epi32(cx_val_vec[0], right_shift);
+        tmp = _mm256_slli_epi32(tmp, 2);
+        tmp = _mm256_add_epi32(tmp, cx_val_vec[0]);
+        prev_cq = (ui32)_mm_cvtsi128_si32(_mm256_castsi256_si128(tmp));
 
         proc_cq = proc_cq2;
         vlc_tbl = vlc_tbl1;

--- a/external/OpenJPH/src/core/openjph/ojph_arch.h
+++ b/external/OpenJPH/src/core/openjph/ojph_arch.h
@@ -5,6 +5,7 @@
 // Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
+// Copyright (c) 2026, Osamu Watanabe
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -39,6 +40,7 @@
 #ifndef OJPH_ARCH_H
 #define OJPH_ARCH_H
 
+#include <cstring>
 #include <cstdio>
 #include <cstdint>
 #include <cmath>
@@ -61,6 +63,17 @@
 
 #ifdef OJPH_COMPILER_MSVC
 #include <intrin.h>
+#endif
+
+  /////////////////////////////////////////////////////////////////////////////
+  // portable force-inline / no-inline function qualifiers
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #define OJPH_FORCE_INLINE static __forceinline
+  #define OJPH_NO_INLINE    static __declspec(noinline)
+#else
+  #define OJPH_FORCE_INLINE static inline __attribute__((always_inline))
+  #define OJPH_NO_INLINE    static __attribute__((noinline))
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -88,12 +101,20 @@
   #define OJPH_ARCH_UNKNOWN
 #endif
 
+// Only little-endian POWER (ppc64le) is supported for SIMD
+#if defined(OJPH_ARCH_PPC64) &&  \
+  (defined(__LITTLE_ENDIAN__) ||  \
+   (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+  #define OJPH_ARCH_PPC64LE
+#endif
+
 namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   //                  disable SIMD for unknown architecture
   ////////////////////////////////////////////////////////////////////////////
 #if !defined(OJPH_ARCH_X86_64) && !defined(OJPH_ARCH_I386) &&  \
-    !defined(OJPH_ARCH_ARM) && !defined(OJPH_DISABLE_SIMD)
+    !defined(OJPH_ARCH_ARM) && !defined(OJPH_ARCH_PPC64LE) &&  \
+    !defined(OJPH_DISABLE_SIMD)
 #define OJPH_DISABLE_SIMD
 #endif // !OJPH_ARCH_UNKNOWN
 
@@ -150,6 +171,14 @@ namespace ojph {
     ARM_CPU_EXT_LEVEL_ASIMD = 1,
     ARM_CPU_EXT_LEVEL_SVE = 2,
     ARM_CPU_EXT_LEVEL_SVE2 = 3,
+  };
+
+  // POWER9 (ISA 3.0) is the minimum supported SIMD level; older CPUs
+  // (POWER8 and earlier) use the generic code paths
+  enum : int {
+    PPC_CPU_EXT_LEVEL_GENERIC = 0,
+    PPC_CPU_EXT_LEVEL_ARCH_3_00 = 1, // ISA 3.0  (POWER9)
+    PPC_CPU_EXT_LEVEL_ARCH_3_1 = 2,  // ISA 3.1  (POWER10)
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -255,6 +284,35 @@ namespace ojph {
   #endif
   }
 
+  /////////////////////////////////////////////////////////////////////////////
+#ifdef OJPH_COMPILER_MSVC
+  #pragma intrinsic(_BitScanForward64)
+#endif
+  static inline ui32 count_trailing_zeros(ui64 val)
+  {
+  #ifdef OJPH_COMPILER_MSVC
+    unsigned long result = 0;
+    #if (defined OJPH_ARCH_X86_64) || (defined OJPH_ARCH_ARM)
+      _BitScanForward64(&result, val);
+    #elif (defined OJPH_ARCH_I386)
+      ui32 lsb = (ui32)val, msb = (ui32)(val >> 32);
+      if (lsb != 0)
+        _BitScanForward(&result, lsb);
+      else {
+        _BitScanForward(&result, msb);
+        result += 32;
+      }
+    #endif
+    return (ui32)result;
+  #elif (defined OJPH_COMPILER_GNUC)
+    return (ui32)__builtin_ctzll(val);
+  #else
+    if ((ui32)val != 0)
+      return count_trailing_zeros((ui32)val);
+    return 32 + count_trailing_zeros((ui32)(val >> 32));
+  #endif
+  }
+
   ////////////////////////////////////////////////////////////////////////////
   static inline si32 ojph_round(float val)
   {
@@ -316,6 +374,124 @@ namespace ojph {
     return reinterpret_cast<T *>(p);
   }
 
+  ////////////////////////////////////////////////////////////////////////////
+  // Determine the byte order of the target at compile time when possible,
+  // so that the compiler can remove the branches for the other byte order.
+  // __BYTE_ORDER__ is a predefined macro that describes the target
+  // architecture, not the machine running the compiler, so it is also
+  // correct when cross-compiling.
+  // All MSVC targets (x86, x64, ARM64 Windows) are little endian.
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+  constexpr bool is_machine_little_endian = false;
+#elif defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  constexpr bool is_machine_little_endian = true;
+#elif defined(OJPH_COMPILER_MSVC)
+  constexpr bool is_machine_little_endian = true;
+#else
+  // fallback in case macro __BYTE_ORDER__ is not defined
+  // If the first byte in memory is 0x01, the machine is Little Endian.
+  // If the first byte in memory is 0x00, the machine is Big Endian.
+  static bool check_if_machine_is_little_endian()
+  {
+    const uint16_t n = 0x0001;
+    bool is_machine_little_endian = (*((uint8_t *)&n) == 0x01);
+    return is_machine_little_endian;
+  }
+  const bool is_machine_little_endian = check_if_machine_is_little_endian();
+#endif
+
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 --> 2 1 on big-endian machines
+  static inline ui16 swap_bytes_if_be(ui16 t)
+  {
+    if (is_machine_little_endian)
+      return t;
+    else
+      return (ui16)((t << 8) | (t >> 8));
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 --> 2 1 on little-endian machines
+  static inline ui16 swap_bytes_if_le(ui16 t)
+  {
+    if (is_machine_little_endian)
+      return (ui16)((t << 8) | (t >> 8));
+    else
+      return t;
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 --> 4 3 2 1 on big-endian machines
+  static inline ui32 swap_bytes_if_be(ui32 t)
+  {
+    if (is_machine_little_endian)
+      return t;
+    else
+    {
+      ui32 u = swap_bytes_if_be((ui16)(t & 0xFFFFu));
+      u <<= 16;
+      u |= swap_bytes_if_be((ui16)(t >> 16));
+      return u;
+    }
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 --> 4 3 2 1 on little-endian machines
+  static inline ui32 swap_bytes_if_le(ui32 t)
+  {
+    if (is_machine_little_endian)
+    {
+      ui32 u = swap_bytes_if_le((ui16)(t & 0xFFFFu));
+      u <<= 16;
+      u |= swap_bytes_if_le((ui16)(t >> 16));
+      return u;
+    }
+    else
+      return t;
+  }
+  ////////////////////////////////////////////////////////////////////////////
+  // swap bytes 1 2 3 4 5 6 7 8 --> 8 7 6 5 4 3 2 1 on little-endian machines
+  static inline ui64 swap_bytes_if_le(ui64 t)
+  {
+    if (is_machine_little_endian)
+    {
+      ui64 u =
+        swap_bytes_if_le((ui32)(t & 0xFFFFFFFFu));
+      u <<= 32;
+      u |= swap_bytes_if_le((ui32)(t >> 32));
+      return u;
+    }
+    else
+      return t;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // loads 4 bytes from p as a little-endian 32-bit integer; that is, the
+  // byte at the lowest address goes into the least-significant byte of the
+  // result, irrespective of the machine's endianness
+  static inline ui32 load_le_ui32(const ui8 *p)
+  {
+    if (is_machine_little_endian) {
+      ui32 val;
+      std::memcpy(&val, p, sizeof(val));
+      return val;
+    }
+    else
+      return (ui32)p[0] | ((ui32)p[1] << 8)
+        | ((ui32)p[2] << 16) | ((ui32)p[3] << 24);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // loads two consecutive ui16 values from p, placing the one at the lower
+  // address in the least-significant 16 bits of the result, irrespective
+  // of the machine's endianness
+  static inline ui32 load_le_ui16x2(const ui16 *p)
+  {
+    if (is_machine_little_endian) {
+      ui32 val;
+      std::memcpy(&val, p, sizeof(val));
+      return val;
+    }
+    else
+      return (ui32)p[0] | ((ui32)p[1] << 16);
+  }
 }
 
 #endif // !OJPH_ARCH_H

--- a/external/OpenJPH/src/core/openjph/ojph_base.h
+++ b/external/OpenJPH/src/core/openjph/ojph_base.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -65,8 +65,18 @@ namespace ojph {
   {
     point org;
     size siz;
+
+    bool operator==(const rect& a) const {
+      return a.org.x == org.x && a.org.y == org.y
+        && a.siz.w == siz.w && a.siz.h == siz.h;
+    }
+
+    bool operator!=(const rect& a) const
+    { return !(a == *this); }
   };
-  
+
+  /////////////////////////////////////////////////////////////////////////////
+
 }
 
 #endif // !OJPH_BASE_H

--- a/external/OpenJPH/src/core/openjph/ojph_file.h
+++ b/external/OpenJPH/src/core/openjph/ojph_file.h
@@ -131,6 +131,20 @@ namespace ojph {
     /**  A destructor */
     ~mem_outfile() override;
 
+    mem_outfile(mem_outfile const&) = delete;
+    mem_outfile& operator=(mem_outfile const&) = delete;
+
+    /**
+     * Move construction leaves the moved-from value in default constructed state
+     * and transfers ownership of the internal state to the moved-to instance.
+     **/
+    mem_outfile(mem_outfile &&) noexcept;
+    /**
+     * move assignment with the same ownership transfer semantics as
+     * move construction.
+     **/
+    mem_outfile& operator=(mem_outfile&&) noexcept;
+
     /**
      *  @brief Call this function to open a memory file.
 	   *
@@ -219,6 +233,12 @@ namespace ojph {
      size_t get_buf_size() const { return buf_size; }
 
   private:
+
+    /**
+     * @brief A utility function to swap the contents of two instances
+     */
+    void swap(mem_outfile& other) noexcept;
+  
     /**
      *  @brief This function expands storage by x1.5 needed space.
      *
@@ -291,6 +311,20 @@ namespace ojph {
     mem_infile() { close(); }
     ~mem_infile() override { }
 
+    mem_infile(mem_infile const&) = delete;
+    mem_infile& operator=(mem_infile const&) = delete;
+
+    /**
+     * Move construction leaves the moved-from value in default constructed state
+     * and transfers ownership of the internal state to the moved-to instance.
+     **/
+    mem_infile(mem_infile &&) noexcept;
+    /**
+     * move assignment with the same ownership transfer semantics as
+     * move construction.
+     **/
+    mem_infile& operator=(mem_infile&&) noexcept;
+
     void open(const ui8* data, size_t size);
 
     //read reads size bytes, returns the number of bytes read
@@ -302,6 +336,9 @@ namespace ojph {
     void close() override { data = cur_ptr = NULL; size = 0; }
 
   private:
+    // swap the contents of two instances
+    void swap(mem_infile&) noexcept;
+
     const ui8 *data, *cur_ptr;
     size_t size;
   };

--- a/external/OpenJPH/src/core/openjph/ojph_mem.h
+++ b/external/OpenJPH/src/core/openjph/ojph_mem.h
@@ -45,6 +45,7 @@
 #include <type_traits>
 
 #include "ojph_arch.h"
+#include "ojph_message.h"
 
 namespace ojph {
 
@@ -91,7 +92,7 @@ namespace ojph {
         allocated_data = allocated_data + (allocated_data + 19) / 20; // 5%
         store = malloc(allocated_data);
         if (store == NULL)
-          throw "malloc failed";
+          OJPH_ERROR(0x00090001, "malloc failed");
       }
       avail_obj = store;
       avail_data = (ui8*)store + size_obj;
@@ -244,11 +245,19 @@ namespace ojph {
   private:
     struct stores_list
     {
+      // Payload (coded_lists + bitstream) must start at a multiple of 16 bytes.
+      // Otherwise coded_lists::buf can be 4 mod 8, which causes misalignment
+      // on 32-bit architectures. So round sizeof(stores_list) to next
+      // multiple of 16.
+      static constexpr ui32 stores_list_size16()
+      {
+        return (ui32) ((sizeof (stores_list) + 15u) & ~15u);
+      }
       stores_list(ui32 available_bytes)
       {
         this->next_store = NULL;
         this->orig_size = this->available = available_bytes;
-        this->orig_data = this->data = (ui8*)this + sizeof(stores_list);
+        this->orig_data = this->data = (ui8*)this + stores_list_size16();
       }
       void restart()
       {
@@ -258,7 +267,7 @@ namespace ojph {
       }
       static ui32 eval_store_bytes(ui32 available_bytes)
       { // calculates how many bytes need to be allocated
-        return available_bytes + (ui32)sizeof(stores_list);
+        return available_bytes + stores_list_size16();
       }
       stores_list *next_store;
       ui8 *orig_data, *data;

--- a/external/OpenJPH/src/core/openjph/ojph_params.h
+++ b/external/OpenJPH/src/core/openjph/ojph_params.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -48,7 +48,6 @@ namespace ojph {
   // defined here
   class param_siz;
   class param_cod;
-  class param_coc;
   class param_qcd;
   class param_cap;
   class param_nlt;
@@ -59,7 +58,6 @@ namespace ojph {
   namespace local {
     struct param_siz;
     struct param_cod;
-    struct param_coc;
     struct param_qcd;
     struct param_cap;
     struct param_nlt;
@@ -99,19 +97,37 @@ namespace ojph {
     local::param_siz* state;
   };
 
-  /***************************************************************************/
+  /*****************************************************************************
+   * @brief An interface to COD and COC marker segments.
+   *
+   *   The param_cod object uses Pimpl design.
+   *   The top set of functions give access to the COD marker segment, while
+   *   the lower set, the ones that have comp_idx as the first parameter,
+   *   gives access to COC marker segment.
+   *   The functions:
+   *   - set_num_decomposition(ui32 comp_idx, ...)
+   *   - set_block_dims(ui32 comp_idx, ...)
+   *   - set_precinct_size(ui32 comp_idx, ...)
+   *   - set_reversible(ui32 comp_idx, ...)
+   *   create a COC segment on first call; subsequent calls to these
+   *   functions on the same component index will use the COC segment
+   *   created by the first call.  On first creation, the COC segment is
+   *   initialized to the default COD settings; in particular, 5 levels of
+   *   decomposition, 64x64 codeblocks, reversible 5/3 transform and no
+   *   precinct size is defined, which gives 32768x32768 precincts.
+   */
   class OJPH_EXPORT param_cod
   {
   public:
     param_cod(local::param_cod* p) : state(p) {}
 
+    // COD marker segment interface
     void set_num_decomposition(ui32 num_decompositions);
     void set_block_dims(ui32 width, ui32 height);
     void set_precinct_size(int num_levels, size* precinct_size);
     void set_progression_order(const char *name);
     void set_color_transform(bool color_transform);
     void set_reversible(bool reversible);
-    param_coc get_coc(ui32 component_idx);
 
     ui32 get_num_decompositions() const;
     size get_block_dims() const;
@@ -127,28 +143,19 @@ namespace ojph {
     bool packets_use_eph() const;
     bool get_block_vertical_causality() const;
 
-  private:
-    local::param_cod* state;
-  };
+    // COC marker segment interface
+    void set_num_decomposition(ui32 comp_idx, ui32 num_decompositions);
+    void set_block_dims(ui32 comp_idx, ui32 width, ui32 height);
+    void set_precinct_size(ui32 comp_idx, int num_levels, size* precinct_size);
+    void set_reversible(ui32 comp_idx, bool reversible);
 
-  /***************************************************************************/
-  class OJPH_EXPORT param_coc
-  {
-  public:
-    param_coc(local::param_cod* p) : state(p) {}
-
-    void set_num_decomposition(ui32 num_decompositions);
-    void set_block_dims(ui32 width, ui32 height);
-    void set_precinct_size(int num_levels, size* precinct_size);
-    void set_reversible(bool reversible);
-
-    ui32 get_num_decompositions() const;
-    size get_block_dims() const;
-    size get_log_block_dims() const;
-    bool is_reversible() const;
-    size get_precinct_size(ui32 level_num) const;
-    size get_log_precinct_size(ui32 level_num) const;
-    bool get_block_vertical_causality() const;
+    ui32 get_num_decompositions(ui32 comp_idx) const;
+    size get_block_dims(ui32 comp_idx) const;
+    size get_log_block_dims(ui32 comp_idx) const;
+    bool is_reversible(ui32 comp_idx) const;
+    size get_precinct_size(ui32 comp_idx, ui32 level_num) const;
+    size get_log_precinct_size(ui32 comp_idx, ui32 level_num) const;
+    bool get_block_vertical_causality(ui32 comp_idx) const;
 
   private:
     local::param_cod* state;
@@ -157,35 +164,83 @@ namespace ojph {
   /***************************************************************************/
   /**
     * @brief Quantization parameters object
-    * 
+    *
     */
   class OJPH_EXPORT param_qcd
   {
   public:
+    enum comp_type : ui8 { // Note the numbers are used by the code
+      OJPH_COMP_Y         = 0,
+      OJPH_COMP_CB        = 1,
+      OJPH_COMP_CR        = 2,
+      OJPH_COMP_UNDEFINED = 0xFF
+    };
+    static comp_type ui8_2_comp_type(ui8 c)
+    {
+      if (c >= OJPH_COMP_Y && c <= OJPH_COMP_CR)
+        return static_cast<comp_type>(c);
+      else
+        return OJPH_COMP_UNDEFINED;
+    }
+
     param_qcd(local::param_qcd* p) : state(p) {}
 
     /**
-     * @brief Set the irreversible quantization base delta.  
-     *  
-     * This represents the default base delta and influences QCD marker 
+     * @brief Set the irreversible quantization base delta.
+     *
+     * This represents the default base delta and influences QCD marker
      * segment
-     * 
-     * @param delta 
+     *
+     * @param delta
      */
     void set_irrev_quant(float delta);
 
     /**
-     * @brief Set the irreversible quantization base delta for a specific 
+     * @brief Sets Qfactor
+     *
+     * This is a top level Qfactor; it will automatically set the qfactor;
+     * if you have one or two channels they will be set to luminance
+     * (or Y) visual weighting. If you have three or more, the first three
+     * will be set to Y, Cb, Cr; channels 4 onwards will be set to luminance.
+     * If that does not match the desired behaviour; then do not set the
+     * top level qfactor, but set the Qfactor for individual channels
+     * according to desired visual weighting type, using
+     * set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
+     *
+     * Note that setting Qfactor takes precedence over setting an
+     * irreversible quantization base delta.
+     *
+     * @param qfactor Compression quality as an integer between
+     *                1 (worst quality) and 100 (best quality)
+     */
+    void set_qfactor(ui8 qfactor);
+
+    /**
+     * @brief Set the irreversible quantization base delta for a specific
      *        component
-     * 
-     * This represents the default base delta for component comp_idx, and 
+     *
+     * This represents the default base delta for component comp_idx, and
      * influences QCC marker segment for the component, inserting one
      * if needed, which is usually the case.
-     * 
-     * @param comp_idx 
-     * @param delta 
+     *
+     * @param comp_idx
+     * @param delta
      */
     void set_irrev_quant(ui32 comp_idx, float delta);
+
+    /**
+     * @brief Sets Qfactor for a specific component.
+     *
+     * Setting Qfactor takes precedence over setting an irreversible
+     * quantization base delta
+     *
+     * @param comp_idx Component index
+     * @param ctype Indicates whether the component is a Y, Cb or Cr channel,
+     *              after the ICT if present
+     * @param qfactor Compression quality as an integer between
+     *                1 (worst quality) and 100 (best quality)
+     */
+    void set_qfactor(ui32 comp_idx, comp_type ctype, ui8 qfactor);
 
   private:
     local::param_qcd* state;
@@ -195,82 +250,82 @@ namespace ojph {
   /**
     * @brief non-linearity point transformation object
     *        (implements NLT marker segment)
-    * 
-    *  There are a few things to know here.  
-      * The NLT marker segment contains the nonlinearity type and the 
+    *
+    *  There are a few things to know here.
+      * The NLT marker segment contains the nonlinearity type and the
       * bit depth and signedness of the component to which it applies.
-      * There is the default component ALL_COMPS which applies to all 
+      * There is the default component ALL_COMPS which applies to all
       * components unless it is overridden by another NLT segment marker.
       * The library checks that the settings make sense, and also make
       * sure that bit depth and signedness are correct, creating any missing
       * NLT marker segments in the process.
       * If all components have the same bit depth and signedness, and need
-      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion), 
+      * nonlinearity type 3 (Binary Complement to Sign Magnitude Conversion),
       * then the best option is to set ALL_COMPS to type 3.
-      * Otherwise, the best option is to set type 3 only to components that 
+      * Otherwise, the best option is to set type 3 only to components that
       * need it, leaving out the default ALL_COMPS nonlinearity not set.
-      * Another option is for the end-user can set the ALL_COMPS to type 3, 
-      * and then put exception for the components that does not need type 3, 
+      * Another option is for the end-user can set the ALL_COMPS to type 3,
+      * and then put exception for the components that does not need type 3,
       * by setting them to type 0.
-      * 
+      *
       * The library, during validity check, which is run when the codestream
       * is created for writing, will do the following:
-      * -- If ALL_COMPS is set to type 0, it will be ignored, and the 
+      * -- If ALL_COMPS is set to type 0, it will be ignored, and the
       * codestream will NOT have the corresponding NLT marker segment.
       * -- If ALL_COMPS is set to type 3, then the following will happen:
-      *   - If all the components (except those with type 0 set for them) have 
-      *   the same bit depth and signedness, then the ALL_COMPS NLT marker 
+      *   - If all the components (except those with type 0 set for them) have
+      *   the same bit depth and signedness, then the ALL_COMPS NLT marker
       *   segment will be respected and inserted into the codestream.
       *   Of course, components with NLT 0 will also have the corresponding
       *   NLT marker segment inserted.
       *   - If components, for which no NTL type 0 is specified, have differing
-      *   bit depth or signedness, then the ALL_COMPS will be ignored, and 
+      *   bit depth or signedness, then the ALL_COMPS will be ignored, and
       *   NLT markers are inserted for each component that needs type 3.
       * Components that have their component field larger than the number of
       * components in the codestream are removed.
-      * 
-      * It also worth noting that type 3 nonlinearity has no effect on 
-      * positive image samples.  It is also not recommended for integer-valued 
-      * types. It is only recommended for floating-point image samples, for 
-      * which some of the samples are negative, where type 3 nonlinearity 
-      * should be beneficial.  This is because the encoding engine expects 
-      * two-complement representation for negative values while floating point 
-      * numbers have a sign bit followed by an exponent, which has a biased 
+      *
+      * It also worth noting that type 3 nonlinearity has no effect on
+      * positive image samples.  It is also not recommended for integer-valued
+      * types. It is only recommended for floating-point image samples, for
+      * which some of the samples are negative, where type 3 nonlinearity
+      * should be beneficial.  This is because the encoding engine expects
+      * two-complement representation for negative values while floating point
+      * numbers have a sign bit followed by an exponent, which has a biased
       * integer representation.  The core idea is to make floating-point
       * representation more compatible with integer representation.
 
-    * 
+    *
     */
   class OJPH_EXPORT param_nlt
   {
   public:
     enum special_comp_num : ui16 { ALL_COMPS = 65535 };
-    enum nonlinearity : ui8 { 
+    enum nonlinearity : ui8 {
       OJPH_NLT_NO_NLT = 0,                // supported
       OJPH_NLT_GAMMA_STYLE_NLT = 1,       // not supported
       OJPH_NLT_LUT_STYLE_NLT = 2,         // not supported
       OJPH_NLT_BINARY_COMPLEMENT_NLT = 3, // supported
-      OJPH_NLT_UNDEFINED = 255          // This is used internally and is 
-                                          // not part of the standard 
+      OJPH_NLT_UNDEFINED = 255          // This is used internally and is
+                                          // not part of the standard
     };
   public:
     param_nlt(local::param_nlt* p) : state(p) {}
 
     /**
-      * @brief enables or disables type 3 nonlinearity for a component 
+      * @brief enables or disables type 3 nonlinearity for a component
       *        or the default setting
-      * 
+      *
       * When creating a codestream for writing, call this function before
       * you call codestream::write_headers.
-      * 
-      * 
+      *
+      *
       * @param comp_num: component number, or 65535 for the default setting
       * @param type: desired non-linearity from enum nonlinearity
       */
     void set_nonlinear_transform(ui32 comp_num, ui8 nl_type);
 
     /**
-      * @brief get the nonlinearity type associated with comp_num, which 
+      * @brief get the nonlinearity type associated with comp_num, which
       *        should be one from enum nonlinearity
       *
       * @param comp_num: component number, or 65535 for the default setting
@@ -279,7 +334,7 @@ namespace ojph {
       * @param type: nonlinearity type
       * @return true if the nonlinearity for comp_num is set
       */
-    bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth, 
+    bool get_nonlinear_transform(ui32 comp_num, ui8& bit_depth,
                                  bool& is_signed, ui8& nl_type) const;
 
   private:

--- a/external/OpenJPH/src/core/openjph/ojph_version.h
+++ b/external/OpenJPH/src/core/openjph/ojph_version.h
@@ -34,5 +34,5 @@
 //***************************************************************************/
 
 #define OPENJPH_VERSION_MAJOR 0
-#define OPENJPH_VERSION_MINOR 26
-#define OPENJPH_VERSION_PATCH 3
+#define OPENJPH_VERSION_MINOR 31
+#define OPENJPH_VERSION_PATCH 0

--- a/external/OpenJPH/src/core/others/ojph_arch.cpp
+++ b/external/OpenJPH/src/core/others/ojph_arch.cpp
@@ -5,7 +5,8 @@
 // Copyright (c) 2019, Aous Naman 
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+// Copyright (c) 2026, Osamu Watanabe
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -143,8 +144,12 @@ namespace ojph {
                           osxsave_avail && ((xcr_val & 0xE0) == 0xE0);
                         bool avx512f_avail = (avx2_abcd[1] & 0x10000) != 0;
                         bool avx512cd_avail = (avx2_abcd[1] & 0x10000000) != 0;
-                        bool avx512_avail = 
-                          zmm_avail && avx512f_avail && avx512cd_avail;
+                        bool avx512bw_avail = (avx2_abcd[1] & 0x40000000) != 0;
+                        bool avx512vl_avail =
+                          (avx2_abcd[1] & 0x80000000u) != 0;
+                        bool avx512_avail = zmm_avail && avx512f_avail
+                          && avx512cd_avail && avx512bw_avail
+                          && avx512vl_avail;
                         if (avx512_avail)
                           level = X86_CPU_EXT_LEVEL_AVX512;
                       }
@@ -224,7 +229,38 @@ namespace ojph {
 
     #endif
 
-  #else // architectures other than Intel/AMD and ARM
+  #elif defined(OJPH_ARCH_PPC64LE)
+
+    #if defined(OJPH_OS_LINUX)
+
+      #include <sys/auxv.h>
+      #include <asm/cputable.h>
+
+      bool init_cpu_ext_level(int& level) {
+        unsigned long hwcap = getauxval(AT_HWCAP);
+        unsigned long hwcap2 = getauxval(AT_HWCAP2);
+        level = PPC_CPU_EXT_LEVEL_GENERIC;
+        if ((hwcap & PPC_FEATURE_HAS_VSX) &&
+            (hwcap2 & PPC_FEATURE2_ARCH_3_00)) {
+          level = PPC_CPU_EXT_LEVEL_ARCH_3_00;
+        #ifdef PPC_FEATURE2_ARCH_3_1
+          if (hwcap2 & PPC_FEATURE2_ARCH_3_1)
+            level = PPC_CPU_EXT_LEVEL_ARCH_3_1;
+        #endif
+        }
+        return true;
+      }
+
+    #else // !OJPH_OS_LINUX
+
+      bool init_cpu_ext_level(int& level) {
+        level = PPC_CPU_EXT_LEVEL_GENERIC;
+        return true;
+      }
+
+    #endif
+
+  #else // architectures other than Intel/AMD, ARM, and PPC64LE
 
   ////////////////////////////////////////////////////////////////////////////
   bool init_cpu_ext_level(int& level) {

--- a/external/OpenJPH/src/core/others/ojph_file.cpp
+++ b/external/OpenJPH/src/core/others/ojph_file.cpp
@@ -1,4 +1,4 @@
-//***************************************************************************/
+//***************************************************************************;
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
@@ -42,6 +42,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <utility>
 
 #include "ojph_mem.h"
 #include "ojph_file.h"
@@ -95,19 +96,33 @@ namespace ojph {
     fh = NULL;
   }
 
-  //*************************************************************************/
+  ////////////////////////////////////////////////////////////////////////////
+  //
+  //
   // mem_outfile
-  //*************************************************************************/
+  //
+  //
+  ////////////////////////////////////////////////////////////////////////////
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
   mem_outfile::mem_outfile()
   {
     is_open = clear_mem = false;
     buf_size = used_size = 0;
-    buf = cur_ptr = NULL;
+    buf = cur_ptr = nullptr;
   }
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_outfile::swap(mem_outfile& other) noexcept {
+    std::swap(this->is_open,other.is_open);
+    std::swap(this->clear_mem,other.clear_mem);
+    std::swap(this->buf_size,other.buf_size);
+    std::swap(this->used_size,other.used_size);
+    std::swap(this->buf,other.buf);
+    std::swap(this->cur_ptr,other.cur_ptr);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   mem_outfile::~mem_outfile()
   {
     if (buf)
@@ -117,7 +132,23 @@ namespace ojph {
     buf = cur_ptr = NULL;
   }
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
+  mem_outfile::mem_outfile(mem_outfile&& rhs) noexcept: mem_outfile()
+  {
+    this->swap(rhs);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  mem_outfile& mem_outfile::operator=(mem_outfile&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      mem_outfile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
+    return *this;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::open(size_t initial_size, bool clear_mem)
   {
     assert(this->is_open == false);
@@ -131,12 +162,13 @@ namespace ojph {
     this->cur_ptr = this->buf;
   }
 
-  /**  */
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::close() {
     is_open = false;
     cur_ptr = buf;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
   /** The seek function expands the buffer whenever offset goes beyond
    *  the buffer end
    */
@@ -162,6 +194,7 @@ namespace ojph {
     return 0;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
   /** Whenever the need arises, the buffer is expanded by a factor approx 1.5x
    */
   size_t mem_outfile::write(const void *ptr, size_t new_size)
@@ -183,7 +216,7 @@ namespace ojph {
     return new_size;
   }
 
-  /** */
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::write_to_file(const char *file_name) const
   {
     assert(is_open == false);
@@ -196,7 +229,7 @@ namespace ojph {
     fclose(f);
   }
 
-  /** */
+  ////////////////////////////////////////////////////////////////////////////
   void mem_outfile::expand_storage(size_t needed_size, bool clear_all)
   {
     if (needed_size > buf_size)
@@ -285,6 +318,22 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
 
   ////////////////////////////////////////////////////////////////////////////
+  mem_infile::mem_infile(mem_infile&& rhs) noexcept: mem_infile()
+  {
+    this->swap(rhs);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  mem_infile& mem_infile::operator=(mem_infile&& rhs) noexcept
+  {
+    if (this != &rhs) {
+      mem_infile tmp(std::move(rhs));
+      this->swap(tmp);
+    }
+    return *this;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
   void mem_infile::open(const ui8* data, size_t size)
   {
     assert(this->data == NULL);
@@ -342,5 +391,12 @@ namespace ojph {
     return result;
   }
 
+  ////////////////////////////////////////////////////////////////////////////
+  void mem_infile::swap(mem_infile& other) noexcept
+  {
+    std::swap(this->data,other.data);
+    std::swap(this->cur_ptr,other.cur_ptr);
+    std::swap(this->size,other.size);
+  }
 
 }

--- a/external/OpenJPH/src/core/others/ojph_mem.cpp
+++ b/external/OpenJPH/src/core/others/ojph_mem.cpp
@@ -112,7 +112,10 @@ namespace ojph {
   ////////////////////////////////////////////////////////////////////////////
   void mem_elastic_allocator::get_buffer(ui32 needed_bytes, coded_lists* &p)
   {
-    ui32 extended_bytes = needed_bytes + (ui32)sizeof(coded_lists);
+    // Round up so each coded_lists (and coded_lists::buf) stays 16-byte aligned
+    // within the store; avoids alignment fault on 32-bit architectures
+    ui32 raw = needed_bytes + (ui32)sizeof (coded_lists);
+    ui32 extended_bytes = (raw + 15u) & ~15u;
 
     if (store == NULL)
       cur_store = store = allocate(&store, extended_bytes);

--- a/external/OpenJPH/src/core/others/ojph_mem_c.c
+++ b/external/OpenJPH/src/core/others/ojph_mem_c.c
@@ -30,7 +30,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //***************************************************************************/
 // This file is part of the OpenJPH software implementation.
-// File: ojph_mem.c
+// File: ojph_mem_c.c
 // Author: Aous Naman
 // Date: 17 October 2025
 //***************************************************************************/

--- a/external/OpenJPH/src/core/shared/ojph_simd_vsx.h
+++ b/external/OpenJPH/src/core/shared/ojph_simd_vsx.h
@@ -1,0 +1,361 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2026, Aous Naman
+// Copyright (c) 2026, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2026, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: ojph_simd_vsx.h
+//
+// 128-bit SIMD helpers for POWER VSX, used by the ojph_*_vsx.cpp
+// kernels.  Lane numbering and operation semantics follow the same
+// conventions as the other 128-bit kernels in this codebase (lane 0
+// is the lowest memory address).  Supported targets are POWER9
+// (ISA 3.0) and newer, little-endian only (ppc64le).
+//***************************************************************************/
+
+#ifndef OJPH_SIMD_VSX_H
+#define OJPH_SIMD_VSX_H
+
+#if !defined(__powerpc64__) && !defined(__PPC64__)
+  #error "this header is for 64-bit POWER targets only"
+#endif
+#if !defined(__LITTLE_ENDIAN__) && \
+    !(defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+  #error "this header assumes a little-endian target (ppc64le)"
+#endif
+
+#include <altivec.h>
+#include <cstring>
+
+#include "ojph_defs.h"
+
+// altivec.h leaks these context-sensitive keywords as macros under GNU C;
+// they break standard headers and the codebase (e.g. std::vector)
+#undef vector
+#undef pixel
+#undef bool
+
+typedef __vector unsigned char v128_t;
+
+typedef __vector signed char        vsx_v_i8;
+typedef __vector unsigned char      vsx_v_u8;
+typedef __vector signed short       vsx_v_i16;
+typedef __vector unsigned short     vsx_v_u16;
+typedef __vector signed int         vsx_v_i32;
+typedef __vector unsigned int       vsx_v_u32;
+typedef __vector signed long long   vsx_v_i64;
+typedef __vector unsigned long long vsx_v_u64;
+typedef __vector float              vsx_v_f32;
+
+//---------------------------------------------------------------------------
+// load/store (alignment-agnostic; lxv/stxv handle unaligned addresses)
+//---------------------------------------------------------------------------
+static inline v128_t vsx_v128_load(const void *p)
+{ return vec_xl(0, (const unsigned char *)p); }
+
+static inline void vsx_v128_store(void *p, v128_t a)
+{ vec_xst(a, 0, (unsigned char *)p); }
+
+#define vsx_v128_store32_lane(p, a, i) \
+  do { vsx_v_i32 t_ = (vsx_v_i32)(a); int v_ = t_[(i)]; \
+       std::memcpy((p), &v_, 4); } while (0)
+
+//---------------------------------------------------------------------------
+// constants, splats, makes
+//---------------------------------------------------------------------------
+// functions, not macros, so that an argument that is itself a macro
+// expanding to an argument list (e.g. OJPH_REPEAT4) works
+static inline v128_t vsx_i8x16_const(
+  signed char c0, signed char c1, signed char c2, signed char c3,
+  signed char c4, signed char c5, signed char c6, signed char c7,
+  signed char c8, signed char c9, signed char c10, signed char c11,
+  signed char c12, signed char c13, signed char c14, signed char c15)
+{ vsx_v_i8 v = {c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15};
+  return (v128_t)v; }
+static inline v128_t vsx_i16x8_const(short c0, short c1, short c2,
+                                      short c3, short c4, short c5,
+                                      short c6, short c7)
+{ vsx_v_i16 v = {c0,c1,c2,c3,c4,c5,c6,c7}; return (v128_t)v; }
+static inline v128_t vsx_u16x8_const(unsigned short c0, unsigned short c1,
+                                      unsigned short c2, unsigned short c3,
+                                      unsigned short c4, unsigned short c5,
+                                      unsigned short c6, unsigned short c7)
+{ vsx_v_u16 v = {c0,c1,c2,c3,c4,c5,c6,c7}; return (v128_t)v; }
+static inline v128_t vsx_i32x4_const(int c0, int c1, int c2, int c3)
+{ vsx_v_i32 v = {c0,c1,c2,c3}; return (v128_t)v; }
+static inline v128_t vsx_u32x4_const(unsigned int c0, unsigned int c1,
+                                      unsigned int c2, unsigned int c3)
+{ vsx_v_u32 v = {c0,c1,c2,c3}; return (v128_t)v; }
+static inline v128_t vsx_i64x2_const(long long c0, long long c1)
+{ vsx_v_i64 v = {c0,c1}; return (v128_t)v; }
+static inline v128_t vsx_u64x2_const(unsigned long long c0,
+                                      unsigned long long c1)
+{ vsx_v_u64 v = {c0,c1}; return (v128_t)v; }
+
+static inline v128_t vsx_i8x16_splat(signed char x)
+{ ojph_unused(x); return (v128_t)vec_splats(x); }
+static inline v128_t vsx_i16x8_splat(short x)
+{ ojph_unused(x); return (v128_t)vec_splats(x); }
+static inline v128_t vsx_i32x4_splat(int x)
+{ ojph_unused(x); return (v128_t)vec_splats(x); }
+static inline v128_t vsx_u32x4_splat(unsigned int x)
+{ ojph_unused(x); return (v128_t)vec_splats(x); }
+static inline v128_t vsx_i64x2_splat(long long x)
+{ ojph_unused(x); return (v128_t)vec_splats((signed long long)x); }
+static inline v128_t vsx_f32x4_splat(float x)
+{ ojph_unused(x); return (v128_t)vec_splats(x); }
+
+static inline v128_t vsx_i32x4_make(int a, int b, int c, int d)
+{ return (v128_t)(vsx_v_i32){a, b, c, d}; }
+
+//---------------------------------------------------------------------------
+// lane extraction (subscript is little-endian lane order)
+//---------------------------------------------------------------------------
+#define vsx_u8x16_extract_lane(a, i)  (((vsx_v_u8)(a))[(i)])
+#define vsx_u16x8_extract_lane(a, i)  (((vsx_v_u16)(a))[(i)])
+#define vsx_i32x4_extract_lane(a, i)  (((vsx_v_i32)(a))[(i)])
+#define vsx_u32x4_extract_lane(a, i)  (((vsx_v_u32)(a))[(i)])
+#define vsx_i64x2_extract_lane(a, i)  (((vsx_v_i64)(a))[(i)])
+
+//---------------------------------------------------------------------------
+// bitwise
+//---------------------------------------------------------------------------
+static inline v128_t vsx_v128_and(v128_t a, v128_t b)
+{ return vec_and(a, b); }
+static inline v128_t vsx_v128_or(v128_t a, v128_t b)
+{ return vec_or(a, b); }
+static inline v128_t vsx_v128_xor(v128_t a, v128_t b)
+{ return vec_xor(a, b); }
+// a & ~b  (same operand order as vec_andc)
+static inline v128_t vsx_v128_andnot(v128_t a, v128_t b)
+{ return vec_andc(a, b); }
+
+//---------------------------------------------------------------------------
+// integer arithmetic
+//---------------------------------------------------------------------------
+static inline v128_t vsx_i8x16_add(v128_t a, v128_t b)
+{ return (v128_t)vec_add((vsx_v_i8)a, (vsx_v_i8)b); }
+static inline v128_t vsx_i16x8_add(v128_t a, v128_t b)
+{ return (v128_t)vec_add((vsx_v_i16)a, (vsx_v_i16)b); }
+static inline v128_t vsx_i32x4_add(v128_t a, v128_t b)
+{ return (v128_t)vec_add((vsx_v_i32)a, (vsx_v_i32)b); }
+static inline v128_t vsx_i64x2_add(v128_t a, v128_t b)
+{ return (v128_t)vec_add((vsx_v_i64)a, (vsx_v_i64)b); }
+
+static inline v128_t vsx_i16x8_sub(v128_t a, v128_t b)
+{ return (v128_t)vec_sub((vsx_v_i16)a, (vsx_v_i16)b); }
+static inline v128_t vsx_i32x4_sub(v128_t a, v128_t b)
+{ return (v128_t)vec_sub((vsx_v_i32)a, (vsx_v_i32)b); }
+static inline v128_t vsx_i64x2_sub(v128_t a, v128_t b)
+{ return (v128_t)vec_sub((vsx_v_i64)a, (vsx_v_i64)b); }
+
+// low half of products; vmladduhm / vmuluwm; i64x2 is lowered by the
+// compiler (mulld on ISA 3.0, vmulld on ISA 3.1)
+static inline v128_t vsx_i16x8_mul(v128_t a, v128_t b)
+{ return (v128_t)((vsx_v_i16)a * (vsx_v_i16)b); }
+static inline v128_t vsx_i32x4_mul(v128_t a, v128_t b)
+{ return (v128_t)((vsx_v_i32)a * (vsx_v_i32)b); }
+static inline v128_t vsx_i64x2_mul(v128_t a, v128_t b)
+{ return (v128_t)((vsx_v_i64)a * (vsx_v_i64)b); }
+
+static inline v128_t vsx_i8x16_abs(v128_t a)
+{ return (v128_t)vec_abs((vsx_v_i8)a); }
+static inline v128_t vsx_u8x16_min(v128_t a, v128_t b)
+{ return (v128_t)vec_min((vsx_v_u8)a, (vsx_v_u8)b); }
+static inline v128_t vsx_i16x8_max(v128_t a, v128_t b)
+{ return (v128_t)vec_max((vsx_v_i16)a, (vsx_v_i16)b); }
+
+//---------------------------------------------------------------------------
+// shifts (scalar count, modulo lane width)
+//---------------------------------------------------------------------------
+static inline v128_t vsx_i16x8_shl(v128_t a, int n)
+{ return (v128_t)vec_sl((vsx_v_i16)a, vec_splats((unsigned short)n)); }
+static inline v128_t vsx_i32x4_shl(v128_t a, int n)
+{ return (v128_t)vec_sl((vsx_v_i32)a, vec_splats((unsigned int)n)); }
+static inline v128_t vsx_i64x2_shl(v128_t a, int n)
+{ return (v128_t)vec_sl((vsx_v_i64)a,
+                        vec_splats((unsigned long long)n)); }
+
+static inline v128_t vsx_i32x4_shr(v128_t a, int n)   // arithmetic
+{ return (v128_t)vec_sra((vsx_v_i32)a, vec_splats((unsigned int)n)); }
+static inline v128_t vsx_i64x2_shr(v128_t a, int n)   // arithmetic
+{ return (v128_t)vec_sra((vsx_v_i64)a,
+                         vec_splats((unsigned long long)n)); }
+
+static inline v128_t vsx_u16x8_shr(v128_t a, int n)   // logical
+{ return (v128_t)vec_sr((vsx_v_u16)a, vec_splats((unsigned short)n)); }
+static inline v128_t vsx_u32x4_shr(v128_t a, int n)   // logical
+{ return (v128_t)vec_sr((vsx_v_u32)a, vec_splats((unsigned int)n)); }
+static inline v128_t vsx_u64x2_shr(v128_t a, int n)   // logical
+{ return (v128_t)vec_sr((vsx_v_u64)a,
+                        vec_splats((unsigned long long)n)); }
+
+//---------------------------------------------------------------------------
+// comparisons (true lanes -> all-ones, false lanes -> all-zeros)
+//---------------------------------------------------------------------------
+static inline v128_t vsx_i8x16_eq(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpeq((vsx_v_i8)a, (vsx_v_i8)b); }
+static inline v128_t vsx_i16x8_eq(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpeq((vsx_v_i16)a, (vsx_v_i16)b); }
+static inline v128_t vsx_i32x4_eq(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpeq((vsx_v_i32)a, (vsx_v_i32)b); }
+
+static inline v128_t vsx_i8x16_gt(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpgt((vsx_v_i8)a, (vsx_v_i8)b); }
+static inline v128_t vsx_i32x4_gt(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpgt((vsx_v_i32)a, (vsx_v_i32)b); }
+static inline v128_t vsx_i32x4_lt(v128_t a, v128_t b)
+{ return (v128_t)vec_cmplt((vsx_v_i32)a, (vsx_v_i32)b); }
+static inline v128_t vsx_i64x2_lt(v128_t a, v128_t b)
+{ return (v128_t)vec_cmplt((vsx_v_i64)a, (vsx_v_i64)b); }
+
+static inline v128_t vsx_f32x4_ge(v128_t a, v128_t b)
+{ return (v128_t)vec_cmpge((vsx_v_f32)a, (vsx_v_f32)b); }
+static inline v128_t vsx_f32x4_lt(v128_t a, v128_t b)
+{ return (v128_t)vec_cmplt((vsx_v_f32)a, (vsx_v_f32)b); }
+
+//---------------------------------------------------------------------------
+// float arithmetic and conversions
+//---------------------------------------------------------------------------
+static inline v128_t vsx_f32x4_add(v128_t a, v128_t b)
+{ return (v128_t)vec_add((vsx_v_f32)a, (vsx_v_f32)b); }
+static inline v128_t vsx_f32x4_sub(v128_t a, v128_t b)
+{ return (v128_t)vec_sub((vsx_v_f32)a, (vsx_v_f32)b); }
+static inline v128_t vsx_f32x4_mul(v128_t a, v128_t b)
+{ return (v128_t)vec_mul((vsx_v_f32)a, (vsx_v_f32)b); }
+
+// xvcvspsxws: truncating, saturating (NaN gives 0x80000000; the
+// callers never pass NaN)
+static inline v128_t vsx_i32x4_trunc_sat_f32x4(v128_t a)
+{ return (v128_t)vec_cts((vsx_v_f32)a, 0); }
+static inline v128_t vsx_f32x4_convert_i32x4(v128_t a)
+{ return (v128_t)vec_ctf((vsx_v_i32)a, 0); }
+
+//---------------------------------------------------------------------------
+// widening
+//---------------------------------------------------------------------------
+static inline v128_t vsx_i64x2_extend_low_i32x4(v128_t a)
+{
+  // vsx_v_i32 v = (vsx_v_i32)a;
+  // return (v128_t)__builtin_convertvector(
+  //   __builtin_shufflevector(v, v, 0, 1), vsx_v_i64);
+
+  // Unpacks and sign-extends elements 0 and 1 on Little Endian
+  return (v128_t)vec_unpackl((vsx_v_i32)a);
+}
+static inline v128_t vsx_i64x2_extend_high_i32x4(v128_t a)
+{
+  // vsx_v_i32 v = (vsx_v_i32)a;
+  // return (v128_t)__builtin_convertvector(
+  //   __builtin_shufflevector(v, v, 2, 3), vsx_v_i64);
+
+  // Unpacks and sign-extends elements 2 and 3 on Little Endian
+  return (v128_t)vec_unpackh((vsx_v_i32)a);
+}
+
+//---------------------------------------------------------------------------
+// shuffles (immediate lane indices; 0..N-1 from a, N..2N-1 from b)
+//---------------------------------------------------------------------------
+// #define vsx_i8x16_shuffle(a, b, c0,c1,c2,c3,c4,c5,c6,c7,
+//                                  c8,c9,c10,c11,c12,c13,c14,c15)
+//   ((v128_t)__builtin_shufflevector((vsx_v_u8)(a), (vsx_v_u8)(b),
+//     c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15))
+// #define vsx_i16x8_shuffle(a, b, c0,c1,c2,c3,c4,c5,c6,c7)
+//   ((v128_t)__builtin_shufflevector((vsx_v_i16)(a), (vsx_v_i16)(b),
+//     c0,c1,c2,c3,c4,c5,c6,c7))
+// #define vsx_i32x4_shuffle(a, b, c0,c1,c2,c3)
+//   ((v128_t)__builtin_shufflevector((vsx_v_i32)(a), (vsx_v_i32)(b),
+//     c0,c1,c2,c3))
+// #define vsx_i64x2_shuffle(a, b, c0,c1)
+//   ((v128_t)__builtin_shufflevector((vsx_v_i64)(a), (vsx_v_i64)(b), c0,c1))
+
+// 8-bit Shuffle (Maps direct element indices to raw byte indices)
+#define vsx_i8x16_shuffle(a, b, c0,c1,c2,c3,c4,c5,c6,c7, \
+                                 c8,c9,c10,c11,c12,c13,c14,c15) \
+  ((v128_t)vec_perm((vsx_v_u8)(a), (vsx_v_u8)(b), (vsx_v_u8){ \
+    (c0), (c1), (c2), (c3), (c4), (c5), (c6), (c7), \
+    (c8), (c9), (c10),(c11),(c12),(c13),(c14),(c15) \
+  }))
+
+// 16-bit Shuffle (Multiplies element index by 2 to get byte offsets)
+#define vsx_i16x8_shuffle(a, b, c0,c1,c2,c3,c4,c5,c6,c7) \
+  ((v128_t)vec_perm((vsx_v_u8)(a), (vsx_v_u8)(b), (vsx_v_u8){ \
+    (c0)*2, (c0)*2+1,  (c1)*2, (c1)*2+1, \
+    (c2)*2, (c2)*2+1,  (c3)*2, (c3)*2+1, \
+    (c4)*2, (c4)*2+1,  (c5)*2, (c5)*2+1, \
+    (c6)*2, (c6)*2+1,  (c7)*2, (c7)*2+1  \
+  }))
+
+// 32-bit Shuffle (Multiplies element index by 4 to get byte offsets)
+#define vsx_i32x4_shuffle(a, b, c0,c1,c2,c3) \
+  ((v128_t)vec_perm((vsx_v_u8)(a), (vsx_v_u8)(b), (vsx_v_u8){ \
+    (c0)*4, (c0)*4+1, (c0)*4+2, (c0)*4+3, \
+    (c1)*4, (c1)*4+1, (c1)*4+2, (c1)*4+3, \
+    (c2)*4, (c2)*4+1, (c2)*4+2, (c2)*4+3, \
+    (c3)*4, (c3)*4+1, (c3)*4+2, (c3)*4+3  \
+  }))
+
+// 64-bit Shuffle (Multiplies element index by 8 to get byte offsets)
+#define vsx_i64x2_shuffle(a, b, c0,c1) \
+  ((v128_t)vec_perm((vsx_v_u8)(a), (vsx_v_u8)(b), (vsx_v_u8){ \
+    (c0)*8, (c0)*8+1, (c0)*8+2, (c0)*8+3,  \
+    (c0)*8+4, (c0)*8+5, (c0)*8+6, (c0)*8+7, \
+    (c1)*8, (c1)*8+1, (c1)*8+2, (c1)*8+3,  \
+    (c1)*8+4, (c1)*8+5, (c1)*8+6, (c1)*8+7  \
+  }))
+
+//---------------------------------------------------------------------------
+// swizzle: runtime byte-table lookup; lanes with index > 15 give 0
+//---------------------------------------------------------------------------
+static inline v128_t vsx_i8x16_swizzle(v128_t a, v128_t idx)
+{
+  v128_t r = vec_perm(a, a, idx);
+  v128_t oob = (v128_t)vec_cmpgt((vsx_v_u8)idx,
+                                 vec_splats((unsigned char)15));
+  return vec_andc(r, oob);
+}
+
+//---------------------------------------------------------------------------
+// bitmask: MSB of each byte lane -> bit of result, lane 0 -> bit 0
+// (vbpermq gathers the 16 selected bits into bits 48..63 of the
+// big-endian first doubleword, which is doubleword 1 on ppc64le)
+//---------------------------------------------------------------------------
+static inline int vsx_i8x16_bitmask(v128_t a)
+{
+#if defined(__POWER10_VECTOR__)
+  return (int)vec_extractm(a);   // ISA 3.1 native movemask
+#else
+  const vsx_v_u8 perm = { 120, 112, 104, 96, 88, 80, 72, 64,
+                            56,  48,  40, 32, 24, 16,  8,  0 };
+  vsx_v_u64 r = (vsx_v_u64)vec_bperm(a, perm);
+  return (int)r[1];
+#endif
+}
+
+#endif // OJPH_SIMD_VSX_H

--- a/external/OpenJPH/src/core/transform/ojph_colour.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_colour.cpp
@@ -37,6 +37,7 @@
 
 #include <cmath>
 #include <climits>
+#include <mutex>
 
 #include "ojph_defs.h"
 #include "ojph_arch.h"
@@ -105,26 +106,22 @@ namespace ojph {
        float *r, float *g, float *b, ui32 repeat) = NULL;
 
     //////////////////////////////////////////////////////////////////////////
-    static bool colour_transform_functions_initialized = false;
-
-    //////////////////////////////////////////////////////////////////////////
     void init_colour_transform_functions()
     {
-      if (colour_transform_functions_initialized)
-        return;
-
+      static std::once_flag colour_transform_functions_init_flag;
+      std::call_once(colour_transform_functions_init_flag, []() {
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
-      rev_convert = gen_rev_convert;
-      rev_convert_nlt_type3 = gen_rev_convert_nlt_type3;
-      irv_convert_to_integer = gen_irv_convert_to_integer;
-      irv_convert_to_float = gen_irv_convert_to_float;
-      irv_convert_to_integer_nlt_type3 = gen_irv_convert_to_integer_nlt_type3;
-      irv_convert_to_float_nlt_type3 = gen_irv_convert_to_float_nlt_type3;
-      rct_forward = gen_rct_forward;
-      rct_backward = gen_rct_backward;
-      ict_forward = gen_ict_forward;
-      ict_backward = gen_ict_backward;
+        rev_convert = gen_rev_convert;
+        rev_convert_nlt_type3 = gen_rev_convert_nlt_type3;
+        irv_convert_to_integer = gen_irv_convert_to_integer;
+        irv_convert_to_float = gen_irv_convert_to_float;
+        irv_convert_to_integer_nlt_type3 = gen_irv_convert_to_integer_nlt_type3;
+        irv_convert_to_float_nlt_type3 = gen_irv_convert_to_float_nlt_type3;
+        rct_forward = gen_rct_forward;
+        rct_backward = gen_rct_backward;
+        ict_forward = gen_ict_forward;
+        ict_backward = gen_ict_backward;
 
   #ifndef OJPH_DISABLE_SIMD
 
@@ -180,26 +177,44 @@ namespace ojph {
 
     #elif defined(OJPH_ARCH_ARM)
 
+    #elif defined(OJPH_ARCH_PPC64LE)
+
+        if (get_cpu_ext_level() >= PPC_CPU_EXT_LEVEL_ARCH_3_00)
+        {
+          // 128-bit VSX kernels; see ojph_simd_vsx.h
+          rev_convert = vsx_rev_convert;
+          rev_convert_nlt_type3 = vsx_rev_convert_nlt_type3;
+          irv_convert_to_integer = vsx_irv_convert_to_integer;
+          irv_convert_to_float = vsx_irv_convert_to_float;
+          irv_convert_to_integer_nlt_type3 =
+            vsx_irv_convert_to_integer_nlt_type3;
+          irv_convert_to_float_nlt_type3 =
+            vsx_irv_convert_to_float_nlt_type3;
+          rct_forward = vsx_rct_forward;
+          rct_backward = vsx_rct_backward;
+          ict_forward = vsx_ict_forward;
+          ict_backward = vsx_ict_backward;
+        }
+
     #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
   #endif // !OJPH_DISABLE_SIMD
 
 #else // OJPH_ENABLE_WASM_SIMD
 
-      rev_convert = wasm_rev_convert;
-      rev_convert_nlt_type3 = wasm_rev_convert_nlt_type3;
-      irv_convert_to_integer = wasm_irv_convert_to_integer;
-      irv_convert_to_float = wasm_irv_convert_to_float;
-      irv_convert_to_integer_nlt_type3 = wasm_irv_convert_to_integer_nlt_type3;
-      irv_convert_to_float_nlt_type3 = wasm_irv_convert_to_float_nlt_type3;
-      rct_forward = wasm_rct_forward;
-      rct_backward = wasm_rct_backward;
-      ict_forward = wasm_ict_forward;
-      ict_backward = wasm_ict_backward;
+        rev_convert = wasm_rev_convert;
+        rev_convert_nlt_type3 = wasm_rev_convert_nlt_type3;
+        irv_convert_to_integer = wasm_irv_convert_to_integer;
+        irv_convert_to_float = wasm_irv_convert_to_float;
+        irv_convert_to_integer_nlt_type3 = wasm_irv_convert_to_integer_nlt_type3;
+        irv_convert_to_float_nlt_type3 = wasm_irv_convert_to_float_nlt_type3;
+        rct_forward = wasm_rct_forward;
+        rct_backward = wasm_rct_backward;
+        ict_forward = wasm_ict_forward;
+        ict_backward = wasm_ict_backward;
 
 #endif // !OJPH_ENABLE_WASM_SIMD
-
-      colour_transform_functions_initialized = true;
+      });
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/external/OpenJPH/src/core/transform/ojph_colour_local.h
+++ b/external/OpenJPH/src/core/transform/ojph_colour_local.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -66,14 +66,14 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void gen_rev_convert_nlt_type3(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
@@ -158,14 +158,14 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rev_convert(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void sse2_rev_convert_nlt_type3(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
@@ -214,14 +214,14 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rev_convert(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void avx2_rev_convert_nlt_type3(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
@@ -257,7 +257,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     //
     //
-    //                              WASM Functions 
+    //                              WASM Functions
     //
     //
     //////////////////////////////////////////////////////////////////////////
@@ -274,14 +274,14 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rev_convert(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_rev_convert_nlt_type3(
-      const line_buf *src_line, const ui32 src_line_offset, 
-      line_buf *dst_line, const ui32 dst_line_offset, 
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
       si64 shift, ui32 width);
 
     //////////////////////////////////////////////////////////////////////////
@@ -310,6 +310,64 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     void wasm_ict_backward(const float *y, const float *cb, const float *cr,
+                           float *r, float *g, float *b, ui32 repeat);
+
+    //////////////////////////////////////////////////////////////////////////
+    //
+    //
+    //                               VSX Functions
+    //
+    //
+    //////////////////////////////////////////////////////////////////////////
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_integer(
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_float(
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_convert(
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
+      si64 shift, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_convert_nlt_type3(
+      const line_buf *src_line, const ui32 src_line_offset,
+      line_buf *dst_line, const ui32 dst_line_offset,
+      si64 shift, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_integer_nlt_type3(
+      const line_buf *src_line, line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_float_nlt_type3(
+      const line_buf *src_line, ui32 src_line_offset,
+      line_buf *dst_line, ui32 bit_depth, bool is_signed, ui32 width);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rct_forward(
+      const line_buf *r, const line_buf *g, const line_buf *b,
+      line_buf *y, line_buf *cb, line_buf *cr, ui32 repeat);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rct_backward(
+      const line_buf *y, const line_buf *cb, const line_buf *cr,
+      line_buf *r, line_buf *g, line_buf *b, ui32 repeat);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_ict_forward(const float *r, const float *g, const float *b,
+                          float *y, float *cb, float *cr, ui32 repeat);
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_ict_backward(const float *y, const float *cb, const float *cr,
                            float *r, float *g, float *b, ui32 repeat);
 
   }

--- a/external/OpenJPH/src/core/transform/ojph_colour_vsx.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_colour_vsx.cpp
@@ -1,0 +1,668 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2021, Aous Naman
+// Copyright (c) 2021, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2021, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: ojph_colour_vsx.cpp
+// Author: Aous Naman
+// Date: 9 February 2021
+//***************************************************************************/
+
+#include <climits>
+#include <cmath>
+#include "ojph_simd_vsx.h"
+
+#include "ojph_defs.h"
+#include "ojph_mem.h"
+#include "ojph_colour.h"
+#include "ojph_colour_local.h"
+
+namespace ojph {
+  namespace local {
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    v128_t ojph_convert_float_to_i32(v128_t a)
+    { // We implement ojph_round, which is
+      // val + (val >= 0.0f ? 0.5f : -0.5f), where val is float; this is
+      // round to nearest with ties away from zero, which is exactly what
+      // xvrspi does.  The instruction is used via inline asm because
+      // GCC's vec_round rounds ties to even.
+      vsx_v_f32 w;
+      __asm__("xvrspi %x0,%x1" : "=wa"(w) : "wa"((vsx_v_f32)a));
+      return (v128_t)vec_cts(w, 0);     // saturating convert to int32
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_convert(const line_buf *src_line,
+                          const ui32 src_line_offset,
+                          line_buf *dst_line,
+                          const ui32 dst_line_offset,
+                          si64 shift, ui32 width)
+    {
+      if (src_line->flags & line_buf::LFT_32BIT)
+      {
+        if (dst_line->flags & line_buf::LFT_32BIT)
+        {
+          const si32 *sp = src_line->i32 + src_line_offset;
+          si32 *dp = dst_line->i32 + dst_line_offset;
+          v128_t sh = vsx_i32x4_splat((si32)shift);
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+          {
+            v128_t s = vsx_v128_load(sp);
+            s = vsx_i32x4_add(s, sh);
+            vsx_v128_store(dp, s);
+          }
+        }
+        else
+        {
+          const si32 *sp = src_line->i32 + src_line_offset;
+          si64 *dp = dst_line->i64 + dst_line_offset;
+          v128_t sh = vsx_i64x2_splat(shift);
+          for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+          {
+            v128_t s, t;
+            s = vsx_v128_load(sp);
+
+            t = vsx_i64x2_extend_low_i32x4(s);
+            t = vsx_i64x2_add(t, sh);
+            vsx_v128_store(dp, t);
+
+            t = vsx_i64x2_extend_high_i32x4(s);
+            t = vsx_i64x2_add(t, sh);
+            vsx_v128_store(dp + 2, t);
+          }
+        }
+      }
+      else
+      {
+        assert(src_line->flags | line_buf::LFT_64BIT);
+        assert(dst_line->flags | line_buf::LFT_32BIT);
+        const si64 *sp = src_line->i64 + src_line_offset;
+        si32 *dp = dst_line->i32 + dst_line_offset;
+        v128_t sh = vsx_i64x2_splat(shift);
+        for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+        {
+          v128_t s0, s1;
+          s0 = vsx_v128_load(sp);
+          s0 = vsx_i64x2_add(s0, sh);
+          s1 = vsx_v128_load(sp + 2);
+          s1 = vsx_i64x2_add(s1, sh);
+          s0 = vsx_i32x4_shuffle(s0, s1, 0, 2, 4 + 0, 4 + 2);
+          vsx_v128_store(dp, s0);
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_convert_nlt_type3(const line_buf *src_line,
+                                    const ui32 src_line_offset,
+                                    line_buf *dst_line,
+                                    const ui32 dst_line_offset,
+                                    si64 shift, ui32 width)
+    {
+      if (src_line->flags & line_buf::LFT_32BIT)
+      {
+        if (dst_line->flags & line_buf::LFT_32BIT)
+        {
+          const si32 *sp = src_line->i32 + src_line_offset;
+          si32 *dp = dst_line->i32 + dst_line_offset;
+          v128_t sh = vsx_i32x4_splat((si32)(-shift));
+          v128_t zero = vsx_i32x4_splat(0);
+          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          {
+            v128_t s = vsx_v128_load(sp);
+            v128_t c = vsx_i32x4_lt(s, zero);     // 0xFFFFFFFF for -ve value
+            v128_t v_m_sh = vsx_i32x4_sub(sh, s); // - shift - value
+            v_m_sh = vsx_v128_and(c, v_m_sh);     // keep only - shift - value
+            s = vsx_v128_andnot(s, c);            // keep only +ve or 0
+            s = vsx_v128_or(s, v_m_sh);           // combine
+            vsx_v128_store(dp, s);
+          }
+        }
+        else
+        {
+          const si32 *sp = src_line->i32 + src_line_offset;
+          si64 *dp = dst_line->i64 + dst_line_offset;
+          v128_t sh = vsx_i64x2_splat(-shift);
+          v128_t zero = vsx_i32x4_splat(0);
+          for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+          {
+            v128_t s, u, c, v_m_sh;
+            s = vsx_v128_load(sp);
+
+            u = vsx_i64x2_extend_low_i32x4(s);
+            c = vsx_i64x2_lt(u, zero);        // 64b -1 for -ve value
+            v_m_sh = vsx_i64x2_sub(sh, u);    // - shift - value
+            v_m_sh = vsx_v128_and(c, v_m_sh); // keep only - shift - value
+            u = vsx_v128_andnot(u, c);        // keep only +ve or 0
+            u = vsx_v128_or(u, v_m_sh);       // combine
+
+            vsx_v128_store(dp, u);
+
+            u = vsx_i64x2_extend_high_i32x4(s);
+            c = vsx_i64x2_lt(u, zero);        // 64b -1 for -ve value
+            v_m_sh = vsx_i64x2_sub(sh, u);    // - shift - value
+            v_m_sh = vsx_v128_and(c, v_m_sh); // keep only - shift - value
+            u = vsx_v128_andnot(u, c);        // keep only +ve or 0
+            u = vsx_v128_or(u, v_m_sh);       // combine
+
+            vsx_v128_store(dp + 2, u);
+          }
+        }
+      }
+      else
+      {
+        assert(src_line->flags | line_buf::LFT_64BIT);
+        assert(dst_line->flags | line_buf::LFT_32BIT);
+        const si64 *sp = src_line->i64 + src_line_offset;
+        si32 *dp = dst_line->i32 + dst_line_offset;
+        v128_t sh = vsx_i64x2_splat(-shift);
+        v128_t zero = vsx_i32x4_splat(0);
+        for (int i = (width + 3) >> 2; i > 0; --i, sp += 4, dp += 4)
+        {
+          // s for source, t for target, p for positive, n for negative,
+          // m for mask, and tm for temp
+          v128_t s, t0, t1, p, n, m, tm;
+          s = vsx_v128_load(sp);
+          m = vsx_i64x2_lt(s, zero);   // 64b -1 for -ve value
+          tm = vsx_i64x2_sub(sh, s);   // - shift - value
+          n = vsx_v128_and(m, tm);     // -ve
+          p = vsx_v128_andnot(s, m);   // +ve
+          t0 = vsx_v128_or(n, p);
+
+          s = vsx_v128_load(sp + 2);
+          m = vsx_i64x2_lt(s, zero);   // 64b -1 for -ve value
+          tm = vsx_i64x2_sub(sh, s);   // - shift - value
+          n = vsx_v128_and(m, tm);     // -ve
+          p = vsx_v128_andnot(s, m);   // +ve
+          t1 = vsx_v128_or(n, p);
+
+          t0 = vsx_i32x4_shuffle(t0, t1, 0, 2, 4 + 0, 4 + 2);
+          vsx_v128_store(dp, t0);
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_cnvrt_si32_to_float_shftd(const si32 *sp, float *dp, float mul,
+                                        ui32 width)
+    {
+      v128_t shift = vsx_f32x4_splat(0.5f);
+      v128_t m = vsx_f32x4_splat(mul);
+      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+      {
+        v128_t t = vsx_v128_load(sp);
+        v128_t s = vsx_f32x4_convert_i32x4(t);
+        s = vsx_f32x4_mul(s, m);
+        s = vsx_f32x4_sub(s, shift);
+        vsx_v128_store(dp, s);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_cnvrt_si32_to_float(const si32 *sp, float *dp, float mul,
+                                  ui32 width)
+    {
+      v128_t m = vsx_f32x4_splat(mul);
+      for (ui32 i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+      {
+        v128_t t = vsx_v128_load(sp);
+        v128_t s = vsx_f32x4_convert_i32x4(t);
+        s = vsx_f32x4_mul(s, m);
+        vsx_v128_store(dp, s);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_cnvrt_float_to_si32_shftd(const float *sp, si32 *dp, float mul,
+                                        ui32 width)
+    {
+      const v128_t half = vsx_f32x4_splat(0.5f);
+      v128_t m = vsx_f32x4_splat(mul);
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+      {
+        v128_t t = vsx_v128_load(sp);
+        v128_t s = vsx_f32x4_add(t, half);
+        s = vsx_f32x4_mul(s, m);
+        s = vsx_f32x4_add(s, half); // + 0.5 and followed by floor next
+        vsx_v128_store(dp, ojph_convert_float_to_i32(s));
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_cnvrt_float_to_si32(const float *sp, si32 *dp, float mul,
+                                  ui32 width)
+    {
+      const v128_t half = vsx_f32x4_splat(0.5f);
+      v128_t m = vsx_f32x4_splat(mul);
+      for (int i = (width + 3) >> 2; i > 0; --i, sp+=4, dp+=4)
+      {
+        v128_t t = vsx_v128_load(sp);
+        v128_t s = vsx_f32x4_mul(t, m);
+        s = vsx_f32x4_add(s, half); // + 0.5 and followed by floor next
+        vsx_v128_store(dp, ojph_convert_float_to_i32(s));
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    v128_t ojph_vsx_i32x4_max_ge(v128_t a, v128_t b, v128_t x, v128_t y)
+    {
+      v128_t c = vsx_f32x4_ge(x, y);    // 0xFFFFFFFF for x >= y
+      return (v128_t)vec_sel((vsx_v_u32)b, (vsx_v_u32)a, (vsx_v_u32)c);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    v128_t ojph_vsx_i32x4_min_lt(v128_t a, v128_t b, v128_t x, v128_t y)
+    {
+      v128_t c = vsx_f32x4_lt(x, y);    // 0xFFFFFFFF for x < y
+      return (v128_t)vec_sel((vsx_v_u32)b, (vsx_v_u32)a, (vsx_v_u32)c);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template <bool NLT_TYPE3>
+    static inline
+    void local_vsx_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      assert((src_line->flags & line_buf::LFT_32BIT) &&
+             (src_line->flags & line_buf::LFT_INTEGER) == 0 &&
+             (dst_line->flags & line_buf::LFT_32BIT) &&
+             (dst_line->flags & line_buf::LFT_INTEGER));
+
+      assert(bit_depth <= 32);
+      const float* sp = src_line->f32;
+      si32* dp = dst_line->i32 + dst_line_offset;
+      // There is the possibility that converting to integer will
+      // exceed the dynamic range of 32bit integer; therefore, care must be
+      // exercised.
+      // We look if the floating point number is outside the half-closed
+      // interval [-0.5f, 0.5f). If so, we limit the resulting integer
+      // to the maximum/minimum that number supports.
+      si32 neg_limit = (si32)INT_MIN >> (32 - bit_depth);
+      v128_t mul = vsx_f32x4_splat((float)(1ull << bit_depth));
+      v128_t fl_up_lim = vsx_f32x4_splat(-(float)neg_limit); // val < upper
+      v128_t fl_low_lim = vsx_f32x4_splat((float)neg_limit); // val >= lower
+      v128_t s32_up_lim = vsx_i32x4_splat(INT_MAX >> (32 - bit_depth));
+      v128_t s32_low_lim = vsx_i32x4_splat(INT_MIN >> (32 - bit_depth));
+
+      if (is_signed)
+      {
+        const v128_t zero = vsx_f32x4_splat(0.0f);
+        v128_t bias = vsx_i32x4_splat(-(si32)((1ULL << (bit_depth - 1)) + 1));
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          v128_t t = vsx_v128_load(sp);
+          t = vsx_f32x4_mul(t, mul);
+          v128_t u = ojph_convert_float_to_i32(t);
+          u = ojph_vsx_i32x4_max_ge(u, s32_low_lim, t, fl_low_lim);
+          u = ojph_vsx_i32x4_min_lt(u, s32_up_lim, t, fl_up_lim);
+          if (NLT_TYPE3)
+          {
+            v128_t c = vsx_i32x4_gt(zero, u);    // 0xFFFFFFFF for -ve value
+            v128_t neg = vsx_i32x4_sub(bias, u); // -bias -value
+            neg = vsx_v128_and(c, neg);          // keep only - bias - value
+            u = vsx_v128_andnot(u, c);           // keep only +ve or 0
+            u = vsx_v128_or(neg, u);             // combine
+          }
+          vsx_v128_store(dp, u);
+        }
+      }
+      else
+      {
+        v128_t ihalf = vsx_i32x4_splat((si32)(1ULL << (bit_depth - 1)));
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          v128_t t = vsx_v128_load(sp);
+          t = vsx_f32x4_mul(t, mul);
+          v128_t u = ojph_convert_float_to_i32(t);
+          u = ojph_vsx_i32x4_max_ge(u, s32_low_lim, t, fl_low_lim);
+          u = ojph_vsx_i32x4_min_lt(u, s32_up_lim, t, fl_up_lim);
+          u = vsx_i32x4_add(u, ihalf);
+          vsx_v128_store(dp, u);
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_integer(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      local_vsx_irv_convert_to_integer<false>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_integer_nlt_type3(const line_buf *src_line,
+      line_buf *dst_line, ui32 dst_line_offset,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      local_vsx_irv_convert_to_integer<true>(src_line, dst_line, 
+        dst_line_offset, bit_depth, is_signed, width);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    template <bool NLT_TYPE3>
+    static inline
+    void local_vsx_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      assert((src_line->flags & line_buf::LFT_32BIT) &&
+             (src_line->flags & line_buf::LFT_INTEGER) &&
+             (dst_line->flags & line_buf::LFT_32BIT) &&
+             (dst_line->flags & line_buf::LFT_INTEGER) == 0);
+
+      assert(bit_depth <= 32);
+      v128_t mul = vsx_f32x4_splat((float)(1.0 / (double)(1ULL << bit_depth)));
+
+      const si32* sp = src_line->i32 + src_line_offset;
+      float* dp = dst_line->f32;
+      if (is_signed)
+      {
+        v128_t zero = vsx_i32x4_splat(0);
+        v128_t bias = vsx_i32x4_splat(-(si32)((1ULL << (bit_depth - 1)) + 1));
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          v128_t t = vsx_v128_load(sp);
+          if (NLT_TYPE3)
+          {
+            v128_t c = vsx_i32x4_lt(t, zero);    // 0xFFFFFFFF for -ve value
+            v128_t neg = vsx_i32x4_sub(bias, t); // - bias - value
+            neg = vsx_v128_and(c, neg);          // keep only - bias - value
+            c = vsx_v128_andnot(t, c);           // keep only +ve or 0
+            t = vsx_v128_or(neg, c);             // combine
+          }
+          v128_t v = vsx_f32x4_convert_i32x4(t);
+          v = vsx_f32x4_mul(v, mul);
+          vsx_v128_store(dp, v);
+        }
+      }
+      else
+      {
+        v128_t half = vsx_i32x4_splat((si32)(1ULL << (bit_depth - 1)));
+        for (int i = (int)width; i > 0; i -= 4, sp += 4, dp += 4) {
+          v128_t t = vsx_v128_load(sp);
+          t = vsx_i32x4_sub(t, half);
+          v128_t v = vsx_f32x4_convert_i32x4(t);
+          v = vsx_f32x4_mul(v, mul);
+          vsx_v128_store(dp, v);
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_float(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      local_vsx_irv_convert_to_float<false>(src_line, src_line_offset,
+        dst_line, bit_depth, is_signed, width);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_convert_to_float_nlt_type3(const line_buf *src_line,
+      ui32 src_line_offset, line_buf *dst_line,
+      ui32 bit_depth, bool is_signed, ui32 width)
+    {
+      local_vsx_irv_convert_to_float<true>(src_line, src_line_offset,
+        dst_line, bit_depth, is_signed, width);
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rct_forward(const line_buf *r,
+                          const line_buf *g,
+                          const line_buf *b,
+                          line_buf *y, line_buf *cb, line_buf *cr,
+                          ui32 repeat)
+    {
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
+             (cb->flags & line_buf::LFT_INTEGER) &&
+             (cr->flags & line_buf::LFT_INTEGER) &&
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
+
+      if  (y->flags & line_buf::LFT_32BIT)
+      {
+        assert((y->flags  & line_buf::LFT_32BIT) &&
+               (cb->flags & line_buf::LFT_32BIT) &&
+               (cr->flags & line_buf::LFT_32BIT) &&
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, * gp = g->i32, * bp = b->i32;
+        si32 *yp = y->i32, * cbp = cb->i32, * crp = cr->i32;
+
+        for (int i = (repeat + 3) >> 2; i > 0; --i)
+        {
+          v128_t mr = vsx_v128_load(rp);
+          v128_t mg = vsx_v128_load(gp);
+          v128_t mb = vsx_v128_load(bp);
+          v128_t t = vsx_i32x4_add(mr, mb);
+          t = vsx_i32x4_add(t, vsx_i32x4_shl(mg, 1));
+          vsx_v128_store(yp, vsx_i32x4_shr(t, 2));
+          t = vsx_i32x4_sub(mb, mg);
+          vsx_v128_store(cbp, t);
+          t = vsx_i32x4_sub(mr, mg);
+          vsx_v128_store(crp, t);
+
+            rp += 4; gp += 4; bp += 4;
+            yp += 4; cbp += 4; crp += 4;
+        }
+      }
+      else
+      {
+        assert((y->flags  & line_buf::LFT_64BIT) &&
+               (cb->flags & line_buf::LFT_64BIT) &&
+               (cr->flags & line_buf::LFT_64BIT) &&
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
+        si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
+        for (int i = (repeat + 3) >> 2; i > 0; --i)
+        {
+          v128_t mr32 = vsx_v128_load(rp);
+          v128_t mg32 = vsx_v128_load(gp);
+          v128_t mb32 = vsx_v128_load(bp);
+          v128_t mr, mg, mb, t;
+          mr = vsx_i64x2_extend_low_i32x4(mr32);
+          mg = vsx_i64x2_extend_low_i32x4(mg32);
+          mb = vsx_i64x2_extend_low_i32x4(mb32);
+
+          t = vsx_i64x2_add(mr, mb);
+          t = vsx_i64x2_add(t, vsx_i64x2_shl(mg, 1));
+          vsx_v128_store(yp, vsx_i64x2_shr(t, 2));
+          t = vsx_i64x2_sub(mb, mg);
+          vsx_v128_store(cbp, t);
+          t = vsx_i64x2_sub(mr, mg);
+          vsx_v128_store(crp, t);
+
+          yp += 2; cbp += 2; crp += 2;
+
+          mr = vsx_i64x2_extend_high_i32x4(mr32);
+          mg = vsx_i64x2_extend_high_i32x4(mg32);
+          mb = vsx_i64x2_extend_high_i32x4(mb32);
+
+          t = vsx_i64x2_add(mr, mb);
+          t = vsx_i64x2_add(t, vsx_i64x2_shl(mg, 1));
+          vsx_v128_store(yp, vsx_i64x2_shr(t, 2));
+          t = vsx_i64x2_sub(mb, mg);
+          vsx_v128_store(cbp, t);
+          t = vsx_i64x2_sub(mr, mg);
+          vsx_v128_store(crp, t);
+
+          rp += 4; gp += 4; bp += 4;
+          yp += 2; cbp += 2; crp += 2;
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rct_backward(const line_buf *y,
+                           const line_buf *cb,
+                           const line_buf *cr,
+                           line_buf *r, line_buf *g, line_buf *b,
+                           ui32 repeat)
+    {
+      assert((y->flags  & line_buf::LFT_INTEGER) &&
+             (cb->flags & line_buf::LFT_INTEGER) &&
+             (cr->flags & line_buf::LFT_INTEGER) &&
+             (r->flags  & line_buf::LFT_INTEGER) &&
+             (g->flags  & line_buf::LFT_INTEGER) &&
+             (b->flags  & line_buf::LFT_INTEGER));
+
+      if (y->flags & line_buf::LFT_32BIT)
+      {
+        assert((y->flags  & line_buf::LFT_32BIT) &&
+               (cb->flags & line_buf::LFT_32BIT) &&
+               (cr->flags & line_buf::LFT_32BIT) &&
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si32 *yp = y->i32, *cbp = cb->i32, *crp = cr->i32;
+        si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
+        for (int i = (repeat + 3) >> 2; i > 0; --i)
+        {
+          v128_t my  = vsx_v128_load(yp);
+          v128_t mcb = vsx_v128_load(cbp);
+          v128_t mcr = vsx_v128_load(crp);
+
+          v128_t t = vsx_i32x4_add(mcb, mcr);
+          t = vsx_i32x4_sub(my, vsx_i32x4_shr(t, 2));
+          vsx_v128_store(gp, t);
+          v128_t u = vsx_i32x4_add(mcb, t);
+          vsx_v128_store(bp, u);
+          u = vsx_i32x4_add(mcr, t);
+          vsx_v128_store(rp, u);
+
+          yp += 4; cbp += 4; crp += 4;
+          rp += 4; gp += 4; bp += 4;
+        }
+      }
+      else
+      {
+        assert((y->flags  & line_buf::LFT_64BIT) &&
+               (cb->flags & line_buf::LFT_64BIT) &&
+               (cr->flags & line_buf::LFT_64BIT) &&
+               (r->flags  & line_buf::LFT_32BIT) &&
+               (g->flags  & line_buf::LFT_32BIT) &&
+               (b->flags  & line_buf::LFT_32BIT));
+        const si64 *yp = y->i64, *cbp = cb->i64, *crp = cr->i64;
+        si32 *rp = r->i32, *gp = g->i32, *bp = b->i32;
+        for (int i = (repeat + 3) >> 2; i > 0; --i)
+        {
+          v128_t my, mcb, mcr, tr0, tg0, tb0, tr1, tg1, tb1;
+          my  = vsx_v128_load(yp);
+          mcb = vsx_v128_load(cbp);
+          mcr = vsx_v128_load(crp);
+
+          tg0 = vsx_i64x2_add(mcb, mcr);
+          tg0 = vsx_i64x2_sub(my, vsx_i64x2_shr(tg0, 2));
+          tb0 = vsx_i64x2_add(mcb, tg0);
+          tr0 = vsx_i64x2_add(mcr, tg0);
+
+          yp += 2; cbp += 2; crp += 2;
+
+          my  = vsx_v128_load(yp);
+          mcb = vsx_v128_load(cbp);
+          mcr = vsx_v128_load(crp);
+
+          tg1 = vsx_i64x2_add(mcb, mcr);
+          tg1 = vsx_i64x2_sub(my, vsx_i64x2_shr(tg1, 2));
+          tb1 = vsx_i64x2_add(mcb, tg1);
+          tr1 = vsx_i64x2_add(mcr, tg1);
+
+          tr0 = vsx_i32x4_shuffle(tr0, tr1, 0, 2, 4 + 0, 4 + 2);
+          tg0 = vsx_i32x4_shuffle(tg0, tg1, 0, 2, 4 + 0, 4 + 2);
+          tb0 = vsx_i32x4_shuffle(tb0, tb1, 0, 2, 4 + 0, 4 + 2);
+
+          vsx_v128_store(rp, tr0);
+          vsx_v128_store(gp, tg0);
+          vsx_v128_store(bp, tb0);
+
+          yp += 2; cbp += 2; crp += 2;
+          rp += 4; gp += 4; bp += 4;
+        }
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_ict_forward(const float *r, const float *g, const float *b,
+                          float *y, float *cb, float *cr, ui32 repeat)
+    {
+      v128_t alpha_rf = vsx_f32x4_splat(CT_CNST::ALPHA_RF);
+      v128_t alpha_gf = vsx_f32x4_splat(CT_CNST::ALPHA_GF);
+      v128_t alpha_bf = vsx_f32x4_splat(CT_CNST::ALPHA_BF);
+      v128_t beta_cbf = vsx_f32x4_splat(CT_CNST::BETA_CbF);
+      v128_t beta_crf = vsx_f32x4_splat(CT_CNST::BETA_CrF);
+      for (ui32 i = (repeat + 3) >> 2; i > 0; --i)
+      {
+        v128_t mr = vsx_v128_load(r);
+        v128_t mb = vsx_v128_load(b);
+        v128_t my = vsx_f32x4_mul(alpha_rf, mr);
+        my = vsx_f32x4_add(my, vsx_f32x4_mul(alpha_gf, vsx_v128_load(g)));
+        my = vsx_f32x4_add(my, vsx_f32x4_mul(alpha_bf, mb));
+        vsx_v128_store(y, my);
+        vsx_v128_store(cb, vsx_f32x4_mul(beta_cbf, vsx_f32x4_sub(mb, my)));
+        vsx_v128_store(cr, vsx_f32x4_mul(beta_crf, vsx_f32x4_sub(mr, my)));
+
+        r += 4; g += 4; b += 4;
+        y += 4; cb += 4; cr += 4;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_ict_backward(const float *y, const float *cb, const float *cr,
+                           float *r, float *g, float *b, ui32 repeat)
+    {
+      v128_t gamma_cr2g = vsx_f32x4_splat(CT_CNST::GAMMA_CR2G);
+      v128_t gamma_cb2g = vsx_f32x4_splat(CT_CNST::GAMMA_CB2G);
+      v128_t gamma_cr2r = vsx_f32x4_splat(CT_CNST::GAMMA_CR2R);
+      v128_t gamma_cb2b = vsx_f32x4_splat(CT_CNST::GAMMA_CB2B);
+      for (ui32 i = (repeat + 3) >> 2; i > 0; --i)
+      {
+        v128_t my = vsx_v128_load(y);
+        v128_t mcr = vsx_v128_load(cr);
+        v128_t mcb = vsx_v128_load(cb);
+        v128_t mg = vsx_f32x4_sub(my, vsx_f32x4_mul(gamma_cr2g, mcr));
+        vsx_v128_store(g, vsx_f32x4_sub(mg, vsx_f32x4_mul(gamma_cb2g, mcb)));
+        vsx_v128_store(r, vsx_f32x4_add(my, vsx_f32x4_mul(gamma_cr2r, mcr)));
+        vsx_v128_store(b, vsx_f32x4_add(my, vsx_f32x4_mul(gamma_cb2b, mcb)));
+
+        y += 4; cb += 4; cr += 4;
+        r += 4; g += 4; b += 4;
+      }
+    }
+
+  }
+}

--- a/external/OpenJPH/src/core/transform/ojph_transform.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform.cpp
@@ -36,6 +36,7 @@
 //***************************************************************************/
 
 #include <cstdio>
+#include <mutex>
 
 #include "ojph_arch.h"
 #include "ojph_mem.h"
@@ -93,25 +94,21 @@ namespace ojph {
       (const param_atk* atk, const line_buf* dst, const line_buf* lsrc,
         const line_buf* hsrc, ui32 width, bool even) = NULL;
 
-    ////////////////////////////////////////////////////////////////////////////
-    static bool wavelet_transform_functions_initialized = false;
-
     //////////////////////////////////////////////////////////////////////////
     void init_wavelet_transform_functions()
     {
-      if (wavelet_transform_functions_initialized)
-        return;
-
+      static std::once_flag wavelet_transform_functions_init_flag;
+      std::call_once(wavelet_transform_functions_init_flag, [](){
 #if !defined(OJPH_ENABLE_WASM_SIMD) || !defined(OJPH_EMSCRIPTEN)
 
-      rev_vert_step             = gen_rev_vert_step;
-      rev_horz_ana              = gen_rev_horz_ana;
-      rev_horz_syn              = gen_rev_horz_syn;
+        rev_vert_step             = gen_rev_vert_step;
+        rev_horz_ana              = gen_rev_horz_ana;
+        rev_horz_syn              = gen_rev_horz_syn;
 
-      irv_vert_step             = gen_irv_vert_step;
-      irv_vert_times_K          = gen_irv_vert_times_K;
-      irv_horz_ana              = gen_irv_horz_ana;
-      irv_horz_syn              = gen_irv_horz_syn;
+        irv_vert_step             = gen_irv_vert_step;
+        irv_vert_times_K          = gen_irv_vert_times_K;
+        irv_horz_ana              = gen_irv_horz_ana;
+        irv_horz_syn              = gen_irv_horz_syn;
 
   #ifndef OJPH_DISABLE_SIMD
 
@@ -171,6 +168,21 @@ namespace ojph {
     
     #elif defined(OJPH_ARCH_ARM)
 
+    #elif defined(OJPH_ARCH_PPC64LE)
+
+        if (get_cpu_ext_level() >= PPC_CPU_EXT_LEVEL_ARCH_3_00)
+        {
+          // 128-bit VSX kernels; see ojph_simd_vsx.h
+          rev_vert_step             = vsx_rev_vert_step;
+          rev_horz_ana              = vsx_rev_horz_ana;
+          rev_horz_syn              = vsx_rev_horz_syn;
+
+          irv_vert_step             = vsx_irv_vert_step;
+          irv_vert_times_K          = vsx_irv_vert_times_K;
+          irv_horz_ana              = vsx_irv_horz_ana;
+          irv_horz_syn              = vsx_irv_horz_syn;
+        }
+
     #endif // !(defined(OJPH_ARCH_X86_64) || defined(OJPH_ARCH_I386))
 
   #endif // !OJPH_DISABLE_SIMD
@@ -185,8 +197,7 @@ namespace ojph {
         irv_horz_ana              = wasm_irv_horz_ana;
         irv_horz_syn              = wasm_irv_horz_syn;
 #endif // !OJPH_ENABLE_WASM_SIMD
-
-      wavelet_transform_functions_initialized = true;
+      });
     }
     
     //////////////////////////////////////////////////////////////////////////

--- a/external/OpenJPH/src/core/transform/ojph_transform_avx2.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform_avx2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -56,8 +56,8 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     // https://github.com/seung-lab/dijkstra3d/blob/master/libdivide.h
-    static inline 
-    __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m) 
+    static inline
+    __m256i avx2_mm256_srai_epi64(__m256i a, int amt, __m256i m)
     {
       // note than m must be obtained using
       // __m256i m = _mm256_set1_epi64x(1ULL << (63 - amt));
@@ -85,7 +85,7 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
+    static inline
     void avx2_interleave32(float* dp, float* spl, float* sph, int width)
     {
       for (; width > 0; width -= 16, dp += 16, spl += 8, sph += 8)
@@ -102,43 +102,50 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void avx2_deinterleave64(double* dpl, double* dph, double* sp, int width)
+    static inline
+    void avx2_deinterleave64(void* dpl, void* dph, const void* sp, int width)
     {
-      for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
+      for (; width > 0; width -= 8,
+             sp = (const char*)sp + 64,
+             dpl = (char*)dpl + 32,
+             dph = (char*)dph + 32)
       {
-        __m256d a = _mm256_load_pd(sp);
-        __m256d b = _mm256_load_pd(sp + 4);
-        __m256d c = _mm256_permute2f128_pd(a, b, (2 << 4) | (0));
-        __m256d d = _mm256_permute2f128_pd(a, b, (3 << 4) | (1));
-        __m256d e = _mm256_shuffle_pd(c, d, 0x0);
-        __m256d f = _mm256_shuffle_pd(c, d, 0xF);
-        _mm256_store_pd(dpl, e);
-        _mm256_store_pd(dph, f);
+        __m256i a = _mm256_load_si256((const __m256i*)sp);
+        __m256i b = _mm256_load_si256((const __m256i*)((const char*)sp + 32));
+        __m256i c = _mm256_permute2f128_si256(a, b, (2 << 4) | (0));
+        __m256i d = _mm256_permute2f128_si256(a, b, (3 << 4) | (1));
+        __m256i e = _mm256_unpacklo_epi64(c, d);
+        __m256i f = _mm256_unpackhi_epi64(c, d);
+        _mm256_store_si256((__m256i*)dpl, e);
+        _mm256_store_si256((__m256i*)dph, f);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void avx2_interleave64(double* dp, double* spl, double* sph, int width)
+    static inline
+    void avx2_interleave64(void* dp, const void* spl, const void* sph,
+                           int width)
     {
-      for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
+      for (; width > 0; width -= 8,
+             dp = (char*)dp + 64,
+             spl = (const char*)spl + 32,
+             sph = (const char*)sph + 32)
       {
-        __m256d a = _mm256_load_pd(spl);
-        __m256d b = _mm256_load_pd(sph);
-        __m256d c = _mm256_unpacklo_pd(a, b);
-        __m256d d = _mm256_unpackhi_pd(a, b);
-        __m256d e = _mm256_permute2f128_pd(c, d, (2 << 4) | (0));
-        __m256d f = _mm256_permute2f128_pd(c, d, (3 << 4) | (1));
-        _mm256_store_pd(dp, e);
-        _mm256_store_pd(dp + 4, f);
+        __m256i a = _mm256_load_si256((const __m256i*)spl);
+        __m256i b = _mm256_load_si256((const __m256i*)sph);
+        __m256i c = _mm256_unpacklo_epi64(a, b);
+        __m256i d = _mm256_unpackhi_epi64(a, b);
+        __m256i e = _mm256_permute2f128_si256(c, d, (2 << 4) | (0));
+        __m256i f = _mm256_permute2f128_si256(c, d, (3 << 4) | (1));
+        _mm256_store_si256((__m256i*)dp, e);
+        _mm256_store_si256((__m256i*)((char*)dp + 32), f);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void avx2_rev_vert_step32(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -149,7 +156,7 @@ namespace ojph {
 
       si32* dst = aug->i32;
       const si32* src1 = sig->i32, * src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -267,19 +274,19 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void avx2_rev_vert_step64(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
       const si32 b = s->rev.Batk;
       const ui8 e = s->rev.Eatk;
       __m256i vb = _mm256_set1_epi64x(b);
-      __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));      
+      __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));
 
       si64* dst = aug->i64;
       const si64* src1 = sig->i64, * src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -377,23 +384,23 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         avx2_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else 
+      else
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         avx2_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
@@ -401,8 +408,8 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void avx2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -569,17 +576,17 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void avx2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          double* dpl = (double*)(even ? ldst->p : hdst->p);
-          double* dph = (double*)(even ? hdst->p : ldst->p);
-          double* sp  = (double*)src->p;
+          void* dpl = even ? ldst->p : hdst->p;
+          void* dph = even ? hdst->p : ldst->p;
+          const void* sp = src->p;
           int w = (int)width;
           avx2_deinterleave64(dpl, dph, sp, w);
         }
@@ -717,29 +724,29 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                           const line_buf* hdst, const line_buf* src, 
+    void avx2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT) 
+      if (src->flags & line_buf::LFT_32BIT)
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         avx2_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else 
+      else
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         avx2_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    } 
-    
+    }
+
     //////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void avx2_rev_horz_syn32(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -906,8 +913,8 @@ namespace ojph {
 
     //////////////////////////////////////////////////////////////////////////
     static
-    void avx2_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void avx2_rev_horz_syn64(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -924,7 +931,7 @@ namespace ojph {
           const si32 b = s->rev.Batk;
           const ui8 e  = s->rev.Eatk;
           __m256i vb = _mm256_set1_epi64x(b);
-          __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));      
+          __m256i ve = _mm256_set1_epi64x(1LL << (63 - e));
 
           // extension
           oth[-1] = oth[0];
@@ -1038,9 +1045,9 @@ namespace ojph {
 
         // combine both lsrc and hsrc into dst
         {
-          double* dp  = (double*)dst->p;
-          double* spl = (double*)(even ? lsrc->p : hsrc->p);
-          double* sph = (double*)(even ? hsrc->p : lsrc->p);
+          void* dp = dst->p;
+          const void* spl = even ? lsrc->p : hsrc->p;
+          const void* sph = even ? hsrc->p : lsrc->p;
           int w = (int)width;
           avx2_interleave64(dp, spl, sph, w);
         }
@@ -1051,23 +1058,23 @@ namespace ojph {
         else
           dst->i64[0] = hsrc->i64[0] >> 1;
       }
-    }    
+    }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
-                           const line_buf* lsrc, const line_buf* hsrc, 
+    void avx2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT) 
+      if (dst->flags & line_buf::LFT_32BIT)
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         avx2_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else 
+      else
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         avx2_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }

--- a/external/OpenJPH/src/core/transform/ojph_transform_avx512.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform_avx512.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019-2024, Aous Naman 
+// Copyright (c) 2019-2024, Aous Naman
 // Copyright (c) 2019-2024, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019-2024, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -56,7 +56,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     // We split multiples of 32 followed by multiples of 16, because
     // we assume byte_alignment == 64
-    static 
+    static
     void avx512_deinterleave32(float* dpl, float* dph, float* sp, int width)
     {
       __m512i idx1 = _mm512_set_epi32(
@@ -92,7 +92,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     // We split multiples of 32 followed by multiples of 16, because
     // we assume byte_alignment == 64
-    static 
+    static
     void avx512_interleave32(float* dp, float* spl, float* sph, int width)
     {
       __m512i idx1 = _mm512_set_epi32(
@@ -128,7 +128,7 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
     // We split multiples of 32 followed by multiples of 16, because
     // we assume byte_alignment == 64
-    static void avx512_deinterleave64(double* dpl, double* dph, double* sp, 
+    static void avx512_deinterleave64(void* dpl, void* dph, const void* sp,
                                       int width)
     {
       __m512i idx1 = _mm512_set_epi64(
@@ -137,33 +137,39 @@ namespace ojph {
       __m512i idx2 = _mm512_set_epi64(
         0x0F, 0x0D, 0x0B, 0x09, 0x07, 0x05, 0x03, 0x01
       );
-      for (; width > 8; width -= 16, sp += 16, dpl += 8, dph += 8)
+      for (; width > 8; width -= 16,
+             sp = (const char*)sp + 128,
+             dpl = (char*)dpl + 64,
+             dph = (char*)dph + 64)
       {
-        __m512d a = _mm512_load_pd(sp);
-        __m512d b = _mm512_load_pd(sp + 16);
-        __m512d c = _mm512_permutex2var_pd(a, idx1, b);
-        __m512d d = _mm512_permutex2var_pd(a, idx2, b);
-        _mm512_store_pd(dpl, c);
-        _mm512_store_pd(dph, d);
+        __m512i a = _mm512_load_si512(sp);
+        __m512i b = _mm512_load_si512((const char*)sp + 64);
+        __m512i c = _mm512_permutex2var_epi64(a, idx1, b);
+        __m512i d = _mm512_permutex2var_epi64(a, idx2, b);
+        _mm512_store_si512(dpl, c);
+        _mm512_store_si512(dph, d);
       }
-      for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
+      for (; width > 0; width -= 8,
+             sp = (const char*)sp + 64,
+             dpl = (char*)dpl + 32,
+             dph = (char*)dph + 32)
       {
-        __m256d a = _mm256_load_pd(sp);
-        __m256d b = _mm256_load_pd(sp + 4);
-        __m256d c = _mm256_permute2f128_pd(a, b, (2 << 4) | (0));
-        __m256d d = _mm256_permute2f128_pd(a, b, (3 << 4) | (1));
-        __m256d e = _mm256_shuffle_pd(c, d, 0x0);
-        __m256d f = _mm256_shuffle_pd(c, d, 0xF);
-        _mm256_store_pd(dpl, e);
-        _mm256_store_pd(dph, f);
+        __m256i a = _mm256_load_si256((const __m256i*)sp);
+        __m256i b = _mm256_load_si256((const __m256i*)((const char*)sp + 32));
+        __m256i c = _mm256_permute2f128_si256(a, b, (2 << 4) | (0));
+        __m256i d = _mm256_permute2f128_si256(a, b, (3 << 4) | (1));
+        __m256i e = _mm256_unpacklo_epi64(c, d);
+        __m256i f = _mm256_unpackhi_epi64(c, d);
+        _mm256_store_si256((__m256i*)dpl, e);
+        _mm256_store_si256((__m256i*)dph, f);
       }
     }
 
     //////////////////////////////////////////////////////////////////////////
     // We split multiples of 32 followed by multiples of 16, because
     // we assume byte_alignment == 64
-    static void avx512_interleave64(double* dp, double* spl, double* sph, 
-                                    int width)
+    static void avx512_interleave64(void* dp, const void* spl,
+                                    const void* sph, int width)
     {
       __m512i idx1 = _mm512_set_epi64(
         0xB, 0x3, 0xA, 0x2, 0x9, 0x1, 0x8, 0x0
@@ -171,25 +177,31 @@ namespace ojph {
       __m512i idx2 = _mm512_set_epi64(
         0xF, 0x7, 0xE, 0x6, 0xD, 0x5, 0xC, 0x4
       );
-      for (; width > 8; width -= 16, dp += 16, spl += 8, sph += 8)
+      for (; width > 8; width -= 16,
+             dp = (char*)dp + 128,
+             spl = (const char*)spl + 64,
+             sph = (const char*)sph + 64)
       {
-        __m512d a = _mm512_load_pd(spl);
-        __m512d b = _mm512_load_pd(sph);
-        __m512d c = _mm512_permutex2var_pd(a, idx1, b);
-        __m512d d = _mm512_permutex2var_pd(a, idx2, b);
-        _mm512_store_pd(dp, c);
-        _mm512_store_pd(dp + 16, d);
+        __m512i a = _mm512_load_si512(spl);
+        __m512i b = _mm512_load_si512(sph);
+        __m512i c = _mm512_permutex2var_epi64(a, idx1, b);
+        __m512i d = _mm512_permutex2var_epi64(a, idx2, b);
+        _mm512_store_si512(dp, c);
+        _mm512_store_si512((char*)dp + 64, d);
       }
-      for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
+      for (; width > 0; width -= 8,
+             dp = (char*)dp + 64,
+             spl = (const char*)spl + 32,
+             sph = (const char*)sph + 32)
       {
-        __m256d a = _mm256_load_pd(spl);
-        __m256d b = _mm256_load_pd(sph);
-        __m256d c = _mm256_unpacklo_pd(a, b);
-        __m256d d = _mm256_unpackhi_pd(a, b);
-        __m256d e = _mm256_permute2f128_pd(c, d, (2 << 4) | (0));
-        __m256d f = _mm256_permute2f128_pd(c, d, (3 << 4) | (1));
-        _mm256_store_pd(dp, e);
-        _mm256_store_pd(dp + 4, f);
+        __m256i a = _mm256_load_si256((const __m256i*)spl);
+        __m256i b = _mm256_load_si256((const __m256i*)sph);
+        __m256i c = _mm256_unpacklo_epi64(a, b);
+        __m256i d = _mm256_unpackhi_epi64(a, b);
+        __m256i e = _mm256_permute2f128_si256(c, d, (2 << 4) | (0));
+        __m256i f = _mm256_permute2f128_si256(c, d, (3 << 4) | (1));
+        _mm256_store_si256((__m256i*)dp, e);
+        _mm256_store_si256((__m256i*)((char*)dp + 32), f);
       }
     }
 
@@ -205,8 +217,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -235,8 +247,8 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void avx512_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -311,10 +323,10 @@ namespace ojph {
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-    
+
     //////////////////////////////////////////////////////////////////////////
-    void avx512_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void avx512_irv_horz_syn(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -382,7 +394,7 @@ namespace ojph {
           float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           avx512_interleave32(dp, spl, sph, w);
-        }        
+        }
       }
       else {
         if (even)
@@ -394,8 +406,8 @@ namespace ojph {
 
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
-                                const line_buf* other, const line_buf* aug, 
+    void avx512_rev_vert_step32(const lifting_step* s, const line_buf* sig,
+                                const line_buf* other, const line_buf* aug,
                                 ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -406,7 +418,7 @@ namespace ojph {
 
       si32* dst = aug->i32;
       const si32* src1 = sig->i32, * src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -523,8 +535,8 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
-                                const line_buf* other, const line_buf* aug, 
+    void avx512_rev_vert_step64(const lifting_step* s, const line_buf* sig,
+                                const line_buf* other, const line_buf* aug,
                                 ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -534,7 +546,7 @@ namespace ojph {
 
       si64* dst = aug->i64;
       const si64* src1 = sig->i64, * src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -619,7 +631,7 @@ namespace ojph {
             _mm512_store_si512((__m512i*)dst, d);
           }
       }
-      else { 
+      else {
         // general case
         // 64bit multiplication is not supported in AVX512F + AVX512CD;
         // in particular, _mm256_mullo_epi64.
@@ -665,31 +677,31 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void avx512_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         avx512_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else 
+      else
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         avx512_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
-                               const line_buf* hdst, const line_buf* src, 
+    void avx512_rev_horz_ana32(const param_atk* atk, const line_buf* ldst,
+                               const line_buf* hdst, const line_buf* src,
                                ui32 width, bool even)
     {
       if (width > 1)
@@ -701,7 +713,7 @@ namespace ojph {
           float* sp  = src->f32;
           int w = (int)width;
           avx512_deinterleave32(dpl, dph, sp, w);
-        }        
+        }
 
         si32* hp = hdst->i32, * lp = ldst->i32;
         ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
@@ -853,22 +865,22 @@ namespace ojph {
           hdst->i32[0] = src->i32[0] << 1;
       }
     }
-    
+
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
-                               const line_buf* hdst, const line_buf* src, 
+    void avx512_rev_horz_ana64(const param_atk* atk, const line_buf* ldst,
+                               const line_buf* hdst, const line_buf* src,
                                ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          double* dpl = (double*)(even ? ldst->p : hdst->p);
-          double* dph = (double*)(even ? hdst->p : ldst->p);
-          double* sp  = (double*)(src->p);
+          void* dpl = even ? ldst->p : hdst->p;
+          void* dph = even ? hdst->p : ldst->p;
+          const void* sp = src->p;
           int w = (int)width;
           avx512_deinterleave64(dpl, dph, sp, w);
-        }        
+        }
 
         si64* hp = hdst->i64, * lp = ldst->i64;
         ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
@@ -975,7 +987,7 @@ namespace ojph {
                 _mm512_store_si512((__m512i*)dp, d);
               }
           }
-          else 
+          else
           {
             // general case
             // 64bit multiplication is not supported in AVX512F + AVX512CD;
@@ -1036,28 +1048,28 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void avx512_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT) 
+      if (src->flags & line_buf::LFT_32BIT)
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         avx512_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else 
+      else
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         avx512_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    } 
+    }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
-                               const line_buf* lsrc, const line_buf* hsrc, 
+    void avx512_rev_horz_syn32(const param_atk* atk, const line_buf* dst,
+                               const line_buf* lsrc, const line_buf* hsrc,
                                ui32 width, bool even)
     {
       if (width > 1)
@@ -1212,7 +1224,7 @@ namespace ojph {
           float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           avx512_interleave32(dp, spl, sph, w);
-        }          
+        }
       }
       else {
         if (even)
@@ -1223,8 +1235,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
-                               const line_buf* lsrc, const line_buf* hsrc, 
+    void avx512_rev_horz_syn64(const param_atk* atk, const line_buf* dst,
+                               const line_buf* lsrc, const line_buf* hsrc,
                                ui32 width, bool even)
     {
       if (width > 1)
@@ -1334,11 +1346,11 @@ namespace ojph {
                 _mm512_store_si512((__m512i*)dp, d);
               }
           }
-          else 
+          else
            {
             // general case
             // 64bit multiplication is not supported in AVX512F + AVX512CD;
-            // in particular, _mm256_mullo_epi64.            
+            // in particular, _mm256_mullo_epi64.
             if (ev)
               for (ui32 i = aug_width; i > 0; --i, sp++, dp++)
                 *dp -= (b + a * (sp[-1] + sp[0])) >> e;
@@ -1388,12 +1400,12 @@ namespace ojph {
 
         // combine both lsrc and hsrc into dst
         {
-          double* dp  = (double*)(dst->p);
-          double* spl = (double*)(even ? lsrc->p : hsrc->p);
-          double* sph = (double*)(even ? hsrc->p : lsrc->p);
+          void* dp = dst->p;
+          const void* spl = even ? lsrc->p : hsrc->p;
+          const void* sph = even ? hsrc->p : lsrc->p;
           int w = (int)width;
           avx512_interleave64(dp, spl, sph, w);
-        }          
+        }
       }
       else {
         if (even)
@@ -1404,20 +1416,20 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void avx512_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT) 
+      if (dst->flags & line_buf::LFT_32BIT)
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         avx512_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else 
+      else
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         avx512_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }

--- a/external/OpenJPH/src/core/transform/ojph_transform_local.h
+++ b/external/OpenJPH/src/core/transform/ojph_transform_local.h
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -63,21 +63,21 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                           const line_buf* other, const line_buf* aug, 
+    void gen_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                           const line_buf* other, const line_buf* aug,
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
     void gen_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                          const line_buf* hdst, const line_buf* src, 
+    void gen_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                          const line_buf* hdst, const line_buf* src,
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_irv_horz_syn(const param_atk *atk, const line_buf* dst, 
-                          const line_buf *lsrc, const line_buf *hsrc, 
+    void gen_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                          const line_buf *lsrc, const line_buf *hsrc,
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -85,18 +85,18 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                           const line_buf* other, const line_buf* aug, 
+    void gen_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                           const line_buf* other, const line_buf* aug,
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                          const line_buf* hdst, const line_buf* src, 
+    void gen_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                          const line_buf* hdst, const line_buf* src,
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
-    void gen_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
-                          const line_buf* lsrc, const line_buf* hsrc, 
+    void gen_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                          const line_buf* lsrc, const line_buf* hsrc,
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -112,8 +112,8 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void sse_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                           const line_buf* other, const line_buf* aug, 
+    void sse_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                           const line_buf* other, const line_buf* aug,
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
@@ -121,12 +121,12 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void sse_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
-                          const line_buf* hdst, const line_buf* src, 
+                          const line_buf* hdst, const line_buf* src,
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void sse_irv_horz_syn(const param_atk *atk, const line_buf* dst,
-                          const line_buf *lsrc, const line_buf *hsrc, 
+                          const line_buf *lsrc, const line_buf *hsrc,
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -142,18 +142,18 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
     void sse2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
-                           const line_buf* hdst, const line_buf* src, 
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void sse2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
-                           const line_buf* lsrc, const line_buf* hsrc, 
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even);
 
 
@@ -170,8 +170,8 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                           const line_buf* other, const line_buf* aug, 
+    void avx_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                           const line_buf* other, const line_buf* aug,
                            ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
@@ -179,12 +179,12 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void avx_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
-                          const line_buf* hdst, const line_buf* src, 
+                          const line_buf* hdst, const line_buf* src,
                           ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void avx_irv_horz_syn(const param_atk *atk, const line_buf* dst,
-                          const line_buf *lsrc, const line_buf *hsrc, 
+                          const line_buf *lsrc, const line_buf *hsrc,
                           ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -200,18 +200,18 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void avx2_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
     void avx2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
-                           const line_buf* hdst, const line_buf* src, 
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void avx2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
-                           const line_buf* lsrc, const line_buf* hsrc, 
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -227,8 +227,8 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void avx512_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
@@ -236,12 +236,12 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void avx512_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
-                             const line_buf* hdst, const line_buf* src, 
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void avx512_irv_horz_syn(const param_atk *atk, const line_buf* dst,
-                             const line_buf *lsrc, const line_buf *hsrc, 
+                             const line_buf *lsrc, const line_buf *hsrc,
                              ui32 width, bool even);
 
 
@@ -251,17 +251,17 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void avx512_rev_vert_step(const lifting_step* s, const line_buf* sig,
-                              const line_buf* other, const line_buf* aug, 
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
     void avx512_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
-                             const line_buf* hdst, const line_buf* src, 
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void avx512_rev_horz_syn(const param_atk* atk, const line_buf* dst,
-                             const line_buf* lsrc, const line_buf* hsrc, 
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -277,8 +277,8 @@ namespace ojph {
     //////////////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
@@ -286,12 +286,12 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void wasm_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
-                           const line_buf* hdst, const line_buf* src, 
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void wasm_irv_horz_syn(const param_atk *atk, const line_buf* dst,
-                           const line_buf *lsrc, const line_buf *hsrc, 
+                           const line_buf *lsrc, const line_buf *hsrc,
                            ui32 width, bool even);
 
     //////////////////////////////////////////////////////////////////////////
@@ -300,17 +300,66 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     void wasm_rev_vert_step(const lifting_step* s, const line_buf* sig,
-                            const line_buf* other, const line_buf* aug, 
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis);
 
     /////////////////////////////////////////////////////////////////////////
     void wasm_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
-                           const line_buf* hdst, const line_buf* src, 
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even);
 
     /////////////////////////////////////////////////////////////////////////
     void wasm_rev_horz_syn(const param_atk* atk, const line_buf* dst,
-                           const line_buf* lsrc, const line_buf* hsrc, 
+                           const line_buf* lsrc, const line_buf* hsrc,
+                           ui32 width, bool even);
+
+    //////////////////////////////////////////////////////////////////////////
+    //
+    //
+    //                           VSX Functions
+    //
+    //
+    //////////////////////////////////////////////////////////////////////////
+
+    //////////////////////////////////////////////////////////////////////////
+    // Irreversible functions
+    //////////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
+                            ui32 repeat, bool synthesis);
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat);
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
+                           ui32 width, bool even);
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_irv_horz_syn(const param_atk *atk, const line_buf* dst,
+                           const line_buf *lsrc, const line_buf *hsrc,
+                           ui32 width, bool even);
+
+    //////////////////////////////////////////////////////////////////////////
+    // Reversible functions
+    //////////////////////////////////////////////////////////////////////////
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
+                            ui32 repeat, bool synthesis);
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
+                           ui32 width, bool even);
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even);
   }
 }

--- a/external/OpenJPH/src/core/transform/ojph_transform_sse2.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform_sse2.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2019, Aous Naman 
+// Copyright (c) 2019, Aous Naman
 // Copyright (c) 2019, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2019, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -56,7 +56,7 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     // https://github.com/seung-lab/dijkstra3d/blob/master/libdivide.h
-    static inline __m128i sse2_mm_srai_epi64(__m128i a, int amt, __m128i m) 
+    static inline __m128i sse2_mm_srai_epi64(__m128i a, int amt, __m128i m)
     {
       // note than m must be obtained using
       // __m128i m = _mm_set1_epi64x(1ULL << (63 - amt));
@@ -97,39 +97,46 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void sse2_deinterleave64(double* dpl, double* dph, double* sp, int width)
+    static inline
+    void sse2_deinterleave64(void* dpl, void* dph, const void* sp, int width)
     {
-      for (; width > 0; width -= 4, sp += 4, dpl += 2, dph += 2)
+      for (; width > 0; width -= 4,
+             sp = (const char*)sp + 32,
+             dpl = (char*)dpl + 16,
+             dph = (char*)dph + 16)
       {
-        __m128d a = _mm_load_pd(sp);
-        __m128d b = _mm_load_pd(sp + 2);
-        __m128d c = _mm_shuffle_pd(a, b, 0);
-        __m128d d = _mm_shuffle_pd(a, b, 3);
-        _mm_store_pd(dpl, c);
-        _mm_store_pd(dph, d);
+        __m128i a = _mm_load_si128((const __m128i*)sp);
+        __m128i b = _mm_load_si128((const __m128i*)((const char*)sp + 16));
+        __m128i c = _mm_unpacklo_epi64(a, b);
+        __m128i d = _mm_unpackhi_epi64(a, b);
+        _mm_store_si128((__m128i*)dpl, c);
+        _mm_store_si128((__m128i*)dph, d);
       }
-    }    
+    }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void sse2_interleave64(double* dp, double* spl, double* sph, int width)
+    static inline
+    void sse2_interleave64(void* dp, const void* spl, const void* sph,
+                           int width)
     {
-      for (; width > 0; width -= 4, dp += 4, spl += 2, sph += 2)
+      for (; width > 0; width -= 4,
+             dp = (char*)dp + 32,
+             spl = (const char*)spl + 16,
+             sph = (const char*)sph + 16)
       {
-        __m128d a = _mm_load_pd(spl);
-        __m128d b = _mm_load_pd(sph);
-        __m128d c = _mm_unpacklo_pd(a, b);
-        __m128d d = _mm_unpackhi_pd(a, b);
-        _mm_store_pd(dp, c);
-        _mm_store_pd(dp + 2, d);
+        __m128i a = _mm_load_si128((const __m128i*)spl);
+        __m128i b = _mm_load_si128((const __m128i*)sph);
+        __m128i c = _mm_unpacklo_epi64(a, b);
+        __m128i d = _mm_unpackhi_epi64(a, b);
+        _mm_store_si128((__m128i*)dp, c);
+        _mm_store_si128((__m128i*)((char*)dp + 16), d);
       }
     }
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void sse2_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void sse2_rev_vert_step32(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -139,7 +146,7 @@ namespace ojph {
 
       si32* dst = aug->i32;
       const si32* src1 = sig->i32, * src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -239,8 +246,8 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void sse2_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void sse2_rev_vert_step64(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si64 a = s->rev.Aatk;
@@ -251,7 +258,7 @@ namespace ojph {
 
       si64* dst = aug->i64;
       const si64* src1 = sig->i64, * src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -348,23 +355,23 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void sse2_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         sse2_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else 
+      else
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         sse2_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
@@ -372,8 +379,8 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void sse2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void sse2_rev_horz_ana32(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -519,17 +526,17 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void sse2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void sse2_rev_horz_ana64(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         // split src into ldst and hdst
         {
-          double* dpl = (double*)(even ? ldst->p : hdst->p);
-          double* dph = (double*)(even ? hdst->p : ldst->p);
-          double* sp  = (double*)src->p;
+          void* dpl = even ? ldst->p : hdst->p;
+          void* dph = even ? hdst->p : ldst->p;
+          const void* sp = src->p;
           int w = (int)width;
           sse2_deinterleave64(dpl, dph, sp, w);
         }
@@ -666,28 +673,28 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                           const line_buf* hdst, const line_buf* src, 
+    void sse2_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT) 
+      if (src->flags & line_buf::LFT_32BIT)
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         sse2_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else 
+      else
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         sse2_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    }    
-    
+    }
+
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void sse2_rev_horz_syn32(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -834,8 +841,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void sse2_rev_horz_syn64(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -965,9 +972,9 @@ namespace ojph {
 
         // combine both lsrc and hsrc into dst
         {
-          double* dp  = (double*)dst->p;
-          double* spl = (double*)(even ? lsrc->p : hsrc->p);
-          double* sph = (double*)(even ? hsrc->p : lsrc->p);
+          void* dp = dst->p;
+          const void* spl = even ? lsrc->p : hsrc->p;
+          const void* sph = even ? hsrc->p : lsrc->p;
           int w = (int)width;
           sse2_interleave64(dp, spl, sph, w);
         }
@@ -981,24 +988,24 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void sse2_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
-                           const line_buf* lsrc, const line_buf* hsrc, 
+    void sse2_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT) 
+      if (dst->flags & line_buf::LFT_32BIT)
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         sse2_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else 
+      else
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         sse2_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }
-    }    
+    }
 
   } // !local
 } // !ojph

--- a/external/OpenJPH/src/core/transform/ojph_transform_vsx.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform_vsx.cpp
@@ -1,0 +1,1317 @@
+//***************************************************************************/
+// This software is released under the 2-Clause BSD license, included
+// below.
+//
+// Copyright (c) 2021, Aous Naman
+// Copyright (c) 2021, Kakadu Software Pty Ltd, Australia
+// Copyright (c) 2021, The University of New South Wales, Australia
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//***************************************************************************/
+// This file is part of the OpenJPH software implementation.
+// File: ojph_transform_vsx.cpp
+// Author: Aous Naman
+// Date: 09 February 2021
+//***************************************************************************/
+
+#include <cstdio>
+#include "ojph_simd_vsx.h"
+
+#include "ojph_defs.h"
+#include "ojph_arch.h"
+#include "ojph_mem.h"
+#include "ojph_params.h"
+#include "../codestream/ojph_params_local.h"
+
+#include "ojph_transform.h"
+#include "ojph_transform_local.h"
+
+namespace ojph {
+  namespace local {
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    void vsx_deinterleave32(float* dpl, float* dph, float* sp, int width)
+    {
+      for (; width > 0; width -= 8, sp += 8, dpl += 4, dph += 4)
+      {
+        v128_t a = vsx_v128_load(sp);
+        v128_t b = vsx_v128_load(sp + 4);
+        v128_t c = vsx_i32x4_shuffle(a, b, 0, 2, 4 + 0, 4 + 2);
+        v128_t d = vsx_i32x4_shuffle(a, b, 1, 3, 4 + 1, 4 + 3);
+        // v128_t c = _mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0));
+        // v128_t d = _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1));
+        vsx_v128_store(dpl, c);
+        vsx_v128_store(dph, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    void vsx_interleave32(float* dp, float* spl, float* sph, int width)
+    {
+      for (; width > 0; width -= 8, dp += 8, spl += 4, sph += 4)
+      {
+        v128_t a = vsx_v128_load(spl);
+        v128_t b = vsx_v128_load(sph);
+        v128_t c = vsx_i32x4_shuffle(a, b, 0, 4 + 0, 1, 4 + 1);
+        v128_t d = vsx_i32x4_shuffle(a, b, 2, 4 + 2, 3, 4 + 3);
+        // v128_t c = _mm_unpacklo_ps(a, b);
+        // v128_t d = _mm_unpackhi_ps(a, b);
+        vsx_v128_store(dp, c);
+        vsx_v128_store(dp + 4, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    void vsx_deinterleave64(void* dpl, void* dph, const void* sp, int width)
+    {
+      for (; width > 0; width -= 4,
+             sp = (const char*)sp + 32,
+             dpl = (char*)dpl + 16,
+             dph = (char*)dph + 16)
+      {
+        v128_t a = vsx_v128_load(sp);
+        v128_t b = vsx_v128_load((const char*)sp + 16);
+        v128_t c = vsx_i64x2_shuffle(a, b, 0, 2 + 0);
+        v128_t d = vsx_i64x2_shuffle(a, b, 1, 2 + 1);
+        vsx_v128_store(dpl, c);
+        vsx_v128_store(dph, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline
+    void vsx_interleave64(void* dp, const void* spl, const void* sph,
+                          int width)
+    {
+      for (; width > 0; width -= 4,
+             dp = (char*)dp + 32,
+             spl = (const char*)spl + 16,
+             sph = (const char*)sph + 16)
+      {
+        v128_t a = vsx_v128_load(spl);
+        v128_t b = vsx_v128_load(sph);
+        v128_t c = vsx_i64x2_shuffle(a, b, 0, 2 + 0);
+        v128_t d = vsx_i64x2_shuffle(a, b, 1, 2 + 1);
+        vsx_v128_store(dp, c);
+        vsx_v128_store((char*)dp + 16, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    static inline void vsx_multiply_const(float* p, float f, int width)
+    {
+      v128_t factor = vsx_f32x4_splat(f);
+      for (; width > 0; width -= 4, p += 4)
+      {
+        v128_t s = vsx_v128_load(p);
+        vsx_v128_store(p, vsx_f32x4_mul(factor, s));
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
+                            ui32 repeat, bool synthesis)
+    {
+      float a = s->irv.Aatk;
+      if (synthesis)
+        a = -a;
+
+      v128_t factor = vsx_f32x4_splat(a);
+
+      float* dst = aug->f32;
+      const float* src1 = sig->f32, * src2 = other->f32;
+      int i = (int)repeat;
+      for ( ; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+      {
+        v128_t s1 = vsx_v128_load(src1);
+        v128_t s2 = vsx_v128_load(src2);
+        v128_t d  = vsx_v128_load(dst);
+        d = vsx_f32x4_add(d, vsx_f32x4_mul(factor, vsx_f32x4_add(s1, s2)));
+        vsx_v128_store(dst, d);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_vert_times_K(float K, const line_buf* aug, ui32 repeat)
+    {
+      vsx_multiply_const(aug->f32, K, (int)repeat);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
+                           ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // split src into ldst and hdst
+        {
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
+          int w = (int)width;
+          vsx_deinterleave32(dpl, dph, sp, w);
+        }
+
+        // the actual horizontal transform
+        float* hp = hdst->f32, * lp = ldst->f32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
+        {
+          const lifting_step* s = atk->get_step(j - 1);
+          const float a = s->irv.Aatk;
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const float* sp = lp;
+          float* dp = hp;
+          int i = (int)h_width;
+          v128_t f = vsx_f32x4_splat(a);
+          if (even)
+          {
+            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            {
+              v128_t m = vsx_v128_load(sp);
+              v128_t n = vsx_v128_load(sp + 1);
+              v128_t p = vsx_v128_load(dp);
+              p = vsx_f32x4_add(p, vsx_f32x4_mul(f, vsx_f32x4_add(m, n)));
+              vsx_v128_store(dp, p);
+            }
+          }
+          else
+          {
+            for (; i > 0; i -= 4, sp += 4, dp += 4)
+            {
+              v128_t m = vsx_v128_load(sp);
+              v128_t n = vsx_v128_load(sp - 1);
+              v128_t p = vsx_v128_load(dp);
+              p = vsx_f32x4_add(p, vsx_f32x4_mul(f, vsx_f32x4_add(m, n)));
+              vsx_v128_store(dp, p);
+            }
+          }
+
+          // swap buffers
+          float* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
+        }
+
+        { // multiply by K or 1/K
+          float K = atk->get_K();
+          float K_inv = 1.0f / K;
+          vsx_multiply_const(lp, K_inv, (int)l_width);
+          vsx_multiply_const(hp, K, (int)h_width);
+        }
+      }
+      else {
+        if (even)
+          ldst->f32[0] = src->f32[0];
+        else
+          hdst->f32[0] = src->f32[0] * 2.0f;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_irv_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
+                           ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        float* oth = hsrc->f32, * aug = lsrc->f32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+
+        { // multiply by K or 1/K
+          float K = atk->get_K();
+          float K_inv = 1.0f / K;
+          vsx_multiply_const(aug, K, (int)aug_width);
+          vsx_multiply_const(oth, K_inv, (int)oth_width);
+        }
+
+        // the actual horizontal transform
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
+        {
+          const lifting_step* s = atk->get_step(j);
+          const float a = s->irv.Aatk;
+
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const float* sp = oth;
+          float* dp = aug;
+          int i = (int)aug_width;
+          v128_t f = vsx_f32x4_splat(a);
+          if (ev)
+          {
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
+            {
+              v128_t m = vsx_v128_load(sp);
+              v128_t n = vsx_v128_load(sp - 1);
+              v128_t p = vsx_v128_load(dp);
+              p = vsx_f32x4_sub(p, vsx_f32x4_mul(f, vsx_f32x4_add(m, n)));
+              vsx_v128_store(dp, p);
+            }
+          }
+          else
+          {
+            for ( ; i > 0; i -= 4, sp += 4, dp += 4)
+            {
+              v128_t m = vsx_v128_load(sp);
+              v128_t n = vsx_v128_load(sp + 1);
+              v128_t p = vsx_v128_load(dp);
+              p = vsx_f32x4_sub(p, vsx_f32x4_mul(f, vsx_f32x4_add(m, n)));
+              vsx_v128_store(dp, p);
+            }
+          }
+
+          // swap buffers
+          float* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
+        }
+
+        // combine both lsrc and hsrc into dst
+        {
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
+          int w = (int)width;
+          vsx_interleave32(dp, spl, sph, w);
+        }
+      }
+      else {
+        if (even)
+          dst->f32[0] = lsrc->f32[0];
+        else
+          dst->f32[0] = hsrc->f32[0] * 0.5f;
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_vert_step32(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
+                              ui32 repeat, bool synthesis)
+    {
+      const si32 a = s->rev.Aatk;
+      const si32 b = s->rev.Batk;
+      const ui8 e = s->rev.Eatk;
+      v128_t va = vsx_i32x4_splat(a);
+      v128_t vb = vsx_i32x4_splat(b);
+
+      si32* dst = aug->i32;
+      const si32* src1 = sig->i32, * src2 = other->i32;
+      // The general definition of the wavelet in Part 2 is slightly
+      // different to part 2, although they are mathematically equivalent
+      // here, we identify the simpler form from Part 1 and employ them
+      if (a == 1)
+      { // 5/3 update and any case with a == 1
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t v = vsx_i32x4_add(vb, t);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t v = vsx_i32x4_add(vb, t);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else if (a == -1 && b == 1 && e == 1)
+      { // 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t w = vsx_i32x4_shr(t, e);
+            d = vsx_i32x4_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t w = vsx_i32x4_shr(t, e);
+            d = vsx_i32x4_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else if (a == -1)
+      { // any case with a == -1, which is not 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t v = vsx_i32x4_sub(vb, t);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t v = vsx_i32x4_sub(vb, t);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else
+      { // general case
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t u = vsx_i32x4_mul(va, t);
+            v128_t v = vsx_i32x4_add(vb, u);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 4, dst += 4, src1 += 4, src2 += 4)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i32x4_add(s1, s2);
+            v128_t u = vsx_i32x4_mul(va, t);
+            v128_t v = vsx_i32x4_add(vb, u);
+            v128_t w = vsx_i32x4_shr(v, e);
+            d = vsx_i32x4_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_vert_step64(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
+                              ui32 repeat, bool synthesis)
+    {
+      const si32 a = s->rev.Aatk;
+      const si32 b = s->rev.Batk;
+      const ui8 e = s->rev.Eatk;
+      v128_t va = vsx_i64x2_splat(a);
+      v128_t vb = vsx_i64x2_splat(b);
+
+      si64* dst = aug->i64;
+      const si64* src1 = sig->i64, * src2 = other->i64;
+      // The general definition of the wavelet in Part 2 is slightly
+      // different to part 2, although they are mathematically equivalent
+      // here, we identify the simpler form from Part 1 and employ them
+      if (a == 1)
+      { // 5/3 update and any case with a == 1
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t v = vsx_i64x2_add(vb, t);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t v = vsx_i64x2_add(vb, t);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else if (a == -1 && b == 1 && e == 1)
+      { // 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t w = vsx_i64x2_shr(t, e);
+            d = vsx_i64x2_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t w = vsx_i64x2_shr(t, e);
+            d = vsx_i64x2_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else if (a == -1)
+      { // any case with a == -1, which is not 5/3 predict
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t v = vsx_i64x2_sub(vb, t);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t v = vsx_i64x2_sub(vb, t);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+      else
+      { // general case
+        int i = (int)repeat;
+        if (synthesis)
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t u = vsx_i64x2_mul(va, t);
+            v128_t v = vsx_i64x2_add(vb, u);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_sub(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+        else
+          for (; i > 0; i -= 2, dst += 2, src1 += 2, src2 += 2)
+          {
+            v128_t s1 = vsx_v128_load((v128_t*)src1);
+            v128_t s2 = vsx_v128_load((v128_t*)src2);
+            v128_t d = vsx_v128_load((v128_t*)dst);
+            v128_t t = vsx_i64x2_add(s1, s2);
+            v128_t u = vsx_i64x2_mul(va, t);
+            v128_t v = vsx_i64x2_add(vb, u);
+            v128_t w = vsx_i64x2_shr(v, e);
+            d = vsx_i64x2_add(d, w);
+            vsx_v128_store((v128_t*)dst, d);
+          }
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
+                            ui32 repeat, bool synthesis)
+    {
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
+          ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
+      {
+        assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
+               (aug == NULL || aug->flags & line_buf::LFT_32BIT));
+        vsx_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
+      }
+      else
+      {
+        assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
+               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
+               (aug == NULL || aug->flags & line_buf::LFT_64BIT));
+        vsx_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    static
+    void vsx_rev_horz_ana32(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // combine both lsrc and hsrc into dst
+        {
+          float* dpl = even ? ldst->f32 : hdst->f32;
+          float* dph = even ? hdst->f32 : ldst->f32;
+          float* sp = src->f32;
+          int w = (int)width;
+          vsx_deinterleave32(dpl, dph, sp, w);
+        }
+
+        si32* hp = hdst->i32, * lp = ldst->i32;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
+        {
+          // first lifting step
+          const lifting_step* s = atk->get_step(j - 1);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          v128_t va = vsx_i32x4_splat(a);
+          v128_t vb = vsx_i32x4_splat(b);
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const si32* sp = lp;
+          si32* dp = hp;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)h_width;
+            if (even)
+            {
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_add(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+            else
+            {
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_add(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t w = vsx_i32x4_shr(t, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t w = vsx_i32x4_shr(t, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_sub(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_sub(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else
+          { // general case
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t u = vsx_i32x4_mul(va, t);
+                v128_t v = vsx_i32x4_add(vb, u);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t u = vsx_i32x4_mul(va, t);
+                v128_t v = vsx_i32x4_add(vb, u);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+
+          // swap buffers
+          si32* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
+        }
+      }
+      else {
+        if (even)
+          ldst->i32[0] = src->i32[0];
+        else
+          hdst->i32[0] = src->i32[0] << 1;
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    static
+    void vsx_rev_horz_ana64(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        // combine both lsrc and hsrc into dst
+        {
+          void* dpl = even ? ldst->p : hdst->p;
+          void* dph = even ? hdst->p : ldst->p;
+          const void* sp = src->p;
+          int w = (int)width;
+          vsx_deinterleave64(dpl, dph, sp, w);
+        }
+
+        si64* hp = hdst->i64, * lp = ldst->i64;
+        ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 h_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = num_steps; j > 0; --j)
+        {
+          // first lifting step
+          const lifting_step* s = atk->get_step(j - 1);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          v128_t va = vsx_i64x2_splat(a);
+          v128_t vb = vsx_i64x2_splat(b);
+
+          // extension
+          lp[-1] = lp[0];
+          lp[l_width] = lp[l_width - 1];
+          // lifting step
+          const si64* sp = lp;
+          si64* dp = hp;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)h_width;
+            if (even)
+            {
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_add(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+            else
+            {
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_add(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t w = vsx_i64x2_shr(t, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t w = vsx_i64x2_shr(t, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_sub(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_sub(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else
+          { // general case
+            int i = (int)h_width;
+            if (even)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t u = vsx_i64x2_mul(va, t);
+                v128_t v = vsx_i64x2_add(vb, u);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t u = vsx_i64x2_mul(va, t);
+                v128_t v = vsx_i64x2_add(vb, u);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+
+          // swap buffers
+          si64* t = lp; lp = hp; hp = t;
+          even = !even;
+          ui32 w = l_width; l_width = h_width; h_width = w;
+        }
+      }
+      else {
+        if (even)
+          ldst->i64[0] = src->i64[0];
+        else
+          hdst->i64[0] = src->i64[0] << 1;
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
+                           ui32 width, bool even)
+    {
+      if (src->flags & line_buf::LFT_32BIT)
+      {
+        assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
+        vsx_rev_horz_ana32(atk, ldst, hdst, src, width, even);
+      }
+      else
+      {
+        assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
+               (src == NULL || src->flags & line_buf::LFT_64BIT));
+        vsx_rev_horz_ana64(atk, ldst, hdst, src, width, even);
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_syn32(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        si32* oth = hsrc->i32, * aug = lsrc->i32;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
+        {
+          const lifting_step* s = atk->get_step(j);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          v128_t va = vsx_i32x4_splat(a);
+          v128_t vb = vsx_i32x4_splat(b);
+
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const si32* sp = oth;
+          si32* dp = aug;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)aug_width;
+            if (ev)
+            {
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_add(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+            else
+            {
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_add(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t w = vsx_i32x4_shr(t, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t w = vsx_i32x4_shr(t, e);
+                d = vsx_i32x4_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_sub(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t v = vsx_i32x4_sub(vb, t);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else
+          { // general case
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t u = vsx_i32x4_mul(va, t);
+                v128_t v = vsx_i32x4_add(vb, u);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 4, sp += 4, dp += 4)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i32x4_add(s1, s2);
+                v128_t u = vsx_i32x4_mul(va, t);
+                v128_t v = vsx_i32x4_add(vb, u);
+                v128_t w = vsx_i32x4_shr(v, e);
+                d = vsx_i32x4_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+
+          // swap buffers
+          si32* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
+        }
+
+        // combine both lsrc and hsrc into dst
+        {
+          float* dp = dst->f32;
+          float* spl = even ? lsrc->f32 : hsrc->f32;
+          float* sph = even ? hsrc->f32 : lsrc->f32;
+          int w = (int)width;
+          vsx_interleave32(dp, spl, sph, w);
+        }
+      }
+      else {
+        if (even)
+          dst->i32[0] = lsrc->i32[0];
+        else
+          dst->i32[0] = hsrc->i32[0] >> 1;
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_syn64(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
+                             ui32 width, bool even)
+    {
+      if (width > 1)
+      {
+        bool ev = even;
+        si64* oth = hsrc->i64, * aug = lsrc->i64;
+        ui32 aug_width = (width + (even ? 1 : 0)) >> 1;  // low pass
+        ui32 oth_width = (width + (even ? 0 : 1)) >> 1;  // high pass
+        ui32 num_steps = atk->get_num_steps();
+        for (ui32 j = 0; j < num_steps; ++j)
+        {
+          const lifting_step* s = atk->get_step(j);
+          const si32 a = s->rev.Aatk;
+          const si32 b = s->rev.Batk;
+          const ui8 e = s->rev.Eatk;
+          v128_t va = vsx_i64x2_splat(a);
+          v128_t vb = vsx_i64x2_splat(b);
+
+          // extension
+          oth[-1] = oth[0];
+          oth[oth_width] = oth[oth_width - 1];
+          // lifting step
+          const si64* sp = oth;
+          si64* dp = aug;
+          if (a == 1)
+          { // 5/3 update and any case with a == 1
+            int i = (int)aug_width;
+            if (ev)
+            {
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_add(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+            else
+            {
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_add(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            }
+          }
+          else if (a == -1 && b == 1 && e == 1)
+          {  // 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t w = vsx_i64x2_shr(t, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t w = vsx_i64x2_shr(t, e);
+                d = vsx_i64x2_add(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else if (a == -1)
+          { // any case with a == -1, which is not 5/3 predict
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_sub(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t v = vsx_i64x2_sub(vb, t);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+          else
+          { // general case
+            int i = (int)aug_width;
+            if (ev)
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp - 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t u = vsx_i64x2_mul(va, t);
+                v128_t v = vsx_i64x2_add(vb, u);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+            else
+              for (; i > 0; i -= 2, sp += 2, dp += 2)
+              {
+                v128_t s1 = vsx_v128_load((v128_t*)sp);
+                v128_t s2 = vsx_v128_load((v128_t*)(sp + 1));
+                v128_t d = vsx_v128_load((v128_t*)dp);
+                v128_t t = vsx_i64x2_add(s1, s2);
+                v128_t u = vsx_i64x2_mul(va, t);
+                v128_t v = vsx_i64x2_add(vb, u);
+                v128_t w = vsx_i64x2_shr(v, e);
+                d = vsx_i64x2_sub(d, w);
+                vsx_v128_store((v128_t*)dp, d);
+              }
+          }
+
+          // swap buffers
+          si64* t = aug; aug = oth; oth = t;
+          ev = !ev;
+          ui32 w = aug_width; aug_width = oth_width; oth_width = w;
+        }
+
+        // combine both lsrc and hsrc into dst
+        {
+          void* dp = dst->p;
+          const void* spl = even ? lsrc->p : hsrc->p;
+          const void* sph = even ? hsrc->p : lsrc->p;
+          int w = (int)width;
+          vsx_interleave64(dp, spl, sph, w);
+        }
+      }
+      else {
+        if (even)
+          dst->i64[0] = lsrc->i64[0];
+        else
+          dst->i64[0] = hsrc->i64[0] >> 1;
+      }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    void vsx_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
+                           ui32 width, bool even)
+    {
+      if (dst->flags & line_buf::LFT_32BIT)
+      {
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
+               (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
+        vsx_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
+      }
+      else
+      {
+        assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
+               (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
+        vsx_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
+      }
+    }
+
+  } // !local
+} // !ojph

--- a/external/OpenJPH/src/core/transform/ojph_transform_wasm.cpp
+++ b/external/OpenJPH/src/core/transform/ojph_transform_wasm.cpp
@@ -2,21 +2,21 @@
 // This software is released under the 2-Clause BSD license, included
 // below.
 //
-// Copyright (c) 2021, Aous Naman 
+// Copyright (c) 2021, Aous Naman
 // Copyright (c) 2021, Kakadu Software Pty Ltd, Australia
 // Copyright (c) 2021, The University of New South Wales, Australia
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright
 // notice, this list of conditions and the following disclaimer in the
 // documentation and/or other materials provided with the distribution.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 // IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
 // TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -85,34 +85,41 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void wasm_deinterleave64(double* dpl, double* dph, double* sp, int width)
+    static inline
+    void wasm_deinterleave64(void* dpl, void* dph, const void* sp, int width)
     {
-      for (; width > 0; width -= 4, sp += 4, dpl += 2, dph += 2)
+      for (; width > 0; width -= 4,
+             sp = (const char*)sp + 32,
+             dpl = (char*)dpl + 16,
+             dph = (char*)dph + 16)
       {
         v128_t a = wasm_v128_load(sp);
-        v128_t b = wasm_v128_load(sp + 2);
+        v128_t b = wasm_v128_load((const char*)sp + 16);
         v128_t c = wasm_i64x2_shuffle(a, b, 0, 2 + 0);
         v128_t d = wasm_i64x2_shuffle(a, b, 1, 2 + 1);
         wasm_v128_store(dpl, c);
         wasm_v128_store(dph, d);
       }
-    }    
+    }
 
     //////////////////////////////////////////////////////////////////////////
-    static inline 
-    void wasm_interleave64(double* dp, double* spl, double* sph, int width)
+    static inline
+    void wasm_interleave64(void* dp, const void* spl, const void* sph,
+                           int width)
     {
-      for (; width > 0; width -= 4, dp += 4, spl += 2, sph += 2)
+      for (; width > 0; width -= 4,
+             dp = (char*)dp + 32,
+             spl = (const char*)spl + 16,
+             sph = (const char*)sph + 16)
       {
         v128_t a = wasm_v128_load(spl);
         v128_t b = wasm_v128_load(sph);
         v128_t c = wasm_i64x2_shuffle(a, b, 0, 2 + 0);
         v128_t d = wasm_i64x2_shuffle(a, b, 1, 2 + 1);
         wasm_v128_store(dp, c);
-        wasm_v128_store(dp + 2, d);
+        wasm_v128_store((char*)dp + 16, d);
       }
-    }    
+    }
 
     //////////////////////////////////////////////////////////////////////////
     static inline void wasm_multiply_const(float* p, float f, int width)
@@ -126,8 +133,8 @@ namespace ojph {
     }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void wasm_irv_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis)
     {
       float a = s->irv.Aatk;
@@ -156,8 +163,8 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                           const line_buf* hdst, const line_buf* src, 
+    void wasm_irv_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even)
     {
       if (width > 1)
@@ -169,7 +176,7 @@ namespace ojph {
           float* sp = src->f32;
           int w = (int)width;
           wasm_deinterleave32(dpl, dph, sp, w);
-        }        
+        }
 
         // the actual horizontal transform
         float* hp = hdst->f32, * lp = ldst->f32;
@@ -232,10 +239,10 @@ namespace ojph {
           hdst->f32[0] = src->f32[0] * 2.0f;
       }
     }
-    
+
     //////////////////////////////////////////////////////////////////////////
-    void wasm_irv_horz_syn(const param_atk* atk, const line_buf* dst, 
-                           const line_buf* lsrc, const line_buf* hsrc, 
+    void wasm_irv_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even)
     {
       if (width > 1)
@@ -303,7 +310,7 @@ namespace ojph {
           float* sph = even ? hsrc->f32 : lsrc->f32;
           int w = (int)width;
           wasm_interleave32(dp, spl, sph, w);
-        }        
+        }
       }
       else {
         if (even)
@@ -314,8 +321,8 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step32(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void wasm_rev_vert_step32(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -326,7 +333,7 @@ namespace ojph {
 
       si32* dst = aug->i32;
       const si32* src1 = sig->i32, * src2 = other->i32;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -411,7 +418,7 @@ namespace ojph {
             wasm_v128_store((v128_t*)dst, d);
           }
       }
-      else 
+      else
       { // general case
         int i = (int)repeat;
         if (synthesis)
@@ -444,8 +451,8 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step64(const lifting_step* s, const line_buf* sig, 
-                              const line_buf* other, const line_buf* aug, 
+    void wasm_rev_vert_step64(const lifting_step* s, const line_buf* sig,
+                              const line_buf* other, const line_buf* aug,
                               ui32 repeat, bool synthesis)
     {
       const si32 a = s->rev.Aatk;
@@ -456,7 +463,7 @@ namespace ojph {
 
       si64* dst = aug->i64;
       const si64* src1 = sig->i64, * src2 = other->i64;
-      // The general definition of the wavelet in Part 2 is slightly 
+      // The general definition of the wavelet in Part 2 is slightly
       // different to part 2, although they are mathematically equivalent
       // here, we identify the simpler form from Part 1 and employ them
       if (a == 1)
@@ -541,7 +548,7 @@ namespace ojph {
             wasm_v128_store((v128_t*)dst, d);
           }
       }
-      else 
+      else
       { // general case
         int i = (int)repeat;
         if (synthesis)
@@ -574,23 +581,23 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_vert_step(const lifting_step* s, const line_buf* sig, 
-                            const line_buf* other, const line_buf* aug, 
+    void wasm_rev_vert_step(const lifting_step* s, const line_buf* sig,
+                            const line_buf* other, const line_buf* aug,
                             ui32 repeat, bool synthesis)
     {
-      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) || 
+      if (((sig != NULL) && (sig->flags & line_buf::LFT_32BIT)) ||
           ((aug != NULL) && (aug->flags & line_buf::LFT_32BIT)) ||
-          ((other != NULL) && (other->flags & line_buf::LFT_32BIT))) 
+          ((other != NULL) && (other->flags & line_buf::LFT_32BIT)))
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_32BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_32BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_32BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_32BIT));
         wasm_rev_vert_step32(s, sig, other, aug, repeat, synthesis);
       }
-      else 
+      else
       {
         assert((sig == NULL || sig->flags & line_buf::LFT_64BIT) &&
-               (other == NULL || other->flags & line_buf::LFT_64BIT) && 
+               (other == NULL || other->flags & line_buf::LFT_64BIT) &&
                (aug == NULL || aug->flags & line_buf::LFT_64BIT));
         wasm_rev_vert_step64(s, sig, other, aug, repeat, synthesis);
       }
@@ -598,8 +605,8 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void wasm_rev_horz_ana32(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void wasm_rev_horz_ana32(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -611,7 +618,7 @@ namespace ojph {
           float* sp = src->f32;
           int w = (int)width;
           wasm_deinterleave32(dpl, dph, sp, w);
-        }        
+        }
 
         si32* hp = hdst->i32, * lp = ldst->i32;
         ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
@@ -719,7 +726,7 @@ namespace ojph {
                 wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else 
+          else
           { // general case
             int i = (int)h_width;
             if (even)
@@ -742,7 +749,7 @@ namespace ojph {
                 v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
                 v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
-                v128_t u = wasm_i32x4_mul(va, t);                
+                v128_t u = wasm_i32x4_mul(va, t);
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_add(d, w);
@@ -766,20 +773,20 @@ namespace ojph {
 
     /////////////////////////////////////////////////////////////////////////
     static
-    void wasm_rev_horz_ana64(const param_atk* atk, const line_buf* ldst, 
-                             const line_buf* hdst, const line_buf* src, 
+    void wasm_rev_horz_ana64(const param_atk* atk, const line_buf* ldst,
+                             const line_buf* hdst, const line_buf* src,
                              ui32 width, bool even)
     {
       if (width > 1)
       {
         // combine both lsrc and hsrc into dst
         {
-          double* dpl = (double*)(even ? ldst->p : hdst->p);
-          double* dph = (double*)(even ? hdst->p : ldst->p);
-          double* sp  = (double*)src->p;
+          void* dpl = even ? ldst->p : hdst->p;
+          void* dph = even ? hdst->p : ldst->p;
+          const void* sp = src->p;
           int w = (int)width;
           wasm_deinterleave64(dpl, dph, sp, w);
-        }        
+        }
 
         si64* hp = hdst->i64, * lp = ldst->i64;
         ui32 l_width = (width + (even ? 1 : 0)) >> 1;  // low pass
@@ -887,7 +894,7 @@ namespace ojph {
                 wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else 
+          else
           { // general case
             int i = (int)h_width;
             if (even)
@@ -910,7 +917,7 @@ namespace ojph {
                 v128_t s2 = wasm_v128_load((v128_t*)(sp - 1));
                 v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
-                v128_t u = wasm_i64x2_mul(va, t);                
+                v128_t u = wasm_i64x2_mul(va, t);
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_add(d, w);
@@ -933,28 +940,28 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_ana(const param_atk* atk, const line_buf* ldst, 
-                           const line_buf* hdst, const line_buf* src, 
+    void wasm_rev_horz_ana(const param_atk* atk, const line_buf* ldst,
+                           const line_buf* hdst, const line_buf* src,
                            ui32 width, bool even)
     {
-      if (src->flags & line_buf::LFT_32BIT) 
+      if (src->flags & line_buf::LFT_32BIT)
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_32BIT) &&
                (hdst == NULL || hdst->flags & line_buf::LFT_32BIT));
         wasm_rev_horz_ana32(atk, ldst, hdst, src, width, even);
       }
-      else 
+      else
       {
         assert((ldst == NULL || ldst->flags & line_buf::LFT_64BIT) &&
-               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) && 
+               (hdst == NULL || hdst->flags & line_buf::LFT_64BIT) &&
                (src == NULL || src->flags & line_buf::LFT_64BIT));
         wasm_rev_horz_ana64(atk, ldst, hdst, src, width, even);
       }
-    } 
+    }
 
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn32(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void wasm_rev_horz_syn32(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -1065,7 +1072,7 @@ namespace ojph {
                 wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else 
+          else
           { // general case
             int i = (int)aug_width;
             if (ev)
@@ -1088,7 +1095,7 @@ namespace ojph {
                 v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
                 v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i32x4_add(s1, s2);
-                v128_t u = wasm_i32x4_mul(va, t);                
+                v128_t u = wasm_i32x4_mul(va, t);
                 v128_t v = wasm_i32x4_add(vb, u);
                 v128_t w = wasm_i32x4_shr(v, e);
                 d = wasm_i32x4_sub(d, w);
@@ -1118,10 +1125,10 @@ namespace ojph {
           dst->i32[0] = hsrc->i32[0] >> 1;
       }
     }
-    
+
     //////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn64(const param_atk* atk, const line_buf* dst, 
-                             const line_buf* lsrc, const line_buf* hsrc, 
+    void wasm_rev_horz_syn64(const param_atk* atk, const line_buf* dst,
+                             const line_buf* lsrc, const line_buf* hsrc,
                              ui32 width, bool even)
     {
       if (width > 1)
@@ -1232,7 +1239,7 @@ namespace ojph {
                 wasm_v128_store((v128_t*)dp, d);
               }
           }
-          else 
+          else
           { // general case
             int i = (int)aug_width;
             if (ev)
@@ -1255,7 +1262,7 @@ namespace ojph {
                 v128_t s2 = wasm_v128_load((v128_t*)(sp + 1));
                 v128_t d = wasm_v128_load((v128_t*)dp);
                 v128_t t = wasm_i64x2_add(s1, s2);
-                v128_t u = wasm_i64x2_mul(va, t);                
+                v128_t u = wasm_i64x2_mul(va, t);
                 v128_t v = wasm_i64x2_add(vb, u);
                 v128_t w = wasm_i64x2_shr(v, e);
                 d = wasm_i64x2_sub(d, w);
@@ -1271,9 +1278,9 @@ namespace ojph {
 
         // combine both lsrc and hsrc into dst
         {
-          double* dp  = (double*)dst->p;
-          double* spl = (double*)(even ? lsrc->p : hsrc->p);
-          double* sph = (double*)(even ? hsrc->p : lsrc->p);
+          void* dp = dst->p;
+          const void* spl = even ? lsrc->p : hsrc->p;
+          const void* sph = even ? hsrc->p : lsrc->p;
           int w = (int)width;
           wasm_interleave64(dp, spl, sph, w);
         }
@@ -1287,24 +1294,24 @@ namespace ojph {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    void wasm_rev_horz_syn(const param_atk* atk, const line_buf* dst, 
-                           const line_buf* lsrc, const line_buf* hsrc, 
+    void wasm_rev_horz_syn(const param_atk* atk, const line_buf* dst,
+                           const line_buf* lsrc, const line_buf* hsrc,
                            ui32 width, bool even)
     {
-      if (dst->flags & line_buf::LFT_32BIT) 
+      if (dst->flags & line_buf::LFT_32BIT)
       {
-        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) && 
+        assert((lsrc == NULL || lsrc->flags & line_buf::LFT_32BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_32BIT));
         wasm_rev_horz_syn32(atk, dst, lsrc, hsrc, width, even);
       }
-      else 
+      else
       {
         assert((dst == NULL || dst->flags & line_buf::LFT_64BIT) &&
-               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) && 
+               (lsrc == NULL || lsrc->flags & line_buf::LFT_64BIT) &&
                (hsrc == NULL || hsrc->flags & line_buf::LFT_64BIT));
         wasm_rev_horz_syn64(atk, dst, lsrc, hsrc, width, even);
       }
-    } 
+    }
 
   } // !local
 } // !ojph

--- a/external/OpenJPH/target_arch.cmake
+++ b/external/OpenJPH/target_arch.cmake
@@ -7,7 +7,7 @@
 
 set(archdetect_c_code "
 #if defined(__arm__) || defined(__TARGET_ARCH_ARM)  \
-  || defined(__aarch64__) || defined(_M_ARM64)
+  || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
   #error cmake_ARCH OJPH_ARCH_ARM
 #elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
   #error cmake_ARCH OJPH_ARCH_I386


### PR DESCRIPTION
CI references have been updated to 0.31.0 already. This brings the vendored version in line.