### PR TITLE
Cleanup compression information routines

### DIFF
--- a/src/lib/OpenEXR/ImfCompression.cpp
+++ b/src/lib/OpenEXR/ImfCompression.cpp
@@ -88,174 +88,25 @@
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
-/// Store codec properties so they may be queried in various places.
-struct CompressionDesc
-{
-    std::string name;         // short name
-    std::string desc;         // method description
-    int         numScanlines; // number of scanlines required
-    bool        lossy;        // true if lossy algorithm
-    bool        deep;         // true is capable of compressing deep data
-
-    CompressionDesc (
-        std::string _name,
-        std::string _desc,
-        int         _scanlines,
-        bool        _lossy,
-        bool        _deep)
-    {
-        name         = _name;
-        desc         = _desc;
-        numScanlines = _scanlines;
-        lossy        = _lossy;
-        deep         = _deep;
-    }
-};
-
-// NOTE: IdToDesc order MUST match Imf::Compression enum.
-// clang-format off
-static const CompressionDesc IdToDesc[] = {
-    CompressionDesc (
-        "none",
-        "no compression.",
-        1,
-        false,
-        true),
-    CompressionDesc (
-        "rle",
-        "run-length encoding.",
-        1,
-        false,
-        true),
-    CompressionDesc (
-        "zips",
-        "zlib compression, one scan line at a time.",
-        1,
-        false,
-        true),
-    CompressionDesc (
-        "zip",
-        "zlib compression, in blocks of 16 scan lines.",
-        16,
-        false,
-        false),
-    CompressionDesc (
-        "piz",
-        "piz-based wavelet compression, in blocks of 32 scan lines.",
-        32,
-        false,
-        false),
-    CompressionDesc (
-        "pxr24",
-        "lossy 24-bit float compression, in blocks of 16 scan lines.",
-        16,
-        true,
-        false),
-    CompressionDesc (
-        "b44",
-        "lossy 4-by-4 pixel block compression, fixed compression rate.",
-        32,
-        true,
-        false),
-    CompressionDesc (
-        "b44a",
-        "lossy 4-by-4 pixel block compression, flat fields are compressed more.",
-        32,
-        true,
-        false),
-    CompressionDesc (
-        "dwaa",
-        "lossy DCT based compression, in blocks of 32 scanlines. More efficient "
-        "for partial buffer access.",
-        32,
-        true,
-        false),
-    CompressionDesc (
-        "dwab",
-        "lossy DCT based compression, in blocks of 256 scanlines. More efficient "
-        "space wise and faster to decode full frames than DWAA_COMPRESSION.",
-        256,
-        true,
-        false),
-    CompressionDesc (
-        "htj2k256",
-        "High-Throughput JPEG 2000, lossless (256 lines)",
-        256,
-        false,
-        false),
-   CompressionDesc (
-        "htj2k32",
-        "High-Throughput JPEG 2000, lossless (32 lines)",
-        32,
-        false,
-        false),
-    CompressionDesc (
-        "lj2k",
-        "High-Throughput JPEG 2000, lossy (256 lines)",
-        256,
-        true,
-        false),
-    CompressionDesc (
-        "zstd",
-        "zstd lossless compression, 1 scan line at a time.",
-        exr_get_zstd_lines_per_chunk (), /* overridden by getCompressionNumScanlines; keep in sync with C API */
-        false,
-        true),
-};
-// clang-format on
-
-// NOTE: CompressionNameToId order MUST match Imf::Compression enum.
-static const std::map<std::string, Compression> CompressionNameToId = {
-    {"no", Compression::NO_COMPRESSION},
-    {"none", Compression::NO_COMPRESSION},
-    {"rle", Compression::RLE_COMPRESSION},
-    {"zips", Compression::ZIPS_COMPRESSION},
-    {"zip", Compression::ZIP_COMPRESSION},
-    {"piz", Compression::PIZ_COMPRESSION},
-    {"pxr24", Compression::PXR24_COMPRESSION},
-    {"b44", Compression::B44_COMPRESSION},
-    {"b44a", Compression::B44A_COMPRESSION},
-    {"dwaa", Compression::DWAA_COMPRESSION},
-    {"dwab", Compression::DWAB_COMPRESSION},
-    {"htj2k256", Compression::HTJ2K256_COMPRESSION},
-    {"htj2k32", Compression::HTJ2K32_COMPRESSION},
-    {"lj2k", Compression::LJ2K_COMPRESSION},
-    {"zstd", Compression::ZSTD_COMPRESSION},
-};
-
-#define UNKNOWN_COMPRESSION_ID_MSG "INVALID COMPRESSION ID"
-
 /// Returns a codec ID's short name (lowercase).
 void
 getCompressionNameFromId (Compression id, std::string& name)
 {
-    if (id < NO_COMPRESSION || id >= NUM_COMPRESSION_METHODS)
-        name = UNKNOWN_COMPRESSION_ID_MSG;
-    name = IdToDesc[static_cast<int> (id)].name;
+    name = exr_compression_name (static_cast<exr_compression_t> (id));
 }
 
 /// Returns a codec ID's short description (lowercase).
 void
 getCompressionDescriptionFromId (Compression id, std::string& desc)
 {
-    if (id < NO_COMPRESSION || id >= NUM_COMPRESSION_METHODS)
-        desc = UNKNOWN_COMPRESSION_ID_MSG;
-    desc = IdToDesc[static_cast<int> (id)].name + ": " +
-           IdToDesc[static_cast<int> (id)].desc;
+    desc = exr_compression_description (static_cast<exr_compression_t> (id));
 }
 
 /// Returns the codec name's ID, NUM_COMPRESSION_METHODS if not found.
 void
 getCompressionIdFromName (const std::string& name, Compression& id)
 {
-    std::string lowercaseName (name);
-    for (auto& ch: lowercaseName)
-        ch = std::tolower (ch);
-
-    auto it = CompressionNameToId.find (lowercaseName);
-    id      = it != CompressionNameToId.end ()
-                  ? it->second
-                  : Compression::NUM_COMPRESSION_METHODS;
+    id = static_cast<Compression> (exr_compression_type_from_name (name.c_str()));
 }
 
 /// Return true if a compression id exists.
@@ -272,33 +123,30 @@ getCompressionNamesString (const std::string& separator, std::string& str)
     int i = 0;
     for (; i < static_cast<int> (NUM_COMPRESSION_METHODS) - 1; i++)
     {
-        str += IdToDesc[i].name + separator;
+        str += exr_compression_name (static_cast<exr_compression_t> (i)) + separator;
     }
-    str += IdToDesc[i].name;
+    str += exr_compression_name (static_cast<exr_compression_t> (i));
 }
 
 /// Return the number of scan lines expected by a given compression method.
 int
 getCompressionNumScanlines (Compression id)
 {
-    if (id < NO_COMPRESSION || id >= NUM_COMPRESSION_METHODS) return -1;
-    return IdToDesc[static_cast<int> (id)].numScanlines;
+    return exr_compression_lines_per_chunk (static_cast<exr_compression_t> (id));
 }
 
 /// Return true is the compression method exists and doesn't preserve data integrity.
 bool
 isLossyCompression (Compression id)
 {
-    return id >= NO_COMPRESSION && id < NUM_COMPRESSION_METHODS &&
-           IdToDesc[static_cast<int> (id)].lossy;
+    return exr_compression_is_lossy (static_cast<exr_compression_t> (id));
 }
 
 /// Return true is the compression method exists and supports deep data.
 bool
 isValidDeepCompression (Compression id)
 {
-    return id >= NO_COMPRESSION && id < NUM_COMPRESSION_METHODS &&
-           IdToDesc[static_cast<int> (id)].deep;
+    return exr_compression_is_valid_for_deep (static_cast<exr_compression_t> (id));
 }
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT

--- a/src/lib/OpenEXR/ImfCompression.h
+++ b/src/lib/OpenEXR/ImfCompression.h
@@ -18,48 +18,32 @@
 #include "ImfForward.h"
 #include <string>
 
+#include "openexr_attr.h"
+
 OPENEXR_IMF_INTERNAL_NAMESPACE_HEADER_ENTER
 
-// All available compression methods.
-// NOTE: Must be extended to add a new codec. Ids must be continuous.
+// All available compression methods. This is a type that is not
+// easily replaced by the core C library as it is a c++ type and so
+// not easily aliased as it would need to be in the global namespace
+// (or have different names). Instead, we replicate it, but keep the
+// numbers in sync.
 enum IMF_EXPORT_ENUM Compression
 {
-    NO_COMPRESSION = 0, // no compression.
-
-    RLE_COMPRESSION = 1, // run length encoding.
-
-    ZIPS_COMPRESSION = 2, // zlib compression, one scan line at a time.
-
-    ZIP_COMPRESSION = 3, // zlib compression, in blocks of 16 scan lines.
-
-    PIZ_COMPRESSION = 4, // piz-based wavelet compression.
-
-    PXR24_COMPRESSION = 5, // lossy 24-bit float compression
-
-    B44_COMPRESSION = 6, // lossy 4-by-4 pixel block compression,
-                         // fixed compression rate.
-
-    B44A_COMPRESSION = 7, // lossy 4-by-4 pixel block compression,
-                          // flat fields are compressed more.
-
-    DWAA_COMPRESSION = 8, // lossy DCT based compression, in blocks
-                          // of 32 scanlines. More efficient for partial
-                          // buffer access.
-
-    DWAB_COMPRESSION = 9, // lossy DCT based compression, in blocks
-                          // of 256 scanlines. More efficient space
-                          // wise and faster to decode full frames
-                          // than DWAA_COMPRESSION.
-
-    HTJ2K256_COMPRESSION = 10,   // High-Throughput JPEG2000 (HTJ2K), lossless, 256 scanlines
-
-    HTJ2K32_COMPRESSION = 11,    // High-Throughput JPEG2000 (HTJ2K), lossless, 32 scanlines
-
-    LJ2K_COMPRESSION = 12,  // High-Throughput JPEG2000 (HTJ2K), lossy, 256 scanlines
-
-    ZSTD_COMPRESSION = 13, // zstd lossless compression, one scan line
-                           // at a time.
-    NUM_COMPRESSION_METHODS // number of different compression methods
+    NO_COMPRESSION = EXR_COMPRESSION_NONE,
+    RLE_COMPRESSION = EXR_COMPRESSION_RLE,
+    ZIPS_COMPRESSION = EXR_COMPRESSION_ZIPS,
+    ZIP_COMPRESSION = EXR_COMPRESSION_ZIP,
+    PIZ_COMPRESSION = EXR_COMPRESSION_PIZ,
+    PXR24_COMPRESSION = EXR_COMPRESSION_PXR24,
+    B44_COMPRESSION = EXR_COMPRESSION_B44,
+    B44A_COMPRESSION = EXR_COMPRESSION_B44A,
+    DWAA_COMPRESSION = EXR_COMPRESSION_DWAA,
+    DWAB_COMPRESSION = EXR_COMPRESSION_DWAB,
+    HTJ2K256_COMPRESSION = EXR_COMPRESSION_HTJ2K256,
+    HTJ2K32_COMPRESSION = EXR_COMPRESSION_HTJ2K32,
+    LJ2K_COMPRESSION = EXR_COMPRESSION_LJ2K,
+    ZSTD_COMPRESSION = EXR_COMPRESSION_ZSTD,
+    NUM_COMPRESSION_METHODS = EXR_COMPRESSION_LAST_TYPE
 };
 
 /// Returns a codec ID's short name (lowercase).

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -328,7 +328,8 @@ Compressor::runDecodeStep (
 Compressor*
 newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
 {
-    Compressor* ret = nullptr;
+    Compressor* ret   = nullptr;
+    int         scans = getCompressionNumScanlines (c);
 
     // clang-format off
     switch (c)
@@ -340,32 +341,32 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
 
         case ZIPS_COMPRESSION:
 
-            ret = new ZipCompressor (hdr, maxScanLineSize, 1);
+            ret = new ZipCompressor (hdr, maxScanLineSize, scans);
             break;
 
         case ZIP_COMPRESSION:
 
-            ret = new ZipCompressor (hdr, maxScanLineSize, 16);
+            ret = new ZipCompressor (hdr, maxScanLineSize, scans);
             break;
 
         case PIZ_COMPRESSION:
 
-            ret = new PizCompressor (hdr, maxScanLineSize, 32);
+            ret = new PizCompressor (hdr, maxScanLineSize, scans);
             break;
 
         case PXR24_COMPRESSION:
 
-            ret = new Pxr24Compressor (hdr, maxScanLineSize, 16);
+            ret = new Pxr24Compressor (hdr, maxScanLineSize, scans);
             break;
 
         case B44_COMPRESSION:
 
-            ret = new B44Compressor (hdr, maxScanLineSize, 32, false);
+            ret = new B44Compressor (hdr, maxScanLineSize, scans, false);
             break;
 
         case B44A_COMPRESSION:
 
-            ret = new B44Compressor (hdr, maxScanLineSize, 32, true);
+            ret = new B44Compressor (hdr, maxScanLineSize, scans, true);
             break;
 
         case DWAA_COMPRESSION:
@@ -373,7 +374,7 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
             ret = new DwaCompressor (
                 hdr,
                 static_cast<int> (maxScanLineSize),
-                32,
+                scans,
                 DwaCompressor::STATIC_HUFFMAN);
             break;
 
@@ -382,22 +383,22 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
             ret = new DwaCompressor (
                 hdr,
                 static_cast<int> (maxScanLineSize),
-                256,
+                scans,
                 DwaCompressor::STATIC_HUFFMAN);
             break;
 
         case HTJ2K256_COMPRESSION:
         case LJ2K_COMPRESSION:
 
-            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), 256);
+            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
 
         case HTJ2K32_COMPRESSION:
 
-            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), 32);
+            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
+
         case ZSTD_COMPRESSION:
 
-            ret = new ZstdCompressor (
-                hdr, maxScanLineSize, exr_get_zstd_lines_per_chunk ());
+            ret = new ZstdCompressor (hdr, maxScanLineSize, scans);
             break;
 
         default: break;

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -394,7 +394,8 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
 
         case HTJ2K32_COMPRESSION:
 
-            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
+            ret = new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
+            break;
 
         case ZSTD_COMPRESSION:
 

--- a/src/lib/OpenEXR/ImfCompressor.cpp
+++ b/src/lib/OpenEXR/ImfCompressor.cpp
@@ -390,7 +390,8 @@ newCompressor (Compression c, size_t maxScanLineSize, const Header& hdr)
         case HTJ2K256_COMPRESSION:
         case LJ2K_COMPRESSION:
 
-            return new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
+            ret = new HTCompressor (hdr, static_cast<int> (maxScanLineSize), scans);
+            break;
 
         case HTJ2K32_COMPRESSION:
 

--- a/src/lib/OpenEXRCore/compression.c
+++ b/src/lib/OpenEXRCore/compression.c
@@ -31,7 +31,14 @@
 #else
 #    include <libdeflate.h>
 #endif
+
 #include <string.h>
+#ifdef _MSC_VER
+static inline int strcasecmp (const char* a, const char* b)
+{
+    return _stricmp (a, b);
+}
+#endif
 
 #if (                                                                          \
     LIBDEFLATE_VERSION_MAJOR > 1 ||                                            \
@@ -229,15 +236,9 @@ exr_rle_uncompress_buffer (size_t in_bytes, size_t max_len, const void* in, void
 }
 
 /**************************************/
-/**************************************/
 
 int
-exr_get_zstd_lines_per_chunk (void)
-{
-    return 1;
-}
-
-int exr_compression_lines_per_chunk (exr_compression_t comptype)
+exr_compression_lines_per_chunk (exr_compression_t comptype)
 {
     int linePerChunk = -1;
 
@@ -245,6 +246,7 @@ int exr_compression_lines_per_chunk (exr_compression_t comptype)
     {
         case EXR_COMPRESSION_NONE:
         case EXR_COMPRESSION_RLE:
+        case EXR_COMPRESSION_ZSTD:
         case EXR_COMPRESSION_ZIPS: linePerChunk = 1; break;
         case EXR_COMPRESSION_ZIP:
         case EXR_COMPRESSION_PXR24: linePerChunk = 16; break;
@@ -256,13 +258,178 @@ int exr_compression_lines_per_chunk (exr_compression_t comptype)
         case EXR_COMPRESSION_DWAB:
         case EXR_COMPRESSION_HTJ2K256:
         case EXR_COMPRESSION_LJ2K: linePerChunk = 256; break;
-        case EXR_COMPRESSION_ZSTD: linePerChunk = exr_get_zstd_lines_per_chunk (); break;
         case EXR_COMPRESSION_LAST_TYPE:
         default:
             /* ERROR CONDITION */
             break;
     }
     return linePerChunk;
+}
+
+/**************************************/
+
+const char *exr_compression_name (exr_compression_t comptype)
+{
+    static char* compressionnames[] = {
+        "none",
+        "rle",
+        "zips",
+        "zip",
+        "piz",
+        "pxr24",
+        "b44",
+        "b44a",
+        "dwaa",
+        "dwab",
+        "htj2k256",
+        "htj2k32",
+        "lj2k",
+        "zstd"
+    };
+    int idx = (int)comptype;
+    if (idx >= 0 && idx < (int)EXR_COMPRESSION_LAST_TYPE)
+        return compressionnames[idx];
+    return "<UNKNOWN>";
+}
+
+/**************************************/
+
+exr_compression_t exr_compression_type_from_name (const char *compname)
+{
+    exr_compression_t retval = EXR_COMPRESSION_LAST_TYPE;
+
+    if (compname == NULL)
+        return retval;
+
+    // C++ routine supported any case spelling by
+    // doing a tolower conversion on the string.
+    //
+    // we'll just test the first character to divide and conquer
+    // then do a strcasecmp rather than do the string dupe and conversion
+    switch (compname[0])
+    {
+        case 'n':
+        case 'N':
+            // c++ allowed no for none as well as none
+            if (0 == strcasecmp (compname, "no") ||
+                0 == strcasecmp (compname, "none"))
+                retval = EXR_COMPRESSION_NONE;
+            break;
+        case 'r':
+        case 'R':
+            if (0 == strcasecmp (compname, "rle"))
+                retval = EXR_COMPRESSION_RLE;
+            break;
+        case 'z':
+        case 'Z':
+            if (0 == strcasecmp (compname, "zips"))
+                retval = EXR_COMPRESSION_ZIPS;
+            else if (0 == strcasecmp (compname, "zip"))
+                retval = EXR_COMPRESSION_ZIP;
+            else if (0 == strcasecmp (compname, "zstd"))
+                retval = EXR_COMPRESSION_ZSTD;
+            break;
+        case 'p':
+        case 'P':
+            if (0 == strcasecmp (compname, "piz"))
+                retval = EXR_COMPRESSION_PIZ;
+            else if (0 == strcasecmp (compname, "pxr24"))
+                retval = EXR_COMPRESSION_PXR24;
+            break;
+        case 'b':
+        case 'B':
+            if (0 == strcasecmp (compname, "b44"))
+                retval = EXR_COMPRESSION_B44;
+            else if (0 == strcasecmp (compname, "b44a"))
+                retval = EXR_COMPRESSION_B44A;
+            break;
+        case 'd':
+        case 'D':
+            if (0 == strcasecmp (compname, "dwaa"))
+                retval = EXR_COMPRESSION_DWAA;
+            else if (0 == strcasecmp (compname, "dwab"))
+                retval = EXR_COMPRESSION_DWAB;
+            break;
+        case 'h':
+        case 'H':
+            if (0 == strcasecmp (compname, "htj2k256"))
+                retval = EXR_COMPRESSION_HTJ2K256;
+            else if (0 == strcasecmp (compname, "htj2k32"))
+                retval = EXR_COMPRESSION_HTJ2K32;
+            break;
+        case 'l':
+        case 'L':
+            if (0 == strcasecmp (compname, "lj2k"))
+                retval = EXR_COMPRESSION_LJ2K;
+            break;
+        default:
+            break;
+    }
+    return retval;
+}
+
+/**************************************/
+
+const char *exr_compression_description (exr_compression_t comptype)
+{
+    static char* compressiondescs[] = {
+        "none: no compression.",
+        "rle: run-length encoding.",
+        "zips: zlib/deflate compression, one scan line at a time.",
+        "zip: zlib/deflate compression, in blocks of 16 scan lines.",
+        "piz: piz-based wavelet compression, in blocks of 32 scan lines.",
+        "pxr24: lossy 24-bit float compression, in blocks of 16 scan lines.",
+        "b44: lossy 4-by-4 pixel block compression, fixed compression rate.",
+        "b44a: lossy 4-by-4 pixel block compression, flat fields are compressed more.",
+        "dwaa: lossy DCT based compression, in blocks of 32 scanlines. More efficient for partial buffer access.",
+        "dwab: lossy DCT based compression, in blocks of 256 scanlines. More efficient space wise and faster to decode full frames than DWAA.",
+        "htj2k256: High-Throughput JPEG 2000, lossless (256 lines)",
+        "htj2k32: High-Throughput JPEG 2000, lossless (32 lines)",
+        "lj2k: High-Throughput JPEG 2000, lossy (256 lines)",
+        "zstd: zstd lossless compression, 1 scan line at a time."
+    };
+    int idx = (int)comptype;
+    if (idx >= 0 && idx < (int)EXR_COMPRESSION_LAST_TYPE)
+        return compressiondescs[idx];
+    return "<UNKNOWN>: INVALID COMPRESSION ID";
+}
+
+/**************************************/
+
+int
+exr_compression_is_lossy (exr_compression_t comptype)
+{
+    switch (comptype)
+    {
+        case EXR_COMPRESSION_PXR24:
+        case EXR_COMPRESSION_B44:
+        case EXR_COMPRESSION_B44A:
+        case EXR_COMPRESSION_DWAA:
+        case EXR_COMPRESSION_DWAB:
+        case EXR_COMPRESSION_LJ2K:
+            return 1;
+        default:
+            break;
+    }
+    return 0;
+}
+
+/**************************************/
+
+int
+exr_compression_is_valid_for_deep (exr_compression_t comptype)
+{
+    switch (comptype)
+    {
+        case EXR_COMPRESSION_NONE:
+        case EXR_COMPRESSION_RLE:
+        case EXR_COMPRESSION_ZIPS:
+        case EXR_COMPRESSION_ZSTD:
+            return 1;
+        default:
+            break;
+    }
+    return 0;
 }
 
 /**************************************/

--- a/src/lib/OpenEXRCore/debug.c
+++ b/src/lib/OpenEXRCore/debug.c
@@ -8,6 +8,7 @@
 #include "internal_constants.h"
 #include "internal_structs.h"
 #include "openexr_attr.h"
+#include "openexr_compression.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -74,23 +75,7 @@ print_attr (const exr_attribute_t* a, int verbose)
                 (double) a->chromaticities->white_y);
             break;
         case EXR_ATTR_COMPRESSION: {
-            static char* compressionnames[] = {
-                "none",
-                "rle",
-                "zips",
-                "zip",
-                "piz",
-                "pxr24",
-                "b44",
-                "b44a",
-                "dwaa",
-                "dwab",
-                "htj2k256",
-                "htj2k32",
-                "lj2k",
-                "zstd"};
-            printf (
-                "'%s'", (a->uc < EXR_COMPRESSION_LAST_TYPE ? compressionnames[a->uc] : "<UNKNOWN>"));
+            printf ("'%s'", exr_compression_name ((exr_compression_t)a->uc));
             if (verbose) printf (" (0x%02X)", a->uc);
             break;
         }

--- a/src/lib/OpenEXRCore/openexr_attr.h
+++ b/src/lib/OpenEXRCore/openexr_attr.h
@@ -35,18 +35,18 @@ extern "C" {
 /** Enum declaring allowed values for \c uint8_t value stored in built-in compression type. */
 typedef enum
 {
-    EXR_COMPRESSION_NONE  = 0,
-    EXR_COMPRESSION_RLE   = 1,
-    EXR_COMPRESSION_ZIPS  = 2,
-    EXR_COMPRESSION_ZIP   = 3,
-    EXR_COMPRESSION_PIZ   = 4,
-    EXR_COMPRESSION_PXR24 = 5,
-    EXR_COMPRESSION_B44   = 6,
-    EXR_COMPRESSION_B44A  = 7,
-    EXR_COMPRESSION_DWAA  = 8,
-    EXR_COMPRESSION_DWAB  = 9,
-    EXR_COMPRESSION_HTJ2K256  = 10,
-    EXR_COMPRESSION_HTJ2K32   = 11,
+    EXR_COMPRESSION_NONE  = 0, /**< no compression */
+    EXR_COMPRESSION_RLE   = 1, /**< run length encoding */
+    EXR_COMPRESSION_ZIPS  = 2, /**< zlib/deflate compression, 1 scanline per chunk */
+    EXR_COMPRESSION_ZIP   = 3, /**< zlib/deflate compression, blocks of 16 scan lines */
+    EXR_COMPRESSION_PIZ   = 4, /**< piz-based wavelet compression */
+    EXR_COMPRESSION_PXR24 = 5, /**< Lossy 24-bit float compression */
+    EXR_COMPRESSION_B44   = 6, /**< Lossy 4x4 block compression, fixed compression rate */
+    EXR_COMPRESSION_B44A  = 7, /**< Lossy 4x4 block compression, flat fields compressed more */
+    EXR_COMPRESSION_DWAA  = 8, /**< Lossy DCT based compression, 32 scanlines */
+    EXR_COMPRESSION_DWAB  = 9, /**< Lossy DCT, 256 scanlines, more space efficient than DWAA, at an overhead of more scanlines per chunk */
+    EXR_COMPRESSION_HTJ2K256  = 10, /**< High-Throughput JPEG 2000, lossless, 256 scanlines */
+    EXR_COMPRESSION_HTJ2K32   = 11, /**< High-Throughput JPEG 2000, lossless, 32 scanlines */
     EXR_COMPRESSION_LJ2K = 12, /**< High-Throughput JPEG 2000, lossy, 256 scanlines */
     EXR_COMPRESSION_ZSTD = 13, /**< zstd lossless compression, one scan line at a time */
     EXR_COMPRESSION_LAST_TYPE /**< Invalid value, provided for range checking. */

--- a/src/lib/OpenEXRCore/openexr_compression.h
+++ b/src/lib/OpenEXRCore/openexr_compression.h
@@ -78,11 +78,49 @@ size_t exr_rle_uncompress_buffer (
 EXR_EXPORT
 int exr_compression_lines_per_chunk (exr_compression_t comptype);
 
-/** Scanlines packed into one ZSTD chunk for scanline / deep-scanline parts.
- *  Tunable constant; must stay in sync with C++ getCompressionNumScanlines for
- *  ZSTD_COMPRESSION. */
+/** Routine to give a short name for a compression type.
+ *
+ * This is useful for building user-facing routines.
+ */
 EXR_EXPORT
-int exr_get_zstd_lines_per_chunk (void);
+const char *exr_compression_name (exr_compression_t comptype);
+
+/** Routine to map a short compression name back to a compression type.
+ *
+ * This is useful for building user-facing routines and similar
+ * string-based storage where you may not want the integer.
+ *
+ * This will return EXR_COMPRESSION_LAST_TYPE when the name is invalid
+ * or otherwise unrecognised.
+ */
+EXR_EXPORT
+exr_compression_t exr_compression_type_from_name (const char *compname);
+
+/** Routine to give a short description for a compression type.
+ *
+ * This is useful for building user-facing routines.
+ */
+EXR_EXPORT
+const char *exr_compression_description (exr_compression_t comptype);
+
+/** Routine to query whether the compression mechanism is lossy.
+ *
+ * when this returns 1 when the compression type is valid and
+ * does NOT preserve data integrity.
+ *
+ * Returns 0 otherwise.
+ */
+EXR_EXPORT
+int exr_compression_is_lossy (exr_compression_t comptype);
+
+/** Routine to query whether the compression mechanism is valid for deep
+ * compression.
+ *
+ * Returns 1 when the compression type is valid to compress deep data.
+ * Returns 0 otherwise.
+ */
+EXR_EXPORT
+int exr_compression_is_valid_for_deep (exr_compression_t comptype);
 
 /** Exposes a method to apply compression to a chunk of data.
  *

--- a/src/lib/OpenEXRCore/validation.c
+++ b/src/lib/OpenEXRCore/validation.c
@@ -8,6 +8,7 @@
 #include "internal_constants.h"
 
 #include "openexr_part.h"
+#include "openexr_compression.h"
 
 #include <limits.h>
 #include <math.h>
@@ -662,11 +663,7 @@ validate_deep_data (exr_context_t f, exr_priv_part_t curpart)
     {
         const exr_attr_chlist_t* channels = curpart->channels->chlist;
 
-        // none, rle, zips
-        if (curpart->comp_type != EXR_COMPRESSION_NONE &&
-            curpart->comp_type != EXR_COMPRESSION_RLE &&
-            curpart->comp_type != EXR_COMPRESSION_ZIPS && 
-            curpart->comp_type != EXR_COMPRESSION_ZSTD)
+        if (! exr_compression_is_valid_for_deep (curpart->comp_type))
             return f->report_error (
                 f, EXR_ERR_INVALID_ATTR, "Invalid compression for deep data");
 

--- a/src/test/OpenEXRTest/testCompressionApi.cpp
+++ b/src/test/OpenEXRTest/testCompressionApi.cpp
@@ -97,9 +97,8 @@ testCompressionApi (const string& tempDir)
 
         cout << "Testing Compressor instantiation" << endl;
 
-        const int zstdLinesPerChunk = exr_get_zstd_lines_per_chunk ();
+        const int zstdLinesPerChunk = getCompressionNumScanlines (ZSTD_COMPRESSION);
         assert (zstdLinesPerChunk == exr_compression_lines_per_chunk (EXR_COMPRESSION_ZSTD));
-        assert (zstdLinesPerChunk == getCompressionNumScanlines (ZSTD_COMPRESSION));
 
         struct CompressorTestCase
         {


### PR DESCRIPTION
- Removes extraneous zstd scanline query, favoring singular routine
- Moves names and descriptions to Core library
- More strongly aliases legacy c++ compression enum to core library