### PR TITLE
LJ2K: pad lossy chunks so that wavelet folds stay on low-pass positions

### DIFF
--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -190,14 +190,25 @@ struct ht_context_cache
  * image origin being (0, 0) and on the codestream having a single tile; if
  * either is ever changed the parity at both ends has to be re-examined.
  *
- * Returns the padded length, or -1 when num_decomps is outside the range
- * this arithmetic supports (a codestream may carry up to 32) or when the
- * padded length would no longer fit in a 32-bit dimension.
+ * HT_NUM_DECOMPS is the number of decomposition levels the encoder writes
+ * and, deliberately, also the largest number the decoder accepts for a
+ * padded codestream: the padding is at most 2^L - 1 rows and columns, so
+ * bounding L keeps the padded extent within a small, content-independent
+ * margin of the chunk size, which the image and tile size limits of the
+ * context have already vetted.  A codestream may declare up to 32 levels;
+ * anything above this constant is rejected as corrupt.  If the encoder
+ * ever needs more levels, raise the constant (files written with the
+ * larger value are then rejected by older readers).
+ *
+ * Returns the padded length, or -1 when num_decomps is out of range or
+ * the padded length would no longer fit in a 32-bit dimension.
  */
+static const int HT_NUM_DECOMPS = 5;
+
 static inline int64_t
 ht_padded_length (int64_t n, int num_decomps)
 {
-    if (n < 0 || num_decomps < 0 || num_decomps > 30) return -1;
+    if (n < 0 || num_decomps < 0 || num_decomps > HT_NUM_DECOMPS) return -1;
     const int64_t m = (int64_t) 1 << num_decomps;
     /* smallest n' >= n with n' == 1 (mod m) */
     const int64_t padded = n + (((1 - n) % m) + m) % m;
@@ -576,7 +587,7 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
 
     ojph::param_cod cod = cs.access_cod ();
 
-    const int num_decomps = 5;
+    const int num_decomps = HT_NUM_DECOMPS;
 
     cod.set_color_transform (isRGB && !isPlanar);
     cod.set_block_dims (128, 32);

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -189,13 +189,20 @@ struct ht_context_cache
  * nothing has to be added to the chunk header.  This analysis relies on the
  * image origin being (0, 0) and on the codestream having a single tile; if
  * either is ever changed the parity at both ends has to be re-examined.
+ *
+ * Returns the padded length, or -1 when num_decomps is outside the range
+ * this arithmetic supports (a codestream may carry up to 32) or when the
+ * padded length would no longer fit in a 32-bit dimension.
  */
-static inline int
-ht_padded_length (int n, int num_decomps)
+static inline int64_t
+ht_padded_length (int64_t n, int num_decomps)
 {
-    const int m = 1 << num_decomps;
+    if (n < 0 || num_decomps < 0 || num_decomps > 30) return -1;
+    const int64_t m = (int64_t) 1 << num_decomps;
     /* smallest n' >= n with n' == 1 (mod m) */
-    return n + (((1 - n) % m) + m) % m;
+    const int64_t padded = n + (((1 - n) % m) + m) % m;
+    if (padded > (int64_t) std::numeric_limits<int32_t>::max ()) return -1;
+    return padded;
 }
 
 static void destroy_ht_decompress_context (exr_decode_pipeline_t* decode)
@@ -329,11 +336,13 @@ ht_undo_impl (
     {
         ojph::param_cod cod0 = cs.access_cod ();
         const int       nd   = (int) cod0.get_num_decompositions ();
+        /* ht_padded_length() returns -1 for an unsupported nd, which can
+         * never equal a real extent, so that case is rejected here too. */
         if (cod0.is_reversible () ||
-            image_width !=
-                (ojph::ui32) ht_padded_length (decode->chunk.width, nd) ||
-            image_height !=
-                (ojph::ui32) ht_padded_length (decode->chunk.height, nd))
+            (int64_t) image_width !=
+                ht_padded_length (decode->chunk.width, nd) ||
+            (int64_t) image_height !=
+                ht_padded_length (decode->chunk.height, nd))
             return EXR_ERR_CORRUPT_CHUNK;
         padded = true;
     }
@@ -593,11 +602,18 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
      * last column so that every dimension is == 1 (mod 2^L); see
      * ht_padded_length().  The padding is only applied to interleaved
      * (unsubsampled) chunks; the decoder recognises it from the SIZ marker. */
-    const bool pad = lossy && !isPlanar;
-    if (pad)
+    if (lossy && !isPlanar)
     {
-        image_width  = ht_padded_length (chunk_width, num_decomps);
-        image_height = ht_padded_length (chunk_height, num_decomps);
+        const int64_t pw = ht_padded_length (chunk_width, num_decomps);
+        const int64_t ph = ht_padded_length (chunk_height, num_decomps);
+        /* If the padded size would not fit in a 32-bit dimension the chunk
+         * is coded unpadded; that is still a valid file, the decoder accepts
+         * the chunk size as-is. */
+        if (pw > 0 && ph > 0)
+        {
+            image_width  = (int) pw;
+            image_height = (int) ph;
+        }
     }
 
     siz.set_image_offset (ojph::point (0, 0));
@@ -816,6 +832,14 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
         assert (output.get_size () >= 0);
         encode->compressed_bytes = output.get_size () + header_sz;
     } catch (const std::range_error& e) {
+        /* The codestream is larger than the uncompressed chunk: store the
+         * chunk uncompressed, as the other codecs do. */
+        if (encode->compressed_alloc_size < encode->packed_bytes)
+            return EXR_ERR_OUT_OF_MEMORY;
+        memcpy (
+            encode->compressed_buffer,
+            encode->packed_buffer,
+            encode->packed_bytes);
         encode->compressed_bytes = encode->packed_bytes;
     }
 

--- a/src/lib/OpenEXRCore/internal_ht.cpp
+++ b/src/lib/OpenEXRCore/internal_ht.cpp
@@ -169,6 +169,35 @@ struct ht_context_cache
     size_t header_sz = 0;
 };
 
+/*
+ * Chunk-boundary padding for lossy (irreversible) coding.
+ *
+ * Every chunk is coded as an independent codestream whose image origin is
+ * (0, 0).  With the whole-sample symmetric extension of JPEG 2000, a chunk
+ * dimension that is even at any decomposition level puts the fold of the
+ * extension on a high-pass position, and the quantization error of the
+ * resulting coefficient shows up as a visible step on the last row / column
+ * of the chunk.  The fold sits on a low-pass position at every one of the L
+ * levels if and only if the coded length n' satisfies
+ *
+ *     n' == 1 (mod 2^L)
+ *
+ * (the image origin being 0).  So, for lossy coding, the last row and the
+ * last column are replicated until both dimensions satisfy this, and the
+ * replicated samples are dropped again after decoding.  The padded size is
+ * carried by the SIZ marker of the codestream and L by its COD marker, so
+ * nothing has to be added to the chunk header.  This analysis relies on the
+ * image origin being (0, 0) and on the codestream having a single tile; if
+ * either is ever changed the parity at both ends has to be re-examined.
+ */
+static inline int
+ht_padded_length (int n, int num_decomps)
+{
+    const int m = 1 << num_decomps;
+    /* smallest n' >= n with n' == 1 (mod m) */
+    return n + (((1 - n) % m) + m) % m;
+}
+
 static void destroy_ht_decompress_context (exr_decode_pipeline_t* decode)
 {
     ht_context_cache* ctxt = static_cast<ht_context_cache*> (decode->compression_context);
@@ -286,19 +315,51 @@ ht_undo_impl (
     ojph::ui32 image_width =
         siz.get_image_extent ().x - siz.get_image_offset ().x;
 
-    if (decode->chunk.width != image_width
-        || decode->chunk.height != image_height
-        || decode->channel_count != siz.get_num_components())
+    if (decode->channel_count != siz.get_num_components ())
         return EXR_ERR_CORRUPT_CHUNK;
+
+    /* The codestream is either exactly the chunk, or (lossy coding) the
+     * chunk padded by row / column replication to the size that keeps every
+     * fold of the wavelet transform on a low-pass position, see
+     * ht_padded_length().  In the padded case the extra rows and columns are
+     * decoded and discarded below. */
+    bool padded = false;
+    if (decode->chunk.width != image_width ||
+        decode->chunk.height != image_height)
+    {
+        ojph::param_cod cod0 = cs.access_cod ();
+        const int       nd   = (int) cod0.get_num_decompositions ();
+        if (cod0.is_reversible () ||
+            image_width !=
+                (ojph::ui32) ht_padded_length (decode->chunk.width, nd) ||
+            image_height !=
+                (ojph::ui32) ht_padded_length (decode->chunk.height, nd))
+            return EXR_ERR_CORRUPT_CHUNK;
+        padded = true;
+    }
 
     for (int cs_i = 0; cs_i < decode->channel_count; cs_i++)
     {
         int file_i = cs_to_file_ch[cs_i].file_index;
 
-        if (decode->channels[file_i].height != siz.get_recon_height (cs_i) ||
+        if (padded)
+        {
+            /* padding is only produced for unsubsampled (interleaved) chunks */
+            if (siz.get_downsampling (cs_i).x != 1 ||
+                siz.get_downsampling (cs_i).y != 1 ||
+                decode->channels[file_i].height != decode->chunk.height ||
+                decode->channels[file_i].width != decode->chunk.width ||
+                siz.get_recon_height (cs_i) != image_height ||
+                siz.get_recon_width (cs_i) != image_width)
+                return EXR_ERR_CORRUPT_CHUNK;
+        }
+        else if (
+            decode->channels[file_i].height != siz.get_recon_height (cs_i) ||
             decode->channels[file_i].width != siz.get_recon_width (cs_i) ||
-            decode->channels[file_i].height != image_height / siz.get_downsampling (cs_i).y ||
-            decode->channels[file_i].width != image_width / siz.get_downsampling (cs_i).x)
+            decode->channels[file_i].height !=
+                image_height / siz.get_downsampling (cs_i).y ||
+            decode->channels[file_i].width !=
+                image_width / siz.get_downsampling (cs_i).x)
             return EXR_ERR_CORRUPT_CHUNK;
     }
 
@@ -314,6 +375,7 @@ ht_undo_impl (
     }
     if (bpl > INT32_MAX || bpl * decode->chunk.height > (int64_t) PTRDIFF_MAX)
         return EXR_ERR_CORRUPT_CHUNK;
+    if (padded && is_planar) return EXR_ERR_CORRUPT_CHUNK;
     cs.set_planar (is_planar);
 
     cs.create ();
@@ -393,8 +455,12 @@ ht_undo_impl (
     {
         uint8_t* line_pixels = static_cast<uint8_t*> (uncompressed_data);
 
-        assert (bpl * image_height == uncompressed_size);
+        const uint32_t out_height = (uint32_t) decode->chunk.height;
+        assert (bpl * out_height == uncompressed_size);
 
+        /* image_height / image_width are the (possibly padded) codestream
+         * dimensions; only the first chunk.height rows and chunk.width
+         * samples of each row are copied out, the rest is discarded. */
         for (uint32_t y = 0; y < image_height; ++y)
         {
             for (int16_t c = 0; c < decode->channel_count; c++)
@@ -402,6 +468,7 @@ ht_undo_impl (
                 int file_c = cs_to_file_ch[c].file_index;
                 cur_line   = cs.pull (next_comp);
                 assert (next_comp == c);
+                if (y >= out_height) continue;
                 if (decode->channels[file_c].data_type == EXR_PIXEL_HALF)
                 {
                     int16_t* channel_pixels =
@@ -471,8 +538,10 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
     bool                               isRGB = make_channel_map (
         encode->channel_count, encode->channels, cs_channel_info);
 
-    int image_height = encode->chunk.height;
-    int image_width  = encode->chunk.width;
+    const int chunk_height = encode->chunk.height;
+    const int chunk_width  = encode->chunk.width;
+    int       image_height = chunk_height;
+    int       image_width  = chunk_width;
 
     ojph::codestream cs;
 
@@ -493,17 +562,16 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
     siz.set_num_components (encode->channel_count);
     cs.set_planar (isPlanar);
 
-    siz.set_image_offset (ojph::point (0, 0));
-    siz.set_image_extent (ojph::point (image_width, image_height));
-
     exr_compression_t comp = EXR_COMPRESSION_HTJ2K256;
     exr_get_compression (encode->context, encode->part_index, &comp);
 
     ojph::param_cod cod = cs.access_cod ();
 
+    const int num_decomps = 5;
+
     cod.set_color_transform (isRGB && !isPlanar);
     cod.set_block_dims (128, 32);
-    cod.set_num_decomposition (5);
+    cod.set_num_decomposition (num_decomps);
 
     /* enable lossy compression on the first 3 channels, only if the compressor
     is EXR_COMPRESSION_LJ2K, we have RGB channels, all RGB channels are
@@ -520,6 +588,20 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                             encode->channels[file_c].y_samples == 1;
         }
     }
+
+    /* Lossy coding: pad the coded array by replicating the last row and the
+     * last column so that every dimension is == 1 (mod 2^L); see
+     * ht_padded_length().  The padding is only applied to interleaved
+     * (unsubsampled) chunks; the decoder recognises it from the SIZ marker. */
+    const bool pad = lossy && !isPlanar;
+    if (pad)
+    {
+        image_width  = ht_padded_length (chunk_width, num_decomps);
+        image_height = ht_padded_length (chunk_height, num_decomps);
+    }
+
+    siz.set_image_offset (ojph::point (0, 0));
+    siz.set_image_extent (ojph::point (image_width, image_height));
 
     if (lossy)
     {
@@ -678,20 +760,28 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
             const uint8_t* line_pixels =
                 static_cast<const uint8_t*> (encode->packed_buffer);
 
-            assert (bpl * image_height == encode->packed_bytes);
+            assert (bpl * chunk_height == encode->packed_bytes);
 
+            /* image_height / image_width may exceed the chunk size by the
+             * padding: rows beyond the chunk repeat its last row, samples
+             * beyond the chunk width repeat the last sample of the row. */
             for (int y = 0; y < image_height; y++)
             {
+                const uint8_t* src_line =
+                    line_pixels +
+                    (int64_t) (y < chunk_height ? y : chunk_height - 1) * bpl;
+
                 for (int16_t c = 0; c < encode->channel_count; c++)
                 {
                     int file_c = cs_channel_info[c].file_index;
+                    const int32_t cw     = encode->channels[file_c].width;
 
                     if (encode->channels[file_c].data_type == EXR_PIXEL_HALF)
                     {
                         int16_t* channel_pixels =
-                            (int16_t*) (line_pixels + cs_channel_info[c].raster_line_offset);
-                        for (int32_t p = 0; p < encode->channels[file_c].width;
-                            p++)
+                            (int16_t*) (src_line +
+                                        cs_channel_info[c].raster_line_offset);
+                        for (int32_t p = 0; p < cw; p++)
                         {
                             if (! cod.is_reversible(c))
                                 cur_line->i32[p] = half_to_int16(half (half::FromBits, (uint16_t) (*channel_pixels++)));
@@ -702,9 +792,9 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                     else
                     {
                         int32_t* channel_pixels =
-                            (int32_t*) (line_pixels + cs_channel_info[c].raster_line_offset);
-                        for (int32_t p = 0; p < encode->channels[file_c].width;
-                            p++)
+                            (int32_t*) (src_line +
+                                        cs_channel_info[c].raster_line_offset);
+                        for (int32_t p = 0; p < cw; p++)
                         {
                             if (! cod.is_reversible(c))
                                 cur_line->i32[p] = float_to_int32(*((float *)channel_pixels++));
@@ -712,10 +802,12 @@ ht_apply_impl (exr_encode_pipeline_t* encode)
                                 cur_line->i32[p] = *channel_pixels++;
                         }
                     }
+                    for (int32_t p = cw; p < image_width; p++)
+                        cur_line->i32[p] = cur_line->i32[cw - 1];
+
                     assert (next_comp == c);
                     cur_line = cs.exchange (cur_line, next_comp);
                 }
-                line_pixels += bpl;
             }
         }
 

--- a/src/test/OpenEXRTest/CMakeLists.txt
+++ b/src/test/OpenEXRTest/CMakeLists.txt
@@ -115,6 +115,8 @@ add_executable(OpenEXRTest
   testStandardAttributes.h
   testTiledCompression.cpp
   testTiledCompression.h
+  testLJ2KBoundary.cpp
+  testLJ2KBoundary.h
   testTiledCopyPixels.cpp
   testTiledCopyPixels.h
   testTiledLineOrder.cpp
@@ -202,6 +204,7 @@ define_openexr_tests(
  testSharedFrameBuffer
  testStandardAttributes
  testTiledCompression
+ testLJ2KBoundary
  testTiledCopyPixels
  testTiledLineOrder
  testTiledRgba

--- a/src/test/OpenEXRTest/main.cpp
+++ b/src/test/OpenEXRTest/main.cpp
@@ -59,6 +59,7 @@
 #include "testSharedFrameBuffer.h"
 #include "testStandardAttributes.h"
 #include "testTiledCompression.h"
+#include "testLJ2KBoundary.h"
 #include "testTiledCopyPixels.h"
 #include "testTiledLineOrder.h"
 #include "testTiledRgba.h"
@@ -199,6 +200,7 @@ main (int argc, char* argv[])
     TEST (testTiledRgba, "basic");
     TEST (testTiledCopyPixels, "basic");
     TEST (testTiledCompression, "basic");
+    TEST (testLJ2KBoundary, "basic");
     TEST (testTiledLineOrder, "basic");
     TEST (testScanLineApi, "basic");
     TEST (testExistingStreams, "core");

--- a/src/test/OpenEXRTest/testLJ2KBoundary.cpp
+++ b/src/test/OpenEXRTest/testLJ2KBoundary.cpp
@@ -1,0 +1,255 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#ifdef NDEBUG
+#    undef NDEBUG
+#endif
+
+#include "ImfArray.h"
+#include "ImfHeader.h"
+#include "ImfRgbaFile.h"
+#include "ImfTiledRgbaFile.h"
+#include "ImfCompression.h"
+
+#include <Imath/ImathBox.h>
+
+#include <assert.h>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+using namespace OPENEXR_IMF_NAMESPACE;
+using namespace IMATH_NAMESPACE;
+using namespace std;
+
+//
+// LJ2K codes every chunk (or tile) as an independent, lossy JPEG 2000
+// codestream.  Without the row / column replication done inside the
+// compressor, an even chunk dimension leaves a visible discontinuity on the
+// last row / column of every chunk (about 10 dB below the interior rows on a
+// smooth gradient).  These tests write smooth gradients and check that the
+// rows and columns adjacent to every chunk / tile boundary are coded about
+// as well as the interior, and that odd chunk sizes round-trip.
+//
+
+namespace
+{
+
+double
+gradient (int x, int y)
+{
+    return (60.0 + 0.25 * y + 30.0 * sin (x / 70.0)) / 255.0;
+}
+
+void
+fillGradient (Array2D<Rgba>& px, int width, int height)
+{
+    for (int y = 0; y < height; ++y)
+        for (int x = 0; x < width; ++x)
+        {
+            float v  = (float) gradient (x, y);
+            px[y][x] = Rgba (v, v, v, 1.f);
+        }
+}
+
+// PSNR of one row / column, on an 8-bit scale, against the gradient
+double
+rowPsnr (const Array2D<Rgba>& px, int width, int y)
+{
+    double e = 0;
+    for (int x = 0; x < width; ++x)
+    {
+        double d = 255.0 * ((double) px[y][x].g - gradient (x, y));
+        e += d * d;
+    }
+    return 10.0 * log10 (255.0 * 255.0 / (e / width));
+}
+
+double
+colPsnr (const Array2D<Rgba>& px, int height, int x)
+{
+    double e = 0;
+    for (int y = 0; y < height; ++y)
+    {
+        double d = 255.0 * ((double) px[y][x].g - gradient (x, y));
+        e += d * d;
+    }
+    return 10.0 * log10 (255.0 * 255.0 / (e / height));
+}
+
+void
+readBack (const string& fn, Array2D<Rgba>& px, int width, int height)
+{
+    RgbaInputFile in (fn.c_str ());
+    Box2i         dw = in.dataWindow ();
+    assert (dw.max.x - dw.min.x + 1 == width);
+    assert (dw.max.y - dw.min.y + 1 == height);
+    px.resizeErase (height, width);
+    in.setFrameBuffer (&px[0][0], 1, width);
+    in.readPixels (dw.min.y, dw.max.y);
+}
+
+// The last row / column of every chunk (the ones that the padding fixes;
+// without it they are 10-15 dB below the interior on this gradient) must be
+// within `tolerance` dB of the interior rows / columns.  The first row /
+// column of the next chunk is printed for information: a small residual
+// there is intrinsic to independent coding of the chunks and not affected
+// by the padding.
+void
+checkBoundaries (
+    const Array2D<Rgba>& px,
+    int                  width,
+    int                  height,
+    int                  stepX,
+    int                  stepY,
+    double               tolerance)
+{
+    double interiorRow = rowPsnr (px, width, stepY / 2);
+    double interiorCol = colPsnr (px, height, stepX / 2);
+
+    cout << "   interior: row " << interiorRow << " dB, column " << interiorCol
+         << " dB" << endl;
+
+    for (int b = stepY; b <= height; b += stepY)
+    {
+        double before = rowPsnr (px, width, b - 1);
+        cout << "   row " << b - 1 << ": " << before << " dB";
+        if (b < height)
+        {
+            cout << ", row " << b << ": " << rowPsnr (px, width, b) << " dB";
+        }
+        cout << endl;
+        assert (before > interiorRow - tolerance);
+    }
+    for (int b = stepX; b <= width; b += stepX)
+    {
+        double before = colPsnr (px, height, b - 1);
+        cout << "   column " << b - 1 << ": " << before << " dB";
+        if (b < width)
+        {
+            cout << ", column " << b << ": " << colPsnr (px, height, b)
+                 << " dB";
+        }
+        cout << endl;
+        assert (before > interiorCol - tolerance);
+    }
+    // the last row / column of the image are chunk boundaries too
+    assert (rowPsnr (px, width, height - 1) > interiorRow - tolerance);
+    assert (colPsnr (px, height, width - 1) > interiorCol - tolerance);
+}
+
+void
+testScanlines (const string& tempDir, int width, int height, float quality)
+{
+    cout << "scanline " << width << "x" << height << ", quality " << quality
+         << endl;
+
+    string fn = tempDir + "imf_test_lj2k_boundary_scanline.exr";
+
+    Array2D<Rgba> px (height, width);
+    fillGradient (px, width, height);
+
+    {
+        Header hdr (width, height);
+        hdr.compression ()       = LJ2K_COMPRESSION;
+        hdr.lossyHTJ2KQuality () = quality;
+        RgbaOutputFile out (fn.c_str (), hdr, WRITE_RGBA);
+        out.setFrameBuffer (&px[0][0], 1, width);
+        out.writePixels (height);
+    }
+
+    Array2D<Rgba> rd;
+    readBack (fn, rd, width, height);
+    checkBoundaries (rd, width, height, width, 256, 6.0);
+    remove (fn.c_str ());
+}
+
+void
+testTiles (
+    const string& tempDir, int width, int height, int tileSize, float quality)
+{
+    cout << "tiled " << width << "x" << height << ", tiles " << tileSize
+         << ", quality " << quality << endl;
+
+    string fn = tempDir + "imf_test_lj2k_boundary_tiled.exr";
+
+    Array2D<Rgba> px (height, width);
+    fillGradient (px, width, height);
+
+    {
+        Header hdr (width, height);
+        hdr.compression ()       = LJ2K_COMPRESSION;
+        hdr.lossyHTJ2KQuality () = quality;
+        TiledRgbaOutputFile out (
+            fn.c_str (), hdr, WRITE_RGBA, tileSize, tileSize, ONE_LEVEL);
+        out.setFrameBuffer (&px[0][0], 1, width);
+        out.writeTiles (0, out.numXTiles () - 1, 0, out.numYTiles () - 1);
+    }
+
+    Array2D<Rgba> rd;
+    readBack (fn, rd, width, height);
+    checkBoundaries (rd, width, height, tileSize, tileSize, 6.0);
+    remove (fn.c_str ());
+}
+
+// Sizes around the padding modulus (2^5 = 32 for 5 decomposition levels)
+// must round-trip; the padded codestream may be up to 31 rows / columns
+// larger than the chunk.
+void
+testCornerSizes (const string& tempDir)
+{
+    const int sizes[] = {1, 2, 3, 31, 32, 33, 63, 64, 65};
+    string    fn      = tempDir + "imf_test_lj2k_boundary_corner.exr";
+
+    for (int width: sizes)
+        for (int height: sizes)
+        {
+            Array2D<Rgba> px (height, width);
+            fillGradient (px, width, height);
+            {
+                Header hdr (width, height);
+                hdr.compression ()       = LJ2K_COMPRESSION;
+                hdr.lossyHTJ2KQuality () = 60.f;
+                RgbaOutputFile out (fn.c_str (), hdr, WRITE_RGBA);
+                out.setFrameBuffer (&px[0][0], 1, width);
+                out.writePixels (height);
+            }
+            Array2D<Rgba> rd;
+            readBack (fn, rd, width, height);
+            for (int y = 0; y < height; ++y)
+                for (int x = 0; x < width; ++x)
+                {
+                    assert (
+                        fabs ((double) rd[y][x].g - gradient (x, y)) < 0.05);
+                    assert ((double) rd[y][x].a == 1.0);
+                }
+            remove (fn.c_str ());
+        }
+    cout << "corner sizes ok" << endl;
+}
+
+} // namespace
+
+void
+testLJ2KBoundary (const string& tempDir)
+{
+    try
+    {
+        cout << "Testing LJ2K chunk / tile boundaries" << endl;
+
+        testScanlines (tempDir, 512, 512, 45.f);
+        testScanlines (tempDir, 500, 300, 60.f);
+        testTiles (tempDir, 512, 512, 64, 45.f);
+        testTiles (tempDir, 500, 300, 64, 60.f);
+        testCornerSizes (tempDir);
+
+        cout << "ok\n" << endl;
+    }
+    catch (const std::exception& e)
+    {
+        cerr << "ERROR -- caught exception: " << e.what () << endl;
+        assert (false);
+    }
+}

--- a/src/test/OpenEXRTest/testLJ2KBoundary.h
+++ b/src/test/OpenEXRTest/testLJ2KBoundary.h
@@ -1,0 +1,8 @@
+//
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Contributors to the OpenEXR Project.
+//
+
+#include <string>
+
+void testLJ2KBoundary (const std::string& tempDir);

--- a/website/TechnicalIntroduction.rst
+++ b/website/TechnicalIntroduction.rst
@@ -880,7 +880,12 @@ Supported compression schemes:
 
      - Lossy compression of HALF and FLOAT data types in blocks of 256
        scanlines, using `JPEG 2000 Part 15 (High-throughput JPEG 2000)
-       <https://www.itu.int/rec/T-REC-T.814>`_,
+       <https://www.itu.int/rec/T-REC-T.814>`_. To avoid a visible
+       discontinuity at chunk and tile boundaries, the coded array is padded
+       by replicating its last row and last column until each dimension is
+       congruent to 1 modulo 2^L (L being the number of wavelet
+       decomposition levels); the padding is removed again when the chunk is
+       decoded.
 
    * - ZSTD (lossless)
 


### PR DESCRIPTION
### Motivation

In #2599, @brechtvl [reported](https://github.com/AcademySoftwareFoundation/openexr/pull/2599#issuecomment-5363682314) that the FLIP error images of LJ2K files show the boundaries between the 256-scanline chunks, that an odd chunk height such as 257 sidesteps the problem, and that the last column of an even-width image shows the same additional error. This PR fixes the chunk/tile-boundary and last-row/last-column artifacts inside the LJ2K compressor without changing the chunk layout or the file format.

### Cause

Every LJ2K chunk (or tile) is an independent HTJ2K codestream with image origin (0, 0), so the wavelet transform is low-pass first and, for an even chunk length, the last sample sits on a high-pass position. JPEG 2000's whole-sample symmetric extension folds the signal there; on a smooth gradient the fold is a V, the last high-pass coefficient carries the local slope, and its quantization error is returned almost entirely to the last row. This is the tile-boundary effect analysed by Wei et al. (IEEE TIP 2005); Part 2's SSO/TSSO transforms address it inside the codestream, but they are not available to Part 1 / Part 15 decoders, so the container has to handle it.

"Odd" is not the condition. Level *l* of the DWT acts on a signal of length ceil(n / 2^(l-1)), so the fold is on a low-pass position at every level if and only if

    n ≡ 1 (mod 2^L)

with *L* the number of decomposition levels (currently 5). 257 works because 257 = 8·32 + 1; 63 or 127 rows would behave like 256.

### What this PR does

* **Encoder** (`internal_ht.cpp`): for lossy, interleaved chunks, compute the padded width and height `n' = n + ((1 − n) mod 2^L)` with *L* taken from `cod.set_num_decomposition`, set them as the SIZ image extent, and replicate the last row and the last column into the padded region. For the standard 256-scanline chunk and for power-of-two tiles this is one extra row and (for even widths) one extra column; the overhead is at most 2^L − 1 rows/columns otherwise.
* **Decoder**: accept a codestream whose SIZ extent is either the chunk size or the padded size computed from *L* read from COD; decode all lines and copy out the first H × W samples. Any other size is still rejected as before.
* Lossless HTJ2K32/HTJ2K256 chunks and the planar (subsampled) path are not affected. The chunk header and the file format are unchanged; the padded size travels in the codestream's SIZ marker.
* Adds `testLJ2KBoundary`, which checks the last row/column of every chunk and tile of smooth gradients (scanline and tiled, including partial border tiles) and round-trips sizes around the padding modulus. It fails on `main` and passes with this PR.
* Adds one sentence to `website/TechnicalIntroduction.rst`.

### What it does not do

The **first** row and first column of the image, which @brechtvl also mentioned, are a different and much smaller effect: the fold there is on a low-pass position, and the extension merely doubles the weight of one boundary coefficient's error. In my measurements it is 1.1–1.7× the interior RMS error (1–5 dB, against 10–15 dB for the seam), it is unchanged by this PR, and it is not addressed here.

### Results

Gradient image, quality 45, PSNR on the 8-bit scale, measured through the real LJ2K path (half floats, transfer function). Interior rows and columns are at 40–45 dB.

| File | Position | main | this PR |
|---|---|---|---|
| scanline 512×512 | row 255 (last of chunk 0) | 30.9 dB | 41.2 dB |
| | column 511 (last of image) | 30.8 dB | 39.3 dB |
| tiled 512×512, 64×64 tiles | last row of each tile row | 30.4–32.6 dB | 40.8–42.5 dB |
| | last column of each tile column | 26.8–31.2 dB | 40.0–43.3 dB |
| | whole image | 36.1 dB | 43.2 dB |

Unpatched, the per-row error rises over the last ~30 rows before a chunk boundary (the coarse-level folds spread their error over about 2^l rows), so in a 64-row tile the whole tile is affected; that is why the tiled image improves everywhere.

The same numbers were obtained independently on a second machine (Ubuntu 24.04, GCC 14) following the written procedure from scratch, to within 0.1 dB; on the wire exactly two bytes per chunk change (Xsiz 512→513, Ysiz 256→257), and all codestreams extracted from the test files decode standalone with OpenJPH.

### Cost and compatibility

* **Size.** The extra row and column also add a row and a column of code-blocks to every subband, so the cost is more than the 0.4 % of extra samples: +1.1 % at quality 110 on a 1920×1080 RGB half image (5 MB file), +2.7 % at quality 90, and 8–15 % at qualities 45–60 where the files are only 18–30 kB and mostly signalling. Worth confirming on real renders.
* **Speed/memory.** Work grows by the padded fraction; no extra buffers; chunks stay independent.
* **Compatibility is one-way.** A library with this PR reads files written before it. A library without it rejects padded files cleanly (`EXR_ERR_CORRUPT_CHUNK` from the existing size guard in `ht_undo_impl`) before decoding any sample. Since LJ2K has not shipped in a tagged release, merging before the first one avoids the question.

### Alternatives considered

* 257-row chunks (option 1 in the original discussion) fix the rows but change the chunk layout, break the 256-row assumptions elsewhere, and do nothing for the last column.
* Packing several chunks as J2K tiles of one codestream cannot be made clean on both sides of a tile boundary, because the condition for an origin other than 0 is tcx0 ≡ 0 and tcx1 ≡ 1 (mod 2^L), which adjacent tiles cannot satisfy simultaneously.
* Part 2 SSO/TSSO is out of reach for Part 15 decoders.

### Questions for reviewers

1. The decoder accepts only the exact padded size (or the unpadded chunk size). Accepting anything ≥ the chunk size would be more lenient; I have no strong preference.
2. Whether a release note about the one-way compatibility is wanted.
3. It would be very useful if the FLIP benchmark from #2599 could be rerun on this branch.

I have a longer write-up with the derivation for general image and tile origins and all measurements; happy to share it if anyone wants the details.
