### PR TITLE
Add ZSTD Zigzag, scanline chunks in blocks

### DIFF
--- a/src/lib/OpenEXRCore/internal_zstd.c
+++ b/src/lib/OpenEXRCore/internal_zstd.c
@@ -53,6 +53,11 @@ extern void delta_decode_row_u16 (uint8_t* p, uint64_t n);
 extern void delta_encode_row_u32 (uint8_t* p, uint64_t n);
 extern void delta_decode_row_u32 (uint8_t* p, uint64_t n);
 
+extern void zigzag_delta_encode_row_u16 (uint8_t* p, uint64_t n);
+extern void zigzag_delta_decode_row_u16 (uint8_t* p, uint64_t n);
+extern void zigzag_delta_encode_row_u32 (uint8_t* p, uint64_t n);
+extern void zigzag_delta_decode_row_u32 (uint8_t* p, uint64_t n);
+
 #define RETURN_ERRORV(pipeline, err_code, msg, ...)                            \
     {                                                                          \
         exr_const_context_t pctxt = pipeline->context;                         \
@@ -294,7 +299,8 @@ compute_sorting_lookup (
     return splitPoint;
 }
 
-/** Apply delta along samples within each channel row (layout from compute_sorting_lookup). */
+/** Apply zigzag delta along samples within each channel row (layout from
+ *  compute_sorting_lookup). */
 static int
 delta_encode_sorted_layout (
     uint8_t*                         buf,
@@ -312,7 +318,7 @@ delta_encode_sorted_layout (
         {
             if (channels[i].bytes_per_element != 2) continue;
             uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) delta_encode_row_u16 (buf + off, n);
+            if (n > 0) zigzag_delta_encode_row_u16 (buf + off, n);
             off += (size_t) n * 2u;
         }
     }
@@ -323,7 +329,7 @@ delta_encode_sorted_layout (
         {
             if (channels[i].bytes_per_element != 4) continue;
             uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) delta_encode_row_u32 (buf + off, n);
+            if (n > 0) zigzag_delta_encode_row_u32 (buf + off, n);
             off += (size_t) n * 4u;
         }
     }
@@ -348,7 +354,7 @@ delta_decode_sorted_layout (
         {
             if (channels[i].bytes_per_element != 2) continue;
             uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) delta_decode_row_u16 (buf + off, n);
+            if (n > 0) zigzag_delta_decode_row_u16 (buf + off, n);
             off += (size_t) n * 2u;
         }
     }
@@ -359,7 +365,7 @@ delta_decode_sorted_layout (
         {
             if (channels[i].bytes_per_element != 4) continue;
             uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) delta_decode_row_u32 (buf + off, n);
+            if (n > 0) zigzag_delta_decode_row_u32 (buf + off, n);
             off += (size_t) n * 4u;
         }
     }
@@ -487,7 +493,7 @@ static const uint64_t MAGIC_NUMBER = 8248453963162350458; // "zstd-exr"
 #define ZSTD_EXR_FLAG_DELTA_AFTER_SORT 1u
 #define ZSTD_EXR_V1_HEADER 24u
 
-/** ZSTD wire: 1 = sort+shuffle (header v1); 2 = sort+delta+shuffle (v2).
+/** ZSTD wire: 1 = sort+shuffle (header v1); 2 = sort+zigzag delta+shuffle (v2).
  *  This is the default wire version (overridable at build time); flat chunks
  *  are bumped to v2 at runtime, see exr_zstd_build_encode_pipeline_sorted. */
 #ifndef EXR_ZSTD_SORTED_WIRE_VERSION
@@ -495,7 +501,9 @@ static const uint64_t MAGIC_NUMBER = 8248453963162350458; // "zstd-exr"
 #endif
 
 /** Encode order: SORT → DELTA → SHUFFLE → ZSTD; decode reverses ZSTD first.
- *  Sort and shuffle always run; only delta is optional (V2 wire format). */
+ *  Sort and shuffle always run; only the delta is optional (V2 wire format).
+ *  The delta is zigzag-mapped; the header is unchanged from v2 as first
+ *  written, so no flag bit is spent to say so. */
 typedef struct
 {
     uint32_t hdr_format;

--- a/src/lib/OpenEXRCore/internal_zstd.c
+++ b/src/lib/OpenEXRCore/internal_zstd.c
@@ -265,36 +265,36 @@ compute_sorting_lookup (
     int                              height,
     const exr_coding_channel_info_t* channels,
     int                              channelsSize,
+    bool                             channel_major,
     uint64_t*                        sorting_lookup)
 {
     uint64_t writeCount = 0;
+    uint64_t splitPoint = 0;
 
-    for (int h = 0; h < height; ++h)
+    for (int pass = 0; pass < 2; ++pass)
     {
-        for (int i = 0; i < channelsSize; ++i)
+        int const want = (pass == 0) ? 2 : 4;
+        /* Row-major places row 0 of every channel, then row 1 of every
+         * channel, and so on. Channel-major places all of channel 0's rows
+         * together, then all of channel 1's: with more than one line in a
+         * chunk that keeps each channel's samples contiguous, so the byte
+         * planes stay homogeneous and zstd's matches stay local. The two
+         * orders are identical when a chunk holds a single line. */
+        int const outer = channel_major ? channelsSize : height;
+        int const inner = channel_major ? height : channelsSize;
+        for (int o = 0; o < outer; ++o)
         {
-            if (channels[i].bytes_per_element == 2)
+            for (int n = 0; n < inner; ++n)
             {
+                int const h = channel_major ? n : o;
+                int const i = channel_major ? o : n;
+                if (channels[i].bytes_per_element != want) continue;
                 *(sorting_lookup + h * channelsSize + i) = writeCount;
                 writeCount +=
-                    num_samples_grid[h * channelsSize + i] * (uint64_t) 2;
+                    num_samples_grid[h * channelsSize + i] * (uint64_t) want;
             }
         }
-    }
-
-    uint64_t const splitPoint = writeCount;
-
-    for (int h = 0; h < height; ++h)
-    {
-        for (int i = 0; i < channelsSize; ++i)
-        {
-            if (channels[i].bytes_per_element == 4)
-            {
-                *(sorting_lookup + h * channelsSize + i) = writeCount;
-                writeCount +=
-                    num_samples_grid[h * channelsSize + i] * (uint64_t) 4;
-            }
-        }
+        if (pass == 0) splitPoint = writeCount;
     }
     return splitPoint;
 }
@@ -309,29 +309,34 @@ delta_encode_sorted_layout (
     const uint64_t*                  num_samples_grid,
     int                              height,
     const exr_coding_channel_info_t* channels,
-    int                              channelsSize)
+    int                              channelsSize,
+    bool                             channel_major)
 {
     uint64_t off = 0;
-    for (int h = 0; h < height; ++h)
+    for (int pass = 0; pass < 2; ++pass)
     {
-        for (int i = 0; i < channelsSize; ++i)
+        int const want  = (pass == 0) ? 2 : 4;
+        int const outer = channel_major ? channelsSize : height;
+        int const inner = channel_major ? height : channelsSize;
+        for (int o = 0; o < outer; ++o)
         {
-            if (channels[i].bytes_per_element != 2) continue;
-            uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) zigzag_delta_encode_row_u16 (buf + off, n);
-            off += (size_t) n * 2u;
+            for (int n_i = 0; n_i < inner; ++n_i)
+            {
+                int const h = channel_major ? n_i : o;
+                int const i = channel_major ? o : n_i;
+                if (channels[i].bytes_per_element != want) continue;
+                uint64_t const n = num_samples_grid[h * channelsSize + i];
+                if (n > 0)
+                {
+                    if (want == 2)
+                        zigzag_delta_encode_row_u16 (buf + off, n);
+                    else
+                        zigzag_delta_encode_row_u32 (buf + off, n);
+                }
+                off += (size_t) n * (size_t) want;
+            }
         }
-    }
-    if (off != splitPoint) return -1;
-    for (int h = 0; h < height; ++h)
-    {
-        for (int i = 0; i < channelsSize; ++i)
-        {
-            if (channels[i].bytes_per_element != 4) continue;
-            uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) zigzag_delta_encode_row_u32 (buf + off, n);
-            off += (size_t) n * 4u;
-        }
+        if (pass == 0 && off != splitPoint) return -1;
     }
     if (off != (uint64_t) total_bytes) return -1;
     return 0;
@@ -345,29 +350,34 @@ delta_decode_sorted_layout (
     const uint64_t*                  num_samples_grid,
     int                              height,
     const exr_coding_channel_info_t* channels,
-    int                              channelsSize)
+    int                              channelsSize,
+    bool                             channel_major)
 {
     uint64_t off = 0;
-    for (int h = 0; h < height; ++h)
+    for (int pass = 0; pass < 2; ++pass)
     {
-        for (int i = 0; i < channelsSize; ++i)
+        int const want  = (pass == 0) ? 2 : 4;
+        int const outer = channel_major ? channelsSize : height;
+        int const inner = channel_major ? height : channelsSize;
+        for (int o = 0; o < outer; ++o)
         {
-            if (channels[i].bytes_per_element != 2) continue;
-            uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) zigzag_delta_decode_row_u16 (buf + off, n);
-            off += (size_t) n * 2u;
+            for (int n_i = 0; n_i < inner; ++n_i)
+            {
+                int const h = channel_major ? n_i : o;
+                int const i = channel_major ? o : n_i;
+                if (channels[i].bytes_per_element != want) continue;
+                uint64_t const n = num_samples_grid[h * channelsSize + i];
+                if (n > 0)
+                {
+                    if (want == 2)
+                        zigzag_delta_decode_row_u16 (buf + off, n);
+                    else
+                        zigzag_delta_decode_row_u32 (buf + off, n);
+                }
+                off += (size_t) n * (size_t) want;
+            }
         }
-    }
-    if (off != splitPoint) return -1;
-    for (int h = 0; h < height; ++h)
-    {
-        for (int i = 0; i < channelsSize; ++i)
-        {
-            if (channels[i].bytes_per_element != 4) continue;
-            uint64_t const n = num_samples_grid[h * channelsSize + i];
-            if (n > 0) zigzag_delta_decode_row_u32 (buf + off, n);
-            off += (size_t) n * 4u;
-        }
+        if (pass == 0 && off != splitPoint) return -1;
     }
     if (off != (uint64_t) total_bytes) return -1;
     return 0;
@@ -452,11 +462,17 @@ sort2_4ByteChannels_tiled (
     const int                        channelsSize,
     const bool                       forward,
     int                              height,
+    bool                             channel_major,
     char*                            outPtr,
     uint64_t*                        sorting_lookup)
 {
     uint64_t splitPoint = compute_sorting_lookup (
-        num_samples_grid, height, channels, channelsSize, sorting_lookup);
+        num_samples_grid,
+        height,
+        channels,
+        channelsSize,
+        channel_major,
+        sorting_lookup);
 
     uint64_t line_start_read = 0;
     for (int h = 0; h < height; ++h)
@@ -958,7 +974,8 @@ exr_zstd_encode_one_wire_version (
                 channel_sample_count_grid,
                 pipeline_height,
                 pack_channels,
-                pack_channel_count) != 0)
+                pack_channel_count,
+                pipe->hdr_format == ZSTD_EXR_FORMAT_V2) != 0)
             return -1;
     }
 
@@ -1130,6 +1147,7 @@ internal_exr_apply_zstd (exr_encode_pipeline_t* encode)
         pack_channel_count,
         true,
         pipeline_height,
+        pipe.hdr_format == ZSTD_EXR_FORMAT_V2,
         (char*) encode->scratch_buffer_1,
         sorting_lookup);
 
@@ -1309,11 +1327,14 @@ exr_undo_zstd_v1 (
     exr_zstd_pack_pipeline pipe;
     exr_zstd_build_decode_pipeline (fr.format, fr.flags, &pipe);
 
+    bool const channel_major = (fr.format == ZSTD_EXR_FORMAT_V2);
+    
     uint64_t split = compute_sorting_lookup (
         channel_sample_count_grid,
         chunk_line_count,
         pack_channels,
         pack_channel_count,
+        channel_major,
         sorting_lookup);
 
     uint64_t  inner_lens[2];
@@ -1355,7 +1376,8 @@ exr_undo_zstd_v1 (
                 channel_sample_count_grid,
                 decode->chunk.height,
                 pack_channels,
-                pack_channel_count) != 0)
+                pack_channel_count,
+                channel_major) != 0)
             return EXR_ERR_CORRUPT_CHUNK;
     }
 
@@ -1366,6 +1388,7 @@ exr_undo_zstd_v1 (
         pack_channel_count,
         false,
         decode->chunk.height,
+        channel_major,
         (char*) uncompressed_data,
         sorting_lookup);
 

--- a/src/lib/OpenEXRCore/internal_zstd_delta.c
+++ b/src/lib/OpenEXRCore/internal_zstd_delta.c
@@ -59,6 +59,99 @@ delta_decode_row_u32_scalar (uint8_t* p, uint64_t n)
     }
 }
 
+/* ------------------------------------------------------------------------- */
+/* ZIGZAG                                                                    */
+/*                                                                           */
+/* Plain delta stores a small negative difference as a large unsigned value: */
+/* -1 becomes 0xffff, which sets every bit in every byte plane and defeats   */
+/* the planar shuffle that follows. Zigzag folds the sign into the low bit   */
+/* (0, -1, 1, -2 -> 0, 1, 2, 3) so small differences of either sign stay     */
+/* small and the high byte planes stay near zero.                            */
+/*                                                                           */
+/* Only the mapping of each difference changes; the differencing itself is   */
+/* still delta_{encode,decode}_row_*, so the decoder can un-zigzag in one    */
+/* elementwise pass and reuse the existing prefix-sum.                       */
+/*                                                                           */
+/* Borrowed from meshoptimizer's vertex codec, which zigzags its deltas for  */
+/* the same reason. meshoptimizer is by Arseny Kapoulkine, MIT licensed:     */
+/* https://github.com/zeux/meshoptimizer                                     */
+/* ------------------------------------------------------------------------- */
+
+static inline uint16_t
+zigzag_u16 (uint16_t v)
+{
+    return (uint16_t) ((v << 1) ^ (uint16_t) (0u - (unsigned) (v >> 15)));
+}
+
+static inline uint16_t
+unzigzag_u16 (uint16_t v)
+{
+    return (uint16_t) ((v >> 1) ^ (uint16_t) (0u - (unsigned) (v & 1u)));
+}
+
+static inline uint32_t
+zigzag_u32 (uint32_t v)
+{
+    return (v << 1) ^ (uint32_t) (0u - (v >> 31));
+}
+
+static inline uint32_t
+unzigzag_u32 (uint32_t v)
+{
+    return (v >> 1) ^ (uint32_t) (0u - (v & 1u));
+}
+
+/* Element 0 of a row is stored verbatim by delta_encode_row_*, so the zigzag
+ * passes below deliberately skip it too. */
+
+static void
+zigzag_row_u16 (uint8_t* p, uint64_t n)
+{
+    for (uint64_t k = 1; k < n; ++k)
+    {
+        uint16_t v;
+        memcpy (&v, p + k * 2, 2);
+        v = zigzag_u16 (v);
+        memcpy (p + k * 2, &v, 2);
+    }
+}
+
+static void
+unzigzag_row_u16 (uint8_t* p, uint64_t n)
+{
+    for (uint64_t k = 1; k < n; ++k)
+    {
+        uint16_t v;
+        memcpy (&v, p + k * 2, 2);
+        v = unzigzag_u16 (v);
+        memcpy (p + k * 2, &v, 2);
+    }
+}
+
+static void
+zigzag_row_u32 (uint8_t* p, uint64_t n)
+{
+    for (uint64_t k = 1; k < n; ++k)
+    {
+        uint32_t v;
+        memcpy (&v, p + k * 4, 4);
+        v = zigzag_u32 (v);
+        memcpy (p + k * 4, &v, 4);
+    }
+}
+
+static void
+unzigzag_row_u32 (uint8_t* p, uint64_t n)
+{
+    for (uint64_t k = 1; k < n; ++k)
+    {
+        uint32_t v;
+        memcpy (&v, p + k * 4, 4);
+        v = unzigzag_u32 (v);
+        memcpy (p + k * 4, &v, 4);
+    }
+}
+
 /* ========================================================================= */
 /* AVX2 IMPLEMENTATIONS                                                      */
 /* ========================================================================= */
@@ -274,4 +367,31 @@ delta_decode_row_u32 (uint8_t* p, uint64_t n)
     }
 #endif
     delta_decode_row_u32_scalar (p, n);
+}
+void
+zigzag_delta_encode_row_u16 (uint8_t* p, uint64_t n)
+{
+    delta_encode_row_u16 (p, n);
+    zigzag_row_u16 (p, n);
+}
+
+void
+zigzag_delta_decode_row_u16 (uint8_t* p, uint64_t n)
+{
+    unzigzag_row_u16 (p, n);
+    delta_decode_row_u16 (p, n);
+}
+
+void
+zigzag_delta_encode_row_u32 (uint8_t* p, uint64_t n)
+{
+    delta_encode_row_u32 (p, n);
+    zigzag_row_u32 (p, n);
+}
+
+void
+zigzag_delta_decode_row_u32 (uint8_t* p, uint64_t n)
+{
+    unzigzag_row_u32 (p, n);
+    delta_decode_row_u32 (p, n);
 }


### PR DESCRIPTION
Idea adapted directly from meshoptimizer. The idea is that the delta has
a mix of negative and positive integers, and corresponding bits are very
different, which doesn't compress as well.

The simple idea is to remap them to be positive: (0, -1, 1, -2, 2, -3, 3)
becomes (0, 1, 2, 3, 4, 5, 6).

Gives about a 4% improvement across my benchmarks.