### PR TITLE
Address comments on PR #2590 regarding zstd-beta

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -407,6 +407,7 @@ cc_library(
         "src/lib/OpenEXR/ImfCompression.h",
         "src/lib/OpenEXR/ImfCompressionAttribute.h",
         "src/lib/OpenEXR/ImfCompressor.h",
+        "src/lib/OpenEXR/ImfCompressorDeepInternal.h",
         "src/lib/OpenEXR/ImfContext.h",
         "src/lib/OpenEXR/ImfContextInit.h",
         "src/lib/OpenEXR/ImfConvert.h",

--- a/src/lib/OpenEXR/CMakeLists.txt
+++ b/src/lib/OpenEXR/CMakeLists.txt
@@ -24,6 +24,7 @@ openexr_define_library(OpenEXR
     ImfCompressionAttribute.cpp
     ImfCompressor.cpp
     ImfCompressor.h
+    ImfCompressorDeepInternal.h
     ImfContext.cpp
     ImfContextInit.cpp
     ImfConvert.cpp

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include "ImfHTCompressor.h"
+#include "ImfCompressorDeepInternal.h"
 #include "openexr_compression.h"
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
@@ -97,12 +98,13 @@ int
 Compressor::compress (
     const char* inPtr, int inSize, int minY, const char*& outPtr)
 {
-    return compress (
-        inPtr, inSize, minY, outPtr, nullptr, 0);
+    return compressWithSampleCountTable (
+        *this, inPtr, inSize, minY, outPtr, nullptr, 0);
 }
 
 int
-Compressor::compress (
+compressWithSampleCountTable (
+    Compressor&  compressor,
     const char*  inPtr,
     int          inSize,
     int          minY,
@@ -110,13 +112,13 @@ Compressor::compress (
     const char*  sampleCountTable,
     int          sampleCountTableSize)
 {
-    IMATH_NAMESPACE::Box2i range = _header.dataWindow ();
+    IMATH_NAMESPACE::Box2i range = compressor._header.dataWindow ();
 
     range.min.y = minY;
-    range.max.y = minY + _numScanLines - 1;
+    range.max.y = minY + compressor._numScanLines - 1;
 
     return static_cast<int> (
-        runEncodeStep (inPtr, inSize, range, outPtr, sampleCountTable, sampleCountTableSize));
+        compressor.runEncodeStep (inPtr, inSize, range, outPtr, sampleCountTable, sampleCountTableSize));
 }
 
 int
@@ -139,12 +141,13 @@ Compressor::compressTile (
     Box2i        range,
     const char*& outPtr)
 {
-    return compressTile (
-        inPtr, inSize, range, outPtr, nullptr, 0);
+    return compressTileWithSampleCountTable (
+        *this, inPtr, inSize, range, outPtr, nullptr, 0);
 }
 
 int
-Compressor::compressTile (
+compressTileWithSampleCountTable (
+    Compressor&  compressor,
     const char*  inPtr,
     int          inSize,
     Box2i        range,
@@ -153,7 +156,7 @@ Compressor::compressTile (
     int          sampleCountTableSize)
 {
     return static_cast<int> (
-        runEncodeStep (inPtr, inSize, range, outPtr, sampleCountTable, sampleCountTableSize));
+        compressor.runEncodeStep (inPtr, inSize, range, outPtr, sampleCountTable, sampleCountTableSize));
 }
 
 int

--- a/src/lib/OpenEXR/ImfCompressor.h
+++ b/src/lib/OpenEXR/ImfCompressor.h
@@ -145,24 +145,12 @@ public:
     virtual int
     compress (const char* inPtr, int inSize, int minY, const char*& outPtr);
 
-    virtual int
-    compress (const char* inPtr, int inSize, int minY, const char*& outPtr,
-              const char* sampleCountTable, int sampleCountTableSize);
-
     IMF_EXPORT
     virtual int compressTile (
         const char*            inPtr,
         int                    inSize,
         IMATH_NAMESPACE::Box2i range,
         const char*&           outPtr);
-
-    virtual int compressTile (
-        const char*            inPtr,
-        int                    inSize,
-        IMATH_NAMESPACE::Box2i range,
-        const char*&           outPtr,
-        const char*            sampleCountTable,
-        int                    sampleCountTableSize);
 
     //-------------------------------------------------------------------------
     // Uncompress an array of bytes that has been compressed by compress():
@@ -197,6 +185,24 @@ public:
     void setStorageType (exr_storage_t st) { _store_type = st; }
 
 protected:
+    friend int compressWithSampleCountTable (
+        Compressor&  compressor,
+        const char*  inPtr,
+        int          inSize,
+        int          minY,
+        const char*& outPtr,
+        const char*  sampleCountTable,
+        int          sampleCountTableSize);
+
+    friend int compressTileWithSampleCountTable (
+        Compressor&            compressor,
+        const char*            inPtr,
+        int                    inSize,
+        IMATH_NAMESPACE::Box2i range,
+        const char*&           outPtr,
+        const char*            sampleCountTable,
+        int                    sampleCountTableSize);
+
     Context _ctxt;
     const Header& _header;
 

--- a/src/lib/OpenEXR/ImfCompressorDeepInternal.h
+++ b/src/lib/OpenEXR/ImfCompressorDeepInternal.h
@@ -1,0 +1,43 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#ifndef INCLUDED_IMF_COMPRESSOR_DEEP_INTERNAL_H
+#define INCLUDED_IMF_COMPRESSOR_DEEP_INTERNAL_H
+
+//-----------------------------------------------------------------------------
+//
+// Internal helpers for deep scanline/tile output. libOpenEXR only.
+//
+//-----------------------------------------------------------------------------
+
+#include "ImfForward.h"
+
+#include <Imath/ImathBox.h>
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
+
+class Compressor;
+
+int compressWithSampleCountTable (
+    Compressor&  compressor,
+    const char*  inPtr,
+    int          inSize,
+    int          minY,
+    const char*& outPtr,
+    const char*  sampleCountTable,
+    int          sampleCountTableSize);
+
+int compressTileWithSampleCountTable (
+    Compressor&            compressor,
+    const char*            inPtr,
+    int                    inSize,
+    IMATH_NAMESPACE::Box2i range,
+    const char*&           outPtr,
+    const char*            sampleCountTable,
+    int                    sampleCountTableSize);
+
+OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_EXIT
+
+#endif

--- a/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepScanLineOutputFile.cpp
@@ -15,6 +15,7 @@
 #include "ImfArray.h"
 #include "ImfChannelList.h"
 #include "ImfCompressor.h"
+#include "ImfCompressorDeepInternal.h"
 #include "ImfDeepScanLineInputFile.h"
 #include "ImfDeepScanLineInputPart.h"
 #include "ImfDeepScanLineOutputFile.h"
@@ -742,7 +743,8 @@ LineBufferTask::execute ()
         {
             const char* compPtr;
 
-            uint64_t compSize = compressor->compress (
+            uint64_t compSize = compressWithSampleCountTable (
+                *compressor,
                 _lineBuffer->dataPtr,
                 static_cast<int> (_lineBuffer->dataSize),
                 _lineBuffer->minY,

--- a/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
+++ b/src/lib/OpenEXR/ImfDeepTiledOutputFile.cpp
@@ -14,6 +14,7 @@
 #include "ImfArray.h"
 #include "ImfChannelList.h"
 #include "ImfCompressor.h"
+#include "ImfCompressorDeepInternal.h"
 #include "ImfDeepFrameBuffer.h"
 #include "ImfDeepTiledInputFile.h"
 #include "ImfDeepTiledInputPart.h"
@@ -1007,7 +1008,8 @@ TileBufferTask::execute ()
             _tileBuffer->compressor->setTileLevel (
                 _tileBuffer->tileCoord.lx,
                 _tileBuffer->tileCoord.ly);
-            uint64_t compSize = _tileBuffer->compressor->compressTile (
+            uint64_t compSize = compressTileWithSampleCountTable (
+                *_tileBuffer->compressor,
                 _tileBuffer->dataPtr,
                 static_cast<int> (_tileBuffer->dataSize),
                 tileRange,

--- a/src/lib/OpenEXRCore/backward_compatibility.h
+++ b/src/lib/OpenEXRCore/backward_compatibility.h
@@ -40,7 +40,27 @@ struct _exr_context_initializer_v2
     int                           max_tile_height;
     int                           zip_level;
     float                         dwa_quality;
-    int                           zstd_level;
+};
+
+struct _exr_context_initializer_v3
+{
+    size_t                        size;
+    exr_error_handler_cb_t        error_handler_fn;
+    exr_memory_allocation_func_t  alloc_fn;
+    exr_memory_free_func_t        free_fn;
+    void*                         user_data;
+    exr_read_func_ptr_t           read_fn;
+    exr_query_size_func_ptr_t     size_fn;
+    exr_write_func_ptr_t          write_fn;
+    exr_destroy_stream_func_ptr_t destroy_fn;
+    int                           max_image_width;
+    int                           max_image_height;
+    int                           max_tile_width;
+    int                           max_tile_height;
+    int                           zip_level;
+    float                         dwa_quality;
+    int                           flags;
+    uint8_t                       pad[4];
 };
 
 #endif /* OPENEXR_BACKWARD_COMPATIBILITY_H */

--- a/src/lib/OpenEXRCore/context.c
+++ b/src/lib/OpenEXRCore/context.c
@@ -129,11 +129,14 @@ fill_context_data (const exr_context_initializer_t* ctxtdata)
         {
             inits.zip_level   = ctxtdata->zip_level;
             inits.dwa_quality = ctxtdata->dwa_quality;
-            inits.zstd_level  = ctxtdata->zstd_level;
         }
         if (ctxtdata->size >= sizeof (struct _exr_context_initializer_v3))
         {
             inits.flags = ctxtdata->flags;
+        }
+        if (ctxtdata->size >= sizeof (struct _exr_context_initializer_v4))
+        {
+            inits.zstd_level = ctxtdata->zstd_level;
         }
     }
 

--- a/src/lib/OpenEXRCore/internal_zstd_shuffle.c
+++ b/src/lib/OpenEXRCore/internal_zstd_shuffle.c
@@ -277,8 +277,6 @@ exr_zstd_shuffle_decode_bytes (
     uint8_t* dst, const uint8_t* shuf, size_t dSize, uint64_t shuffle_el_bytes)
 {
 #if defined(__GNUC__) && defined(__x86_64__)
-    __builtin_cpu_init ();
-
     if (shuffle_el_bytes == 4)
     {
         /* AVX512 BW & DQ are required for the unpack+permutex2var logic */

--- a/src/lib/OpenEXRCore/openexr_context.h
+++ b/src/lib/OpenEXRCore/openexr_context.h
@@ -190,7 +190,7 @@ typedef int64_t (*exr_write_func_ptr_t) (
  * \endcode
  *
  */
-typedef struct _exr_context_initializer_v3
+typedef struct _exr_context_initializer_v4
 {
     /** @brief Size member to tag initializer for version stability.
      *
@@ -319,17 +319,17 @@ typedef struct _exr_context_initializer_v3
      */
     float dwa_quality;
 
-    /** Default zstd compression level for this context (1-22; values are
-     * clamped). See exr_set_default_zstd_compression_level() for the global
-     * default (5).
-     */
-    int zstd_level;
-
     /** Initialize with a bitwise or of the various context flags
      */
     int flags;
 
     uint8_t pad[4];
+
+    /** Default zstd compression level for this context (1-22; values are
+     * clamped). See exr_set_default_zstd_compression_level() for the global
+     * default (5).
+     */
+    int zstd_level;
 } exr_context_initializer_t;
 
 /** @brief context flag which will enforce strict header validation
@@ -359,7 +359,7 @@ typedef struct _exr_context_initializer_v3
 /* clang-format off */
 /** @brief Simple macro to initialize the context initializer with default values. */
 #define EXR_DEFAULT_CONTEXT_INITIALIZER                                        \
-    { sizeof (exr_context_initializer_t), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, -1.f, -1, 0, { 0, 0, 0, 0 } }
+    { sizeof (exr_context_initializer_t), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -2, -1.f, 0, { 0, 0, 0, 0 }, -1 }
 /* clang-format on */
 
 /** @} */ /* context function pointer declarations */

--- a/src/lib/OpenEXRCore/openexr_decode.h
+++ b/src/lib/OpenEXRCore/openexr_decode.h
@@ -161,7 +161,6 @@ typedef struct _exr_decode_pipeline
      */
     int32_t* sample_count_table;
     size_t   sample_count_alloc_size;
-    int     sample_count_valid; // We actually decompressed it.
 
     /** A scratch buffer of unpacked_size for intermediate results.
      *
@@ -265,6 +264,9 @@ typedef struct _exr_decode_pipeline
      * this being used.
      */
     exr_coding_channel_info_t _quick_chan_store[5];
+
+    /** Set when the sample count table has been decompressed. */
+    int sample_count_valid;
 } exr_decode_pipeline_t;
 
 /** @brief Simple macro to initialize an empty decode pipeline. */

--- a/src/lib/OpenEXRCore/openexr_encode.h
+++ b/src/lib/OpenEXRCore/openexr_encode.h
@@ -124,7 +124,6 @@ typedef struct _exr_encode_pipeline
      * samples must always be width * height for the chunk.
      */
     size_t sample_count_alloc_size;
-    int skip_sample_count_table_compression;
 
     /** Packed sample table (compressed, raw on disk representation)
      * for deep or other non-image data.
@@ -278,6 +277,9 @@ typedef struct _exr_encode_pipeline
      * this being used.
      */
     exr_coding_channel_info_t _quick_chan_store[5];
+
+    /** When set, skip compressing the sample count table separately. */
+    int skip_sample_count_table_compression;
 } exr_encode_pipeline_t;
 
 /** @brief Simple macro to initialize an empty decode pipeline. */


### PR DESCRIPTION
## Description of changes
All changes address @kdt3rd's review feedback on #2590. They are ABI-preservation
fixes plus one dead-code removal — no functional or file-format changes. Files
written before this change still read back identically.
### 1. Context initializer versioning
> _"do we really want this? This was here largely for backwards compatibility"_
`zstd_level` had been inserted into the frozen `_exr_context_initializer_v2` in
`backward_compatibility.h`, and into the middle of the live struct ahead of
`flags`/`pad[4]`. Both shift offsets that released binaries depend on.
- Reverted `_exr_context_initializer_v2` to its released layout (`zip_level`,
  `dwa_quality` only).
- Added `_exr_context_initializer_v3` to `backward_compatibility.h` as a frozen
  snapshot of the last released layout. This is needed because the live typedef
  in `openexr_context.h` was previously named `_exr_context_initializer_v3`, and
  `fill_context_data()` still needs `sizeof(v3)` to gate the `flags` field for
  older callers.
- Renamed the live typedef to `_exr_context_initializer_v4` and moved
  `zstd_level` to the **end**, after `flags` and `pad[4]`.
- `EXR_DEFAULT_CONTEXT_INITIALIZER` reordered to match, with `zstd_level`
  defaulting to `-1` (use global default).
- `fill_context_data()` now gates `zstd_level` behind
  `sizeof(struct _exr_context_initializer_v4)`, leaving the `v2` and `v3` blocks
  as they were on main.
An application built against the previous release passes the old `size` and
simply never has `zstd_level` read from it.
### 2. Encode/decode pipeline ABI
Two fields had been inserted mid-struct. Both moved to the end of their structs
so existing field offsets are unchanged:
- `sample_count_valid` → end of `exr_decode_pipeline_t`
- `skip_sample_count_table_compression` → end of `exr_encode_pipeline_t`
### 3. Compressor vtable
> _"NB: abi change"_
The new `sampleCountTable` overloads of `compress()` and `compressTile()` were
`virtual`, which inserts entries into the middle of `Compressor`'s vtable and
breaks any third-party subclass.
- Removed both virtual overloads from `ImfCompressor.h`. The released vtable
  layout is now byte-identical to the previous release.
- Replaced them with two free functions, `compressWithSampleCountTable()` and
  `compressTileWithSampleCountTable()`, declared `friend` so they can reach
  `_header`, `_numScanLines`, and `runEncodeStep()`.
- Added `ImfCompressorDeepInternal.h`, a new **internal** header (added to
  `SOURCES`, not `HEADERS`, so it is not installed) declaring the two helpers.
  They are not exported and are not part of the public API.
- The public four-argument `compress()` and `compressTile()` now delegate to
  these helpers with `nullptr, 0`, so there is no duplicated encode logic.
- Deep output call sites in `ImfDeepScanLineOutputFile.cpp` and
  `ImfDeepTiledOutputFile.cpp` updated to call the helpers directly.
### 4. Redundant CPU init
Removed the `__builtin_cpu_init()` call in `exr_zstd_shuffle_decode_bytes()`.
GCC and Clang emit the initialization automatically ahead of
`__builtin_cpu_supports()`, so the explicit call was redundant.