### PR TITLE
Add Windows ARM64 Python wheel CI

### DIFF
--- a/.github/workflows/python-wheels-publish-test.yml
+++ b/.github/workflows/python-wheels-publish-test.yml
@@ -70,6 +70,10 @@ jobs:
             cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
+            cibw_archs_windows: AMD64
+          - os: windows-11-arm
+            arch: arm64
+            cibw_archs_windows: ARM64
 
     permissions:
       contents: read
@@ -100,11 +104,13 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           # Split macOS arches across runners so artifact merge does not collide on filenames.
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           # Build Python 3.9 through 3.13.
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "*-win32 *_i686"
+          # NumPy's Windows ARM64 wheels require Python 3.11 or newer.
+          CIBW_SKIP: "*-win32 *_i686 cp39-win_arm64 cp310-win_arm64"
           CIBW_ENVIRONMENT: OPENEXR_RELEASE_CANDIDATE_TAG="${{ github.ref_name }}"
 
       - name: Upload artifact

--- a/.github/workflows/python-wheels-publish.yml
+++ b/.github/workflows/python-wheels-publish.yml
@@ -66,6 +66,10 @@ jobs:
             cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
+            cibw_archs_windows: AMD64
+          - os: windows-11-arm
+            arch: arm64
+            cibw_archs_windows: ARM64
 
     permissions:
       contents: read
@@ -94,11 +98,13 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           # Split macOS arches across runners so artifact merge does not collide on filenames.
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "*-win32 *_i686"
+          # NumPy's Windows ARM64 wheels require Python 3.11 or newer.
+          CIBW_SKIP: "*-win32 *_i686 cp39-win_arm64 cp310-win_arm64"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -54,6 +54,10 @@ jobs:
             cibw_archs_macos: arm64
           - os: windows-latest
             arch: x64
+            cibw_archs_windows: AMD64
+          - os: windows-11-arm
+            arch: arm64
+            cibw_archs_windows: ARM64
 
     permissions:
       contents: read
@@ -81,11 +85,13 @@ jobs:
         env:
           # Split macOS arches across runners so artifact merge does not collide on filenames.
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           # Build Python 3.9 through 3.13
           # Skip 32-bit wheels builds on Windows
           # Also skip the PyPy builds, since they fail the unit tests
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_SKIP: "*-win32 *_i686"
+          # NumPy's Windows ARM64 wheels require Python 3.11 or newer.
+          CIBW_SKIP: "*-win32 *_i686 cp39-win_arm64 cp310-win_arm64"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Add native Windows ARM64 wheel builds using `windows-11-arm` runners to the regular CI, PyPI, and TestPyPI workflows.

- Explicitly select AMD64 or ARM64 for Windows builds.
- Build and test ARM64 wheels for Python 3.11–3.13.
- Skip older Windows ARM64 Python versions because NumPy wheels require Python 3.11+.
- Preserve existing platform targets and artifact publishing.

This complements #1989, which added Linux ARM wheel CI but not Windows ARM.